### PR TITLE
Normalize path from bundle to fix theoretical vulnerability

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/BundleImpl.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/BundleImpl.java
@@ -109,7 +109,7 @@ public class BundleImpl implements Bundle {
   }
 
   private static Path entryPath(Path targetPath, ArchiveEntry entry) {
-    Path entryPath = targetPath.resolve(entry.getName());
+    Path entryPath = targetPath.resolve(entry.getName()).normalize();
     if (!entryPath.startsWith(targetPath)) {
       throw new IllegalStateException("Archive entry " + entry.getName() + " is not within " + targetPath);
     }


### PR DESCRIPTION
Vulnerability is theoretical, because we control the bundle which is being extracted.

