### PR TITLE
Fix parsing of regular expression literals for JDK 9

### DIFF
--- a/javascript-frontend/src/main/java/org/sonar/javascript/lexer/JavaScriptRegexpChannel.java
+++ b/javascript-frontend/src/main/java/org/sonar/javascript/lexer/JavaScriptRegexpChannel.java
@@ -37,13 +37,14 @@ import static org.sonar.javascript.lexer.JavaScriptTokenType.REGULAR_EXPRESSION_
  */
 public class JavaScriptRegexpChannel extends Channel<Lexer> {
 
-  private static final String NON_TERMINATOR = "[^\\r\\n\\u2028\\u2029]";
+  private static final String LINE_TERMINATOR_CHARACTERS = "\\r\\n\\u2028\\u2029";
 
-  private static final String BACKSLASH_SEQUENCE = "\\\\" + NON_TERMINATOR;
+  private static final String BACKSLASH_SEQUENCE = "\\\\[^" + LINE_TERMINATOR_CHARACTERS + "]";
 
   private static final String CLASS = "\\["
     + "(?:"
-    + "[^\\]\\\\&&" + NON_TERMINATOR + "]"
+    // any character except closing square bracket, backslash, line terminator
+    + "[^\\]\\\\" + LINE_TERMINATOR_CHARACTERS + "]"
     + "|" + BACKSLASH_SEQUENCE
     + ")*+"
     + "\\]";
@@ -51,9 +52,13 @@ public class JavaScriptRegexpChannel extends Channel<Lexer> {
   public static final String REGULAR_EXPRESSION = ""
     // A slash starts a regexp but only if not a comment start
     + "\\/(?![*/])"
+    // which can contain any number of
     + "(?:"
-    + "[^\\\\\\[/&&" + NON_TERMINATOR + "]"
+    // any character except backslash, opening square bracket, slash, line terminator
+    + "[^\\\\\\[/" + LINE_TERMINATOR_CHARACTERS + "]"
+    // or class
     + "|" + CLASS
+    // or escape sequence
     + "|" + BACKSLASH_SEQUENCE
     + ")*+"
     // finished by a '/'

--- a/javascript-frontend/src/test/java/org/sonar/javascript/parser/lexical/RegularExpressionLiteralTest.java
+++ b/javascript-frontend/src/test/java/org/sonar/javascript/parser/lexical/RegularExpressionLiteralTest.java
@@ -37,4 +37,12 @@ public class RegularExpressionLiteralTest {
       .matches("/[\\B]/");
   }
 
+  @Test
+  public void cannot_contain_line_terminator() {
+    assertThat(JavaScriptTokenType.REGULAR_EXPRESSION_LITERAL)
+      .notMatches("/\n/")
+      .notMatches("/\\\n/")
+      .notMatches("/[\n]/");
+  }
+
 }


### PR DESCRIPTION
This is required due to https://bugs.openjdk.java.net/browse/JDK-8189343

Fixes #801