### PR TITLE
Add 'languagesToCover' to sonarpedia file

### DIFF
--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,6 +3,10 @@
   "languages": [
     "JS"
   ],
+  "languagesToCover": [
+    "JS",
+    "TS"
+  ],
   "latest-update": "2019-11-12T10:20:44.939197Z",
   "options": {
     "no-language-in-filenames": true,


### PR DESCRIPTION
Replaces #1758 

Job updating Coverage Languages in RSPEC jira project will work due to https://jira.sonarsource.com/browse/RCOV-24 and https://jira.sonarsource.com/browse/RCOV-25 (release of RCOV project is required before SonarJS release)