### PR TITLE
Add internal parameter 'sonar-runtime' for rules to enable/disable secondary locations

### DIFF
--- a/eslint-bridge/src/linter.ts
+++ b/eslint-bridge/src/linter.ts
@@ -48,10 +48,10 @@ function removeIrrelevantProperties(eslintIssue: Linter.LintMessage): Issue | nu
 function createLinterConfig(inputRules: Rule[]) {
   const ruleConfig: Linter.Config = { rules: {}, parserOptions: { sourceType: "module" } };
   inputRules.forEach(inputRule => {
-    const ruleDefinition = linter.getRules().get(inputRule.key);
+    const ruleModule = linter.getRules().get(inputRule.key);
     ruleConfig.rules![inputRule.key] = [
       "error",
-      ...getRuleConfig(ruleDefinition && ruleDefinition.meta, inputRule),
+      ...getRuleConfig(ruleModule && ruleModule.meta, inputRule),
     ];
   });
   return ruleConfig;

--- a/eslint-bridge/tests/linter.test.ts
+++ b/eslint-bridge/tests/linter.test.ts
@@ -1,40 +1,31 @@
-import { Rule } from "eslint";
-import { createLinterConfig } from "../src/linter";
+import { getRuleConfig } from "../src/linter";
 
-describe("#createLinterConfig", () => {
-  const rules = {
-    regularRule: {
-      create(context: Rule.RuleContext) {
-        return {};
-      },
-    },
-    ruleUsingSecondaryLocations: {
-      meta: { schema: { enum: ["sonar-runtime"] } },
-      create(context: Rule.RuleContext) {
-        return {};
-      },
-    },
+describe("#getRuleConfig", () => {
+  const ruleUsingSecondaryLocations = {
+    schema: { enum: ["sonar-runtime"] },
   };
 
   it("should set sonar-runtime when it's defined in the rule schema", () => {
-    const config = createLinterConfig(rules, [
-      { key: "ruleUsingSecondaryLocations", configurations: [] },
-    ]);
-    const options = config.rules.ruleUsingSecondaryLocations;
-    expect(options).toContain("sonar-runtime");
+    const config = getRuleConfig(ruleUsingSecondaryLocations, {
+      key: "ruleUsingSecondaryLocations",
+      configurations: [],
+    });
+    expect(config).toContain("sonar-runtime");
   });
 
   it("should not set sonar-runtime when it's not defined in the rule schema", () => {
-    const config = createLinterConfig(rules, [{ key: "regularRule", configurations: [] }]);
-    const options = config.rules.regularRule;
-    expect(options).not.toContain("sonar-runtime");
+    const config = getRuleConfig(undefined, {
+      key: "regularRule",
+      configurations: [],
+    });
+    expect(config).not.toContain("sonar-runtime");
   });
 
   it("should always set sonar-runtime as last option", () => {
-    const config = createLinterConfig(rules, [
-      { key: "ruleUsingSecondaryLocations", configurations: ["someOtherOption"] },
-    ]);
-    const options = config.rules.ruleUsingSecondaryLocations;
-    expect(options).toEqual(["error", "someOtherOption", "sonar-runtime"]);
+    const config = getRuleConfig(ruleUsingSecondaryLocations, {
+      key: "ruleUsingSecondaryLocations",
+      configurations: ["someOtherOption"],
+    });
+    expect(config).toEqual(["someOtherOption", "sonar-runtime"]);
   });
 });

--- a/eslint-bridge/tests/linter.test.ts
+++ b/eslint-bridge/tests/linter.test.ts
@@ -1,0 +1,40 @@
+import { Rule } from "eslint";
+import { createLinterConfig } from "../src/linter";
+
+describe("#createLinterConfig", () => {
+  const rules = {
+    regularRule: {
+      create(context: Rule.RuleContext) {
+        return {};
+      },
+    },
+    ruleUsingSecondaryLocations: {
+      meta: { schema: { enum: ["sonar-runtime"] } },
+      create(context: Rule.RuleContext) {
+        return {};
+      },
+    },
+  };
+
+  it("should set sonar-runtime when it's defined in the rule schema", () => {
+    const config = createLinterConfig(rules, [
+      { key: "ruleUsingSecondaryLocations", configurations: [] },
+    ]);
+    const options = config.rules.ruleUsingSecondaryLocations;
+    expect(options).toContain("sonar-runtime");
+  });
+
+  it("should not set sonar-runtime when it's not defined in the rule schema", () => {
+    const config = createLinterConfig(rules, [{ key: "regularRule", configurations: [] }]);
+    const options = config.rules.regularRule;
+    expect(options).not.toContain("sonar-runtime");
+  });
+
+  it("should always set sonar-runtime as last option", () => {
+    const config = createLinterConfig(rules, [
+      { key: "ruleUsingSecondaryLocations", configurations: ["someOtherOption"] },
+    ]);
+    const options = config.rules.ruleUsingSecondaryLocations;
+    expect(options).toEqual(["error", "someOtherOption", "sonar-runtime"]);
+  });
+});


### PR DESCRIPTION
Fixes #1175 
