### PR TITLE
Run Java frontend and Java based rules in single sensor

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/CancellationException.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/CancellationException.java
@@ -23,11 +23,11 @@ package org.sonar.plugins.javascript;
  * Exception thrown when the context is cancelled.
  *
  */
-class CancellationException extends RuntimeException {
+public class CancellationException extends RuntimeException {
 
   private static final long serialVersionUID = 2694991398328066200L;
 
-  CancellationException(String message) {
+  public CancellationException(String message) {
     super(message);
   }
 

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptSensor.java
@@ -33,16 +33,14 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.ArrayUtils;
-import org.sonar.api.batch.DependsUpon;
+import org.sonar.api.batch.InstantiationStrategy;
+import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.rule.CheckFactory;
-import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.rule.RuleKey;
@@ -64,13 +62,15 @@ import org.sonar.plugins.javascript.api.visitors.LineIssue;
 import org.sonar.plugins.javascript.api.visitors.PreciseIssue;
 import org.sonar.plugins.javascript.api.visitors.TreeVisitor;
 import org.sonarsource.analyzer.commons.ProgressReport;
+import org.sonarsource.api.sonarlint.SonarLintSide;
 
 import static org.sonar.plugins.javascript.JavaScriptPlugin.DEPRECATED_ESLINT_PROPERTY;
 import static org.sonar.plugins.javascript.JavaScriptPlugin.ESLINT_REPORT_PATHS;
 
-// Required for No Sonar
-@DependsUpon("ESLINT_SENSOR")
-public class JavaScriptSensor implements Sensor {
+@ScannerSide
+@InstantiationStrategy(InstantiationStrategy.PER_PROJECT)
+@SonarLintSide
+public class JavaScriptSensor {
 
   private static final Logger LOG = Loggers.get(JavaScriptSensor.class);
 
@@ -250,15 +250,6 @@ public class JavaScriptSensor implements Sensor {
     return ruleKey;
   }
 
-  @Override
-  public void describe(SensorDescriptor descriptor) {
-    descriptor
-      .onlyOnLanguage(JavaScriptLanguage.KEY)
-      .name("SonarJS")
-      .onlyOnFileType(Type.MAIN);
-  }
-
-  @Override
   public void execute(SensorContext context) {
     checkDeprecatedEslintProperty(context);
 

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptSensor.java
@@ -131,7 +131,7 @@ public class JavaScriptSensor {
       success = true;
     } catch (CancellationException e) {
       // do not propagate the exception
-      LOG.debug(e.toString());
+      LOG.info(e.toString());
     } finally {
       stopProgressReport(progressReport, success);
     }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
@@ -24,14 +24,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.sonar.api.SonarProduct;
-import org.sonar.api.batch.DependedUpon;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -52,6 +47,7 @@ import org.sonar.api.rule.RuleKey;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.javascript.checks.ParsingErrorCheck;
+import org.sonar.plugins.javascript.CancellationException;
 import org.sonar.plugins.javascript.JavaScriptChecks;
 import org.sonar.plugins.javascript.JavaScriptPlugin;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisResponse;
@@ -64,10 +60,8 @@ import org.sonar.plugins.javascript.eslint.EslintBridgeServer.Metrics;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.ParsingError;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.ParsingErrorCode;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.Rule;
-import org.sonarsource.analyzer.commons.ProgressReport;
 import org.sonarsource.nodejs.NodeCommandException;
 
-@DependedUpon("ESLINT_SENSOR")
 abstract class AbstractEslintSensor implements Sensor {
   private static final Logger LOG = Loggers.get(AbstractEslintSensor.class);
 
@@ -82,14 +76,12 @@ abstract class AbstractEslintSensor implements Sensor {
   // parsingErrorRuleKey equals null if ParsingErrorCheck is not activated
   private RuleKey parsingErrorRuleKey = null;
 
-  protected ProgressReport progressReport =
-    new ProgressReport("Report about progress of ESLint-based rules", TimeUnit.SECONDS.toMillis(10));
   SensorContext context;
   private boolean failFast;
 
   AbstractEslintSensor(JavaScriptChecks checks, NoSonarFilter noSonarFilter,
-      FileLinesContextFactory fileLinesContextFactory, EslintBridgeServer eslintBridgeServer,
-      @Nullable AnalysisWarnings analysisWarnings) {
+                       FileLinesContextFactory fileLinesContextFactory, EslintBridgeServer eslintBridgeServer,
+                       @Nullable AnalysisWarnings analysisWarnings) {
     this.checks = checks;
     this.rules = checks.eslintBasedChecks().stream()
       .map(check -> new EslintBridgeServer.Rule(check.eslintKey(), check.configurations()))
@@ -112,11 +104,7 @@ abstract class AbstractEslintSensor implements Sensor {
     failFast = context.config().getBoolean("sonar.internal.analysis.failFast").orElse(false);
     try {
       eslintBridgeServer.startServerLazily(context);
-      List<InputFile> inputFiles = getInputFiles();
-      startProgressReport(inputFiles);
-
-      analyzeFiles(inputFiles);
-      progressReport.stop();
+      analyzeFiles();
     } catch (ServerAlreadyFailedException e) {
       LOG.debug("Skipping start of eslint-bridge server due to the failure during first analysis");
       LOG.debug("Skipping execution of eslint-based rules due to the problems with eslint-bridge server");
@@ -134,12 +122,10 @@ abstract class AbstractEslintSensor implements Sensor {
       if (failFast) {
         throw new IllegalStateException("Analysis failed (\"sonar.internal.analysis.failFast\"=true)", e);
       }
-    } finally {
-      progressReport.cancel();
     }
   }
 
-  abstract void analyzeFiles(List<InputFile> inputFiles) throws IOException;
+  abstract void analyzeFiles() throws IOException, InterruptedException;
 
   private void processParsingError(SensorContext sensorContext, InputFile inputFile, ParsingError parsingError) {
     Integer line = parsingError.line;
@@ -192,17 +178,6 @@ abstract class AbstractEslintSensor implements Sensor {
   protected boolean shouldSendFileContent(InputFile file) {
     return context.runtime().getProduct() == SonarProduct.SONARLINT
       || !StandardCharsets.UTF_8.equals(file.charset());
-  }
-
-  protected abstract List<InputFile> getInputFiles();
-
-
-  private void startProgressReport(Iterable<InputFile> inputFiles) {
-    Collection<String> files = StreamSupport.stream(inputFiles.spliterator(), false)
-      .map(InputFile::toString)
-      .collect(Collectors.toList());
-
-    progressReport.start(files);
   }
 
   protected void processResponse(InputFile file, AnalysisResponse response) {

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
@@ -105,6 +105,9 @@ abstract class AbstractEslintSensor implements Sensor {
     try {
       eslintBridgeServer.startServerLazily(context);
       analyzeFiles();
+    } catch (CancellationException e) {
+      // do not propagate the exception
+      LOG.info(e.toString());
     } catch (ServerAlreadyFailedException e) {
       LOG.debug("Skipping start of eslint-bridge server due to the failure during first analysis");
       LOG.debug("Skipping execution of eslint-based rules due to the problems with eslint-bridge server");

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
@@ -38,6 +38,7 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.api.utils.log.Profiler;
 import org.sonar.javascript.checks.CheckList;
+import org.sonar.plugins.javascript.CancellationException;
 import org.sonar.plugins.javascript.JavaScriptChecks;
 import org.sonar.plugins.javascript.JavaScriptLanguage;
 import org.sonar.plugins.javascript.JavaScriptSensor;
@@ -86,6 +87,9 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
       List<InputFile> inputFiles = getInputFiles();
       progressReport.start(inputFiles.stream().map(InputFile::toString).collect(Collectors.toList()));
       for (InputFile inputFile : inputFiles) {
+        if (context.isCancelled()) {
+          throw new CancellationException("Analysis interrupted because the SensorContext is in cancelled state");
+        }
         if (eslintBridgeServer.isAlive()) {
           analyze(inputFile);
           progressReport.nextFile();

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
@@ -134,6 +134,9 @@ public class TypeScriptSensor extends AbstractEslintSensor {
 
   private void analyzeFilesWithTsConfig(List<InputFile> files, TsConfigFile tsConfigFile, ProgressReport progressReport) throws IOException {
     for (InputFile inputFile : files) {
+      if (context.isCancelled()) {
+        throw new CancellationException("Analysis interrupted because the SensorContext is in cancelled state");
+      }
       if (eslintBridgeServer.isAlive()) {
         analyze(inputFile, tsConfigFile);
         progressReport.nextFile();

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/TypeScriptSensor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
@@ -39,10 +40,12 @@ import org.sonar.api.utils.TempFolder;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.javascript.checks.CheckList;
+import org.sonar.plugins.javascript.CancellationException;
 import org.sonar.plugins.javascript.JavaScriptChecks;
 import org.sonar.plugins.javascript.TypeScriptLanguage;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisRequest;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisResponse;
+import org.sonarsource.analyzer.commons.ProgressReport;
 import org.sonarsource.nodejs.NodeCommandException;
 
 import static java.util.Collections.singletonList;
@@ -84,8 +87,7 @@ public class TypeScriptSensor extends AbstractEslintSensor {
       .onlyOnFileType(Type.MAIN);
   }
 
-  @Override
-  protected List<InputFile> getInputFiles() {
+  private List<InputFile> getInputFiles() {
     FileSystem fileSystem = context.fileSystem();
     FilePredicate mainFilePredicate = filePredicate(fileSystem);
     return StreamSupport.stream(fileSystem.inputFiles(mainFilePredicate).spliterator(), false)
@@ -99,24 +101,38 @@ public class TypeScriptSensor extends AbstractEslintSensor {
   }
 
   @Override
-  void analyzeFiles(List<InputFile> inputFiles) throws IOException {
+  void analyzeFiles() throws IOException, InterruptedException {
+    boolean success = false;
+    ProgressReport progressReport = new ProgressReport("Progress of TypeScript analysis", TimeUnit.SECONDS.toMillis(10));
+    List<InputFile> inputFiles = getInputFiles();
     List<String> tsConfigs = tsConfigs();
     Map<TsConfigFile, List<InputFile>> filesByTsConfig = TsConfigFile.inputFilesByTsConfig(loadTsConfigs(tsConfigs), inputFiles);
-    for (Map.Entry<TsConfigFile, List<InputFile>> entry : filesByTsConfig.entrySet()) {
-      TsConfigFile tsConfigFile = entry.getKey();
-      List<InputFile> files = entry.getValue();
-      if (TsConfigFile.UNMATCHED_CONFIG.equals(tsConfigFile)) {
-        LOG.info("Skipping {} files with no tsconfig.json", files.size());
-        LOG.debug("Skipped files: " + files.stream().map(InputFile::toString).collect(Collectors.joining("\n")));
-        continue;
+    try {
+      progressReport.start(filesByTsConfig.values().stream().flatMap(List::stream).map(InputFile::toString).collect(Collectors.toList()));
+      for (Map.Entry<TsConfigFile, List<InputFile>> entry : filesByTsConfig.entrySet()) {
+        TsConfigFile tsConfigFile = entry.getKey();
+        List<InputFile> files = entry.getValue();
+        if (TsConfigFile.UNMATCHED_CONFIG.equals(tsConfigFile)) {
+          LOG.info("Skipping {} files with no tsconfig.json", files.size());
+          LOG.debug("Skipped files: " + files.stream().map(InputFile::toString).collect(Collectors.joining("\n")));
+          continue;
+        }
+        LOG.info("Analyzing {} files using tsconfig: {}", files.size(), tsConfigFile);
+        analyzeFilesWithTsConfig(files, tsConfigFile, progressReport);
+        eslintBridgeServer.newTsConfig();
       }
-      LOG.info("Analyzing {} files using tsconfig: {}", files.size(), tsConfigFile);
-      analyzeFilesWithTsConfig(files, tsConfigFile);
-      eslintBridgeServer.newTsConfig();
+      success = true;
+    } finally {
+      if (success) {
+        progressReport.stop();
+      } else {
+        progressReport.cancel();
+      }
+      progressReport.join();
     }
   }
 
-  private void analyzeFilesWithTsConfig(List<InputFile> files, TsConfigFile tsConfigFile) throws IOException {
+  private void analyzeFilesWithTsConfig(List<InputFile> files, TsConfigFile tsConfigFile, ProgressReport progressReport) throws IOException {
     for (InputFile inputFile : files) {
       if (eslintBridgeServer.isAlive()) {
         analyze(inputFile, tsConfigFile);

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptSensorTest.java
@@ -127,16 +127,6 @@ public class JavaScriptSensorTest {
   }
 
   @Test
-  public void should_contain_sensor_descriptor() {
-    DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
-
-    createSensor().describe(descriptor);
-    assertThat(descriptor.name()).isEqualTo("SonarJS");
-    assertThat(descriptor.languages()).containsOnly("js");
-    assertThat(descriptor.type()).isEqualTo(Type.MAIN);
-  }
-
-  @Test
   public void should_only_log_debug_if_a_parsing_error() {
     String relativePath = "cpd/parsingError.js";
     InputFile inputFile = inputFile(relativePath);

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensorTest.java
@@ -489,6 +489,15 @@ public class JavaScriptEslintBasedSensorTest {
     assertThat(context.allIssues()).extracting(i -> i.ruleKey().toString()).containsExactly("javascript:OctalNumber");
   }
 
+  @Test
+  public void stop_analysis_if_cancelled() throws Exception {
+    JavaScriptEslintBasedSensor sensor = createSensor();
+    createInputFile(context);
+    context.setCancelled(true);
+    sensor.execute(context);
+    assertThat(logTester.logs(LoggerLevel.INFO)).contains("org.sonar.plugins.javascript.CancellationException: Analysis interrupted because the SensorContext is in cancelled state");
+  }
+
   private static CheckFactory checkFactory(String... ruleKeys) {
     ActiveRulesBuilder builder = new ActiveRulesBuilder();
     for (String ruleKey : ruleKeys) {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensorTest.java
@@ -60,6 +60,7 @@ import org.sonar.api.utils.log.LogAndArguments;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.javascript.checks.CheckList;
+import org.sonar.plugins.javascript.JavaScriptSensor;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisRequest;
 import org.sonar.plugins.javascript.eslint.EslintBridgeServer.AnalysisResponse;
 import org.sonarsource.nodejs.NodeCommandException;
@@ -347,7 +348,13 @@ public class JavaScriptEslintBasedSensorTest {
   public void handle_missing_node() throws Exception {
     doThrow(new NodeCommandException("Exception Message", new IOException())).when(eslintBridgeServerMock).startServerLazily(any());
     AnalysisWarnings analysisWarnings = mock(AnalysisWarnings.class);
-    JavaScriptEslintBasedSensor javaScriptEslintBasedSensor = new JavaScriptEslintBasedSensor(checkFactory(ESLINT_BASED_RULE), new NoSonarFilter(), fileLinesContextFactory, eslintBridgeServerMock, analysisWarnings);
+    JavaScriptEslintBasedSensor javaScriptEslintBasedSensor = new JavaScriptEslintBasedSensor(checkFactory(ESLINT_BASED_RULE),
+      new NoSonarFilter(),
+      fileLinesContextFactory,
+      eslintBridgeServerMock,
+      analysisWarnings,
+      mock(JavaScriptSensor.class));
+
     javaScriptEslintBasedSensor.execute(context);
     assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Exception Message");
     verify(analysisWarnings).addUnique("Eslint-based rules were not executed. Exception Message");
@@ -437,7 +444,7 @@ public class JavaScriptEslintBasedSensorTest {
     ArgumentCaptor<AnalysisRequest> captor = ArgumentCaptor.forClass(AnalysisRequest.class);
     createSensor().execute(ctx);
     verify(eslintBridgeServerMock).analyzeJavaScript(captor.capture());
-    assertThat(captor.getValue().fileContent).isEqualTo(content );
+    assertThat(captor.getValue().fileContent).isEqualTo(content);
   }
 
   @Test
@@ -463,6 +470,25 @@ public class JavaScriptEslintBasedSensorTest {
       .hasMessage("Analysis failed (\"sonar.internal.analysis.failFast\"=true)");
   }
 
+  @Test
+  public void should_run_old_frontend() throws Exception {
+    DefaultInputFile inputFile = new TestInputFileBuilder("moduleKey", "dir/file.js")
+      .setLanguage("js")
+      .setCharset(StandardCharsets.UTF_8)
+      .setContents("0123;")
+      .build();
+    context.fileSystem().add(inputFile);
+
+    CheckFactory checkFactory = checkFactory("OctalNumber");
+    NoSonarFilter noSonarFilter = new NoSonarFilter();
+    JavaScriptSensor jsSensor = new JavaScriptSensor(checkFactory, context.fileSystem(), null, null);
+    JavaScriptEslintBasedSensor sensor = new JavaScriptEslintBasedSensor(checkFactory, noSonarFilter, fileLinesContextFactory, eslintBridgeServerMock, jsSensor);
+    sensor.execute(context);
+
+    assertThat(context.allIssues()).hasSize(1);
+    assertThat(context.allIssues()).extracting(i -> i.ruleKey().toString()).containsExactly("javascript:OctalNumber");
+  }
+
   private static CheckFactory checkFactory(String... ruleKeys) {
     ActiveRulesBuilder builder = new ActiveRulesBuilder();
     for (String ruleKey : ruleKeys) {
@@ -483,6 +509,6 @@ public class JavaScriptEslintBasedSensorTest {
 
 
   private JavaScriptEslintBasedSensor createSensor() {
-    return new JavaScriptEslintBasedSensor(checkFactory(ESLINT_BASED_RULE, "ParsingError", "S1451"), new NoSonarFilter(), fileLinesContextFactory, eslintBridgeServerMock);
+    return new JavaScriptEslintBasedSensor(checkFactory(ESLINT_BASED_RULE, "ParsingError", "S1451"), new NoSonarFilter(), fileLinesContextFactory, eslintBridgeServerMock, mock(JavaScriptSensor.class));
   }
 }


### PR DESCRIPTION
Fix #1738 
Fix #1736 

In addition, this PR also adds support for cancellation of analysis (used mostly in SonarLint)