### PR TITLE
Use only babel-eslint to parse

### DIFF
--- a/eslint-bridge/package.json
+++ b/eslint-bridge/package.json
@@ -42,7 +42,6 @@
     "body-parser": "1.18.3",
     "eslint": "5.6.0",
     "eslint-plugin-sonarjs": "0.2.0",
-    "espree": "4.0.0",
     "express": "4.16.3"
   },
   "prettier": {

--- a/eslint-bridge/src/parser.ts
+++ b/eslint-bridge/src/parser.ts
@@ -17,7 +17,6 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import * as espree from "espree";
 import * as babel from "babel-eslint";
 import { SourceCode, Linter } from "eslint";
 
@@ -38,12 +37,8 @@ const PARSER_CONFIG: Linter.ParserOptions = {
 const PARSER_CONFIG_NOT_STRICT: Linter.ParserOptions = { ...PARSER_CONFIG, sourceType: "script" };
 
 export function parseSourceFile(fileContent: string, fileUri: string): SourceCode | undefined {
-  let parse = espree.parse;
-  let parser = "espree";
-  if (fileContent.includes("@flow")) {
-    parse = babel.parse;
-    parser = "babel-eslint";
-  }
+  const parse = babel.parse;
+  const parser = "babel-eslint";
 
   try {
     return parseSourceFileAsModule(parse, fileContent);

--- a/eslint-bridge/tests/parser.test.ts
+++ b/eslint-bridge/tests/parser.test.ts
@@ -1,5 +1,5 @@
 import { parseSourceFile, parseSourceFileAsModule, parseSourceFileAsScript } from "../src/parser";
-import * as espree from "espree";
+import * as babel from "babel-eslint";
 
 describe("parseSourceFile", () => {
   beforeEach(() => {
@@ -14,13 +14,11 @@ describe("parseSourceFile", () => {
   it("should not parse when invalid code and log reason", () => {
     expect(parseSourceFile("export { a, a }", "foo.js")).toBeUndefined();
     expect(console.error).toBeCalledWith(
-      "Failed to parse file [foo.js] at line 1: Duplicate export 'a' (with espree parser in module mode)",
+      "Failed to parse file [foo.js] at line 1: `a` has already been exported. Exported identifiers must be unique. (1:12) (with babel-eslint parser in module mode)",
     );
     expect(console.log).toBeCalledWith(
-      "DEBUG Failed to parse file [foo.js] at line 1: 'import' and 'export' may appear only with 'sourceType: module' (with espree parser in script mode)",
+      "DEBUG Failed to parse file [foo.js] at line 1: `a` has already been exported. Exported identifiers must be unique. (1:12) (with babel-eslint parser in script mode)",
     );
-
-    expect(parseSourceFile("export Foo from 'Foo'", "foo.js")).toBeUndefined();
   });
 
   it("should parse jsx", () => {
@@ -32,7 +30,6 @@ describe("parseSourceFile", () => {
   it("should parse flow when with @flow", () => {
     expect(parseSourceFile("/* @flow */ const foo: string = 'hello';", "foo.js")).toBeDefined();
     expect(parseSourceFile("/* @flow */ var eval = 42", "foo.js")).toBeDefined();
-    expect(parseSourceFile("const foo: string = 'hello';", "foo.js")).toBeUndefined();
   });
 
   it("should parse scripts (with retry after module)", () => {
@@ -41,30 +38,48 @@ describe("parseSourceFile", () => {
   });
 
   it("should parse as script (non-strict mode)", () => {
-    expectToParseInNonStrictMode(`var eval = 42`, `"Binding eval in strict mode"`);
-    expectToParseInNonStrictMode(`eval = 42`, `"Assigning to eval in strict mode"`);
-    expectToParseInNonStrictMode(
-      `function foo() {}\n var foo = 42;`,
-      `"Identifier 'foo' has already been declared"`,
-    );
+    expectToParseInNonStrictMode(`var eval = 42`, `"eval is a reserved word in strict mode (1:4)"`);
+    expectToParseInNonStrictMode(`eval = 42`, `"eval is a reserved word in strict mode (1:0)"`);
 
-    expectToParseInNonStrictMode(`x = 043;`, `"Invalid number"`);
-    expectToParseInNonStrictMode(`'\\033'`, `"Octal literal in strict mode"`);
-    expectToParseInNonStrictMode(`with (a) {}`, `"'with' in strict mode"`);
-    expectToParseInNonStrictMode(`public = 42`, `"The keyword 'public' is reserved"`);
-    expectToParseInNonStrictMode(`function foo(a, a) {}`, `"Argument name clash"`);
-    expectToParseInNonStrictMode(`delete x`, `"Deleting local variable in strict mode"`);
+    // this is not an error in babel,
+    // see https://github.com/babel/babel/issues/6722
+    // expectToParseInNonStrictMode(
+    //   `function foo() {}\n var foo = 42;`,
+    //   `"Identifier 'foo' has already been declared"`,
+    // );
+
+    expectToParseInNonStrictMode(`x = 043;`, `"Invalid number (1:4)"`);
+    expectToParseInNonStrictMode(`'\\033'`, `"Octal literal in strict mode (1:2)"`);
+    expectToParseInNonStrictMode(`with (a) {}`, `"'with' in strict mode (1:0)"`);
+    expectToParseInNonStrictMode(`public = 42`, `"public is a reserved word in strict mode (1:0)"`);
+    expectToParseInNonStrictMode(
+      `function foo(a, a) {}`,
+      `"Argument name clash in strict mode (1:16)"`,
+    );
+    expectToParseInNonStrictMode(`delete x`, `"Deleting local variable in strict mode (1:0)"`);
 
     function expectToParseInNonStrictMode(sourceCode, msgInStrictMode) {
       expect(() =>
-        parseSourceFileAsModule(espree.parse, sourceCode),
+        parseSourceFileAsModule(babel.parse, sourceCode),
       ).toThrowErrorMatchingInlineSnapshot(msgInStrictMode);
-      expect(parseSourceFileAsScript(espree.parse, sourceCode)).toBeDefined();
+      expect(parseSourceFileAsScript(babel.parse, sourceCode)).toBeDefined();
     }
   });
 
   it("should parse recent javascript syntax", () => {
     let sourceCode;
+    // stage-0
+    sourceCode = parseSourceFile(
+      `
+        class Foo {
+          static prop = 1;
+          bar = () => {}
+        }
+      `,
+      "foo.js",
+    );
+    expect(sourceCode.ast.body.length).toBeGreaterThan(0);
+
     // ES2018
     sourceCode = parseSourceFile(
       `const obj = {foo: 1, bar: 2, baz: 3};
@@ -103,7 +118,7 @@ describe("parseSourceFile", () => {
     expect(sourceCode).toBeUndefined();
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
-      `Failed to parse file [foo.js] at line 1: Unexpected token ) (with espree parser in module mode)`,
+      `Failed to parse file [foo.js] at line 1: Unexpected token (1:3) (with babel-eslint parser in module mode)`,
     );
   });
 

--- a/eslint-bridge/typings/espree.d.ts
+++ b/eslint-bridge/typings/espree.d.ts
@@ -1,4 +1,0 @@
-declare module "espree" {
-  import { AST, Linter } from "eslint";
-  function parse(input: string, config?: Linter.ParserOptions): AST.Program;
-}

--- a/eslint-bridge/yarn.lock
+++ b/eslint-bridge/yarn.lock
@@ -1291,7 +1291,7 @@ eslint@5.6.0:
     table "^4.0.3"
     text-table "^0.2.0"
 
-espree@4.0.0, espree@^4.0.0:
+espree@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
   integrity sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==


### PR DESCRIPTION
Update tests to check for babel-eslint error messages. I was forced to comment out the duplicate identifier test, because babel does not throw errors for duplicate identifiers (see [this issue](https://github.com/babel/babel/issues/6722)).

Fixes #1100 #1141 

Would this be a viable approach? I initially wanted to add a config flag to allow switching between `espree` and `babel-eslint`, but it would complicate some cases (e.g., `Flow` files cannot be parsed by `espree`).