### PR TITLE
Fix link to S3523 replacement

### DIFF
--- a/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S3523.html
+++ b/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S3523.html
@@ -18,5 +18,5 @@ var obj = JSON.parse(data);
   <li> OWASP Top 10 2017 Category A1 - Injection </li>
 </ul>
 <h2>Deprecated</h2>
-<p>This rule is deprecated; use {rule:javascript:S1523} instead.</p>
+<p>This rule is deprecated; use {rule:javascript:Eval} instead.</p>
 


### PR DESCRIPTION
javascript:S1523 is not a rule key in SonarJS -- it is actually javascript:Eval. This should fix the link within a user's SonarQube instance

