### PR TITLE
Update LCOVParser.java

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -72,7 +72,7 @@ public final class LCOVParser {
         // BRDA:<line number>,<block number>,<branch number>,<taken>
         String[] tokens = line.substring(BRDA.length()).trim().split(",");
         String lineNumber = tokens[0];
-        boolean taken = "1".equals(tokens[3]);
+        boolean taken = !( "0".equals(tokens[3]) );
 
         BranchData branchData = branches.get(lineNumber);
         if (branchData == null) {


### PR DESCRIPTION
Some lcov output returns the number of times a branch was taken, instead of whether or not the branch was taken. By checking against "NOT 0" instead of "IS 1" branches will still be counted even if the last number is not a boolean value but a true integer. 
