### PR TITLE
Create default configuration if no tsconfig file is found

### DIFF
--- a/its/plugin/projects/missing-tsconfig/package-lock.json
+++ b/its/plugin/projects/missing-tsconfig/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "dev": true
+    }
+  }
+}

--- a/its/plugin/projects/missing-tsconfig/package.json
+++ b/its/plugin/projects/missing-tsconfig/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "typescript": "3.5.3"
+  }
+}

--- a/its/plugin/projects/missing-tsconfig/src/main.ts
+++ b/its/plugin/projects/missing-tsconfig/src/main.ts
@@ -1,0 +1,3 @@
+function x(x: number) {
+  let y = x as number;
+}

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TsConfigProvider.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TsConfigProvider.java
@@ -127,6 +127,7 @@ class TsConfigProvider {
     public List<String> tsconfigs(SensorContext context) throws IOException {
       if (context.runtime().getProduct() == SonarProduct.SONARLINT) {
         // we don't support per analysis temporary files in SonarLint see https://jira.sonarsource.com/browse/SLCORE-235
+        LOG.warn("Generating temporary tsconfig is not supported in SonarLint context.");
         return emptyList();
       }
       Iterable<InputFile> inputFiles = context.fileSystem().inputFiles(TypeScriptSensor.filePredicate(context.fileSystem()));

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TsConfigProvider.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TsConfigProvider.java
@@ -1,0 +1,151 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.javascript.eslint;
+
+import com.google.gson.Gson;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.utils.TempFolder;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.plugins.javascript.JavaScriptPlugin;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+class TsConfigProvider {
+
+  private static final Logger LOG = Loggers.get(TsConfigProvider.class);
+
+  interface Provider {
+    List<String> tsconfigs(SensorContext context) throws IOException;
+  }
+
+  private final List<Provider> providers;
+
+  TsConfigProvider(TempFolder folder) {
+    providers = Arrays.asList(
+      new PropertyTsConfigProvider(),
+      new LookupTsConfigProvider(),
+      new DefaultTsConfigProvider(folder));
+  }
+
+  List<String> tsconfigs(SensorContext context) throws IOException {
+    for (Provider provider : providers) {
+      List<String> tsconfigs = provider.tsconfigs(context);
+      if (!tsconfigs.isEmpty()) {
+        return tsconfigs;
+      }
+    }
+    // this should be impossible, DefaultTsConfigProvider always creates the file
+    throw new IllegalStateException("Failed to provide tsconfig.json file");
+  }
+
+  static class PropertyTsConfigProvider implements Provider {
+
+    @Override
+    public List<String> tsconfigs(SensorContext context) {
+      Optional<String> tsConfigProperty = context.config().get(JavaScriptPlugin.TSCONFIG_PATH);
+      if (tsConfigProperty.isPresent()) {
+        Path tsconfig = Paths.get(tsConfigProperty.get());
+        tsconfig = tsconfig.isAbsolute() ? tsconfig : context.fileSystem().baseDir().toPath().resolve(tsconfig);
+        if (!tsconfig.toFile().exists()) {
+          String msg = format("Provided tsconfig.json path doesn't exist. Path: '%s'", tsconfig);
+          LOG.error(msg);
+          throw new IllegalStateException(msg);
+        }
+        LOG.info("Using {} from {} property", tsconfig, JavaScriptPlugin.TSCONFIG_PATH);
+        return singletonList(tsconfig.toString());
+      }
+      return emptyList();
+    }
+  }
+
+  static class LookupTsConfigProvider implements Provider {
+
+    @Override
+    public List<String> tsconfigs(SensorContext context) throws IOException {
+      FileSystem fs = context.fileSystem();
+      Path baseDir = fs.baseDir().toPath();
+      try (Stream<Path> files = Files.walk(baseDir)) {
+        List<String> tsconfigs = files
+          .filter(p -> p.endsWith("tsconfig.json") && !isNodeModulesPath(p))
+          .map(p -> p.toAbsolutePath().toString())
+          .collect(Collectors.toList());
+        LOG.info("Found " + tsconfigs.size() + " tsconfig.json file(s): " + tsconfigs);
+        return tsconfigs;
+      }
+    }
+
+    private static boolean isNodeModulesPath(Path p) {
+      Path nodeModules = Paths.get("node_modules");
+      return StreamSupport.stream(p.spliterator(), false).anyMatch(nodeModules::equals);
+    }
+  }
+
+  static class DefaultTsConfigProvider implements Provider {
+
+    private final TempFolder folder;
+
+    DefaultTsConfigProvider(TempFolder folder) {
+      this.folder = folder;
+    }
+
+    @Override
+    public List<String> tsconfigs(SensorContext context) throws IOException {
+      Iterable<InputFile> inputFiles = context.fileSystem().inputFiles(TypeScriptSensor.filePredicate(context.fileSystem()));
+      TsConfig tsConfig = new TsConfig(inputFiles);
+      File tsconfigFile = writeToJsonFile(tsConfig);
+      LOG.info("Using generated tsconfig.json file {}", tsconfigFile.getAbsolutePath());
+      return singletonList(tsconfigFile.getAbsolutePath());
+    }
+
+    private File writeToJsonFile(TsConfig tsConfig) throws IOException {
+      String json = new Gson().toJson(tsConfig);
+      File tsconfigFile = folder.newFile();
+      Files.write(tsconfigFile.toPath(), json.getBytes(StandardCharsets.UTF_8));
+      return tsconfigFile;
+    }
+
+    private static class TsConfig {
+      List<String> files;
+
+      TsConfig(Iterable<InputFile> inputFiles) {
+        files = new ArrayList<>();
+        inputFiles.forEach(f -> files.add(f.absolutePath()));
+      }
+    }
+  }
+}

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
@@ -20,15 +20,7 @@
 package org.sonar.plugins.javascript.eslint;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.FileSystem;
@@ -40,33 +32,33 @@ import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.notifications.AnalysisWarnings;
+import org.sonar.api.utils.TempFolder;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.javascript.checks.CheckList;
 import org.sonar.plugins.javascript.JavaScriptChecks;
-import org.sonar.plugins.javascript.JavaScriptPlugin;
 import org.sonar.plugins.javascript.TypeScriptLanguage;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisRequest;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisResponse;
-
-import static java.lang.String.format;
 
 public class TypeScriptSensor extends AbstractEslintSensor {
 
   private static final Logger LOG = Loggers.get(TypeScriptSensor.class);
   private List<String> tsconfigs;
+  private final TempFolder tempFolder;
 
   /**
    * Required for SonarLint
    */
-  public TypeScriptSensor(CheckFactory checkFactory, NoSonarFilter noSonarFilter, FileLinesContextFactory fileLinesContextFactory, EslintBridgeServer eslintBridgeServer) {
-    this(checkFactory, noSonarFilter, fileLinesContextFactory, eslintBridgeServer, null);
+  public TypeScriptSensor(CheckFactory checkFactory, NoSonarFilter noSonarFilter, FileLinesContextFactory fileLinesContextFactory, EslintBridgeServer eslintBridgeServer, TempFolder tempFolder) {
+    this(checkFactory, noSonarFilter, fileLinesContextFactory, eslintBridgeServer, null, tempFolder);
   }
 
   public TypeScriptSensor(CheckFactory checkFactory, NoSonarFilter noSonarFilter,
-      FileLinesContextFactory fileLinesContextFactory, EslintBridgeServer eslintBridgeServer,
-      @Nullable AnalysisWarnings analysisWarnings) {
+                          FileLinesContextFactory fileLinesContextFactory, EslintBridgeServer eslintBridgeServer,
+                          @Nullable AnalysisWarnings analysisWarnings, TempFolder tempFolder) {
     super(checks(checkFactory), noSonarFilter, fileLinesContextFactory, eslintBridgeServer, analysisWarnings);
+    this.tempFolder = tempFolder;
   }
 
   private static JavaScriptChecks checks(CheckFactory checkFactory) {
@@ -109,38 +101,8 @@ public class TypeScriptSensor extends AbstractEslintSensor {
 
   private List<String> tsConfigs(SensorContext context) throws IOException {
     if (tsconfigs == null) {
-      Optional<String> tsConfigProperty = context.config().get(JavaScriptPlugin.TSCONFIG_PATH);
-      if (tsConfigProperty.isPresent()) {
-        Path tsconfig = Paths.get(tsConfigProperty.get());
-        tsconfig = tsconfig.isAbsolute() ? tsconfig : context.fileSystem().baseDir().toPath().resolve(tsconfig);
-        if (!tsconfig.toFile().exists()) {
-          String msg = format("Provided tsconfig.json path doesn't exist. Path: '%s'", tsconfig);
-          LOG.error(msg);
-          throw new IllegalStateException(msg);
-        }
-        tsconfigs = Collections.singletonList(tsconfig.toString());
-        LOG.info("Using {} from {} property", tsconfig, JavaScriptPlugin.TSCONFIG_PATH);
-      } else {
-        tsconfigs = lookupTsConfig(context);
-        LOG.info("Found " + tsconfigs.size() + " tsconfig.json file(s): " + tsconfigs);
-      }
+      tsconfigs = new TsConfigProvider(tempFolder).tsconfigs(context);
     }
     return tsconfigs;
-  }
-
-  private static List<String> lookupTsConfig(SensorContext context) throws IOException {
-    FileSystem fs = context.fileSystem();
-    Path baseDir = fs.baseDir().toPath();
-    try (Stream<Path> files = Files.walk(baseDir)) {
-      return files
-        .filter(p -> p.endsWith("tsconfig.json") && !isNodeModulesPath(p))
-        .map(p -> p.toAbsolutePath().toString())
-        .collect(Collectors.toList());
-    }
-  }
-
-  private static boolean isNodeModulesPath(Path p) {
-    Path nodeModules = Paths.get("node_modules");
-    return StreamSupport.stream(p.spliterator(), false).anyMatch(nodeModules::equals);
   }
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
@@ -40,6 +40,7 @@ import org.sonar.plugins.javascript.JavaScriptChecks;
 import org.sonar.plugins.javascript.TypeScriptLanguage;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisRequest;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisResponse;
+import org.sonarsource.nodejs.NodeCommandException;
 
 public class TypeScriptSensor extends AbstractEslintSensor {
 
@@ -102,6 +103,9 @@ public class TypeScriptSensor extends AbstractEslintSensor {
   private List<String> tsConfigs(SensorContext context) throws IOException {
     if (tsconfigs == null) {
       tsconfigs = new TsConfigProvider(tempFolder).tsconfigs(context);
+      if (tsconfigs.isEmpty()) {
+        throw new NodeCommandException("No tsconfig.json file found, analysis will be stopped.");
+      }
     }
     return tsconfigs;
   }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
@@ -51,13 +51,18 @@ public class TypeScriptSensor extends AbstractEslintSensor {
   /**
    * Required for SonarLint
    */
-  public TypeScriptSensor(CheckFactory checkFactory, NoSonarFilter noSonarFilter, FileLinesContextFactory fileLinesContextFactory, EslintBridgeServer eslintBridgeServer, TempFolder tempFolder) {
+  public TypeScriptSensor(CheckFactory checkFactory, NoSonarFilter noSonarFilter,
+                          FileLinesContextFactory fileLinesContextFactory,
+                          EslintBridgeServer eslintBridgeServer,
+                          TempFolder tempFolder) {
     this(checkFactory, noSonarFilter, fileLinesContextFactory, eslintBridgeServer, null, tempFolder);
   }
 
   public TypeScriptSensor(CheckFactory checkFactory, NoSonarFilter noSonarFilter,
-                          FileLinesContextFactory fileLinesContextFactory, EslintBridgeServer eslintBridgeServer,
-                          @Nullable AnalysisWarnings analysisWarnings, TempFolder tempFolder) {
+                          FileLinesContextFactory fileLinesContextFactory,
+                          EslintBridgeServer eslintBridgeServer,
+                          @Nullable AnalysisWarnings analysisWarnings,
+                          TempFolder tempFolder) {
     super(checks(checkFactory), noSonarFilter, fileLinesContextFactory, eslintBridgeServer, analysisWarnings);
     this.tempFolder = tempFolder;
   }
@@ -84,8 +89,8 @@ public class TypeScriptSensor extends AbstractEslintSensor {
 
   static FilePredicate filePredicate(FileSystem fileSystem) {
     return fileSystem.predicates().and(
-        fileSystem.predicates().hasType(Type.MAIN),
-        fileSystem.predicates().hasLanguage(TypeScriptLanguage.KEY));
+      fileSystem.predicates().hasType(Type.MAIN),
+      fileSystem.predicates().hasLanguage(TypeScriptLanguage.KEY));
   }
 
   @Override

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigProviderTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigProviderTest.java
@@ -31,6 +31,8 @@ import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.internal.SonarRuntimeImpl;
+import org.sonar.api.utils.Version;
 import org.sonar.api.utils.internal.JUnitTempFolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,6 +118,17 @@ public class TsConfigProviderTest {
     assertThat(tsconfigs).hasSize(1);
     String tsconfig = new String(Files.readAllBytes(Paths.get(tsconfigs.get(0))), StandardCharsets.UTF_8);
     assertThat(tsconfig).isEqualTo("{\"files\":[\"moduleKey/file1.ts\",\"moduleKey/file2.ts\"]}");
+  }
+
+  @Test
+  public void should_not_create_tsconfig_in_sonarlint() throws Exception {
+    SensorContextTester ctx = SensorContextTester.create(baseDir);
+    createInputFile(ctx, "file1.ts");
+    createInputFile(ctx, "file2.ts");
+    ctx.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(4,4)));
+
+    List<String> tsconfigs = new TsConfigProvider(tempFolder).tsconfigs(ctx);
+    assertThat(tsconfigs).isEmpty();
   }
 
   private static void createInputFile(SensorContextTester context, String relativePath) {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigProviderTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigProviderTest.java
@@ -1,0 +1,128 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.javascript.eslint;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.utils.internal.JUnitTempFolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TsConfigProviderTest {
+
+  @Rule
+  public JUnitTempFolder tempFolder = new JUnitTempFolder();
+
+  private Path baseDir;
+
+  @Before
+  public void setUp() {
+    baseDir = tempFolder.newDir().toPath();
+  }
+
+  @Test
+  public void should_lookup_tsconfig_files() throws Exception {
+    Path tsconfig1 = baseDir.resolve("tsconfig.json");
+    Files.createFile(tsconfig1);
+    Path subdir = baseDir.resolve("subdir");
+    Files.createDirectory(subdir);
+    Files.createDirectory(subdir.resolve("node_modules"));
+    Path tsconfig2 = Files.createFile(subdir.resolve("tsconfig.json"));
+    // these should not be taken into account
+    Files.createFile(subdir.resolve("node_modules/tsconfig.json"));
+    Files.createFile(subdir.resolve("base.tsconfig.json"));
+
+    SensorContextTester ctx = SensorContextTester.create(baseDir);
+    createInputFile(ctx, "file1.ts");
+    createInputFile(ctx, "file2.ts");
+
+    List<String> tsconfigs = new TsConfigProvider(tempFolder).tsconfigs(ctx);
+    assertThat(tsconfigs).containsExactlyInAnyOrder(tsconfig1.toAbsolutePath().toString(), tsconfig2.toAbsolutePath().toString());
+  }
+
+  @Test
+  public void should_use_tsconfig_from_property() throws Exception {
+    Path baseDir = tempFolder.newDir().toPath();
+    Files.createFile(baseDir.resolve("custom.tsconfig.json"));
+    SensorContextTester ctx = SensorContextTester.create(baseDir);
+    ctx.setSettings(new MapSettings().setProperty("sonar.typescript.tsconfigPath", "custom.tsconfig.json"));
+    createInputFile(ctx, "file.ts");
+
+    List<String> tsconfigs = new TsConfigProvider(tempFolder).tsconfigs(ctx);
+    String absolutePath = baseDir.resolve("custom.tsconfig.json").toAbsolutePath().toString();
+    assertThat(tsconfigs).containsExactly(absolutePath);
+  }
+
+  @Test
+  public void should_validate_tsconfig_from_property() throws Exception {
+    SensorContextTester ctx = SensorContextTester.create(baseDir);
+    ctx.setSettings(new MapSettings().setProperty("sonar.typescript.tsconfigPath", "custom.tsconfig.json"));
+    createInputFile(ctx, "file.ts");
+
+    String absolutePath = baseDir.resolve("custom.tsconfig.json").toAbsolutePath().toString();
+    assertThatThrownBy(() -> new TsConfigProvider(tempFolder).tsconfigs(ctx))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Provided tsconfig.json path doesn't exist. Path: '" + absolutePath + "'");
+  }
+
+  @Test
+  public void should_use_absolute_path_from_property() throws Exception {
+    Path baseDir = tempFolder.newDir().toPath();
+    Files.createFile(baseDir.resolve("custom.tsconfig.json"));
+    SensorContextTester ctx = SensorContextTester.create(baseDir);
+    String absolutePath = baseDir.resolve("custom.tsconfig.json").toAbsolutePath().toString();
+    ctx.setSettings(new MapSettings().setProperty("sonar.typescript.tsconfigPath", absolutePath));
+    createInputFile(ctx, "file.ts");
+
+    List<String> tsconfigs = new TsConfigProvider(tempFolder).tsconfigs(ctx);
+    assertThat(tsconfigs).containsExactly(absolutePath);
+  }
+
+  @Test
+  public void should_create_tsconfig() throws Exception {
+    SensorContextTester ctx = SensorContextTester.create(baseDir);
+    createInputFile(ctx, "file1.ts");
+    createInputFile(ctx, "file2.ts");
+
+    List<String> tsconfigs = new TsConfigProvider(tempFolder).tsconfigs(ctx);
+    assertThat(tsconfigs).hasSize(1);
+    String tsconfig = new String(Files.readAllBytes(Paths.get(tsconfigs.get(0))), StandardCharsets.UTF_8);
+    assertThat(tsconfig).isEqualTo("{\"files\":[\"moduleKey/file1.ts\",\"moduleKey/file2.ts\"]}");
+  }
+
+  private static void createInputFile(SensorContextTester context, String relativePath) {
+    DefaultInputFile inputFile = new TestInputFileBuilder("moduleKey", relativePath)
+      .setLanguage("ts")
+      .setContents("if (cond)\ndoFoo(); \nelse \ndoFoo();")
+      .build();
+    context.fileSystem().add(inputFile);
+  }
+}

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
@@ -21,11 +21,9 @@ package org.sonar.plugins.javascript.eslint;
 
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -174,57 +172,7 @@ public class TypeScriptSensorTest {
     assertThat(context.allIssues()).isEmpty();
   }
 
-  @Test
-  public void should_lookup_tsconfig_files() throws Exception {
-    Path baseDir = tempFolder.newDir().toPath();
-    Path tsconfig1 = baseDir.resolve("tsconfig.json");
-    Files.createFile(tsconfig1);
-    Path subdir = baseDir.resolve("subdir");
-    Files.createDirectory(subdir);
-    Files.createDirectory(subdir.resolve("node_modules"));
-    Path tsconfig2 = Files.createFile(subdir.resolve("tsconfig.json"));
-    // these should not be taken into account
-    Files.createFile(subdir.resolve("node_modules/tsconfig.json"));
-    Files.createFile(subdir.resolve("base.tsconfig.json"));
 
-    SensorContextTester ctx = SensorContextTester.create(baseDir);
-    createInputFile(ctx, "file1.ts");
-    createInputFile(ctx, "file2.ts");
-    TypeScriptSensor typeScriptSensor = createSensor();
-    typeScriptSensor.execute(ctx);
-
-    ArgumentCaptor<AnalysisRequest> request = ArgumentCaptor.forClass(AnalysisRequest.class);
-    verify(eslintBridgeServerMock, times(2)).analyzeTypeScript(request.capture());
-
-    List<String> firstCall = request.getAllValues().get(0).tsConfigs;
-    List<String> secondCall = request.getAllValues().get(1).tsConfigs;
-
-    assertThat(firstCall).containsOnly(tsconfig1.toString(), tsconfig2.toString());
-
-    // test that we cache the instance and don't lookup twice
-    assertThat(firstCall).isSameAs(secondCall);
-  }
-
-  @Test
-  public void should_use_tsconfig_from_property() throws Exception {
-    Path baseDir = tempFolder.newDir().toPath();
-    Files.createFile(baseDir.resolve("custom.tsconfig.json"));
-    SensorContextTester ctx = SensorContextTester.create(baseDir);
-    ctx.setSettings(new MapSettings().setProperty("sonar.typescript.tsconfigPath", "custom.tsconfig.json"));
-    createInputFile(ctx);
-    TypeScriptSensor typeScriptSensor = createSensor();
-    typeScriptSensor.execute(ctx);
-
-    ArgumentCaptor<AnalysisRequest> request = ArgumentCaptor.forClass(AnalysisRequest.class);
-    verify(eslintBridgeServerMock).analyzeTypeScript(request.capture());
-
-    String absolutePath = baseDir.resolve("custom.tsconfig.json").toAbsolutePath().toString();
-    assertThat(request.getValue().tsConfigs).containsOnly(absolutePath);
-
-    ctx.setSettings(new MapSettings().setProperty("sonar.typescript.tsconfigPath", absolutePath));
-    createSensor().execute(ctx);
-    assertThat(request.getValue().tsConfigs).containsOnly(absolutePath);
-  }
 
   @Test
   public void should_log_and_stop_with_wrong_tsconfig() throws Exception {
@@ -308,7 +256,7 @@ public class TypeScriptSensorTest {
   }
 
   private TypeScriptSensor createSensor() {
-    return new TypeScriptSensor(checkFactory(ESLINT_BASED_RULE, "ParsingError"), new NoSonarFilter(), fileLinesContextFactory, eslintBridgeServerMock);
+    return new TypeScriptSensor(checkFactory(ESLINT_BASED_RULE, "ParsingError"), new NoSonarFilter(), fileLinesContextFactory, eslintBridgeServerMock, tempFolder);
   }
 
   private AnalysisResponse createResponse() {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
@@ -20,7 +20,9 @@
 package org.sonar.plugins.javascript.eslint;
 
 import com.google.gson.Gson;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Iterator;
@@ -60,6 +62,7 @@ import org.sonar.javascript.checks.CheckList;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisRequest;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisResponse;
 
+import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
@@ -220,9 +223,11 @@ public class TypeScriptSensorTest {
 
   @Test
   public void should_send_content_on_sonarlint() throws Exception {
-    SensorContextTester ctx = SensorContextTester.create(tempFolder.newDir());
+    File baseDir = tempFolder.newDir();
+    SensorContextTester ctx = SensorContextTester.create(baseDir);
     ctx.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(4, 4)));
     createInputFile(ctx);
+    Files.write(baseDir.toPath().resolve("tsconfig.json"), singleton("{}"));
     ArgumentCaptor<AnalysisRequest> captor = ArgumentCaptor.forClass(AnalysisRequest.class);
     createSensor().execute(ctx);
     verify(eslintBridgeServerMock).analyzeTypeScript(captor.capture());


### PR DESCRIPTION
Fixes #1392 
I refactored logic around tsconfig to separate class to make unit testing easier and also to simplify TypeScriptSensor