### PR TITLE
Generate TSConfig file per analyzed JavaScript file

### DIFF
--- a/its/ruling/src/test/expected/js/angular.js/javascript-S3525.json
+++ b/its/ruling/src/test/expected/js/angular.js/javascript-S3525.json
@@ -124,10 +124,6 @@
 'angular.js:test/ng/directive/ngRepeatSpec.js':[
 604,
 ],
-'angular.js:test/ng/filter/filterSpec.js':[
-306,
-341,
-],
 'angular.js:test/ng/logSpec.js':[
 172,
 ],

--- a/its/ruling/src/test/expected/js/prototype/javascript-S3525.json
+++ b/its/ruling/src/test/expected/js/prototype/javascript-S3525.json
@@ -1,6 +1,5 @@
 {
 'prototype:src/prototype/lang/class.js':[
-67,
 69,
 ],
 'prototype:test/unit/phantomjs/core-extensions.js':[

--- a/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
@@ -85,9 +85,9 @@ public class JavaScriptRulingTest {
   @Parameters(name = "{0}")
   public static Object[][] projects() {
     return new Object[][]{
-      jsProject("amplify", "external/**"),
+      //jsProject("amplify", "external/**"),
       jsProject("angular.js", "src/ngLocale/**", "i18n/**"),
-      jsProject("backbone"),
+      /*jsProject("backbone"),
       jsProject("es5-shim"),
       jsProject("javascript-test-sources"),
       jsProject("jquery"),
@@ -101,7 +101,7 @@ public class JavaScriptRulingTest {
       jsProject("prototype", "dist/**", "vendor/**"),
       jsProject("qunit"),
       jsProject("sizzle", "external/**", "dist/**"),
-      jsProject("underscore", "test/vendor/**"),
+      jsProject("underscore", "test/vendor/**"),*/
     };
   }
 

--- a/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
@@ -85,9 +85,9 @@ public class JavaScriptRulingTest {
   @Parameters(name = "{0}")
   public static Object[][] projects() {
     return new Object[][]{
-      //jsProject("amplify", "external/**"),
+      jsProject("amplify", "external/**"),
       jsProject("angular.js", "src/ngLocale/**", "i18n/**"),
-      /*jsProject("backbone"),
+      jsProject("backbone"),
       jsProject("es5-shim"),
       jsProject("javascript-test-sources"),
       jsProject("jquery"),
@@ -101,7 +101,7 @@ public class JavaScriptRulingTest {
       jsProject("prototype", "dist/**", "vendor/**"),
       jsProject("qunit"),
       jsProject("sizzle", "external/**", "dist/**"),
-      jsProject("underscore", "test/vendor/**"),*/
+      jsProject("underscore", "test/vendor/**"),
     };
   }
 


### PR DESCRIPTION
A TSConfig file is now generated per analysed JavaScript source file. Furthermore, each JavaScript analysis requests clearing the cache of typescript-eslint parser. And even though the impact is minimal here, the changes in ruling show a positive impact for rules relying on type information. Type inference was incorrect for these cases leading to FPs, which now are no longer reported.