### PR TITLE
Fix parsing of template literal with escaped '\', '$' and '`'

### DIFF
--- a/javascript-checks/src/test/resources/checks/unusedVariable.js
+++ b/javascript-checks/src/test/resources/checks/unusedVariable.js
@@ -106,3 +106,8 @@ function objectDestructuringException(obj) {
 
   var {} = obj;
 }
+
+function used_in_template_string() {
+  const foo = '.';
+  return new RegExp(`\\${foo}`);
+}

--- a/javascript-frontend/src/main/java/org/sonar/javascript/parser/EcmaScriptLexer.java
+++ b/javascript-frontend/src/main/java/org/sonar/javascript/parser/EcmaScriptLexer.java
@@ -140,6 +140,8 @@ public enum EcmaScriptLexer implements GrammarRuleKey {
    **/
   BACKSLASH,
 
+  BACKSLASH_DOLLAR,
+
   KEYWORD,
   LETTER_OR_DIGIT,
 
@@ -415,10 +417,11 @@ public enum EcmaScriptLexer implements GrammarRuleKey {
       b.regexp(JavaScriptRegexpChannel.REGULAR_EXPRESSION));
 
     b.rule(TEMPLATE_CHARACTER).is(b.firstOf(
-      b.sequence(DOLLAR_SIGN, b.nextNot(LCURLYBRACE)),
+      b.sequence("$", b.nextNot(LCURLYBRACE)),
       b.sequence(BACKSLASH, JavaScriptLexer.WHITESPACE),
-      b.sequence(BACKSLASH, BACKTICK),
-      b.sequence(BACKSLASH, DOLLAR_SIGN),
+      "\\`",
+      "\\$",
+      "\\\\",
       LINE_CONTINUATION,
       b.regexp(JavaScriptLexer.LINE_TERMINATOR_SEQUENCE),
       b.regexp("[^`\\$" + JavaScriptLexer.LINE_TERMINATOR + "]")));

--- a/javascript-frontend/src/test/java/org/sonar/javascript/tree/impl/expression/TemplateLiteralTreeModelTest.java
+++ b/javascript-frontend/src/test/java/org/sonar/javascript/tree/impl/expression/TemplateLiteralTreeModelTest.java
@@ -56,4 +56,27 @@ public class TemplateLiteralTreeModelTest extends JavaScriptTreeModelTest {
     assertThat(tree.closeBacktickToken().text()).isEqualTo("`");
   }
 
+  @Test
+  public void with_escape_and_expression() throws Exception {
+    TemplateLiteralTree tree = parse("`\\\\${ expression1 }`", Kind.TEMPLATE_LITERAL);
+
+    assertThat(tree.strings().get(0).value()).isEqualTo("\\\\");
+    assertThat(tree.expressions()).hasSize(1);
+  }
+
+  @Test
+  public void with_escaped_dollar() throws Exception {
+    TemplateLiteralTree tree = parse("`\\$`", Kind.TEMPLATE_LITERAL);
+
+    assertThat(tree.strings().get(0).value()).isEqualTo("\\$");
+    assertThat(tree.expressions()).hasSize(0);
+  }
+
+  @Test
+  public void with_escaped_backtick() throws Exception {
+    TemplateLiteralTree tree = parse("`\\``", Kind.TEMPLATE_LITERAL);
+
+    assertThat(tree.strings().get(0).value()).isEqualTo("\\`");
+    assertThat(tree.expressions()).hasSize(0);
+  }
 }

--- a/javascript-frontend/src/test/java/org/sonar/javascript/tree/symbols/UsageTest.java
+++ b/javascript-frontend/src/test/java/org/sonar/javascript/tree/symbols/UsageTest.java
@@ -233,6 +233,12 @@ public class UsageTest extends JavaScriptTreeModelTest {
     assertThat(SYMBOL_MODEL.getSymbols("member3")).isEmpty();
   }
 
+  @Test
+  public void usage_in_string_template() throws Exception {
+    Symbol usedInTemplate = symbol("usedInTemplate");
+    assertThat(usedInTemplate.usages()).hasSize(2);
+  }
+
   private void assertImported(String name, boolean isUsed) {
     Symbol symbol = symbol(name);
     assertThat(symbol.scope().isGlobal()).isTrue();

--- a/javascript-frontend/src/test/resources/ast/resolve/usage.js
+++ b/javascript-frontend/src/test/resources/ast/resolve/usage.js
@@ -87,3 +87,6 @@ import DefaultMember1, {member4} from "module-name";
 
 member1();
 new DefaultMember();
+
+var usedInTemplate = 42;
+console.log(`\\${usedInTemplate}`);


### PR DESCRIPTION
Fixes #881 
