### PR TITLE
Report only on 'case' keyword for S128

### DIFF
--- a/eslint-bridge/src/rules/sonar-no-fallthrough.ts
+++ b/eslint-bridge/src/rules/sonar-no-fallthrough.ts
@@ -52,7 +52,7 @@ export const rule: Rule.RuleModule = {
           context.report({
             message:
               "End this switch case with an unconditional break, continue, return or throw statement.",
-            node,
+            loc: context.getSourceCode().getFirstToken(node)!.loc,
           });
         }
       },

--- a/eslint-bridge/tests/rules/sonar-no-fallthrough.test.ts
+++ b/eslint-bridge/tests/rules/sonar-no-fallthrough.test.ts
@@ -65,7 +65,7 @@ ruleTester.run("No fallthrough in switch statement", rule, {
               return;
             case 3: // OK
               throw new Error();
-            case 4: // Noncompliant {{End this switch case with an unconditional break, continue, return or throw statement.}}
+            case 4: // Noncompliant
               doSomething();
             case 5: // OK
               continue;
@@ -79,6 +79,9 @@ ruleTester.run("No fallthrough in switch statement", rule, {
           message:
             "End this switch case with an unconditional break, continue, return or throw statement.",
           line: 12,
+          column: 13,
+          endLine: 12,
+          endColumn: 17,
         },
       ],
     },


### PR DESCRIPTION
Currently we are reporting on entire `case` clause
![image](https://user-images.githubusercontent.com/10108186/72740093-46b2ff80-3ba5-11ea-8737-2e929df94a92.png)
