### PR TITLE
Fix code coverage reporting of conditions on non-executable lines

### DIFF
--- a/its/plugin/projects/lcov-jsx/conditions-on-non-executable-lines.lcov
+++ b/its/plugin/projects/lcov-jsx/conditions-on-non-executable-lines.lcov
@@ -1,0 +1,15 @@
+TN:
+SF:./file.jsx
+FN:3,(anonymous_0)
+FNF:1
+FNH:1
+FNDA:1,(anonymous_0)
+DA:3,1
+DA:4,1
+LF:2
+LH:2
+BRDA:5,0,0,1
+BRDA:5,0,1,0
+BRF:2
+BRH:1
+end_of_record

--- a/its/plugin/projects/lcov-jsx/file.jsx
+++ b/its/plugin/projects/lcov-jsx/file.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const Test = ({ condition }) => (
+  <div>
+    {condition && <span>Test1</span>}
+
+    <span>Test2</span>
+  </div>
+)
+
+export default Test

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
@@ -193,10 +193,29 @@ public class CoverageTest {
       .contains("DEBUG: Problem during processing LCOV report: can't save DA data for line 12 of coverage report file")
       .contains("DEBUG: Problem during processing LCOV report: can't save BRDA data for line 18 of coverage report file");
 
-    assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(6);
+    assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(7);
     assertThat(getMeasureAsInt(projectKey, "uncovered_lines")).isEqualTo(1);
     assertThat(getMeasureAsInt(projectKey, "conditions_to_cover")).isEqualTo(3);
     assertThat(getMeasureAsInt(projectKey, "uncovered_conditions")).isEqualTo(0);
   }
 
+  @Test
+  public void conditions_on_non_executable_lines() {
+    final String projectKey = "ConditionsOnNonExecutableLines";
+    SonarScanner build = Tests.createScanner()
+      .setProjectDir(TestUtils.projectDir("lcov-jsx"))
+      .setProjectKey(projectKey)
+      .setProjectName(projectKey)
+      .setProjectVersion("1.0")
+      .setSourceDirs(".")
+      .setDebugLogs(true)
+      .setProperty("sonar.javascript.lcov.reportPaths", TestUtils.file("projects/lcov-jsx/conditions-on-non-executable-lines.lcov").getAbsolutePath());
+    Tests.setEmptyProfile(projectKey);
+    orchestrator.executeBuild(build);
+
+    assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(3);
+    assertThat(getMeasureAsInt(projectKey, "uncovered_lines")).isEqualTo(0);
+    assertThat(getMeasureAsInt(projectKey, "conditions_to_cover")).isEqualTo(2);
+    assertThat(getMeasureAsInt(projectKey, "uncovered_conditions")).isEqualTo(1);
+  }
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -206,6 +206,7 @@ class LCOVParser {
         newCoverage.lineHits(e.getKey(), e.getValue());
       }
       for (Map.Entry<Integer, Map<String, Integer>> e : branches.entrySet()) {
+        int line = e.getKey();
         int conditions = e.getValue().size();
         int covered = 0;
         for (Integer taken : e.getValue().values()) {
@@ -214,7 +215,8 @@ class LCOVParser {
           }
         }
 
-        newCoverage.conditions(e.getKey(), conditions, covered);
+        newCoverage.conditions(line, conditions, covered);
+        newCoverage.lineHits(line, hits.getOrDefault(line, 0) + covered);
       }
     }
 


### PR DESCRIPTION
Fixes #2558 

--
Using the code snippet provided by the community, here is what we get on SonarQube UI before/after the changes introduced by this pull request.

**Before**

<img width="1416" alt="before" src="https://user-images.githubusercontent.com/52890329/116085279-f297a480-a69e-11eb-9fcd-4bf3198643c6.png">

There is an uncovered condition at line 5. The metrics do say that there are two conditions and that one of them is actually uncovered. However, there is no partial coverage highlighting on the line.

**After**

<img width="1416" alt="after" src="https://user-images.githubusercontent.com/52890329/116085299-f7f4ef00-a69e-11eb-8d39-15505b5337e9.png">

The metrics regarding condition coverage remain the same: there are two conditions and one of the two is uncovered. However, there is now one more executable line, which is line 5. Furthermore, the very same line is now highlighted with a red marker denoting a partially covered line. And finally, the overall code coverage changes since executable lines are considered in the computation.