### PR TITLE
Log JavaScript parsing failure with TypeScript compiler at debug level

### DIFF
--- a/eslint-bridge/src/parser.ts
+++ b/eslint-bridge/src/parser.ts
@@ -68,7 +68,7 @@ export function parseJavaScriptSourceFile(
   if (parsed instanceof SourceCode) {
     return parsed;
   }
-  console.log(`Failed to parse ${filePath} with TypeScript compiler: ${parsed.message}`);
+  console.log(`DEBUG Failed to parse ${filePath} with TypeScript compiler: ${parsed.message}`);
 
   let parseFunctions = [espree.parse, babel.parseForESLint];
   if (fileContent.includes('@flow')) {

--- a/eslint-bridge/tests/parser.test.ts
+++ b/eslint-bridge/tests/parser.test.ts
@@ -153,7 +153,7 @@ import { ParseExceptionCode } from '../src/parser';
   it(`should log error on TypeScript compiler's parsing failure`, () => {
     parseJavaScriptSourceFile('if (true) {', 'foo.js');
     const callsToLogger = (console.log as jest.Mock).mock.calls;
-    const message = `Failed to parse foo.js with TypeScript compiler: '}' expected.`;
+    const message = `DEBUG Failed to parse foo.js with TypeScript compiler: '}' expected.`;
     expect(callsToLogger.filter(args => args[0] === message)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Fixes #

--
I don't see any time improvements for JavaScript ruling...