### PR TITLE
Improve FunctionDefinitionInsideLoop: ignore all safe Array functions

### DIFF
--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/FunctionDefinitionInsideLoopCheck.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/FunctionDefinitionInsideLoopCheck.java
@@ -40,7 +40,7 @@ import org.sonar.plugins.javascript.api.visitors.SubscriptionVisitorCheck;
 public class FunctionDefinitionInsideLoopCheck extends SubscriptionVisitorCheck {
 
   private static final String MESSAGE = "Define this function outside of a loop.";
-  private static final Set<String> ALLOWED_CALLBACKS = ImmutableSet.of("replace", "forEach", "filter", "map");
+  private static final Set<String> ALLOWED_CALLBACKS = ImmutableSet.of("replace", "forEach", "filter", "map", "find", "findIndex", "every", "some", "reduce", "reduceRight", "sort");
 
   private Deque<Tree> functionAndLoopScopes = new ArrayDeque<>();
 

--- a/javascript-checks/src/test/resources/checks/FunctionDefinitionInsideLoop.js
+++ b/javascript-checks/src/test/resources/checks/FunctionDefinitionInsideLoop.js
@@ -111,6 +111,34 @@ function some_callbacks_ok() {
       return i;
     });
 
+    arr.find(function() {              // OK
+      return i;
+    });
+
+    arr.findIndex(function() {              // OK
+      return i;
+    });
+
+    arr.every(function() {              // OK
+      return i;
+    });
+
+    arr.some(function() {              // OK
+      return i;
+    });
+
+    arr.reduce(function() {              // OK
+      return i;
+    });
+
+    arr.reduceRight(function() {              // OK
+      return i;
+    });
+
+    arr.sort(function() {              // OK
+      return i;
+    });
+
     arr.unknown(function() {              // Noncompliant
       return i;
     });


### PR DESCRIPTION
Adds `find`, `findIndex`, `every`, `some`, `reduce`, `reduceRight` and `sort` to the safe list (`ALLOWED_CALLBACKS`).

Fixes #915
