### PR TITLE
Log absolute path of LCOV file to make debug easier.

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/coverage/LCOVParser.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/coverage/LCOVParser.java
@@ -44,7 +44,7 @@ public final class LCOVParser {
     try {
       lines = FileUtils.readLines(file);
     } catch (IOException e) {
-      LOG.debug("Cound not read content from file: " + file.getName());
+      LOG.debug("Cound not read content from file: {}", file.getAbsolutePath(), e);
     }
 
     List<JavaScriptFileCoverage> coveredFiles = new LinkedList<JavaScriptFileCoverage>();


### PR DESCRIPTION
Today I used this patch to know why this plugin did not work well.
And I found that we used absolute path for `sonar.javascript.jstestdriver.coveragefile` property.

I guess that other user will face similar problem.
I wish this patch helps them.
