### PR TITLE
Add rule S1862 (based on 'eslint-plugin-sonarjs/no-identical-conditions') for TS

### DIFF
--- a/its/ruling/src/test/expected/ts/ag-grid/typescript-S1862.json
+++ b/its/ruling/src/test/expected/ts/ag-grid/typescript-S1862.json
@@ -1,0 +1,5 @@
+{
+'ag-grid:src/ts/headerRendering/bodyDropPivotTarget.ts':[
+42,
+]
+}

--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/CheckList.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/CheckList.java
@@ -105,7 +105,7 @@ public final class CheckList {
       DifferentTypesComparisonCheck.class,
       DuplicateAllBranchImplementationCheck.class,
       DuplicateBranchImplementationCheck.class,
-      DuplicateConditionIfElseAndSwitchCasesCheck.class,
+      DuplicateConditionIfCheck.class,
       DuplicateFunctionArgumentCheck.class,
       DuplicatePropertyNameCheck.class,
       ElementTypeSelectorCheck.class,

--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/DuplicateConditionIfCheck.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/DuplicateConditionIfCheck.java
@@ -21,10 +21,12 @@ package org.sonar.javascript.checks;
 
 import org.sonar.check.Rule;
 import org.sonar.javascript.checks.annotations.JavaScriptRule;
+import org.sonar.javascript.checks.annotations.TypeScriptRule;
 
 @JavaScriptRule
+@TypeScriptRule
 @Rule(key = "S1862")
-public class DuplicateConditionIfElseAndSwitchCasesCheck extends EslintBasedCheck {
+public class DuplicateConditionIfCheck extends EslintBasedCheck {
 
   @Override
   public String eslintKey() {

--- a/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1862.html
+++ b/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1862.html
@@ -1,11 +1,8 @@
-<p>A <code>switch</code> and a chain of <code>if</code>/<code>else if</code> statements is evaluated from top to bottom. At most, only one branch will
-be executed: the first one with a condition that evaluates to <code>true</code>.</p>
+<p>A chain of <code>if</code>/<code>else if</code> statements is evaluated from top to bottom. At most, only one branch will be executed: the first
+one with a condition that evaluates to <code>true</code>.</p>
 <p>Therefore, duplicating a condition automatically leads to dead code. Usually, this is due to a copy/paste error. At best, it's simply dead code and
 at worst, it's a bug that is likely to induce further bugs as the code is maintained, and obviously it could lead to unexpected behavior.</p>
-<p>For a <code>switch</code>, if the first case ends with a <code>break</code>, the second case will never be executed, rendering it dead code. Worse
-there is the risk in this situation that future maintenance will be done on the dead case, rather than on the one that's actually used.</p>
-<p>On the other hand, if the first case does not end with a <code>break</code>, both cases will be executed, but future maintainers may not notice
-that.</p>
+<p>&nbsp;</p>
 <p><em>Note that this rule requires Node.js to be available during analysis.</em></p>
 <h2>Noncompliant Code Example</h2>
 <pre>
@@ -15,22 +12,6 @@ else if (param == 2)
   closeWindow();
 else if (param == 1)  // Noncompliant
   moveWindowToTheBackground();
-
-
-switch(i) {
-  case 1:
-    //...
-    break;
-  case 3:
-    //...
-    break;
-  case 1:  // Noncompliant
-    //...
-    break;
-  default:
-    // ...
-    break;
-}
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
@@ -40,19 +21,6 @@ else if (param == 2)
   closeWindow();
 else if (param == 3)
   moveWindowToTheBackground();
-
-
-switch(i) {
-  case 1:
-    //...
-    break;
-  case 3:
-    //...
-    break;
-  default:
-    // ...
-    break;
-}
 </pre>
 <h2>See</h2>
 <ul>

--- a/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1862.json
+++ b/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1862.json
@@ -1,8 +1,9 @@
 {
-  "title": "Related \"if\/else if\" statements and \"cases\" in a \"switch\" should not have the same condition",
+  "title": "Related \"if\/else if\" statements should not have the same condition",
   "type": "BUG",
   "compatibleLanguages": [
-    "JAVASCRIPT"
+    "JAVASCRIPT",
+    "TYPESCRIPT"
   ],
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
Fixes #1430 

### Changes in the rule

* We no longer report duplicate switch cases for TypeScript.

(The spec was outdated with regard to handling duplicate switch cases.)