### PR TITLE
Add language to CustomRuleRepository definition

### DIFF
--- a/eslint-bridge/src/analyzer.ts
+++ b/eslint-bridge/src/analyzer.ts
@@ -136,7 +136,7 @@ let linter: LinterWrapper;
 const customRules: AdditionalRule[] = [];
 
 export function initLinter(rules: Rule[]) {
-  console.log(`DEBUG initializing linter with ${rules}`);
+  console.log(`DEBUG initializing linter with ${rules.map(r => r.key)}`);
   linter = new LinterWrapper(rules, [
     SYMBOL_HIGHLIGHTING_RULE,
     COGNITIVE_COMPLEXITY_RULE,

--- a/its/plugin/plugins/eslint-custom-rules-plugin/bundle/rules.js
+++ b/its/plugin/plugins/eslint-custom-rules-plugin/bundle/rules.js
@@ -42,4 +42,21 @@ exports.rules = [
     },
     ruleConfig: [],
   },
+  {
+    ruleId: "tsrule",
+    ruleModule: {
+      create(context) {
+        return {
+          CallExpression(node) {
+            console.log("ts rule detected call expression");
+            context.report({
+              node: node.callee,
+              message: "tsrule call",
+            });
+          },
+        };
+      },
+    },
+    ruleConfig: [],
+  },
 ];

--- a/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/CustomRule.java
+++ b/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/CustomRule.java
@@ -22,8 +22,10 @@ package org.sonar.samples.javascript;
 import org.sonar.check.Rule;
 import org.sonar.plugins.javascript.api.EslintBasedCheck;
 import org.sonar.plugins.javascript.api.JavaScriptRule;
+import org.sonar.plugins.javascript.api.TypeScriptRule;
 
 @JavaScriptRule
+@TypeScriptRule
 @Rule(key = CustomRule.RULE_KEY)
 public class CustomRule implements EslintBasedCheck {
 

--- a/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/EslintCustomRulesPlugin.java
+++ b/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/EslintCustomRulesPlugin.java
@@ -26,6 +26,6 @@ public class EslintCustomRulesPlugin implements Plugin {
 
   @Override
   public void define(Context context) {
-    context.addExtensions(EslintRulesBundle.class, CustomRulesDefinition.class, RuleRepository.class);
+    context.addExtensions(EslintRulesBundle.class, CustomRulesDefinition.class, RuleRepository.class, TsRepository.class);
   }
 }

--- a/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/RuleRepository.java
+++ b/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/RuleRepository.java
@@ -20,13 +20,20 @@
 package org.sonar.samples.javascript;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import org.sonar.plugins.javascript.api.CustomRuleRepository;
 import org.sonar.plugins.javascript.api.JavaScriptCheck;
 
 public class RuleRepository implements CustomRuleRepository {
 
   public static final String REPOSITORY_KEY = "eslint-custom-rules";
+
+  @Override
+  public Set<CustomRuleRepository.Language> languages() {
+    return EnumSet.of(Language.JAVASCRIPT, Language.TYPESCRIPT);
+  }
 
   @Override
   public String repositoryKey() {

--- a/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/TsRepository.java
+++ b/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/TsRepository.java
@@ -19,24 +19,32 @@
  */
 package org.sonar.samples.javascript;
 
-import org.sonar.api.server.rule.RulesDefinition;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.sonar.plugins.javascript.api.CustomRuleRepository;
+import org.sonar.plugins.javascript.api.JavaScriptCheck;
 
-public class CustomRulesDefinition implements RulesDefinition {
+/**
+ * This repository will register rule only for TypeScript. We reuse same rule implementation
+ */
+public class TsRepository implements CustomRuleRepository {
+
+  public static final String REPOSITORY_KEY = "ts-custom-rules";
 
   @Override
-  public void define(Context context) {
-    NewRepository repository = context.createRepository(RuleRepository.REPOSITORY_KEY, "js")
-      .setName("ESLint Custom Rules");
-    repository.createRule(CustomRule.RULE_KEY)
-      .setName("ESLint Custom Rule")
-      .setHtmlDescription("Description");
-    repository.done();
+  public Set<Language> languages() {
+    return EnumSet.of(Language.TYPESCRIPT);
+  }
 
-    NewRepository tsRepository = context.createRepository(TsRepository.REPOSITORY_KEY, "ts")
-      .setName("TypeScript Custom Rules");
-    tsRepository.createRule(TsRule.RULE_KEY)
-      .setName("TypeScript Custom Rule")
-      .setHtmlDescription("Description");
-    tsRepository.done();
+  @Override
+  public String repositoryKey() {
+    return REPOSITORY_KEY;
+  }
+
+  @Override
+  public List<Class<? extends JavaScriptCheck>> checkClasses() {
+    return Collections.singletonList(TsRule.class);
   }
 }

--- a/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/TsRule.java
+++ b/its/plugin/plugins/eslint-custom-rules-plugin/src/main/java/org/sonar/samples/javascript/TsRule.java
@@ -19,24 +19,18 @@
  */
 package org.sonar.samples.javascript;
 
-import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Rule;
+import org.sonar.plugins.javascript.api.EslintBasedCheck;
+import org.sonar.plugins.javascript.api.TypeScriptRule;
 
-public class CustomRulesDefinition implements RulesDefinition {
+@TypeScriptRule
+@Rule(key = TsRule.RULE_KEY)
+public class TsRule implements EslintBasedCheck {
+
+  public static final String RULE_KEY = "tsRuleKey";
 
   @Override
-  public void define(Context context) {
-    NewRepository repository = context.createRepository(RuleRepository.REPOSITORY_KEY, "js")
-      .setName("ESLint Custom Rules");
-    repository.createRule(CustomRule.RULE_KEY)
-      .setName("ESLint Custom Rule")
-      .setHtmlDescription("Description");
-    repository.done();
-
-    NewRepository tsRepository = context.createRepository(TsRepository.REPOSITORY_KEY, "ts")
-      .setName("TypeScript Custom Rules");
-    tsRepository.createRule(TsRule.RULE_KEY)
-      .setName("TypeScript Custom Rule")
-      .setHtmlDescription("Description");
-    tsRepository.done();
+  public String eslintKey() {
+    return "tsrule";
   }
 }

--- a/its/plugin/projects/custom_rules/src/dir/file.ts
+++ b/its/plugin/projects/custom_rules/src/dir/file.ts
@@ -1,0 +1,4 @@
+
+
+// eslint based custom rule reports on CallExpression
+foo();

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CustomRulesTest.java
@@ -86,6 +86,7 @@ public class CustomRulesTest {
       .addPlugin(FileLocation.byWildcardMavenFilename(
         new File("../plugins/" + customRulesArtifactId + "/target"), customRulesArtifactId + "-*.jar"))
       .restoreProfileAtStartup(FileLocation.ofClasspath("/profile-javascript-custom-rules.xml"))
+      .restoreProfileAtStartup(FileLocation.ofClasspath("/profile-typescript-custom-rules.xml"))
       .restoreProfileAtStartup(FileLocation.ofClasspath("/nosonar.xml"))
       .build();
     orchestrator.start();
@@ -102,6 +103,7 @@ public class CustomRulesTest {
       .setSourceDirs("src");
     orchestrator.getServer().provisionProject("custom-rules", "Custom Rules");
     orchestrator.getServer().associateProjectToQualityProfile("custom-rules", "js", "javascript-custom-rules-profile");
+    orchestrator.getServer().associateProjectToQualityProfile("custom-rules", "ts", "ts-custom-rules-profile");
     return orchestrator.executeBuild(build);
   }
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
@@ -22,11 +22,14 @@ package com.sonar.javascript.it.plugin;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
 import java.io.File;
+import java.io.File;
 import java.util.List;
+import org.assertj.core.groups.Tuple;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.sonarqube.ws.Issues;
+import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.CustomRulesTest.initOrchestrator;
 import static com.sonar.javascript.it.plugin.CustomRulesTest.runBuild;
@@ -52,14 +55,22 @@ public class EslintCustomRulesTest {
   public void test() {
     BuildResult buildResult = runBuild(orchestrator);
     assertThat(buildResult.getLogsLines(l -> l.matches(".*INFO: Deploying custom rules bundle jar:file:.*/custom-eslint-based-rules-1\\.0\\.0\\.tgz to .*"))).hasSize(1);
-    List<Issues.Issue> issues = CustomRulesTest.findIssues("eslint-custom-rules:sqKey", orchestrator);
-    assertThat(issues).hasSize(1);
-    Issues.Issue issue = issues.get(0);
-    assertThat(issue.getRule()).isEqualTo("eslint-custom-rules:sqKey");
-    assertThat(issue.getLine()).isEqualTo(21);
-    assertThat(issue.getMessage()).isEqualTo("call");
+    List<Issue> issues = CustomRulesTest.findIssues("eslint-custom-rules:sqKey", orchestrator);
+    assertThat(issues).hasSize(2);
+    assertThat(issues).extracting(Issue::getRule, Issue::getComponent, Issue::getLine, Issue::getMessage)
+      .containsExactlyInAnyOrder(
+        new Tuple("eslint-custom-rules:sqKey", "custom-rules:src/dir/Person.js", 21, "call"),
+        new Tuple("eslint-custom-rules:sqKey", "custom-rules:src/dir/file.ts", 4, "call")
+      );
     Issues.Location secondaryLocation = issue.getFlows(0).getLocations(0);
     assertThat(secondaryLocation.getMsg()).isEqualTo(new File(TestUtils.projectDir("custom_rules"), ".scannerwork").getAbsolutePath());
+
+    issues = CustomRulesTest.findIssues("ts-custom-rules:tsRuleKey", orchestrator);
+    assertThat(issues).extracting(Issue::getRule, Issue::getComponent, Issue::getLine, Issue::getMessage)
+      .containsExactlyInAnyOrder(
+        new Tuple("ts-custom-rules:tsRuleKey", "custom-rules:src/dir/file.ts", 4, "tsrule call")
+      );
+
   }
 
 }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
@@ -62,7 +62,7 @@ public class EslintCustomRulesTest {
         new Tuple("eslint-custom-rules:sqKey", "custom-rules:src/dir/Person.js", 21, "call"),
         new Tuple("eslint-custom-rules:sqKey", "custom-rules:src/dir/file.ts", 4, "call")
       );
-    Issues.Location secondaryLocation = issue.getFlows(0).getLocations(0);
+    Issues.Location secondaryLocation = issues.get(0).getFlows(0).getLocations(0);
     assertThat(secondaryLocation.getMsg()).isEqualTo(new File(TestUtils.projectDir("custom_rules"), ".scannerwork").getAbsolutePath());
 
     issues = CustomRulesTest.findIssues("ts-custom-rules:tsRuleKey", orchestrator);

--- a/its/plugin/tests/src/test/resources/profile-typescript-custom-rules.xml
+++ b/its/plugin/tests/src/test/resources/profile-typescript-custom-rules.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile>
+  <name>ts-custom-rules-profile</name>
+  <language>ts</language>
+  <rules>
+    <rule>
+      <repositoryKey>eslint-custom-rules</repositoryKey>
+      <key>sqKey</key>
+      <priority>MAJOR</priority>
+    </rule>
+    <rule>
+      <repositoryKey>ts-custom-rules</repositoryKey>
+      <key>tsRuleKey</key>
+      <priority>MAJOR</priority>
+    </rule>
+  </rules>
+</profile>
+

--- a/javascript-frontend/src/main/java/org/sonar/plugins/javascript/api/CustomRuleRepository.java
+++ b/javascript-frontend/src/main/java/org/sonar/plugins/javascript/api/CustomRuleRepository.java
@@ -19,7 +19,9 @@
  */
 package org.sonar.plugins.javascript.api;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import org.sonar.api.scanner.ScannerSide;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
@@ -27,12 +29,19 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
  * This interface should be implemented by custom rules plugins to register their rules with SonarJS
  *
  * @deprecated since 6.0. Consider using ESlint custom rules with external issue import instead.
- *
  */
 @ScannerSide
 @SonarLintSide
 @Deprecated
 public interface CustomRuleRepository {
+
+  enum Language {
+    JAVASCRIPT, TYPESCRIPT
+  }
+
+  default Set<Language> languages() {
+    return EnumSet.of(Language.JAVASCRIPT);
+  }
 
   /**
    * Key of the custom rule repository.
@@ -41,6 +50,7 @@ public interface CustomRuleRepository {
 
   /**
    * List of the custom rules classes.
+   *
    * @return
    */
   List<Class<? extends JavaScriptCheck>> checkClasses();

--- a/javascript-frontend/src/test/java/org/sonar/plugins/javascript/api/CustomRuleRepositoryTest.java
+++ b/javascript-frontend/src/test/java/org/sonar/plugins/javascript/api/CustomRuleRepositoryTest.java
@@ -1,0 +1,58 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.javascript.api;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class CustomRuleRepositoryTest {
+
+  @Test
+  public void test() {
+    MyRepository repo = new MyRepository();
+    assertThat(repo.languages()).containsExactly(CustomRuleRepository.Language.JAVASCRIPT);
+  }
+
+  static class MyRepository implements CustomRuleRepository {
+
+    @Override
+    public String repositoryKey() {
+      return "key";
+    }
+
+    @Override
+    public List<Class<? extends JavaScriptCheck>> checkClasses() {
+      return Collections.singletonList(Check.class);
+    }
+  }
+
+  static class Check implements EslintBasedCheck {
+
+    @Override
+    public String eslintKey() {
+      return "rulekey";
+    }
+  }
+
+}

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/AbstractChecks.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/AbstractChecks.java
@@ -51,9 +51,9 @@ public class AbstractChecks {
     this.customRuleRepositories = customRuleRepositories;
   }
 
-  protected void addChecks(String repositoryKey, Iterable<Class<? extends JavaScriptCheck>> checkClass) {
+  protected void addChecks(CustomRuleRepository.Language language, String repositoryKey, Iterable<Class<? extends JavaScriptCheck>> checkClass) {
     doAddChecks(repositoryKey, checkClass);
-    addCustomChecks();
+    addCustomChecks(language);
   }
 
   private void doAddChecks(String repositoryKey, Iterable<Class<? extends JavaScriptCheck>> checkClass) {
@@ -62,7 +62,7 @@ public class AbstractChecks {
       .addAnnotatedChecks(checkClass));
   }
 
-  private void addCustomChecks() {
+  private void addCustomChecks(CustomRuleRepository.Language language) {
 
     if (customRulesDefinitions != null) {
       LOG.warn("JavaScript analyzer custom rules are deprecated. Consider using ESlint custom rules instead");
@@ -75,9 +75,12 @@ public class AbstractChecks {
 
     if (customRuleRepositories != null) {
       for (CustomRuleRepository repo : customRuleRepositories) {
-        LOG.debug("Adding rules for repository '{}' {} from {}", repo.repositoryKey(), repo.checkClasses(),
-          repo.getClass().getCanonicalName());
-        doAddChecks(repo.repositoryKey(), repo.checkClasses());
+        if (repo.languages().contains(language)) {
+          LOG.debug("Adding rules for repository '{}', language: {}, {} from {}", repo.repositoryKey(), language,
+            repo.checkClasses(),
+            repo.getClass().getCanonicalName());
+          doAddChecks(repo.repositoryKey(), repo.checkClasses());
+        }
       }
     }
 

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptChecks.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptChecks.java
@@ -58,7 +58,7 @@ public class JavaScriptChecks extends AbstractChecks {
   public JavaScriptChecks(CheckFactory checkFactory, @Nullable CustomJavaScriptRulesDefinition[] customRulesDefinitions,
                           @Nullable CustomRuleRepository[] customRuleRepositories) {
     super(checkFactory, customRulesDefinitions, customRuleRepositories);
-    addChecks(CheckList.JS_REPOSITORY_KEY, CheckList.getJavaScriptChecks());
+    addChecks(CustomRuleRepository.Language.JAVASCRIPT, CheckList.JS_REPOSITORY_KEY, CheckList.getJavaScriptChecks());
   }
 
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/TypeScriptChecks.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/TypeScriptChecks.java
@@ -58,7 +58,7 @@ public class TypeScriptChecks extends AbstractChecks {
   public TypeScriptChecks(CheckFactory checkFactory, @Nullable CustomJavaScriptRulesDefinition[] customRulesDefinitions,
                           @Nullable CustomRuleRepository[] customRuleRepositories) {
     super(checkFactory, customRulesDefinitions, customRuleRepositories);
-    addChecks(CheckList.TS_REPOSITORY_KEY, CheckList.getTypeScriptChecks());
+    addChecks(CustomRuleRepository.Language.TYPESCRIPT, CheckList.TS_REPOSITORY_KEY, CheckList.getTypeScriptChecks());
   }
 
 }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/TypeScriptChecksTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/TypeScriptChecksTest.java
@@ -20,7 +20,9 @@
 package org.sonar.plugins.javascript;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.Test;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.check.Rule;
@@ -45,15 +47,35 @@ public class TypeScriptChecksTest {
 
   @Test
   public void should_add_custom_checks() {
-    TypeScriptChecks checks = new TypeScriptChecks(checkFactory("repo", "customcheck"), new CustomRuleRepository[]{ new RuleRepository()});
+    TypeScriptChecks checks = new TypeScriptChecks(checkFactory("repo", "customcheck"),
+      new CustomRuleRepository[]{new TsRepository(), new JsRepository()});
+    assertThat(checks.eslintBasedChecks()).hasSize(1);
     assertThat(checks.ruleKeyByEslintKey("key")).isEqualTo(RuleKey.parse("repo:customcheck"));
   }
 
-  public static class RuleRepository implements CustomRuleRepository {
+  public static class TsRepository implements CustomRuleRepository {
+
+    @Override
+    public Set<Language> languages() {
+      return EnumSet.of(Language.TYPESCRIPT);
+    }
 
     @Override
     public String repositoryKey() {
       return "repo";
+    }
+
+    @Override
+    public List<Class<? extends JavaScriptCheck>> checkClasses() {
+      return Collections.singletonList(CustomTsCheck.class);
+    }
+  }
+
+  public static class JsRepository implements CustomRuleRepository {
+
+    @Override
+    public String repositoryKey() {
+      return "js-repo";
     }
 
     @Override


### PR DESCRIPTION
We need to distinguish custom rule repository by language, otherwise, we instantiate rules from repository for incorrect language. Missing coverage is due to tests being located in another module (`sonar-javascript-plugin`)
