### PR TITLE
Support syntax highlighting for Vue.js Single File Components templates

### DIFF
--- a/eslint-bridge/src/runner/symbol-highlighter.ts
+++ b/eslint-bridge/src/runner/symbol-highlighter.ts
@@ -108,11 +108,14 @@ export const rule: Rule.RuleModule = {
           } else if (token.type === 'HTMLSelfClosingTagClose') {
             openHtmlTagsStack.pop();
           } else if (token.type === 'HTMLEndTagOpen') {
-            const highlightedSymbol: HighlightedSymbol = {
-              declaration: location(openHtmlTagsStack.pop()!.loc),
-              references: [location(token.loc)],
-            };
-            result.push(highlightedSymbol);
+            const openHtmlTag = openHtmlTagsStack.pop();
+            if (openHtmlTag) {
+              const highlightedSymbol: HighlightedSymbol = {
+                declaration: location(openHtmlTag.loc),
+                references: [location(token.loc)],
+              };
+              result.push(highlightedSymbol);
+            }
           }
         });
 

--- a/eslint-bridge/src/runner/symbol-highlighter.ts
+++ b/eslint-bridge/src/runner/symbol-highlighter.ts
@@ -92,30 +92,34 @@ export const rule: Rule.RuleModule = {
         const openCurlyBracesStack: AST.Token[] = [];
         const openHtmlTagsStack: AST.Token[] = [];
         extractTokensAndComments(context.getSourceCode()).tokens.forEach(token => {
-          if (token.type === 'Punctuator') {
-            if (token.value === '{') {
-              openCurlyBracesStack.push(token);
-            }
-            if (token.value === '}') {
-              const highlightedSymbol: HighlightedSymbol = {
-                declaration: location(openCurlyBracesStack.pop()!.loc),
-                references: [location(token.loc)],
-              };
-              result.push(highlightedSymbol);
-            }
-          } else if (token.type === 'HTMLTagOpen') {
-            openHtmlTagsStack.push(token);
-          } else if (token.type === 'HTMLSelfClosingTagClose') {
-            openHtmlTagsStack.pop();
-          } else if (token.type === 'HTMLEndTagOpen') {
-            const openHtmlTag = openHtmlTagsStack.pop();
-            if (openHtmlTag) {
-              const highlightedSymbol: HighlightedSymbol = {
-                declaration: location(openHtmlTag.loc),
-                references: [location(token.loc)],
-              };
-              result.push(highlightedSymbol);
-            }
+          switch (token.type) {
+            case 'Punctuator':
+              if (token.value === '{') {
+                openCurlyBracesStack.push(token);
+              } else if (token.value === '}') {
+                const highlightedSymbol: HighlightedSymbol = {
+                  declaration: location(openCurlyBracesStack.pop()!.loc),
+                  references: [location(token.loc)],
+                };
+                result.push(highlightedSymbol);
+              }
+              break;
+            case 'HTMLTagOpen':
+              openHtmlTagsStack.push(token);
+              break;
+            case 'HTMLSelfClosingTagClose':
+              openHtmlTagsStack.pop();
+              break;
+            case 'HTMLEndTagOpen':
+              const openHtmlTag = openHtmlTagsStack.pop();
+              if (openHtmlTag) {
+                const highlightedSymbol: HighlightedSymbol = {
+                  declaration: location(openHtmlTag.loc),
+                  references: [location(token.loc)],
+                };
+                result.push(highlightedSymbol);
+              }
+              break;
           }
         });
 

--- a/eslint-bridge/src/runner/utils-token.ts
+++ b/eslint-bridge/src/runner/utils-token.ts
@@ -1,0 +1,36 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { SourceCode } from 'eslint';
+import { AST } from 'vue-eslint-parser';
+
+export function extractTokensAndComments(
+  sourceCode: SourceCode,
+): { tokens: AST.Token[]; comments: AST.Token[] } {
+  const ast = sourceCode.ast as AST.ESLintProgram;
+  const tokens = [...(ast.tokens || [])];
+  const comments = [...(ast.comments || [])];
+  if (ast.templateBody) {
+    const { templateBody } = ast;
+    tokens.push(...templateBody.tokens);
+    comments.push(...templateBody.comments);
+  }
+  return { tokens, comments };
+}

--- a/eslint-bridge/tests/runner/highlighter.test.ts
+++ b/eslint-bridge/tests/runner/highlighter.test.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import getHighlighting, { Highlight, SonarTypeOfText } from 'runner/highlighter';
-import { parseTypeScriptSourceFile } from 'parser';
+import { parseJavaScriptVueSourceFile, parseTypeScriptSourceFile } from 'parser';
 import { join } from 'path';
 import { SourceCode } from 'eslint';
 
@@ -82,6 +82,47 @@ it('should highlight numbers', () => {
   expect(actual('0.0')).toContainEqual(token(1, 0, 1, 3, 'CONSTANT'));
   expect(actual('-0.0')).toContainEqual(token(1, 1, 1, 4, 'CONSTANT'));
   expect(actual('10e-2')).toContainEqual(token(1, 0, 1, 5, 'CONSTANT'));
+});
+
+it('should highlight Vue templates', () => {
+  function highlights(code: string): Highlight[] {
+    const sourceCode = parseJavaScriptVueSourceFile(code, '/some/path/file.vue', []) as SourceCode;
+    return getHighlighting(sourceCode).highlights;
+  }
+  expect(highlights('<template></template>')).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining(token(1, 0, 1, 9, 'KEYWORD')), // <template
+      expect.objectContaining(token(1, 9, 1, 10, 'KEYWORD')), // >
+      expect.objectContaining(token(1, 10, 1, 20, 'KEYWORD')), // </template
+      expect.objectContaining(token(1, 20, 1, 21, 'KEYWORD')), // >
+    ]),
+  );
+  expect(highlights(`<template><!DOCTYPE></template>`)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining(token(1, 10, 1, 20, 'STRUCTURED_COMMENT')), // <!DOCTYPE>
+    ]),
+  );
+  expect(highlights(`<template><!-- comment ></template>`)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining(token(1, 10, 1, 35, 'COMMENT')), // <!-- comment >
+    ]),
+  );
+  expect(highlights(`<template><tag /></template>`)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining(token(1, 15, 1, 17, 'KEYWORD')), // <tag
+      expect.objectContaining(token(1, 17, 1, 27, 'KEYWORD')), // />
+    ]),
+  );
+  expect(highlights(`<template><tag attr=5 /></template>`)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining(token(1, 20, 1, 21, 'STRING')), // 5
+    ]),
+  );
+  expect(highlights(`<template><tag attr="value" /></template>`)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining(token(1, 20, 1, 27, 'STRING')), // "value"
+    ]),
+  );
 });
 
 function token(

--- a/eslint-bridge/tests/runner/symbol-highlighter.test.ts
+++ b/eslint-bridge/tests/runner/symbol-highlighter.test.ts
@@ -138,10 +138,8 @@ it('should highlight Vue templates', () => {
   const filePath = '/some/path/file.vue';
   const fileContent = `
   <template>
-    <foo>
-      <bar>
-        <baz/> <!-- ignored -->
-      </bar>
+    <foo a="v" b="w">
+      <baz/> <!-- ignored: self-closing -->
     </foo>
   </template>`;
 
@@ -149,16 +147,29 @@ it('should highlight Vue templates', () => {
   const { highlightedSymbols } = analyzeJavaScript({ filePath, fileContent, tsConfigs: [] });
   expect(highlightedSymbols).toEqual([
     {
-      declaration: { startLine: 4, startCol: 6, endLine: 4, endCol: 10 } /* <bar> */,
-      references: [{ startLine: 6, startCol: 6, endLine: 6, endCol: 11 }] /* </bar> */,
+      declaration: { startLine: 3, startCol: 4, endLine: 3, endCol: 8 } /* <foo */,
+      references: [{ startLine: 5, startCol: 4, endLine: 5, endCol: 9 }] /* </foo */,
     },
     {
-      declaration: { startLine: 3, startCol: 4, endLine: 3, endCol: 8 } /* <foo> */,
-      references: [{ startLine: 7, startCol: 4, endLine: 7, endCol: 9 }] /* </foo> */,
+      declaration: { startLine: 2, startCol: 2, endLine: 2, endCol: 11 } /* <template */,
+      references: [{ startLine: 6, startCol: 2, endLine: 6, endCol: 12 }] /* </template */,
     },
+  ]);
+});
+
+it('should highlight inconsistent Vue templates', () => {
+  const filePath = '/some/path/file.vue';
+  const fileContent = `
+  <template>
+    </p>
+  </template> <!-- ignored: inconsistency -->`;
+
+  initLinter([]);
+  const { highlightedSymbols } = analyzeJavaScript({ filePath, fileContent, tsConfigs: [] });
+  expect(highlightedSymbols).toEqual([
     {
-      declaration: { startLine: 2, startCol: 2, endLine: 2, endCol: 11 } /* <template> */,
-      references: [{ startLine: 8, startCol: 2, endLine: 8, endCol: 12 }] /* </template> */,
+      declaration: { startLine: 2, startCol: 2, endLine: 2, endCol: 11 } /* <template */,
+      references: [{ startLine: 3, startCol: 4, endLine: 3, endCol: 7 }] /* </p */,
     },
   ]);
 });

--- a/eslint-bridge/tests/runner/symbol-highlighter.test.ts
+++ b/eslint-bridge/tests/runner/symbol-highlighter.test.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { join } from 'path';
-import { analyzeTypeScript, initLinter } from 'analyzer';
+import { analyzeJavaScript, analyzeTypeScript, initLinter } from 'analyzer';
 import { HighlightedSymbol } from 'runner/symbol-highlighter';
 import { Location } from 'runner/location';
 import { setContext } from 'context';
@@ -132,6 +132,35 @@ it('should highlight TS enums', () => {
     declaration: { endCol: 28, endLine: 2, startCol: 9, startLine: 2 },
     references: [],
   });
+});
+
+it('should highlight Vue templates', () => {
+  const filePath = '/some/path/file.vue';
+  const fileContent = `
+  <template>
+    <foo>
+      <bar>
+        <baz/> <!-- ignored -->
+      </bar>
+    </foo>
+  </template>`;
+
+  initLinter([]);
+  const { highlightedSymbols } = analyzeJavaScript({ filePath, fileContent, tsConfigs: [] });
+  expect(highlightedSymbols).toEqual([
+    {
+      declaration: { startLine: 4, startCol: 6, endLine: 4, endCol: 10 } /* <bar> */,
+      references: [{ startLine: 6, startCol: 6, endLine: 6, endCol: 11 }] /* </bar> */,
+    },
+    {
+      declaration: { startLine: 3, startCol: 4, endLine: 3, endCol: 8 } /* <foo> */,
+      references: [{ startLine: 7, startCol: 4, endLine: 7, endCol: 9 }] /* </foo> */,
+    },
+    {
+      declaration: { startLine: 2, startCol: 2, endLine: 2, endCol: 11 } /* <template> */,
+      references: [{ startLine: 8, startCol: 2, endLine: 8, endCol: 12 }] /* </template> */,
+    },
+  ]);
 });
 
 function location(startLine: number, startCol: number, endLine: number, endCol: number): Location {


### PR DESCRIPTION
Fixes #2668 

Syntax highlighting for the template section of Vue Single File Components takes inspiration from [sonar-html](https://github.com/SonarSource/sonar-html/blob/dbfc23fa354db91c784786c6a45baf054e612521/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java#L73-L92) and how it implements such highlighting. 

Below is a table that summarises how Vue.js ESLint represents HTML in terms of AST nodes and how such nodes will be highlighted:

| HTML  |  Vue ESLint Node    | Highlighting |
|---|------|----|
| `<tag`  |   `HTMLTagOpen `   | `KEYWORD`  |
|  `>` |   `HTMLTagClose `   | `KEYWORD`  |
| `</tag`  | `HTMLEndTagOpen ` | `KEYWORD`  |
|  `/>` |   `HTMLSelfClosingTagClose `  | `KEYWORD`  |
|  `<!-- foo -->` |   `HTMLComment `   | `COMMENT`  |
|  `<!DOCTYPE ->` |   `HTMLBogusComment `  | `STRUCTURED_COMMENT `  |
|  attr=`"value"` |   `HTMLLiteral `   | `STRING`  |

> The value of a Vue.js directive-like attribute, e.g. `:href="myLink"`, is a JavaScript expression. Therefore, it is not highlighted as a string but as plain JavaScript code.

This PR also introduces symbol highlighting for the template part of Vue Single File Components. It only considers tags and highlights tags that are not self closing, i.e., tags that come in pair like `<foo></foo>`.