### PR TITLE
Remove null elements in ts config lists

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TsConfigFile.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TsConfigFile.java
@@ -69,6 +69,7 @@ class TsConfigFile implements Predicate<InputFile> {
 
     FilesMatcher(Path baseDir, List<String> files) {
       this.files = files.stream()
+        .filter(Objects::nonNull)
         .map(Paths::get)
         .map(p -> p.isAbsolute() ? p : baseDir.resolve(p))
         .map(Path::normalize)
@@ -90,6 +91,7 @@ class TsConfigFile implements Predicate<InputFile> {
     GlobMatcher(Path baseDir, Model model) {
       if (model.include != null) {
         this.includes = model.include.stream()
+          .filter(Objects::nonNull)
           .flatMap(include -> defaultGlobPattern(baseDir, include))
           .collect(Collectors.toList());
       } else if (model.files == null) {
@@ -99,6 +101,7 @@ class TsConfigFile implements Predicate<InputFile> {
       }
       if (model.exclude != null) {
         this.excludes = model.exclude.stream()
+          .filter(Objects::nonNull)
           .flatMap(exclude -> defaultGlobPattern(baseDir, exclude))
           .collect(Collectors.toList());
       } else {
@@ -180,7 +183,7 @@ class TsConfigFile implements Predicate<InputFile> {
       Model model = GSON.fromJson(reader, Model.class);
       return new TsConfigFile(filename, path.getParent(), model);
     } catch (Exception e) {
-      LOG.error("Failed to load tsconfig file from " + filename + ". It will be ignored!", e);
+      LOG.error("Failed to load tsconfig file from " + filename + ". It will be ignored!\n" + e.toString());
       return null;
     }
   }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigFileTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigFileTest.java
@@ -198,6 +198,18 @@ public class TsConfigFileTest {
     );
   }
 
+  @Test
+  public void should_return_files_by_tsconfig_with_null_element() throws Exception {
+    Path tsconfig = writeTsConfig("{\n" +
+      "  \"include\": [\"src/**/*\",]\n" + //Trailing comma here
+      "}");
+    InputFile file1 = TestInputFileBuilder.create(tsconfig.getParent().toString(), "src/file1.ts").build();
+    Map<String, List<InputFile>> map = TsConfigFile.inputFilesByTsConfig(Arrays.asList(tsconfig.toString()), Arrays.asList(file1));
+    assertThat(map).containsExactly(
+      entry(tsconfig.toString(), Arrays.asList(file1))
+    );
+  }
+
   private static Path writeTsConfig(String json) throws IOException {
     Path tsconfig = temp.newFile().toPath();
     Files.write(tsconfig, json.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Fixing the NPE:

```
ERROR: Failed to load tsconfig file from /tmp/cirrus-ci-build/kibana/workspace/test/tsconfig.json. It will be ignored!
java.lang.NullPointerException: null
	at org.sonar.plugins.javascript.eslint.TsConfigFile$GlobMatcher.defaultGlobPattern(TsConfigFile.java:110)
	at org.sonar.plugins.javascript.eslint.TsConfigFile$GlobMatcher.lambda$new$0(TsConfigFile.java:93)
	at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:267)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
[...]
```
and omit to print the stacktrace of the exception.