### PR TITLE
Fix parsing of jsx tag name containing hyphen, colon and dot

### DIFF
--- a/javascript-frontend/src/main/java/org/sonar/javascript/parser/EcmaScriptLexer.java
+++ b/javascript-frontend/src/main/java/org/sonar/javascript/parser/EcmaScriptLexer.java
@@ -443,8 +443,8 @@ public enum EcmaScriptLexer implements GrammarRuleKey {
     b.rule(JSX_IDENTIFIER).is(SPACING, b.regexp(JavaScriptLexer.JSX_IDENTIFIER));
 
     // JSX looks at first letter: capital - JS identifier, small - html tag
-    // "this" is the exception of this rule
-    b.rule(JSX_HTML_TAG).is(SPACING, b.regexp("^(?!this)[a-z][\\w]*"));
+    // "this" is the exception to this rule
+    b.rule(JSX_HTML_TAG).is(SPACING, b.regexp("^(?!this)[a-z]\\w*+([-:.]\\w++)*+"));
 
     // Keywords
     b.rule(ASYNC).is(word(b, "async"));

--- a/javascript-frontend/src/test/java/org/sonar/javascript/tree/impl/expression/jsx/JsxElementTreeModelTest.java
+++ b/javascript-frontend/src/test/java/org/sonar/javascript/tree/impl/expression/jsx/JsxElementTreeModelTest.java
@@ -99,6 +99,14 @@ public class JsxElementTreeModelTest extends JavaScriptTreeModelTest {
   }
 
   @Test
+  public void complex_tag_name() throws Exception {
+    JsxStandardElementTree tree = parse("<foo:bar-baz.qux>Hello</foo:bar-baz.qux>", Kind.JSX_STANDARD_ELEMENT);
+    assertThat(tree.is(Kind.JSX_STANDARD_ELEMENT)).isTrue();
+    assertThat(expressionToString(tree.openingElement().elementName())).isEqualTo("foo:bar-baz.qux");
+    assertThat(expressionToString(tree.closingElement().elementName())).isEqualTo("foo:bar-baz.qux");
+  }
+
+  @Test
   public void short_fragment_syntax() throws Exception {
     JsxShortFragmentElementTree tree = parse("<> Hello <div/><div/></>", Kind.JSX_SHORT_FRAGMENT_ELEMENT);
 


### PR DESCRIPTION
Fixes #1031