### PR TITLE
Fix symbol highlighting for TS enums

### DIFF
--- a/eslint-bridge/src/runner/symbol-highlighter.ts
+++ b/eslint-bridge/src/runner/symbol-highlighter.ts
@@ -81,8 +81,8 @@ export const rule: Rule.RuleModule = {
             return;
           }
           const highlightedSymbol: HighlightedSymbol = {
-            declaration: identifierLocation(allRef[0] as TSESTree.Identifier),
-            references: allRef.slice(1).map(r => identifierLocation(r as TSESTree.Identifier)),
+            declaration: identifierLocation(allRef[0] as TSESTree.Node),
+            references: allRef.slice(1).map(r => identifierLocation(r as TSESTree.Node)),
           };
           result.push(highlightedSymbol);
         });

--- a/eslint-bridge/tests/runner/symbol-highlighter.test.ts
+++ b/eslint-bridge/tests/runner/symbol-highlighter.test.ts
@@ -114,6 +114,19 @@ it('should highlight constructor', () => {
   });
 });
 
+it('should highlight TS enums', () => {
+  expect(
+    actual(`
+    enum PublishSettingsType {
+      'enterprise',
+      'dotcom',
+    }`),
+  ).toContainEqual({
+    declaration: { endCol: 28, endLine: 2, startCol: 9, startLine: 2 },
+    references: [],
+  });
+});
+
 function location(startLine: number, startCol: number, endLine: number, endCol: number): Location {
   return {
     startLine,


### PR DESCRIPTION
`Variable#identifiers` doesn't containt ASTNode for TS enums. This will result in trying to find location for undefined value. 

As per https://eslint.org/docs/developer-guide/scope-manager-interface#identifiers is planned to be deprecated. Replacement is `Definition#name` which is generic ASTNode (although typings in `.d.ts` are incorrect) and contains `Literal` node for TS enum.

This PR has a fix on two levels 
- we use `Definition#name` instead of `Variable#identifiers`, which works correctly for TS enums
- we defensively check if there is at least one AST node for each variable instance before creating highlighting