### PR TITLE
Improve logging for lcov parser when coverage report is inconsistent

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
@@ -164,14 +164,15 @@ public class CoverageTest {
       .setProjectName(Tests.PROJECT_KEY)
       .setProjectVersion("1.0")
       .setSourceDirs(".")
+      .setDebugLogs(true)
       .setProperty("sonar.javascript.lcov.reportPaths", TestUtils.file("projects/lcov/coverage-wrong-line.lcov").getAbsolutePath());
     Tests.setEmptyProfile(Tests.PROJECT_KEY, Tests.PROJECT_KEY);
     BuildResult result = orchestrator.executeBuild(build);
 
     // Check that a log is printed
     assertThat(result.getLogs())
-      .contains("WARN: Problem during processing LCOV report: can't save DA data for line 12 of coverage report file")
-      .contains("WARN: Problem during processing LCOV report: can't save BRDA data for line 18 of coverage report file");
+      .contains("DEBUG: Problem during processing LCOV report: can't save DA data for line 12 of coverage report file")
+      .contains("DEBUG: Problem during processing LCOV report: can't save BRDA data for line 18 of coverage report file");
 
     assertThat(getProjectMeasureAsInt("lines_to_cover")).isEqualTo(6);
     assertThat(getProjectMeasureAsInt("uncovered_lines")).isEqualTo(1);

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/CoverageSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/CoverageSensor.java
@@ -103,6 +103,11 @@ public class CoverageSensor implements Sensor {
           "Could not resolve %d file paths in %s, first unresolved path: %s",
           unresolvedPaths.size(), lcovFiles, unresolvedPaths.get(0)));
     }
+
+    int inconsistenciesNumber = parser.inconsistenciesNumber();
+    if (inconsistenciesNumber > 0) {
+      LOG.warn("Found {} inconsistencies in coverage report. Re-run analyse in debug mode to see details.", inconsistenciesNumber);
+    }
   }
 
   /**

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -49,6 +49,7 @@ public final class LCOVParser {
   private final Map<InputFile, NewCoverage> coverageByFile;
   private final SensorContext context;
   private final List<String> unresolvedPaths = Lists.newArrayList();
+  private int inconsistenciesCounter = 0;
 
   private static final Logger LOG = Loggers.get(LCOVParser.class);
 
@@ -75,6 +76,10 @@ public final class LCOVParser {
 
   List<String> unresolvedPaths() {
     return unresolvedPaths;
+  }
+
+  int inconsistenciesNumber() {
+    return inconsistenciesCounter;
   }
 
   private Map<InputFile, NewCoverage> parse(List<String> lines) {
@@ -107,7 +112,7 @@ public final class LCOVParser {
     return coveredFiles;
   }
 
-  private static void parseBranchCoverage(FileData fileData, int reportLineNum, String line) {
+  private void parseBranchCoverage(FileData fileData, int reportLineNum, String line) {
     try {
       // BRDA:<line number>,<block number>,<branch number>,<taken>
       String[] tokens = line.substring(BRDA.length()).trim().split(",");
@@ -121,7 +126,7 @@ public final class LCOVParser {
     }
   }
 
-  private static void parseLineCoverage(FileData fileData, int reportLineNum, String line) {
+  private void parseLineCoverage(FileData fileData, int reportLineNum, String line) {
     try {
       // DA:<line number>,<execution count>[,<checksum>]
       String execution = line.substring(DA.length());
@@ -134,8 +139,9 @@ public final class LCOVParser {
     }
   }
 
-  private static void logWrongDataWarning(String dataType, int reportLineNum, Exception e) {
-    LOG.warn(String.format("Problem during processing LCOV report: can't save %s data for line %s of coverage report file (%s).", dataType, reportLineNum, e.toString()));
+  private void logWrongDataWarning(String dataType, int reportLineNum, Exception e) {
+    LOG.debug(String.format("Problem during processing LCOV report: can't save %s data for line %s of coverage report file (%s).", dataType, reportLineNum, e.toString()));
+    inconsistenciesCounter++;
   }
 
   @CheckForNull

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorTest.java
@@ -34,6 +34,7 @@ import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.plugins.javascript.JavaScriptPlugin;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -142,9 +143,10 @@ public class CoverageSensorTest {
     assertThat(context.conditions("moduleKey:file1.js", 2)).isEqualTo(2);
     assertThat(context.coveredConditions("moduleKey:file1.js", 2)).isEqualTo(2);
 
-    assertThat(logTester.logs()).contains("Problem during processing LCOV report: can't save DA data for line 3 of coverage report file (java.lang.NumberFormatException: For input string: \"1.\").");
-    assertThat(logTester.logs()).contains("Problem during processing LCOV report: can't save DA data for line 4 of coverage report file (java.lang.StringIndexOutOfBoundsException: String index out of range: -1).");
-    assertThat(logTester.logs()).contains("Problem during processing LCOV report: can't save BRDA data for line 6 of coverage report file (java.lang.ArrayIndexOutOfBoundsException: 3).");
+    assertThat(logTester.logs(LoggerLevel.DEBUG)).contains("Problem during processing LCOV report: can't save DA data for line 3 of coverage report file (java.lang.NumberFormatException: For input string: \"1.\").");
+    assertThat(logTester.logs(LoggerLevel.DEBUG)).contains("Problem during processing LCOV report: can't save DA data for line 4 of coverage report file (java.lang.StringIndexOutOfBoundsException: String index out of range: -1).");
+    assertThat(logTester.logs(LoggerLevel.DEBUG)).contains("Problem during processing LCOV report: can't save BRDA data for line 6 of coverage report file (java.lang.ArrayIndexOutOfBoundsException: 3).");
+    assertThat(logTester.logs(LoggerLevel.WARN)).contains("Found 3 inconsistencies in coverage report. Re-run analyse in debug mode to see details.");
   }
 
   @Test


### PR DESCRIPTION
Fixes #942 