### PR TITLE
Improve exception message in case of IOException (#1987)

### DIFF
--- a/javascript-frontend/src/main/java/org/sonar/javascript/visitors/JavaScriptFileImpl.java
+++ b/javascript-frontend/src/main/java/org/sonar/javascript/visitors/JavaScriptFileImpl.java
@@ -38,6 +38,11 @@ public class JavaScriptFileImpl implements JavaScriptFile {
   }
 
   @Override
+  public String toString() {
+    return inputFile.toString();
+  }
+
+  @Override
   public String contents() throws IOException {
     return inputFile.contents();
   }

--- a/javascript-frontend/src/main/java/org/sonar/plugins/javascript/api/visitors/JavaScriptFile.java
+++ b/javascript-frontend/src/main/java/org/sonar/plugins/javascript/api/visitors/JavaScriptFile.java
@@ -36,4 +36,10 @@ public interface JavaScriptFile {
    * You should not assume it is a file:// URI.
    */
   URI uri();
+
+  /**
+   * Return a string to identify this file (suitable for logs).
+   */
+  @Override
+  String toString();
 }


### PR DESCRIPTION
Fixes #1987

Old behaviour:
```java.lang.IllegalStateException: Unable to read file org.sonar.javascript.visitors.JavaScriptFileImpl@5a2bd7c8```

New behaviour
```java.lang.IllegalStateException: Unable to read file test.js```