### PR TITLE
Drop deprecated TypeScript properties: `sonar.typescript.lcov.reportPaths`, `sonar.typescript.node`, `sonar.typescript.eslint.reportPaths`

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
@@ -92,27 +92,6 @@ public class CoverageTest {
   }
 
   @Test
-  public void LCOV_report_paths_deprecated_key() {
-    final String projectKey = "LcovReportPathsDeprecatedKey";
-    SonarScanner build = Tests.createScanner()
-      .setProjectDir(TestUtils.projectDir("lcov"))
-      .setProjectKey(projectKey)
-      .setProjectName(projectKey)
-      .setProjectVersion("1.0")
-      .setSourceDirs(".")
-      .setProperty("sonar.typescript.lcov.reportPaths", TestUtils.file("projects/lcov/coverage.lcov").getAbsolutePath());
-    Tests.setEmptyProfile(projectKey);
-    BuildResult result = orchestrator.executeBuild(build);
-
-    assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(7);
-    assertThat(getMeasureAsInt(projectKey, "uncovered_lines")).isEqualTo(1);
-    assertThat(getMeasureAsInt(projectKey, "conditions_to_cover")).isEqualTo(4);
-    assertThat(getMeasureAsInt(projectKey, "uncovered_conditions")).isEqualTo(1);
-
-    assertThat(result.getLogs()).contains("The use of sonar.typescript.lcov.reportPaths for coverage import is deprecated, use sonar.javascript.lcov.reportPaths instead.");
-  }
-
-  @Test
   public void zero_coverage() {
     final String projectKey = "ZeroCoverage";
     SonarScanner build = Tests.createScanner()

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -129,21 +128,6 @@ public class SonarLintTest {
     List<Issue> issues = analyze("foo.ts", "x = true ? 42 : 42");
     assertThat(issues).isEmpty();
     assertThat(LOGS).contains("No tsconfig.json file found, analysis will be skipped.");
-  }
-
-  @Test
-  public void should_log_deprecation_for_typescript_node_property() throws Exception {
-    List<Issue> issues = new ArrayList<>();
-
-    StandaloneAnalysisConfiguration configuration = StandaloneAnalysisConfiguration.builder()
-      .setBaseDir(baseDir.toPath())
-      .addInputFile(TestUtils.prepareInputFile(baseDir, FILE_PATH, "let x = true ? 42 : 42"))
-      .putExtraProperty("sonar.typescript.node", "some/node").build();
-    sonarlintEngine.analyze(configuration, issues::add, null, null);
-    assertThat(issues).extracting(Issue::getRuleKey).containsExactly("javascript:S3923");
-    assertThat(LOGS.stream().anyMatch(s -> s.matches("The use of sonar\\.typescript\\.node is deprecated, use sonar\\.nodejs\\.executable instead\\."))).isTrue();
-    // we are forced to properly set `sonar.nodejs.executable` as its version is checked by SonarLint at plugin load stage
-    assertThat(LOGS.stream().anyMatch(s -> s.matches("Using Node\\.js executable .* from property sonar\\.nodejs\\.executable\\."))).isTrue();
   }
 
   @Test

--- a/nodejs-utils/src/main/java/org/sonarsource/nodejs/NodeCommandBuilderImpl.java
+++ b/nodejs-utils/src/main/java/org/sonarsource/nodejs/NodeCommandBuilderImpl.java
@@ -48,7 +48,6 @@ public class NodeCommandBuilderImpl implements NodeCommandBuilder {
   private static final String NODE_EXECUTABLE_DEFAULT_MACOS = "package/node_modules/run-node/run-node";
 
   private static final String NODE_EXECUTABLE_PROPERTY = "sonar.nodejs.executable";
-  private static final String NODE_EXECUTABLE_PROPERTY_TS = "sonar.typescript.node";
 
   private static final Pattern NODEJS_VERSION_PATTERN = Pattern.compile("v?(\\d+)\\.\\d+\\.\\d+");
 
@@ -188,31 +187,15 @@ public class NodeCommandBuilderImpl implements NodeCommandBuilder {
   }
 
   private String retrieveNodeExecutableFromConfig(@Nullable Configuration configuration) throws NodeCommandException, IOException {
-    if (configuration != null) {
-      String nodeExecutable = null;
-      String usedProperty = null;
-
-      if (configuration.hasKey(NODE_EXECUTABLE_PROPERTY_TS)) {
-        LOG.warn("The use of " + NODE_EXECUTABLE_PROPERTY_TS + " is deprecated, use "
-          + NODE_EXECUTABLE_PROPERTY + " instead.");
-        usedProperty = NODE_EXECUTABLE_PROPERTY_TS;
-        nodeExecutable = configuration.get(NODE_EXECUTABLE_PROPERTY_TS).get();
-      }
-
-      if (configuration.hasKey(NODE_EXECUTABLE_PROPERTY)) {
-        usedProperty = NODE_EXECUTABLE_PROPERTY;
-        nodeExecutable = configuration.get(NODE_EXECUTABLE_PROPERTY).get();
-      }
-
-      if (nodeExecutable != null) {
-        File file = new File(nodeExecutable);
-        if (file.exists()) {
-          LOG.info("Using Node.js executable {} from property {}.", file.getAbsoluteFile(), usedProperty);
-          return nodeExecutable;
-        } else {
-          LOG.error("Provided Node.js executable file does not exist. Property '{}' was set to '{}'", usedProperty, nodeExecutable);
-          throw new NodeCommandException("Provided Node.js executable file does not exist.");
-        }
+    if (configuration != null && configuration.hasKey(NODE_EXECUTABLE_PROPERTY)) {
+      String nodeExecutable = configuration.get(NODE_EXECUTABLE_PROPERTY).get();
+      File file = new File(nodeExecutable);
+      if (file.exists()) {
+        LOG.info("Using Node.js executable {} from property {}.", file.getAbsoluteFile(), NODE_EXECUTABLE_PROPERTY);
+        return nodeExecutable;
+      } else {
+        LOG.error("Provided Node.js executable file does not exist. Property '{}' was set to '{}'", NODE_EXECUTABLE_PROPERTY, nodeExecutable);
+        throw new NodeCommandException("Provided Node.js executable file does not exist.");
       }
     }
 

--- a/nodejs-utils/src/test/java/org/sonarsource/nodejs/NodeCommandTest.java
+++ b/nodejs-utils/src/test/java/org/sonarsource/nodejs/NodeCommandTest.java
@@ -47,7 +47,6 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -186,48 +185,6 @@ public class NodeCommandTest {
   }
 
   @Test
-  public void test_node_with_deprecated_key() throws Exception {
-    String NODE_EXECUTABLE_PROPERTY_TS = "sonar.typescript.node";
-    File nodeExecutable = temporaryFolder.newFile("custom-node");
-    MapSettings mapSettings = new MapSettings();
-    mapSettings.setProperty(NODE_EXECUTABLE_PROPERTY_TS, nodeExecutable.getAbsolutePath());
-    Configuration configuration = mapSettings.asConfig();
-    NodeCommand nodeCommand = NodeCommand.builder(mockProcessWrapper)
-      .configuration(configuration)
-      .script("not-used")
-      .build();
-    nodeCommand.start();
-
-    assertThat(captureProcessWrapperArgument()).contains(nodeExecutable.getAbsolutePath());
-    await().until(() -> logTester.logs(LoggerLevel.WARN)
-      .contains("The use of " + NODE_EXECUTABLE_PROPERTY_TS + " is deprecated, use sonar.nodejs.executable instead."));
-    await().until(() -> logTester.logs(LoggerLevel.INFO)
-      .contains("Using Node.js executable " + nodeExecutable.getAbsolutePath() + " from property " + NODE_EXECUTABLE_PROPERTY_TS + "."));
-  }
-
-  @Test
-  public void test_node_with_both_key() throws Exception {
-    String NODE_EXECUTABLE_PROPERTY_TS = "sonar.typescript.node";
-    String NODE_EXECUTABLE_PROPERTY = "sonar.typescript.node";
-    File nodeExecutable = temporaryFolder.newFile("custom-node");
-    MapSettings mapSettings = new MapSettings();
-    mapSettings.setProperty(NODE_EXECUTABLE_PROPERTY, nodeExecutable.getAbsolutePath());
-    mapSettings.setProperty(NODE_EXECUTABLE_PROPERTY_TS, nodeExecutable.getAbsolutePath());
-    Configuration configuration = mapSettings.asConfig();
-    NodeCommand nodeCommand = NodeCommand.builder(mockProcessWrapper)
-      .configuration(configuration)
-      .script("not-used")
-      .build();
-    nodeCommand.start();
-
-    assertThat(captureProcessWrapperArgument()).contains(nodeExecutable.getAbsolutePath());
-    await().until(() -> logTester.logs(LoggerLevel.WARN)
-      .contains("The use of " + NODE_EXECUTABLE_PROPERTY_TS + " is deprecated, use sonar.nodejs.executable instead."));
-    await().until(() -> logTester.logs(LoggerLevel.INFO)
-      .contains("Using Node.js executable " + nodeExecutable.getAbsolutePath() + " from property " + NODE_EXECUTABLE_PROPERTY + "."));
-  }
-
-  @Test
   public void test_empty_configuration() throws Exception {
     NodeCommand nodeCommand = NodeCommand.builder(mockProcessWrapper)
       .configuration(new MapSettings().asConfig())
@@ -258,22 +215,6 @@ public class NodeCommandTest {
 
     await().until(() -> logTester.logs(LoggerLevel.ERROR)
       .contains("Provided Node.js executable file does not exist. Property 'sonar.nodejs.executable' was set to 'non-existing-file'"));
-  }
-
-  @Test
-  public void test_non_existing_node_file_deprecated_key() throws Exception {
-    MapSettings settings = new MapSettings();
-    settings.setProperty("sonar.typescript.node", "non-existing-file");
-    NodeCommandBuilder nodeCommand = NodeCommand.builder(mockProcessWrapper)
-      .configuration(settings.asConfig())
-      .script("not-used");
-
-    assertThatThrownBy(nodeCommand::build)
-      .isInstanceOf(NodeCommandException.class)
-      .hasMessage("Provided Node.js executable file does not exist.");
-
-    await().until(() -> logTester.logs(LoggerLevel.ERROR)
-      .contains("Provided Node.js executable file does not exist. Property 'sonar.typescript.node' was set to 'non-existing-file'"));
   }
 
   @Test

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -75,11 +75,7 @@ public class JavaScriptPlugin implements Plugin {
   public static final String ESLINT_REPORT_PATHS = "sonar.eslint.reportPaths";
   public static final String TSLINT_REPORT_PATHS = "sonar.typescript.tslint.reportPaths";
 
-  public static final String DEPRECATED_ESLINT_PROPERTY = "sonar.typescript.eslint.reportPaths";
-
   private static final String FILE_SUFFIXES_DESCRIPTION = "List of suffixes for files to analyze.";
-
-  public static final String TS_LCOV_REPORT_PATHS = "sonar.typescript.lcov.reportPaths";
 
   public static final String TSCONFIG_PATH = "sonar.typescript.tsconfigPath";
   public static final String PROPERTY_KEY_MAX_FILE_SIZE = "sonar.javascript.maxFileSize";

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/CoverageSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/CoverageSensor.java
@@ -48,7 +48,7 @@ public class CoverageSensor implements Sensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .onlyOnLanguages(JavaScriptLanguage.KEY, TypeScriptLanguage.KEY)
-      .onlyWhenConfiguration(conf -> conf.hasKey(JavaScriptPlugin.LCOV_REPORT_PATHS) || conf.hasKey(JavaScriptPlugin.TS_LCOV_REPORT_PATHS))
+      .onlyWhenConfiguration(conf -> conf.hasKey(JavaScriptPlugin.LCOV_REPORT_PATHS))
       .name("JavaScript/TypeScript Coverage")
       .onlyOnFileType(Type.MAIN);
   }
@@ -56,13 +56,6 @@ public class CoverageSensor implements Sensor {
   @Override
   public void execute(SensorContext context) {
     Set<String> reports = new HashSet<>(Arrays.asList(context.config().getStringArray(JavaScriptPlugin.LCOV_REPORT_PATHS)));
-
-    if (context.config().hasKey(JavaScriptPlugin.TS_LCOV_REPORT_PATHS)) {
-      LOG.warn("The use of " + JavaScriptPlugin.TS_LCOV_REPORT_PATHS + " for coverage import is deprecated, use "
-        + JavaScriptPlugin.LCOV_REPORT_PATHS + " instead.");
-      reports.addAll(Arrays.asList(context.config().getStringArray(JavaScriptPlugin.TS_LCOV_REPORT_PATHS)));
-    }
-
     List<File> lcovFiles = getLcovFiles(context.fileSystem().baseDir(), reports);
     if (lcovFiles.isEmpty()) {
       LOG.warn("No coverage information will be saved because all LCOV files cannot be found.");

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorTest.java
@@ -48,7 +48,6 @@ public class CoverageSensorTest {
   private static final String REPORT2 = "reports/report_2.lcov";
   private static final String TWO_REPORTS = REPORT1 + ", " + REPORT2;
 
-  private final String DEPRECATED_MESSAGE = "The use of sonar.typescript.lcov.reportPaths for coverage import is deprecated, use sonar.javascript.lcov.reportPaths instead.";
   private SensorContextTester context;
   private MapSettings settings;
   @ClassRule
@@ -100,36 +99,6 @@ public class CoverageSensorTest {
     settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, TWO_REPORTS);
     coverageSensor.execute(context);
     assertTwoReportsCoverageDataPresent();
-  }
-
-  @Test
-  public void should_work_and_log_warning_when_deprecated_key() throws Exception {
-    settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, "");
-    settings.setProperty(JavaScriptPlugin.TS_LCOV_REPORT_PATHS, TWO_REPORTS);
-    coverageSensor.execute(context);
-
-    assertTwoReportsCoverageDataPresent();
-    assertThat(logTester.logs(LoggerLevel.WARN)).contains(DEPRECATED_MESSAGE);
-  }
-
-  @Test
-  public void should_include_coverage_from_both_key() throws Exception {
-    settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, REPORT1);
-    settings.setProperty(JavaScriptPlugin.TS_LCOV_REPORT_PATHS, REPORT2);
-    coverageSensor.execute(context);
-
-    assertTwoReportsCoverageDataPresent();
-    assertThat(logTester.logs(LoggerLevel.WARN)).contains(DEPRECATED_MESSAGE);
-  }
-
-  @Test
-  public void both_properties_reports_paths_overlap() throws Exception {
-    settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, TWO_REPORTS);
-    settings.setProperty(JavaScriptPlugin.TS_LCOV_REPORT_PATHS, TWO_REPORTS);
-    coverageSensor.execute(context);
-
-    assertTwoReportsCoverageDataPresent();
-    assertThat(logTester.logs(LoggerLevel.WARN)).contains(DEPRECATED_MESSAGE);
   }
 
   private void assertTwoReportsCoverageDataPresent() {
@@ -217,7 +186,6 @@ public class CoverageSensorTest {
     assertThat(descriptor.languages()).contains("js", "ts");
     assertThat(descriptor.type()).isEqualTo(Type.MAIN);
     assertThat(descriptor.configurationPredicate().test(new MapSettings().setProperty("sonar.javascript.lcov.reportPaths", "foo").asConfig())).isTrue();
-    assertThat(descriptor.configurationPredicate().test(new MapSettings().setProperty("sonar.typescript.lcov.reportPaths", "foo").asConfig())).isTrue();
     assertThat(descriptor.configurationPredicate().test(new MapSettings().asConfig())).isFalse();
   }
 


### PR DESCRIPTION
Fixes #2758 
