### PR TITLE
Fix secondary locations in S1526

### DIFF
--- a/eslint-bridge/src/rules/no-variable-usage-before-declaration.ts
+++ b/eslint-bridge/src/rules/no-variable-usage-before-declaration.ts
@@ -25,6 +25,15 @@ import { toEncodedMessage } from "./utils";
 import { TSESTree } from "@typescript-eslint/experimental-utils";
 
 export const rule: Rule.RuleModule = {
+  meta: {
+    schema: [
+      {
+        // internal parameter for rules having secondary locations
+        enum: ["sonar-runtime"],
+      },
+    ],
+  },
+
   create(context: Rule.RuleContext) {
     return {
       "VariableDeclaration[kind='var']": (node: estree.Node) => {


### PR DESCRIPTION
We miss `sonar-runtime` parameter, to indicate that error message should be parsed as JSON to provide secondary locations.