### PR TITLE
Check license compliance on Travis

### DIFF
--- a/check-license-compliance.sh
+++ b/check-license-compliance.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# See https://xtranet.sonarsource.com/display/DEV/Open+Source+Licenses
+
+mvn org.codehaus.mojo:license-maven-plugin:aggregate-add-third-party

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>44</version>
+    <version>45</version>
   </parent>
 
   <groupId>org.sonarsource.javascript</groupId>

--- a/third-party-licenses.sh
+++ b/third-party-licenses.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-mvn org.codehaus.mojo:license-maven-plugin:aggregate-add-third-party -Dlicense.includedScopes=compile
-
-cat target/generated-sources/license/THIRD-PARTY.txt

--- a/travis.sh
+++ b/travis.sh
@@ -12,3 +12,5 @@ configureTravis
 
 export DEPLOY_PULL_REQUEST=true
 regular_mvn_build_deploy_analyze
+
+./check-license-compliance.sh


### PR DESCRIPTION
Upgrading to parent 45 allows to improve the verification of
license compliance of third-party dependencies.

The new script check-license-compliance.sh fails if a dependency
has a license that is not compatible with SonarSource policy.

See https://xtranet.sonarsource.com/display/DEV/Open+Source+Licenses
for more details.

Fixes #<!-- PUT ISSUE NUMBER HERE IF APPLICABLE -->
