### PR TITLE
Sanitize TypeScript ESLint rules requiring type information

### DIFF
--- a/eslint-bridge/typings/typescript-eslint/index.d.ts
+++ b/eslint-bridge/typings/typescript-eslint/index.d.ts
@@ -1,3 +1,4 @@
 declare module '@typescript-eslint/eslint-plugin' {
-  export const rules: any;
+  import { Rule } from "eslint";
+  export const rules: { [name: string]: Rule.RuleModule };
 }


### PR DESCRIPTION
Fixes #2483 

--
To sanitize TypeScript ESLint rules, we basically decorate the rules; each decorated rule now checks on creation whether it requires type information and if type information is available. If both conditions are met, then the original behaviour of the rule is preserved, otherwise the rule does nothing.