### PR TITLE
Log failures from TypeScript compiler without analysis abort

### DIFF
--- a/eslint-bridge/src/parser.ts
+++ b/eslint-bridge/src/parser.ts
@@ -200,6 +200,7 @@ export enum ParseExceptionCode {
   Parsing = 'PARSING',
   MissingTypeScript = 'MISSING_TYPESCRIPT',
   UnsupportedTypeScript = 'UNSUPPORTED_TYPESCRIPT',
+  FailingTypeScript = 'FAILING_TYPESCRIPT',
   GeneralError = 'GENERAL_ERROR',
 }
 
@@ -209,6 +210,8 @@ export function parseExceptionCodeOf(exceptionMsg: string): ParseExceptionCode {
     return ParseExceptionCode.MissingTypeScript;
   } else if (exceptionMsg.startsWith('You are using version of TypeScript')) {
     return ParseExceptionCode.UnsupportedTypeScript;
+  } else if (exceptionMsg.startsWith('Debug Failure')) {
+    return ParseExceptionCode.FailingTypeScript;
   } else {
     return ParseExceptionCode.Parsing;
   }

--- a/eslint-bridge/tests/analyzer.test.ts
+++ b/eslint-bridge/tests/analyzer.test.ts
@@ -168,6 +168,21 @@ describe('#analyzeJavaScript', () => {
       expect(e.message).toBe('Linter is undefined. Did you call /init-linter?');
     }
   });
+
+  it('should report exception from TypeScript compiler as parsing error', () => {
+    const filePath = join(__dirname, './fixtures/failing-typescript/sample.lint.js');
+    const tsConfig = join(__dirname, './fixtures/failing-typescript/tsconfig.json');
+    const codeToTest = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+    initLinter([{ key: 'arguments-order', configurations: [] }]);
+    const { parsingError } = analyzeJavaScript({
+      filePath: filePath,
+      fileContent: codeToTest,
+      tsConfigs: [tsConfig],
+    });
+    expect(parsingError).toBeDefined();
+    expect(parsingError.message).toContain('Debug Failure');
+  });
 });
 
 describe('#analyzeTypeScript', () => {

--- a/eslint-bridge/tests/fixtures/failing-typescript/sample.lint.js
+++ b/eslint-bridge/tests/fixtures/failing-typescript/sample.lint.js
@@ -1,0 +1,10 @@
+YUI.add('dd-proxy', function (Y) {
+
+  /**
+   * @class DDProxy
+   */
+  var DDM = Y.DD.DDM,
+      P = function() {
+          P.superclass.constructor.apply(this, arguments);
+      };
+});

--- a/eslint-bridge/tests/fixtures/failing-typescript/tsconfig.json
+++ b/eslint-bridge/tests/fixtures/failing-typescript/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "allowJs": true
+  }
+}

--- a/eslint-bridge/tests/parser.test.ts
+++ b/eslint-bridge/tests/parser.test.ts
@@ -239,6 +239,9 @@ describe('parseTypeScriptSourceFile', () => {
       ParseExceptionCode.UnsupportedTypeScript,
     );
     expect(parseExceptionCodeOf('Unexpected token )')).toEqual(ParseExceptionCode.Parsing);
+    expect(parseExceptionCodeOf('Debug Failure. False expression')).toEqual(
+      ParseExceptionCode.FailingTypeScript,
+    );
   });
 });
 

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
@@ -145,6 +145,8 @@ abstract class AbstractEslintSensor implements Sensor {
 
     if (line != null) {
       LOG.error("Failed to parse file [{}] at line {}: {}", inputFile.toString(), line, message);
+    } else if (parsingError.code == ParsingErrorCode.FAILING_TYPESCRIPT) {
+      LOG.error("Failed to analyze file [{}] from TypeScript: {}", inputFile.toString(), message);
     } else {
       if (parsingError.code == ParsingErrorCode.MISSING_TYPESCRIPT) {
         // effectively this is dead code, because missing typescript should be detected at the time we load tsconfig file

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/EslintBridgeServer.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/EslintBridgeServer.java
@@ -102,6 +102,7 @@ public interface EslintBridgeServer extends Startable {
     PARSING,
     MISSING_TYPESCRIPT,
     UNSUPPORTED_TYPESCRIPT,
+    FAILING_TYPESCRIPT,
     GENERAL_ERROR
   }
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
@@ -311,6 +311,20 @@ public class TypeScriptSensorTest {
   }
 
   @Test
+  public void should_log_when_failing_typescript() throws Exception {
+    AnalysisResponse parseError = new AnalysisResponse();
+    parseError.parsingError = new EslintBridgeServer.ParsingError();
+    parseError.parsingError.message = "Debug Failure. False expression.";
+    parseError.parsingError.code = ParsingErrorCode.FAILING_TYPESCRIPT;
+    when(eslintBridgeServerMock.analyzeTypeScript(any())).thenReturn(parseError);
+    createInputFile(context, "dir/file1.ts");
+    createInputFile(context, "dir/file2.ts");
+    createSensor().execute(context);
+    assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Failed to analyze file [dir/file1.ts] from TypeScript: Debug Failure. False expression.");
+    assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Failed to analyze file [dir/file2.ts] from TypeScript: Debug Failure. False expression.");
+  }
+
+  @Test
   public void should_create_ui_warning_missing_typescript() throws Exception {
     when(eslintBridgeServerMock.loadTsConfig(any())).thenThrow(new MissingTypeScriptException());
     createInputFile(context, "dir/file1.ts");


### PR DESCRIPTION
Fixes #

--
Failures from TypeScript compiler raised in eslint-bridge are communicated to ESLint sensor as "parsing" errors. The sensor then logs these errors, but does not abort the analysis.