### PR TITLE
Do not show logs when running jest tests during mvn build

### DIFF
--- a/eslint-bridge/pom.xml
+++ b/eslint-bridge/pom.xml
@@ -55,7 +55,7 @@
             </goals>
             <configuration>
               <executable>yarn</executable>
-              <commandlineArgs>test --coverage</commandlineArgs>
+              <commandlineArgs>test --coverage --silent</commandlineArgs>
               <skip>${skipTests}</skip>
             </configuration>
           </execution>


### PR DESCRIPTION
I suggest to hide logging when executing jest tests in MVN build. They are many and decrease readability of logs greatly