### PR TITLE
Prefer direct TypeScript dependency (#1928)

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImpl.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImpl.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.stream.Stream;
 import okhttp3.HttpUrl;
@@ -328,7 +329,7 @@ public class EslintBridgeServerImpl implements EslintBridgeServer {
     try (Stream<Path> files = Files.walk(baseDir.toPath())) {
       return files
         .filter(p -> p.toFile().isDirectory() && p.endsWith("node_modules/typescript"))
-        .findFirst()
+        .min(Comparator.comparing(Path::getNameCount))
         .map(Path::getParent);
     }
   }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImplTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImplTest.java
@@ -265,6 +265,25 @@ public class EslintBridgeServerImplTest {
   }
 
   @Test
+  public void should_prefer_direct_typescript_from_filesystem() throws Exception {
+    eslintBridgeServer = createEslintBridgeServer(START_SERVER_SCRIPT);
+    eslintBridgeServer.deploy();
+    Path baseDir = tempFolder.newDir().toPath();
+    SensorContextTester ctx = SensorContextTester.create(baseDir);
+    DefaultInputFile tsFile = TestInputFileBuilder.create("", "foo.ts").setLanguage("ts").build();
+    ctx.fileSystem().add(tsFile);
+    Path tsDir = baseDir.resolve("dir/node_modules/typescript");
+    Files.createDirectories(tsDir);
+    Path earlyNestedTsDir = baseDir.resolve("dir/node_modules/a-mydependency/node_modules/typescript");
+    Files.createDirectories(earlyNestedTsDir);
+    Path lateNestedTsDir = baseDir.resolve("dir/node_modules/z-mydependency/node_modules/typescript");
+    Files.createDirectories(lateNestedTsDir);
+    eslintBridgeServer.startServer(ctx);
+    assertThat(eslintBridgeServer.getCommandInfo())
+      .startsWith("Node.js command to start eslint-bridge was: {NODE_PATH=" + baseDir.resolve("dir/node_modules") + "}");
+  }
+
+  @Test
   public void should_not_search_typescript_when_no_ts_file() throws Exception {
     eslintBridgeServer = createEslintBridgeServer(START_SERVER_SCRIPT);
     eslintBridgeServer.deploy();


### PR DESCRIPTION
Adjust getTypeScriptLocation to pick the top-most
(in terms of directory hierarchy) TypeScript dependency it
can find.
This prevents it from finding a nested transitive
TypeScript dependency that might not match the version
requirements.

The average search performance is a bit worse now, since
it's forced to do a full directory search. Before, it
might've found a match earlier, though worst-case performance
was still more or less a full search.

Fixes #1928
