### PR TITLE
Support default imports and inlined requires in 'utils'

### DIFF
--- a/eslint-bridge/src/rules/cors.ts
+++ b/eslint-bridge/src/rules/cors.ts
@@ -22,11 +22,12 @@
 import { Rule } from 'eslint';
 import * as estree from 'estree';
 import {
-  getModuleNameOfIdentifier,
+  getModuleNameOfNode,
   toEncodedMessage,
   getUniqueWriteUsage,
   getObjectExpressionProperty,
 } from './utils';
+
 import { isLiteral } from 'eslint-plugin-sonarjs/lib/utils/nodes';
 
 const MESSAGE = `Make sure that enabling CORS is safe here.`;
@@ -49,9 +50,7 @@ export const rule: Rule.RuleModule = {
     }
 
     function isCorsCall(callee: estree.Node) {
-      return (
-        callee.type === 'Identifier' && getModuleNameOfIdentifier(callee, context)?.value === 'cors'
-      );
+      return getModuleNameOfNode(callee, context)?.value === 'cors';
     }
 
     return {

--- a/eslint-bridge/tests/rules/cors.test.ts
+++ b/eslint-bridge/tests/rules/cors.test.ts
@@ -66,6 +66,12 @@ ruleTester.run('Enabling Cross-Origin Resource Sharing is security-sensitive', r
       app.use(cors(foo()));
       `,
     },
+    {
+      code: `
+      const express = require('express');
+      app.use(require('cors')({ origin: 'http://localhost' })); // Compliant
+      `,
+    },
   ],
   invalid: [
     {
@@ -92,6 +98,37 @@ ruleTester.run('Enabling Cross-Origin Resource Sharing is security-sensitive', r
           endLine: 4,
           column: 17,
           endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: ` // with default import aliases
+        import express from 'express';
+        import cors from 'cors';
+        app.use(cors());`,
+      errors: [
+        {
+          message: EXPECTED_MESSAGE_WITHOUT_SECONDARY_LOC,
+          line: 4,
+          endLine: 4,
+          column: 17,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: `
+        // renaming imported module as something else shouldn't matter.
+        import * as express from 'express';
+        import * as c from 'cors';
+        app.use(c());`,
+      errors: [
+        {
+          message: EXPECTED_MESSAGE_WITHOUT_SECONDARY_LOC,
+          line: 5,
+          endLine: 5,
+          column: 17,
+          endColumn: 20,
         },
       ],
     },
@@ -233,6 +270,14 @@ ruleTester.run('Enabling Cross-Origin Resource Sharing is security-sensitive', r
           endColumn: 22,
         },
       ],
+    },
+    {
+      code: `
+      // inlined require('cors') invocation
+      const express = require('express');
+      app.use(require('cors')({ origin: '*' })); // Sensitive
+      `,
+      errors: 1,
     },
   ],
 });

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S4790.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S4790.json
@@ -29,4 +29,7 @@
 39,
 40,
 ],
+'javascript-test-sources:src/ecmascript6/reddit-mobile/src/config.es6.js':[
+12,
+],
 }


### PR DESCRIPTION
Two small enhancements in utils.ts, specifically of the methods that search for module names of expressions:

  1. Inlined requires are now supported:
        ```
        app.use(require('middleware')());
        ```
  now works without requiring intermediate variables. This is a common enough way to instantiate middleware ([example from DVNA](https://github.com/appsecco/dvna/blob/c637437d6515bd4c732e91c58e62d38e88260d3c/server.js#L35))

  2. Default export aliases are supported in import clauses (no need for `* as foo` - `foo` is enough):

        ```
        import serveStatic from 'serve-static'
        ```

  This is important, because middleware-modules usually don't have any other useful functions in the namespace: it's often just the middleware, so the `* as middlewareName` doesn't make much sense. [Example usage](https://nuxtjs.org/api/configuration-servermiddleware/).
