### PR TITLE
EslintBridgeServer restarts always fail

### DIFF
--- a/nodejs-utils/src/main/java/org/sonarsource/nodejs/NodeCommandBuilder.java
+++ b/nodejs-utils/src/main/java/org/sonarsource/nodejs/NodeCommandBuilder.java
@@ -34,10 +34,24 @@ public interface NodeCommandBuilder {
 
   NodeCommandBuilder maxOldSpaceSize(int maxOldSpaceSize);
 
+  /**
+   * Adds Node.js arguments. This does not replace previously set Node.js arguments.
+   * Use {@link NodeCommandBuilder#reset()} to reset the builder in cases in which you are
+   * reusing it.
+   *
+   * @return this
+   */
   NodeCommandBuilder nodeJsArgs(String... nodeJsArgs);
 
   NodeCommandBuilder script(String scriptFilename);
 
+  /**
+   * Adds additional script arguments. This does not replace previously set script arguments.
+   * Use {@link NodeCommandBuilder#reset()} to reset the builder in cases in which you are
+   * reusing it.
+   *
+   * @return this
+   */
   NodeCommandBuilder scriptArgs(String... args);
 
   NodeCommandBuilder outputConsumer(Consumer<String> consumer);
@@ -47,4 +61,12 @@ public interface NodeCommandBuilder {
   NodeCommandBuilder pathResolver(BundlePathResolver pathResolver);
 
   NodeCommand build() throws IOException;
+
+  /**
+   * Resets the state of the builder as if none of the {@link NodeCommandBuilder} APIs
+   * have been used before.
+   *
+   * @return this
+   */
+  NodeCommandBuilder reset();
 }

--- a/nodejs-utils/src/main/java/org/sonarsource/nodejs/NodeCommandBuilderImpl.java
+++ b/nodejs-utils/src/main/java/org/sonarsource/nodejs/NodeCommandBuilderImpl.java
@@ -53,16 +53,31 @@ class NodeCommandBuilderImpl implements NodeCommandBuilder {
   private final NodeCommand.ProcessWrapper processWrapper;
   private Integer minNodeVersion;
   private Configuration configuration;
-  private List<String> args = new ArrayList<>();
-  private List<String> nodeJsArgs = new ArrayList<>();
-  private Consumer<String> outputConsumer = LOG::info;
-  private Consumer<String> errorConsumer = LOG::error;
+  private List<String> args;
+  private List<String> nodeJsArgs;
+  private Consumer<String> outputConsumer;
+  private Consumer<String> errorConsumer;
   private String scriptFilename;
   private BundlePathResolver pathResolver;
   private int actualNodeVersion;
 
   NodeCommandBuilderImpl(NodeCommand.ProcessWrapper processWrapper) {
     this.processWrapper = processWrapper;
+    reset();
+  }
+
+  @Override
+  public NodeCommandBuilder reset() {
+    minNodeVersion = null;
+    configuration = null;
+    args = new ArrayList<>();
+    nodeJsArgs = new ArrayList<>();
+    outputConsumer = LOG::info;
+    errorConsumer = LOG::error;
+    scriptFilename = null;
+    pathResolver = null;
+    actualNodeVersion = 0;
+    return this;
   }
 
   @Override

--- a/nodejs-utils/src/test/java/org/sonarsource/nodejs/NodeCommandTest.java
+++ b/nodejs-utils/src/test/java/org/sonarsource/nodejs/NodeCommandTest.java
@@ -355,6 +355,21 @@ public class NodeCommandTest {
   }
 
   @Test
+  public void test_reset() throws IOException {
+    when(mockProcessWrapper.isMac()).thenReturn(false);
+    NodeCommand nodeCommand = NodeCommand.builder(mockProcessWrapper)
+      .nodeJsArgs("--verbose")
+      .scriptArgs("arg1", "arg2")
+      .reset()
+      .scriptArgs("newArg1", "newArg2")
+      .nodeJsArgs("-v")
+      .script("script.js")
+      .build();
+
+    assertThat(nodeCommand.toString()).endsWith("node -v script.js newArg1 newArg2");
+  }
+
+  @Test
   public void test_command_on_mac() throws Exception {
     if (System.getProperty("os.name").toLowerCase().contains("win")) {
       // we can't test this on Windows as we are setting permissions

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImpl.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImpl.java
@@ -56,7 +56,7 @@ public class EslintBridgeServerImpl implements EslintBridgeServer {
 
   private static final int DEFAULT_TIMEOUT_SECONDS = 5 * 60;
   // internal property to set "--max-old-space-size" for Node process running this server
-  private static final String MAX_OLD_SPACE_SIZE_PROPERTY = "sonar.javascript.node.maxspace";
+  static final String MAX_OLD_SPACE_SIZE_PROPERTY = "sonar.javascript.node.maxspace";
   private static final String ALLOW_TS_PARSER_JS_FILES = "sonar.javascript.allowTsParserJsFiles";
   private static final Gson GSON = new Gson();
   private static final int MIN_NODE_VERSION = 8;
@@ -152,6 +152,7 @@ public class EslintBridgeServerImpl implements EslintBridgeServer {
       LOG.info("Running in SonarLint context, metrics will not be computed.");
     }
     nodeCommandBuilder
+      .reset()
       .outputConsumer(message -> {
         if (message.startsWith("DEBUG")) {
           LOG.debug(message.substring(5).trim());


### PR DESCRIPTION
# Why

the ESLint bridge server might need restarts as part of a single
scan. The scanner is trying to achieve this and currently always fails.
This is the case because the script arguments passed to the Node.js
process from the Java process are duplicated on subsequent starts. The
following excerpt from a scan log nicely shows this:

```
14:08:04.672 DEBUG: Starting Node.js process to start eslint-bridge server at port 39139
14:08:04.673 DEBUG: Launching command node --max-old-space-size=8192 --max-old-space-size=8192 /usr/src/.scannerwork/.sonartmp/eslint-bridge-bundle/package/bin/server 37023 127.0.0.1 /usr/src/.scannerwork true  39139 127.0.0.1 /usr/src/.scannerwork true
14:08:11.554 DEBUG: starting eslint-bridge server at port 37023
14:08:11.673 DEBUG: eslint-bridge server is running at port 37023
14:13:04.771 ERROR: Failed to start server (300s timeout)
org.sonarsource.nodejs.NodeCommandException: Failed to start server (300s timeout)
```

Note how the `Launching command node` log line lists all Node.js and script
arguments twice. This is the result of a missing reset of the `NodeCommandBuilder`.

# What

In order to keep my changes for this bugfix as small as possible, I opted
for an API to reset the `NodeCommandBuilder` state. This API is now used
before the `EslintBridgeServerImpl` constructs the Node.js command. This
then fixes `EslintBridgeServer` restarts.

# Future Work

`NodeCommandBuilder` is currently part of the dependency injection context.
This in itself is problematic and should be reconsidered. Maybe instead of
injecting a `NodeCommandBuilder`, instead inject `NodeCommand.ProcessWrapper`
and manually create a `NodeCommandBuilder` instance whenever necessary?

# References

 - [Bug Report](https://community.sonarsource.com/t/eslint-bridge-server-restarts-fail-due-to-missing-script-argument-resets/47292)

Fixes #47292
