### PR TITLE
Fix detection of input file when absolute paths are used in eslint report

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/AbstractExternalIssuesSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/AbstractExternalIssuesSensor.java
@@ -56,7 +56,7 @@ abstract class AbstractExternalIssuesSensor implements Sensor {
 
   InputFile getInputFile(SensorContext context, String fileName) {
     FilePredicates predicates = context.fileSystem().predicates();
-    InputFile inputFile = context.fileSystem().inputFile(predicates.or(predicates.hasRelativePath(fileName), predicates.hasAbsolutePath(fileName)));
+    InputFile inputFile = context.fileSystem().inputFile(predicates.hasPath(fileName));
     if (inputFile == null) {
       LOG.warn("No input file found for {}. No {} issues will be imported on this file.", fileName, linterName());
       return null;


### PR DESCRIPTION
Fixes #1985 

I didn't add any unit test as anyway in unit test test implementation of FileSystem will be used which does not prove to work in real environment.