### PR TITLE
Clear cache instead of unloading module

### DIFF
--- a/eslint-bridge/src/parser.ts
+++ b/eslint-bridge/src/parser.ts
@@ -120,8 +120,8 @@ export function checkTypeScriptVersionCompatibility(currentVersion: string) {
 }
 
 export function unloadTypeScriptEslint() {
-  const tsParser = require.resolve("@typescript-eslint/parser");
-  delete require.cache[tsParser];
+  const tsParser = require("@typescript-eslint/parser");
+  tsParser.clearCaches();
 }
 
 export function parseVueSourceFile(fileContent: string): SourceCode | ParsingError {


### PR DESCRIPTION
This seems to improve perf, together with the upgrade done earlier.

Tested on vscode project
```
6.1
Sensor TypeScript analysis [javascript] (done) | time=473269ms

6.2
INFO: Sensor TypeScript analysis [javascript] (done) | time=165577ms
```
