### PR TITLE
Fix unclear UntrustedContentCheck rule description

### DIFF
--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/UntrustedContentCheck.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/UntrustedContentCheck.java
@@ -39,7 +39,7 @@ public class UntrustedContentCheck extends SubscriptionVisitorCheck {
 
   @RuleProperty(
     key = "domainsToIgnore",
-    description = "Comma-delimited list of domains to ignore. Regexes may be used, e.g. (.*\\.)?example.com,foo.org"
+    description = "Comma-delimited list of domains to ignore. Regexes may be used, e.g. (.*\\.)?example\\.com,foo\\.org"
   )
   public String domainsToIgnore = "";
   private List<Pattern> patterns = null;


### PR DESCRIPTION
The current description make it unclear if dots are considered as litteral or special characters.
Since the source code consider that every piece of the list is a regex, litteral dots should be escaped.