### PR TITLE
Stop using deprecared @BatchSide

### DIFF
--- a/javascript-frontend/src/main/java/org/sonar/plugins/javascript/api/CustomJavaScriptRulesDefinition.java
+++ b/javascript-frontend/src/main/java/org/sonar/plugins/javascript/api/CustomJavaScriptRulesDefinition.java
@@ -22,7 +22,7 @@ package org.sonar.plugins.javascript.api;
 import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableList;
 import org.sonar.api.ExtensionPoint;
-import org.sonar.api.batch.BatchSide;
+import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.squidbridge.annotations.AnnotationBasedRulesDefinition;
 
@@ -31,7 +31,7 @@ import org.sonar.squidbridge.annotations.AnnotationBasedRulesDefinition;
  */
 @Beta
 @ExtensionPoint
-@BatchSide
+@ScannerSide
 public abstract class CustomJavaScriptRulesDefinition implements RulesDefinition {
 
   /**


### PR DESCRIPTION
Fixes compatibility of custom rules with SQ 7.3 (to be released)
In SQ 7.3 a lot of deprecated API will be removed, including annotation `BatchSide`.

Note that with SQ >=7.3 and SonarJS <4.2 custom rules will not work due to the usage of deprecated `@BatchSide`.