### PR TITLE
Fix BoundOrAssignedEvalOrArgumentsCheck to ignore equality expressions.

### DIFF
--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/BoundOrAssignedEvalOrArgumentsCheck.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/BoundOrAssignedEvalOrArgumentsCheck.java
@@ -92,7 +92,8 @@ public class BoundOrAssignedEvalOrArgumentsCheck extends SquidCheck<LexerlessGra
 
   private void checkModification(AstNode astNode) {
     if (isEvalOrArguments(astNode.getTokenValue()) && !astNode.hasDirectChildren(EcmaScriptPunctuator.LBRACKET)
-      && !astNode.getParent().is(EcmaScriptGrammar.CALL_EXPRESSION)) {
+      && !astNode.getParent().is(EcmaScriptGrammar.CALL_EXPRESSION)
+      && !astNode.hasAncestor(EcmaScriptGrammar.EQUALITY_EXPRESSION)) {
       getContext().createLineViolation(this, "Remove the modification of '" + astNode.getTokenValue() + "'.", astNode);
     }
   }

--- a/javascript-checks/src/test/resources/checks/boundOrAssignedEvalOrArguments.js
+++ b/javascript-checks/src/test/resources/checks/boundOrAssignedEvalOrArguments.js
@@ -11,3 +11,9 @@ var f = new Function("arguments", "return 17;");
 
 eval("");
 arguments[0];
+
+function foo() {
+    var a = arguments.length == 0;
+    var b = arguments.length === 0;
+    return true;
+}


### PR DESCRIPTION
An easy way for a JS function to check how many arguments it has is
  arguments.length === x

The old check thinks the above is a modification. We can change the check to
  not fire if it has an ancestor that is an equality expression.

Unfortunately, the new check won't generate a violation for the following:
  (arguments = 1) === 1

I'm hoping the latter won't occur too much, while the former is a common
  pattern and false positives are annoying. There might be a way to catch
  the second case while ignoring the first, but I'm not familiar enough with
  the generated AST.
