### PR TITLE
SONARPLUGINS-2844 LCOV parsing should handle dots

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.javascript.lcov;
 
 import com.google.common.collect.Maps;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.FileUtils;
 import org.sonar.api.measures.CoverageMeasuresBuilder;
 import org.sonar.api.utils.SonarException;
@@ -58,7 +59,7 @@ public final class LCOVParser {
     for (String line : lines) {
       if (line.startsWith(SF)) {
         fileCoverage = CoverageMeasuresBuilder.create();
-        filePath = line.substring(SF.length());
+        filePath = FilenameUtils.normalize(line.substring(SF.length()));
 
       } else if (line.startsWith(DA)) {
         // DA:<line number>,<execution count>[,<checksum>]

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/LCOVParserTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/LCOVParserTest.java
@@ -74,4 +74,24 @@ public class LCOVParserTest {
     parser.parseFile(new File("not-found"));
   }
 
+  @Test
+  public void dotInPath() {
+    Map<String, CoverageMeasuresBuilder> result = parser.parse(Arrays.asList(
+        "SF:./file1.js",
+        "DA:1,1",
+        "end_of_record"));
+    CoverageMeasuresBuilder fileCoverage = result.get("file1.js");
+    assertThat(fileCoverage).isNotNull();
+  }
+
+  @Test
+  public void dotDotInPath() {
+    Map<String, CoverageMeasuresBuilder> result = parser.parse(Arrays.asList(
+        "SF:./path/../file1.js",
+        "DA:1,1",
+        "end_of_record"));
+    CoverageMeasuresBuilder fileCoverage = result.get("file1.js");
+    assertThat(fileCoverage).isNotNull();
+  }
+
 }


### PR DESCRIPTION
Some coverage tooling (including istanbul) report with ./ prepended to the filepath

```
SF:./file1.js
DA:1,1
end_of_record
```

Sonar is not able to match this path to the source file.
This patch addresses the issue by normalizing the filepath using `org.apache.commons.io.FilenameUtils.normalize`

I have also added the corresponding tests that would fail without the patch.

Please let me know if I have missed something
