### PR TITLE
Migrate to JUnit 5 API and SQ 8.9 API

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,7 +96,7 @@ plugin_qa_task:
     SONARSOURCE_QA: true
     matrix:
       - SQ_VERSION: LATEST_RELEASE
-      - SQ_VERSION: LATEST_RELEASE[7.9]
+      - SQ_VERSION: LATEST_RELEASE[8.9]
       - SQ_VERSION: DOGFOOD
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -74,7 +74,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <includes>
-            <include>**/Test.java</include>
+            <include>**/*Test.java</include>
           </includes>
         </configuration>
       </plugin>

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -36,12 +36,18 @@
       <version>${sonar.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sonarlint.core</groupId>
       <artifactId>sonarlint-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -36,13 +36,13 @@
       <version>${sonar.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api-impl</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarlint.core</groupId>
-      <artifactId>sonarlint-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -74,9 +74,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <includes>
-            <include>**/Tests.java</include>
-            <include>**/TypeScriptRuleTest.java</include>
-            <include>**/EslintCustomRulesTest.java</include>
+            <include>**/Test.java</include>
           </includes>
         </configuration>
       </plugin>

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
@@ -26,25 +26,25 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static com.sonar.javascript.it.plugin.Tests.getMeasureAsInt;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getMeasureAsInt;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class CoverageTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   @Test
   public void LCOV_path_can_be_relative() {
     final String projectKey = "LcovPathCanBeRelative";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1.0")
       .setSourceDirs(".")
       .setProperty("sonar.javascript.lcov.reportPaths", "coverage.lcov");
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     orchestrator.executeBuild(build);
 
     assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(7);
@@ -56,14 +56,14 @@ public class CoverageTest {
   @Test
   public void LCOV_path_can_be_absolute() {
     final String projectKey = "LcovPathCanBeAbsolute";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1.0")
       .setSourceDirs(".")
       .setProperty("sonar.javascript.lcov.reportPaths", TestUtils.file("projects/lcov/coverage.lcov").getAbsolutePath());
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     orchestrator.executeBuild(build);
 
     assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(7);
@@ -75,14 +75,14 @@ public class CoverageTest {
   @Test
   public void LCOV_report_paths() {
     final String projectKey = "LcovReportPaths";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1.0")
       .setSourceDirs(".")
       .setProperty("sonar.javascript.lcov.reportPaths", TestUtils.file("projects/lcov/coverage.lcov").getAbsolutePath());
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     orchestrator.executeBuild(build);
 
     assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(7);
@@ -94,14 +94,14 @@ public class CoverageTest {
   @Test
   public void zero_coverage() {
     final String projectKey = "ZeroCoverage";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1.0")
       .setSourceDirs(".");
 
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     orchestrator.executeBuild(build);
 
     assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(5);
@@ -114,13 +114,13 @@ public class CoverageTest {
   @Test
   public void no_coverage_information_saved() {
     final String projectKey = "NoCoverageInfo";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1.0")
       .setSourceDirs(".");
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     orchestrator.executeBuild(build);
 
 
@@ -134,7 +134,7 @@ public class CoverageTest {
   // SONARJS-301
   public void print_log_for_not_found_resource() {
     final String projectKey = "PrintLogForNotFoundResource";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
@@ -142,7 +142,7 @@ public class CoverageTest {
       .setSourceDirs(".")
       .setProperty("sonar.javascript.lcov.reportPaths", TestUtils.file("projects/lcov/coverage-wrong-file-name.lcov").getAbsolutePath())
       .setDebugLogs(true);
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     BuildResult result = orchestrator.executeBuild(build);
 
     // Check that a log is printed
@@ -156,7 +156,7 @@ public class CoverageTest {
   // SONARJS-547
   public void wrong_line_in_report() {
     final String projectKey = "WrongLineInReport";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
@@ -164,7 +164,7 @@ public class CoverageTest {
       .setSourceDirs(".")
       .setDebugLogs(true)
       .setProperty("sonar.javascript.lcov.reportPaths", TestUtils.file("projects/lcov/coverage-wrong-line.lcov").getAbsolutePath());
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     BuildResult result = orchestrator.executeBuild(build);
 
     // Check that a log is printed
@@ -181,7 +181,7 @@ public class CoverageTest {
   @Test
   public void conditions_on_non_executable_lines() {
     final String projectKey = "ConditionsOnNonExecutableLines";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov-jsx"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
@@ -189,7 +189,7 @@ public class CoverageTest {
       .setSourceDirs(".")
       .setDebugLogs(true)
       .setProperty("sonar.javascript.lcov.reportPaths", TestUtils.file("projects/lcov-jsx/conditions-on-non-executable-lines.lcov").getAbsolutePath());
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     orchestrator.executeBuild(build);
 
     assertThat(getMeasureAsInt(projectKey, "lines_to_cover")).isEqualTo(3);
@@ -201,14 +201,14 @@ public class CoverageTest {
   @Test
   public void wildcard_LCOV_report_paths() {
     final String projectKey = "LcovWildcardReportPaths";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("lcov-wildcard"))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1.0")
       .setSourceDirs(".")
       .setProperty("sonar.javascript.lcov.reportPaths", "foo.lcov,bar/*.lcov,**/qux/*.lcov");
-    Tests.setEmptyProfile(projectKey);
+    OrchestratorStarter.setEmptyProfile(projectKey);
     orchestrator.executeBuild(build);
 
     assertThat(getMeasureAsInt(projectKey + ":foo.js", "uncovered_lines")).isEqualTo(1);

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
@@ -24,7 +24,7 @@ import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.regex.Pattern;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.sonar.javascript.it.plugin.Tests.getMeasureAsInt;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CoverageTest.java
@@ -23,16 +23,16 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.regex.Pattern;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static com.sonar.javascript.it.plugin.Tests.getMeasureAsInt;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class CoverageTest {
 
-  @ClassRule
-  public static Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
   @Test
   public void LCOV_path_can_be_relative() {

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ECMAScriptModulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ECMAScriptModulesTest.java
@@ -24,7 +24,7 @@ import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Issues;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ECMAScriptModulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ECMAScriptModulesTest.java
@@ -23,17 +23,17 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
 import java.util.List;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class ECMAScriptModulesTest {
 
-  @ClassRule
-  public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
   private static final File PROJECT_DIR = TestUtils.projectDir("esm-project");
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ECMAScriptModulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ECMAScriptModulesTest.java
@@ -27,13 +27,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 
-import static com.sonar.javascript.it.plugin.Tests.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class ECMAScriptModulesTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   private static final File PROJECT_DIR = TestUtils.projectDir("esm-project");
 
@@ -46,7 +46,7 @@ public class ECMAScriptModulesTest {
       .setSourceDirs(".")
       .setProjectDir(PROJECT_DIR);
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "js");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "js");
     orchestrator.executeBuild(build);
 
     List<Issues.Issue> issuesList = getIssues(projectKey);

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBasedRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBasedRulesTest.java
@@ -31,8 +31,8 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.List;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.SearchRequest;
 import org.sonarsource.analyzer.commons.ProfileGenerator;
@@ -41,10 +41,10 @@ import static com.sonar.javascript.it.plugin.Tests.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class EslintBasedRulesTest {
 
-  @ClassRule
-  public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
   @Test
   public void test_without_ts() {

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBasedRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBasedRulesTest.java
@@ -32,7 +32,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.SearchRequest;
 import org.sonarsource.analyzer.commons.ProfileGenerator;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBasedRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBasedRulesTest.java
@@ -37,14 +37,14 @@ import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.SearchRequest;
 import org.sonarsource.analyzer.commons.ProfileGenerator;
 
-import static com.sonar.javascript.it.plugin.Tests.newWsClient;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class EslintBasedRulesTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   @Test
   public void test_without_ts() {
@@ -70,14 +70,14 @@ public class EslintBasedRulesTest {
       "javascript", new ProfileGenerator.RulesConfiguration(), new HashSet<>());
     orchestrator.getServer().restoreProfile(FileLocation.of(jsProfile));
 
-    Tests.setProfile(projectKey, "rules", "js");
+    OrchestratorStarter.setProfile(projectKey, "rules", "js");
 
     BuildResult buildResult = orchestrator.executeBuild(build);
     assertThat(buildResult.getLogsLines(l -> l.startsWith("ERROR"))).isEmpty();
 
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList(projectKey)).setRules(singletonList("javascript:S3923"));
-    List<Issue> issuesList = newWsClient(Tests.ORCHESTRATOR).issues().search(request).getIssuesList();
+    List<Issue> issuesList = newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList();
     assertThat(issuesList).hasSize(1);
     assertThat(issuesList.get(0).getLine()).isEqualTo(1);
   }
@@ -91,13 +91,13 @@ public class EslintBasedRulesTest {
       .setSourceDirs(".")
       .setProjectDir(TestUtils.projectDir("(dir with paren)/eslint_based_rules"));
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "js");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "js");
 
     orchestrator.executeBuild(build);
 
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList(projectKey)).setRules(singletonList("javascript:S3923"));
-    List<Issue> issuesList = newWsClient(Tests.ORCHESTRATOR).issues().search(request).getIssuesList();
+    List<Issue> issuesList = newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList();
     assertThat(issuesList).hasSize(1);
     assertThat(issuesList.get(0).getLine()).isEqualTo(5);
   }
@@ -111,13 +111,13 @@ public class EslintBasedRulesTest {
       .setSourceDirs(".")
       .setProjectDir(TestUtils.projectDir("js-with-ts-eslint-project"));
 
-    Tests.setProfile(projectKey, "js-with-ts-eslint-profile", "js");
+    OrchestratorStarter.setProfile(projectKey, "js-with-ts-eslint-profile", "js");
 
     orchestrator.executeBuild(build);
 
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList(projectKey)).setRules(singletonList("javascript:S3525"));
-    List<Issue> issuesList = newWsClient(Tests.ORCHESTRATOR).issues().search(request).getIssuesList();
+    List<Issue> issuesList = newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList();
     assertThat(issuesList).hasSize(1);
     assertThat(issuesList.get(0).getLine()).isEqualTo(2);
   }
@@ -136,7 +136,7 @@ public class EslintBasedRulesTest {
       "javascript", new ProfileGenerator.RulesConfiguration(), new HashSet<>());
     orchestrator.getServer().restoreProfile(FileLocation.of(jsProfile));
 
-    Tests.setProfile(projectKey, "rules", "js");
+    OrchestratorStarter.setProfile(projectKey, "rules", "js");
 
     BuildResult buildResult = orchestrator.executeBuild(build);
     assertThat(buildResult.getLogsLines(l -> l.startsWith("ERROR"))).isEmpty();

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBridgeIntegrationTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBridgeIntegrationTest.java
@@ -47,7 +47,7 @@ import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBridgeIntegrationTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBridgeIntegrationTest.java
@@ -46,9 +46,8 @@ import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.utils.IOUtils;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,21 +62,21 @@ import static org.awaitility.Awaitility.await;
  */
 public class EslintBridgeIntegrationTest {
 
-  @ClassRule
-  public static TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  Path temp;
 
   static Path pluginJar = Tests.JAVASCRIPT_PLUGIN_LOCATION.getFile().toPath();
   static final Gson gson = new Gson();
 
   @Test
   public void test() throws Exception {
-    Path dest = temp.newFolder().toPath();
+
     String filename = "eslint-bridge-1.0.0.tgz";
       EslintBridge eslintBridge = new EslintBridge();
     try (FileSystem fileSystem = FileSystems.newFileSystem(pluginJar, null)) {
       Path fileToExtract = fileSystem.getPath(filename);
-      extractArchive(fileToExtract, dest);
-      eslintBridge.start(dest);
+      extractArchive(fileToExtract, temp);
+      eslintBridge.start(temp);
       assertStatus(eslintBridge);
       eslintBridge.request(gson.toJson(InitLinter.build("sonar-no-unused-vars")), "init-linter");
       assertAnalyzeJs(eslintBridge);
@@ -93,7 +92,7 @@ public class EslintBridgeIntegrationTest {
       + "  var c; // NOSONAR\n"
       + "  var b = 42; \n"
       + "} \n";
-    r.filePath = temp.newFile().getAbsolutePath();
+    r.filePath = temp.resolve("file.js").toAbsolutePath().toString();
     String response = eslintBridge.request(gson.toJson(r), "analyze-js");
     JsonObject jsonObject = gson.fromJson(response, JsonObject.class);
     JsonArray issues = jsonObject.getAsJsonArray("issues");
@@ -150,7 +149,7 @@ public class EslintBridgeIntegrationTest {
   }
 
 
-  static class EslintBridge {
+  class EslintBridge {
     int port;
     final OkHttpClient client;
     private Process process;
@@ -163,7 +162,7 @@ public class EslintBridgeIntegrationTest {
     void start(Path dest) throws IOException {
       port = findOpenPort();
       String[] cmd = {"node", dest.resolve("package/bin/server").toString(), String.valueOf(port), "127.0.0.1",
-        temp.newFolder().getAbsolutePath(), "true", "true"};
+        temp.toString(), "true", "true"};
       ProcessBuilder pb = new ProcessBuilder(cmd);
       pb.inheritIO();
       process = pb.start();
@@ -201,7 +200,7 @@ public class EslintBridgeIntegrationTest {
         .build();
     }
 
-    static int findOpenPort() throws IOException {
+    int findOpenPort() throws IOException {
       try (ServerSocket socket = new ServerSocket(0)) {
         return socket.getLocalPort();
       }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBridgeIntegrationTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBridgeIntegrationTest.java
@@ -65,7 +65,7 @@ public class EslintBridgeIntegrationTest {
   @TempDir
   Path temp;
 
-  static Path pluginJar = Tests.JAVASCRIPT_PLUGIN_LOCATION.getFile().toPath();
+  static Path pluginJar = OrchestratorStarter.JAVASCRIPT_PLUGIN_LOCATION.getFile().toPath();
   static final Gson gson = new Gson();
 
   @Test

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
@@ -27,8 +27,8 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import org.assertj.core.groups.Tuple;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Common;
 import org.sonarqube.ws.Issues;
@@ -42,13 +42,13 @@ public class EslintCustomRulesTest {
 
   private static Orchestrator orchestrator;
 
-  @BeforeClass
+  @BeforeAll
   public static void before() {
     orchestrator = initOrchestrator(PLUGIN_ARTIFACT_ID);
   }
 
 
-  @AfterClass
+  @AfterAll
   public static void after() {
     orchestrator.stop();
   }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
@@ -34,7 +34,7 @@ import org.sonarqube.ws.Common;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.javascript.it.plugin.Tests.JAVASCRIPT_PLUGIN_LOCATION;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.JAVASCRIPT_PLUGIN_LOCATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EslintCustomRulesTest {
@@ -71,12 +71,12 @@ public class EslintCustomRulesTest {
   static List<Issue> findIssues(String ruleKey, Orchestrator orchestrator) {
     org.sonarqube.ws.client.issues.SearchRequest searchRequest = new org.sonarqube.ws.client.issues.SearchRequest();
     searchRequest.setRules(Collections.singletonList(ruleKey));
-    Issues.SearchWsResponse response = Tests.newWsClient(orchestrator).issues().search(searchRequest);
+    Issues.SearchWsResponse response = OrchestratorStarter.newWsClient(orchestrator).issues().search(searchRequest);
     return response.getIssuesList();
   }
 
   static BuildResult runBuild(Orchestrator orchestrator) {
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("custom_rules"))
       .setProjectKey("custom-rules")
       .setProjectName("Custom Rules")

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
@@ -29,7 +29,8 @@ import java.util.List;
 import org.assertj.core.groups.Tuple;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.sonarqube.ws.Common;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.Issues.Issue;
 
@@ -101,7 +102,7 @@ public class EslintCustomRulesTest {
         new Tuple("eslint-custom-rules:sqKey", "custom-rules:src/dir/Person.js", 21, "call"),
         new Tuple("eslint-custom-rules:sqKey", "custom-rules:src/dir/file.ts", 4, "call")
       );
-    Issues.Location secondaryLocation = issues.get(0).getFlows(0).getLocations(0);
+    Common.Location secondaryLocation = issues.get(0).getFlows(0).getLocations(0);
     assertThat(secondaryLocation.getMsg()).isEqualTo(new File(TestUtils.projectDir("custom_rules"), ".scannerwork").getAbsolutePath());
 
     issues = findIssues("ts-custom-rules:tsRuleKey", orchestrator);

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintReportTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintReportTest.java
@@ -27,7 +27,7 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintReportTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintReportTest.java
@@ -30,15 +30,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.javascript.it.plugin.Tests.getIssues;
-import static com.sonar.javascript.it.plugin.Tests.setEmptyProfile;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.setEmptyProfile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class EslintReportTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   private static final String PROJECT_KEY_PREFIX = "SonarJS-eslint-report-test";
   private static final File PROJECT_DIR = TestUtils.projectDir("eslint_report");
@@ -47,7 +47,7 @@ public class EslintReportTest {
   public void should_save_issues_from_external_report_with_relative_paths() {
     String projectKey = PROJECT_KEY_PREFIX + "-relative";
 
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(PROJECT_DIR)
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
@@ -64,7 +64,7 @@ public class EslintReportTest {
   @Test
   public void should_save_issues_from_external_report_with_absolute_paths() throws IOException {
     String projectKey = PROJECT_KEY_PREFIX + "-absolute";
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(PROJECT_DIR)
       .setProjectKey(projectKey)
       .setProjectName(projectKey)

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintReportTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintReportTest.java
@@ -26,8 +26,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;
@@ -35,10 +35,10 @@ import static com.sonar.javascript.it.plugin.Tests.setEmptyProfile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+@ExtendWith(Tests.class)
 public class EslintReportTest {
 
-  @ClassRule
-  public static Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
   private static final String PROJECT_KEY_PREFIX = "SonarJS-eslint-report-test";
   private static final File PROJECT_DIR = TestUtils.projectDir("eslint_report");

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MetricsTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MetricsTest.java
@@ -26,26 +26,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Measures.Measure;
 
-import static com.sonar.javascript.it.plugin.Tests.getMeasure;
-import static com.sonar.javascript.it.plugin.Tests.getMeasureAsDouble;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getMeasure;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getMeasureAsDouble;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class MetricsTest {
 
   private static final String PROJECT_KEY = "MetricsTest";
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   @BeforeAll
   public static void prepare() {
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("metrics"))
       .setProjectKey(PROJECT_KEY)
       .setProjectName(PROJECT_KEY)
       .setProjectVersion("1.0")
       .setSourceDirs("src");
-    Tests.setEmptyProfile(PROJECT_KEY);
+    OrchestratorStarter.setEmptyProfile(PROJECT_KEY);
     orchestrator.executeBuild(build);
   }
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MetricsTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MetricsTest.java
@@ -21,23 +21,23 @@ package com.sonar.javascript.it.plugin;
 
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Measures.Measure;
 
 import static com.sonar.javascript.it.plugin.Tests.getMeasure;
 import static com.sonar.javascript.it.plugin.Tests.getMeasureAsDouble;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class MetricsTest {
 
   private static final String PROJECT_KEY = "MetricsTest";
 
-  @ClassRule
-  public static Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
-  @BeforeClass
+  @BeforeAll
   public static void prepare() {
     SonarScanner build = Tests.createScanner()
       .setProjectDir(TestUtils.projectDir("metrics"))

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MetricsTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MetricsTest.java
@@ -23,7 +23,7 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Measures.Measure;
 
 import static com.sonar.javascript.it.plugin.Tests.getMeasure;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MinifiedFilesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MinifiedFilesTest.java
@@ -21,21 +21,21 @@ package com.sonar.javascript.it.plugin;
 
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static com.sonar.javascript.it.plugin.Tests.getMeasureAsInt;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class MinifiedFilesTest {
 
   private static final String PROJECT_KEY = "minifiedFilesTest";
 
-  @ClassRule
-  public static Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
-  @BeforeClass
+  @BeforeAll
   public static void prepare() {
     SonarScanner build = Tests.createScanner()
       .setProjectDir(TestUtils.projectDir("minified_files"))

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MinifiedFilesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MinifiedFilesTest.java
@@ -25,25 +25,25 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static com.sonar.javascript.it.plugin.Tests.getMeasureAsInt;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getMeasureAsInt;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class MinifiedFilesTest {
 
   private static final String PROJECT_KEY = "minifiedFilesTest";
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   @BeforeAll
   public static void prepare() {
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
       .setProjectDir(TestUtils.projectDir("minified_files"))
       .setProjectKey(PROJECT_KEY)
       .setProjectName(PROJECT_KEY)
       .setProjectVersion("1.0")
       .setSourceDirs("src");
-    Tests.setEmptyProfile(PROJECT_KEY);
+    OrchestratorStarter.setEmptyProfile(PROJECT_KEY);
     orchestrator.executeBuild(build);
   }
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MinifiedFilesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MinifiedFilesTest.java
@@ -23,7 +23,7 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.sonar.javascript.it.plugin.Tests.getMeasureAsInt;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MultiTsconfigTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MultiTsconfigTest.java
@@ -22,18 +22,18 @@ package com.sonar.javascript.it.plugin;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+@ExtendWith(Tests.class)
 public class MultiTsconfigTest {
 
-  @ClassRule
-  public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
   private static final String PROJECT = "multi-tsconfig-test-project";
   private static final File PROJECT_DIR = TestUtils.projectDir(PROJECT);

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MultiTsconfigTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MultiTsconfigTest.java
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.javascript.it.plugin.Tests.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class MultiTsconfigTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   private static final String PROJECT = "multi-tsconfig-test-project";
   private static final File PROJECT_DIR = TestUtils.projectDir(PROJECT);

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MultiTsconfigTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MultiTsconfigTest.java
@@ -23,7 +23,7 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/NoSonarTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/NoSonarTest.java
@@ -27,14 +27,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
-import static com.sonar.javascript.it.plugin.Tests.newWsClient;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class NoSonarTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   private static final File PROJECT_DIR = TestUtils.projectDir("nosonar");
 
@@ -49,7 +49,7 @@ public class NoSonarTest {
       .setSourceDirs(".")
       .setProjectDir(PROJECT_DIR);
 
-    Tests.setProfile(projectKey, "nosonar-profile", "js");
+    OrchestratorStarter.setProfile(projectKey, "nosonar-profile", "js");
 
     orchestrator.executeBuild(build);
   }
@@ -58,7 +58,7 @@ public class NoSonarTest {
   public void test() {
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList("nosonar-project")).setSeverities(singletonList("INFO")).setRules(singletonList("javascript:S1116"));
-    assertThat(newWsClient(Tests.ORCHESTRATOR).issues().search(request).getIssuesList()).hasSize(1);
+    assertThat(newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList()).hasSize(1);
   }
 
 }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/NoSonarTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/NoSonarTest.java
@@ -24,7 +24,7 @@ import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
 import static com.sonar.javascript.it.plugin.Tests.newWsClient;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/NoSonarTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/NoSonarTest.java
@@ -22,23 +22,23 @@ package com.sonar.javascript.it.plugin;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
 import static com.sonar.javascript.it.plugin.Tests.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class NoSonarTest {
 
-  @ClassRule
-  public static Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
   private static final File PROJECT_DIR = TestUtils.projectDir("nosonar");
 
-  @BeforeClass
+  @BeforeAll
   public static void startServer() {
     String projectKey = "nosonar-project";
     SonarScanner build = SonarScanner.create()

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithBOMTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithBOMTest.java
@@ -28,15 +28,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
-import static com.sonar.javascript.it.plugin.Tests.newWsClient;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class ProjectWithBOMTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   @Test
   public void test() {
@@ -47,13 +47,13 @@ public class ProjectWithBOMTest {
       .setSourceDirs(".")
       .setProjectDir(TestUtils.projectDir(projectKey));
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "js");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "js");
     BuildResult buildResult = orchestrator.executeBuild(build);
     assertThat(buildResult.getLogs()).doesNotContain("Failure during analysis");
 
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList(projectKey)).setRules(singletonList("javascript:S3923"));
-    List<Issues.Issue> issuesList = newWsClient(Tests.ORCHESTRATOR).issues().search(request).getIssuesList();
+    List<Issues.Issue> issuesList = newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList();
     assertThat(issuesList).extracting(Issues.Issue::getLine, Issues.Issue::getComponent, Issues.Issue::getRule)
       .containsExactly(tuple(1, "project-with-bom:fileWithBom.js", "javascript:S3923"));
   }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithBOMTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithBOMTest.java
@@ -23,8 +23,8 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.List;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
@@ -33,9 +33,10 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+@ExtendWith(Tests.class)
 public class ProjectWithBOMTest {
-  @ClassRule
-  public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
+
+  public static Orchestrator orchestrator;
 
   @Test
   public void test() {

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithBOMTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithBOMTest.java
@@ -24,7 +24,7 @@ import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithDifferentEncodingTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithDifferentEncodingTest.java
@@ -28,15 +28,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
-import static com.sonar.javascript.it.plugin.Tests.newWsClient;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class ProjectWithDifferentEncodingTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   @Test
   public void test() {
@@ -47,13 +47,13 @@ public class ProjectWithDifferentEncodingTest {
       .setSourceDirs(".")
       .setProjectDir(TestUtils.projectDir(projectKey));
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "js");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "js");
     BuildResult buildResult = orchestrator.executeBuild(build);
     assertThat(buildResult.getLogs()).doesNotContain("Failure during analysis");
 
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList(projectKey)).setRules(singletonList("javascript:S3923"));
-    List<Issues.Issue> issuesList = newWsClient(Tests.ORCHESTRATOR).issues().search(request).getIssuesList();
+    List<Issues.Issue> issuesList = newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList();
     assertThat(issuesList).extracting(Issues.Issue::getLine, Issues.Issue::getComponent, Issues.Issue::getRule)
       .containsExactly(tuple(2, projectKey + ":fileWithUtf16.js", "javascript:S3923"));
   }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithDifferentEncodingTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithDifferentEncodingTest.java
@@ -23,8 +23,8 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.List;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
@@ -33,9 +33,10 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+@ExtendWith(Tests.class)
 public class ProjectWithDifferentEncodingTest {
-  @ClassRule
-  public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
+
+  public static Orchestrator orchestrator;
 
   @Test
   public void test() {

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithDifferentEncodingTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithDifferentEncodingTest.java
@@ -24,7 +24,7 @@ import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
@@ -167,7 +167,7 @@ public class SonarLintTest {
     return StandaloneGlobalConfiguration.builder()
       .addEnabledLanguage(Language.JS)
       .addEnabledLanguage(Language.TS)
-      .addPlugin(Tests.JAVASCRIPT_PLUGIN_LOCATION.getFile().toURI().toURL())
+      .addPlugin(OrchestratorStarter.JAVASCRIPT_PLUGIN_LOCATION.getFile().toURI().toURL())
       .setSonarLintUserHome(sonarLintHome)
       .setLogOutput(logOutput)
       .setNodeJs(nodePath, nodeVersion)

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
@@ -63,13 +63,12 @@ public class SonarLintTest {
 
   @TempDir
   File baseDir;
-
   private static StandaloneGlobalConfiguration sonarLintConfig;
   private StandaloneSonarLintEngine sonarlintEngine = new StandaloneSonarLintEngineImpl(sonarLintConfig);
 
   @BeforeAll
-  public static void prepare(@TempDir Path sonarLintHome) throws Exception {
-    sonarLintConfig = getSonarLintConfig(sonarLintHome);
+  public static void prepare() throws Exception {
+    sonarLintConfig = getSonarLintConfig();
   }
 
   @AfterEach
@@ -127,9 +126,9 @@ public class SonarLintTest {
   }
 
   @Test
-  public void should_log_failure_only_once(@TempDir Path sonarLintHome) throws IOException {
+  public void should_log_failure_only_once() throws IOException {
     // version `42` will let us pass SonarLint check of version
-    sonarlintEngine = new StandaloneSonarLintEngineImpl(getSonarLintConfig(new File("invalid/path/node").toPath(), Version.create("42"), sonarLintHome));
+    sonarlintEngine = new StandaloneSonarLintEngineImpl(getSonarLintConfig(new File("invalid/path/node").toPath(), Version.create("42")));
     List<Issue> issues = analyze(FILE_PATH, "");
     assertThat(LOGS).contains("Provided Node.js executable file does not exist.");
     assertThat(issues).isEmpty();
@@ -151,14 +150,14 @@ public class SonarLintTest {
     return issues;
   }
 
-  private static StandaloneGlobalConfiguration getSonarLintConfig(Path sonarLintHome) throws IOException {
+  private static StandaloneGlobalConfiguration getSonarLintConfig() throws IOException {
     NodeJsHelper nodeJsHelper = new NodeJsHelper();
     nodeJsHelper.detect(null);
 
-    return getSonarLintConfig(nodeJsHelper.getNodeJsPath(), nodeJsHelper.getNodeJsVersion(), sonarLintHome);
+    return getSonarLintConfig(nodeJsHelper.getNodeJsPath(), nodeJsHelper.getNodeJsVersion());
   }
 
-  private static StandaloneGlobalConfiguration getSonarLintConfig(Path nodePath, Version nodeVersion, Path sonarLintHome) throws IOException {
+  private static StandaloneGlobalConfiguration getSonarLintConfig(Path nodePath, Version nodeVersion) throws IOException {
     LogOutput logOutput = (formattedMessage, level) -> {
       LOGS.add(formattedMessage);
       System.out.println(formattedMessage);
@@ -168,7 +167,6 @@ public class SonarLintTest {
       .addEnabledLanguage(Language.JS)
       .addEnabledLanguage(Language.TS)
       .addPlugin(OrchestratorStarter.JAVASCRIPT_PLUGIN_LOCATION.getFile().toURI().toURL())
-      .setSonarLintUserHome(sonarLintHome)
       .setLogOutput(logOutput)
       .setNodeJs(nodePath, nodeVersion)
       .build();

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
@@ -26,11 +26,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonarsource.sonarlint.core.NodeJsHelper;
 import org.sonarsource.sonarlint.core.StandaloneSonarLintEngineImpl;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestCodeAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestCodeAnalysisTest.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.SearchRequest;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestCodeAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestCodeAnalysisTest.java
@@ -25,13 +25,14 @@ import com.sonar.orchestrator.locator.FileLocation;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.SearchRequest;
 import org.sonarsource.analyzer.commons.ProfileGenerator;
@@ -47,15 +48,15 @@ import static com.sonar.javascript.it.plugin.Tests.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class TestCodeAnalysisTest {
   
   private static final String project = "test-code-project";
 
-  @ClassRule
-  public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
-  @ClassRule
-  public static final TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  Path sonarLintUserHome;
 
   @Test
   public void sonarqube() {
@@ -95,7 +96,7 @@ public class TestCodeAnalysisTest {
       .addEnabledLanguage(Language.JS)
       .addEnabledLanguage(Language.TS)
       .addPlugin(Tests.JAVASCRIPT_PLUGIN_LOCATION.getFile().toURI().toURL())
-      .setSonarLintUserHome(temp.newFolder().toPath())
+      .setSonarLintUserHome(sonarLintUserHome)
       .setNodeJs(nodeJsHelper.getNodeJsPath(), nodeJsHelper.getNodeJsVersion())
       .setLogOutput((formattedMessage, level) -> {
         System.out.println(formattedMessage);

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestCodeAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestCodeAnalysisTest.java
@@ -44,16 +44,16 @@ import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneAnalysisCo
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneGlobalConfiguration;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneSonarLintEngine;
 
-import static com.sonar.javascript.it.plugin.Tests.newWsClient;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class TestCodeAnalysisTest {
   
   private static final String project = "test-code-project";
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   @TempDir
   Path sonarLintUserHome;
@@ -74,7 +74,7 @@ public class TestCodeAnalysisTest {
       orchestrator.getServer().getUrl(), "js", "javascript", new ProfileGenerator.RulesConfiguration(), new HashSet<>());
     orchestrator.getServer().restoreProfile(FileLocation.of(jsProfile));
 
-    Tests.setProfile(project, "rules", "js");
+    OrchestratorStarter.setProfile(project, "rules", "js");
 
     orchestrator.executeBuild(build);
 
@@ -95,7 +95,7 @@ public class TestCodeAnalysisTest {
     StandaloneGlobalConfiguration globalConfig = StandaloneGlobalConfiguration.builder()
       .addEnabledLanguage(Language.JS)
       .addEnabledLanguage(Language.TS)
-      .addPlugin(Tests.JAVASCRIPT_PLUGIN_LOCATION.getFile().toURI().toURL())
+      .addPlugin(OrchestratorStarter.JAVASCRIPT_PLUGIN_LOCATION.getFile().toURI().toURL())
       .setSonarLintUserHome(sonarLintUserHome)
       .setNodeJs(nodeJsHelper.getNodeJsPath(), nodeJsHelper.getNodeJsVersion())
       .setLogOutput((formattedMessage, level) -> {

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TslintExternalReportTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TslintExternalReportTest.java
@@ -23,7 +23,7 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TslintExternalReportTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TslintExternalReportTest.java
@@ -22,19 +22,19 @@ package com.sonar.javascript.it.plugin;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.List;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class TslintExternalReportTest {
 
   private static final String PROJECT_KEY = "SonarJS-tslint-report-test";
 
-  @ClassRule
-  public static Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
   @Test
   public void should_save_issues_from_external_report() {

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TslintExternalReportTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TslintExternalReportTest.java
@@ -26,21 +26,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.javascript.it.plugin.Tests.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class TslintExternalReportTest {
 
   private static final String PROJECT_KEY = "SonarJS-tslint-report-test";
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   @Test
   public void should_save_issues_from_external_report() {
-    Tests.setEmptyProfile(PROJECT_KEY);
+    OrchestratorStarter.setEmptyProfile(PROJECT_KEY);
 
-    SonarScanner build = Tests.createScanner()
+    SonarScanner build = OrchestratorStarter.createScanner()
     .setProjectDir(TestUtils.projectDir("tslint-report-project"))
     .setProjectKey(PROJECT_KEY)
     .setProjectName(PROJECT_KEY)

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptAnalysisTest.java
@@ -25,18 +25,18 @@ import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+@ExtendWith(Tests.class)
 public class TypeScriptAnalysisTest {
 
-  @ClassRule
-  public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
   private static final File PROJECT_DIR = TestUtils.projectDir("tsproject");
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptAnalysisTest.java
@@ -29,14 +29,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.javascript.it.plugin.Tests.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class TypeScriptAnalysisTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
   private static final File PROJECT_DIR = TestUtils.projectDir("tsproject");
 
@@ -49,7 +49,7 @@ public class TypeScriptAnalysisTest {
       .setSourceDirs(".")
       .setProjectDir(PROJECT_DIR);
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "ts");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "ts");
     BuildResult result = orchestrator.executeBuild(build);
 
     String sampleFileKey = projectKey + ":sample.lint.ts";
@@ -57,17 +57,17 @@ public class TypeScriptAnalysisTest {
     assertThat(issuesList).hasSize(1);
     assertThat(issuesList.get(0).getLine()).isEqualTo(4);
 
-    assertThat(Tests.getMeasureAsInt(sampleFileKey, "ncloc")).isEqualTo(7);
-    assertThat(Tests.getMeasureAsInt(sampleFileKey, "classes")).isEqualTo(0);
-    assertThat(Tests.getMeasureAsInt(sampleFileKey, "functions")).isEqualTo(1);
-    assertThat(Tests.getMeasureAsInt(sampleFileKey, "statements")).isEqualTo(3);
-    assertThat(Tests.getMeasureAsInt(sampleFileKey, "comment_lines")).isEqualTo(1);
-    assertThat(Tests.getMeasureAsInt(sampleFileKey, "complexity")).isEqualTo(2);
-    assertThat(Tests.getMeasureAsInt(sampleFileKey, "cognitive_complexity")).isEqualTo(2);
+    assertThat(OrchestratorStarter.getMeasureAsInt(sampleFileKey, "ncloc")).isEqualTo(7);
+    assertThat(OrchestratorStarter.getMeasureAsInt(sampleFileKey, "classes")).isEqualTo(0);
+    assertThat(OrchestratorStarter.getMeasureAsInt(sampleFileKey, "functions")).isEqualTo(1);
+    assertThat(OrchestratorStarter.getMeasureAsInt(sampleFileKey, "statements")).isEqualTo(3);
+    assertThat(OrchestratorStarter.getMeasureAsInt(sampleFileKey, "comment_lines")).isEqualTo(1);
+    assertThat(OrchestratorStarter.getMeasureAsInt(sampleFileKey, "complexity")).isEqualTo(2);
+    assertThat(OrchestratorStarter.getMeasureAsInt(sampleFileKey, "cognitive_complexity")).isEqualTo(2);
 
-    assertThat(Tests.getMeasureAsDouble(projectKey, "duplicated_lines")).isEqualTo(111.0);
-    assertThat(Tests.getMeasureAsDouble(projectKey, "duplicated_blocks")).isEqualTo(2.0);
-    assertThat(Tests.getMeasureAsDouble(projectKey, "duplicated_files")).isEqualTo(1.0);
+    assertThat(OrchestratorStarter.getMeasureAsDouble(projectKey, "duplicated_lines")).isEqualTo(111.0);
+    assertThat(OrchestratorStarter.getMeasureAsDouble(projectKey, "duplicated_blocks")).isEqualTo(2.0);
+    assertThat(OrchestratorStarter.getMeasureAsDouble(projectKey, "duplicated_files")).isEqualTo(1.0);
 
     issuesList = getIssues(projectKey + ":nosonar.lint.ts");
     assertThat(issuesList).hasSize(1);
@@ -85,7 +85,7 @@ public class TypeScriptAnalysisTest {
       .setProjectDir(PROJECT_DIR)
       .setProperty("sonar.typescript.tsconfigPath", "custom.tsconfig.json");
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "ts");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "ts");
     BuildResult result = orchestrator.executeBuild(build);
 
     List<Issue> issuesList = getIssues(projectKey);
@@ -110,7 +110,7 @@ public class TypeScriptAnalysisTest {
       .setProjectDir(dir)
       .setDebugLogs(true);
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "ts");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "ts");
     BuildResult result = orchestrator.executeBuild(build);
 
     List<Issue> issuesList = getIssues(projectKey);
@@ -133,7 +133,7 @@ public class TypeScriptAnalysisTest {
       .setProjectDir(dir)
       .setDebugLogs(true);
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "ts");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "ts");
     BuildResult result = orchestrator.executeBuild(build);
 
     List<Issue> issuesList = getIssues(projectKey);
@@ -156,7 +156,7 @@ public class TypeScriptAnalysisTest {
       .setProjectDir(dir)
       .setDebugLogs(true);
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "ts");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "ts");
     BuildResult result = orchestrator.executeBuild(build);
 
     List<Issue> issuesList = getIssues(projectKey);

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptAnalysisTest.java
@@ -26,7 +26,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptRuleTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptRuleTest.java
@@ -31,7 +31,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonarsource.analyzer.commons.ProfileGenerator;
 
 import static com.sonar.javascript.it.plugin.Tests.JAVASCRIPT_PLUGIN_LOCATION;

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptRuleTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptRuleTest.java
@@ -29,8 +29,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.analyzer.commons.ProfileGenerator;
 
@@ -44,7 +44,7 @@ public class TypeScriptRuleTest {
 
   private static Orchestrator orchestrator;
 
-  @BeforeClass
+  @BeforeAll
   public static void before() throws IOException, InterruptedException {
     orchestrator = Orchestrator.builderEnv()
       .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE"))
@@ -73,7 +73,7 @@ public class TypeScriptRuleTest {
       .restoreProfile(FileLocation.ofClasspath("/empty-js-profile.xml"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void after() {
     orchestrator.stop();
   }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptRuleTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptRuleTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.analyzer.commons.ProfileGenerator;
 
-import static com.sonar.javascript.it.plugin.Tests.JAVASCRIPT_PLUGIN_LOCATION;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.JAVASCRIPT_PLUGIN_LOCATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeScriptRuleTest {

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
@@ -23,7 +23,7 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonarqube.ws.Issues;
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
@@ -21,21 +21,19 @@ package com.sonar.javascript.it.plugin;
 
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
-import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(Tests.class)
 public class VueAnalysisTest {
 
-  public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  public static Orchestrator orchestrator;
 
-  @TempDir
-  static Path tempDir;
 
   @Test
   public void sonarqube() {

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 
-import static com.sonar.javascript.it.plugin.Tests.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(OrchestratorStarter.class)
 public class VueAnalysisTest {
 
-  public static Orchestrator orchestrator;
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
 
 
   @Test
@@ -44,20 +44,20 @@ public class VueAnalysisTest {
       .setSourceDirs(".")
       .setProjectDir(TestUtils.projectDir(projectKey));
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "js");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "js");
     orchestrator.executeBuild(build);
 
     List<Issues.Issue> issuesList = getIssues(projectKey);
     assertThat(issuesList).hasSize(1);
     assertThat(issuesList.get(0).getLine()).isEqualTo(6);
 
-    assertThat(Tests.getMeasureAsInt(projectKey, "ncloc")).isEqualTo(7);
-    assertThat(Tests.getMeasureAsInt(projectKey, "classes")).isEqualTo(0);
-    assertThat(Tests.getMeasureAsInt(projectKey, "functions")).isEqualTo(0);
-    assertThat(Tests.getMeasureAsInt(projectKey, "statements")).isEqualTo(3);
-    assertThat(Tests.getMeasureAsInt(projectKey, "comment_lines")).isEqualTo(0);
-    assertThat(Tests.getMeasureAsInt(projectKey, "complexity")).isEqualTo(1);
-    assertThat(Tests.getMeasureAsInt(projectKey, "cognitive_complexity")).isEqualTo(2);
+    assertThat(OrchestratorStarter.getMeasureAsInt(projectKey, "ncloc")).isEqualTo(7);
+    assertThat(OrchestratorStarter.getMeasureAsInt(projectKey, "classes")).isEqualTo(0);
+    assertThat(OrchestratorStarter.getMeasureAsInt(projectKey, "functions")).isEqualTo(0);
+    assertThat(OrchestratorStarter.getMeasureAsInt(projectKey, "statements")).isEqualTo(3);
+    assertThat(OrchestratorStarter.getMeasureAsInt(projectKey, "comment_lines")).isEqualTo(0);
+    assertThat(OrchestratorStarter.getMeasureAsInt(projectKey, "complexity")).isEqualTo(1);
+    assertThat(OrchestratorStarter.getMeasureAsInt(projectKey, "cognitive_complexity")).isEqualTo(2);
   }
 
   @Test
@@ -69,7 +69,7 @@ public class VueAnalysisTest {
       .setSourceDirs(".")
       .setProjectDir(TestUtils.projectDir("vue-js-project-with-lang-js"));
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "js");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "js");
     orchestrator.executeBuild(build);
 
     List<Issues.Issue> issuesList = getIssues(projectKey);
@@ -86,18 +86,18 @@ public class VueAnalysisTest {
       .setSourceDirs(".")
       .setProjectDir(TestUtils.projectDir("vue-js-project-with-lang-ts"));
 
-    Tests.setProfile(projectKey, "eslint-based-rules-profile", "ts");
+    OrchestratorStarter.setProfile(projectKey, "eslint-based-rules-profile", "ts");
     orchestrator.executeBuild(build);
 
     // assert metrics on .vue file
     String vueFileKey = projectKey + ":file.vue";
-    assertThat(Tests.getMeasureAsInt(vueFileKey, "ncloc")).isEqualTo(7);
-    assertThat(Tests.getMeasureAsInt(vueFileKey, "classes")).isEqualTo(0);
-    assertThat(Tests.getMeasureAsInt(vueFileKey, "functions")).isEqualTo(0);
-    assertThat(Tests.getMeasureAsInt(vueFileKey, "statements")).isEqualTo(3);
-    assertThat(Tests.getMeasureAsInt(vueFileKey, "comment_lines")).isEqualTo(0);
-    assertThat(Tests.getMeasureAsInt(vueFileKey, "complexity")).isEqualTo(1);
-    assertThat(Tests.getMeasureAsInt(vueFileKey, "cognitive_complexity")).isEqualTo(2);
+    assertThat(OrchestratorStarter.getMeasureAsInt(vueFileKey, "ncloc")).isEqualTo(7);
+    assertThat(OrchestratorStarter.getMeasureAsInt(vueFileKey, "classes")).isEqualTo(0);
+    assertThat(OrchestratorStarter.getMeasureAsInt(vueFileKey, "functions")).isEqualTo(0);
+    assertThat(OrchestratorStarter.getMeasureAsInt(vueFileKey, "statements")).isEqualTo(3);
+    assertThat(OrchestratorStarter.getMeasureAsInt(vueFileKey, "comment_lines")).isEqualTo(0);
+    assertThat(OrchestratorStarter.getMeasureAsInt(vueFileKey, "complexity")).isEqualTo(1);
+    assertThat(OrchestratorStarter.getMeasureAsInt(vueFileKey, "cognitive_complexity")).isEqualTo(2);
 
     // assert both .vue and .ts files are analyzed
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
@@ -21,10 +21,10 @@ package com.sonar.javascript.it.plugin;
 
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
+import java.nio.file.Path;
 import java.util.List;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonarqube.ws.Issues;
 
 import static com.sonar.javascript.it.plugin.Tests.getIssues;
@@ -32,11 +32,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class VueAnalysisTest {
 
-  @ClassRule
   public static final Orchestrator orchestrator = Tests.ORCHESTRATOR;
 
-  @ClassRule
-  public static final TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  static Path tempDir;
 
   @Test
   public void sonarqube() {

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -41,8 +41,9 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
@@ -55,7 +55,7 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JavaScriptRulingTest {
+class JavaScriptRulingTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(JavaScriptRulingTest.class);
 

--- a/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
@@ -37,12 +37,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonarqube.ws.Qualityprofiles;
@@ -56,12 +55,10 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class JavaScriptRulingTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(JavaScriptRulingTest.class);
 
-  @ClassRule
   public static final Orchestrator orchestrator = Orchestrator.builderEnv()
     .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE"))
     .addPlugin(FileLocation.byWildcardMavenFilename(
@@ -69,22 +66,8 @@ public class JavaScriptRulingTest {
     .addPlugin(MavenLocation.of("org.sonarsource.sonar-lits-plugin", "sonar-lits-plugin", "0.9.0.1682"))
     .build();
 
-
-  String project;
-  String language;
-  String sourceDir;
-  List<String> exclusions;
-
-  public JavaScriptRulingTest(String project, String language, String sourceDir, List<String> exclusions) {
-    this.project = project;
-    this.language = language;
-    this.sourceDir = sourceDir;
-    this.exclusions = exclusions;
-  }
-
-  @Parameters(name = "{0}")
-  public static Object[][] projects() {
-    return new Object[][]{
+  public static Stream<Arguments> ruling() {
+    return Stream.of(
       jsProject("amplify", "external/**"),
       jsProject("angular.js", "src/ngLocale/**", "i18n/**"),
       jsProject("backbone"),
@@ -102,18 +85,19 @@ public class JavaScriptRulingTest {
       jsProject("prototype", "dist/**", "vendor/**"),
       jsProject("qunit"),
       jsProject("sizzle", "external/**", "dist/**"),
-      jsProject("underscore", "test/vendor/**"),
-    };
+      jsProject("underscore", "test/vendor/**")
+      );
   }
 
-  private static Object[] jsProject(String project, String... exclusions) {
+  private static Arguments jsProject(String project, String... exclusions) {
     List<String> exclusionList = Stream.concat(Stream.of("**/.*", "**/*.ts"), Arrays.stream(exclusions))
       .collect(Collectors.toList());
-    return new Object[]{project, "js", "../sources/" + project, exclusionList};
+    return Arguments.of(project, "js", "../sources/" + project, exclusionList);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
+    orchestrator.start();
     ProfileGenerator.RulesConfiguration jsRulesConfiguration = new ProfileGenerator.RulesConfiguration()
       .add("S1451", "headerFormat", "// Copyright 20\\d\\d The Closure Library Authors. All Rights Reserved.")
       .add("S1451", "isRegularExpression", "true")
@@ -150,8 +134,14 @@ public class JavaScriptRulingTest {
       "regularExpression=\".*TODO.*\";message=\"bad user\";flags=\"i\"");
   }
 
-  @Test
-  public void ruling() throws Exception {
+  @AfterAll
+  static void afterAll() {
+    orchestrator.stop();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void ruling(String project, String language, String sourceDir, List<String> exclusions) throws Exception {
     runRulingTest(project, language, sourceDir, exclusions);
   }
 
@@ -207,10 +197,10 @@ public class JavaScriptRulingTest {
     if (!StringUtils.isEmpty(profileKey)) {
       newAdminWsClient(orchestrator).qualityprofiles()
         .activateRule(new ActivateRuleRequest()
-        .setKey(profileKey)
-        .setRule(keyPrefix + instantiationKey)
-        .setSeverity("INFO")
-        .setParams(Collections.emptyList()));
+          .setKey(profileKey)
+          .setRule(keyPrefix + instantiationKey)
+          .setSeverity("INFO")
+          .setParams(Collections.emptyList()));
       LOG.warn(String.format("Successfully activated template rule '%s'", keyPrefix + instantiationKey));
     } else {
       throw new IllegalStateException("Could not retrieve profile key : Template rule " + ruleTemplateKey + " has not been activated");

--- a/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;

--- a/its/ruling/src/test/java/org/sonar/javascript/it/TypeScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/TypeScriptRulingTest.java
@@ -21,7 +21,7 @@ package org.sonar.javascript.it;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;

--- a/its/ruling/src/test/java/org/sonar/javascript/it/TypeScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/TypeScriptRulingTest.java
@@ -21,21 +21,15 @@ package org.sonar.javascript.it;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class TypeScriptRulingTest extends JavaScriptRulingTest {
 
-  public TypeScriptRulingTest(String project, String language, String sourceDir, List<String> exclusions) {
-    super(project, language, sourceDir, exclusions);
-  }
-
-  @Parameters(name = "{0}")
-  public static Object[][] projects() {
-    return new Object[][]{
+  public static Stream<Arguments> ts_ruling() {
+    return Stream.of(
       tsProject("ag-grid"),
       tsProject("ant-design"),
       tsProject("console"),
@@ -49,20 +43,21 @@ public class TypeScriptRulingTest extends JavaScriptRulingTest {
       tsProject("prettier-vscode"),
       tsProject("rxjs"),
       tsProject("searchkit"),
-      tsProject("TypeScript"),
-    };
+      tsProject("TypeScript")
+      );
   }
 
-  private static Object[] tsProject(String project) {
+  private static Arguments tsProject(String project) {
     return tsProject(project, Arrays.asList("**/*.d.ts", "**/*.js"));
   }
 
-  private static Object[] tsProject(String project, List<String> exclusions) {
-    return new Object[]{project, "ts", "../typescript-test-sources/src/" + project, exclusions};
+  private static Arguments tsProject(String project, List<String> exclusions) {
+    return Arguments.of(project, "ts", "../typescript-test-sources/src/" + project, exclusions);
   }
 
-  @Test
-  public void ruling() throws Exception {
+  @ParameterizedTest
+  @MethodSource
+  void ts_ruling(String project, String language, String sourceDir, List<String> exclusions) throws Exception {
     runRulingTest(project, language, sourceDir, exclusions);
   }
 

--- a/its/ruling/src/test/java/org/sonar/javascript/it/TypeScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/TypeScriptRulingTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class TypeScriptRulingTest extends JavaScriptRulingTest {
+class TypeScriptRulingTest extends JavaScriptRulingTest {
 
-  public static Stream<Arguments> ts_ruling() {
+  public static Stream<Arguments> ruling() {
     return Stream.of(
       tsProject("ag-grid"),
       tsProject("ant-design"),
@@ -57,7 +57,8 @@ public class TypeScriptRulingTest extends JavaScriptRulingTest {
 
   @ParameterizedTest
   @MethodSource
-  void ts_ruling(String project, String language, String sourceDir, List<String> exclusions) throws Exception {
+  @Override
+  void ruling(String project, String language, String sourceDir, List<String> exclusions) throws Exception {
     runRulingTest(project, language, sourceDir, exclusions);
   }
 

--- a/javascript-checks/pom.xml
+++ b/javascript-checks/pom.xml
@@ -31,8 +31,9 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/AngleBracketTypeAssertionCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/AngleBracketTypeAssertionCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/ArrowFunctionConventionCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/ArrowFunctionConventionCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/CheckListTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/CheckListTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.rules.AnnotationRuleParser;
 import org.sonar.api.rules.Rule;
 import org.sonar.plugins.javascript.api.EslintBasedCheck;

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/ClassNameCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/ClassNameCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/CognitiveComplexityFunctionCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/CognitiveComplexityFunctionCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/CommentRegularExpressionCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/CommentRegularExpressionCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/ConsoleLoggingCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/ConsoleLoggingCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/ContentLengthCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/ContentLengthCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/CyclomaticComplexityJavaScriptCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/CyclomaticComplexityJavaScriptCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/CyclomaticComplexityTypeScriptCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/CyclomaticComplexityTypeScriptCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/EmptyBlockCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/EmptyBlockCheckTest.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import com.google.gson.Gson;
 
 public class EmptyBlockCheckTest {
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/EqEqEqCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/EqEqEqCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/EscapeUtilsTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/EscapeUtilsTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/ExpressionComplexityCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/ExpressionComplexityCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/FileHeaderCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/FileHeaderCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/FunctionNameCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/FunctionNameCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/GetterSetterCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/GetterSetterCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/HardcodedCredentialsCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/HardcodedCredentialsCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/ImplicitDependenciesCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/ImplicitDependenciesCheckTest.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import com.google.gson.Gson;
 
 public class ImplicitDependenciesCheckTest {
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/IntrusivePermissionsCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/IntrusivePermissionsCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/LineLengthCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/LineLengthCheckTest.java
@@ -21,7 +21,7 @@ package org.sonar.javascript.checks;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/MaxParameterCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/MaxParameterCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/MaxSwitchCasesCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/MaxSwitchCasesCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/MaxUnionSizeCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/MaxUnionSizeCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/MissingNewlineAtEndOfFileCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/MissingNewlineAtEndOfFileCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/MissingTrailingCommaCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/MissingTrailingCommaCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/NestedControlFlowDepthCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/NestedControlFlowDepthCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/NewOperatorMisuseCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/NewOperatorMisuseCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/NoDuplicateStringCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/NoDuplicateStringCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/NoMagicNumbersCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/NoMagicNumbersCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/NoThisAliasCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/NoThisAliasCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/OpenCurlyBracesAtEOLCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/OpenCurlyBracesAtEOLCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/RedeclaredSymbolCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/RedeclaredSymbolCheckTest.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import com.google.gson.Gson;
 
 public class RedeclaredSymbolCheckTest {
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/StrictModeCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/StrictModeCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/StringLiteralsQuotesCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/StringLiteralsQuotesCheckTest.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.javascript.checks;
 
-import org.junit.Test;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import com.google.gson.Gson;
 
 public class StringLiteralsQuotesCheckTest {
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/TooManyLinesInFileCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/TooManyLinesInFileCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/TooManyLinesInFunctionCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/TooManyLinesInFunctionCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/TrailingCommentCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/TrailingCommentCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/UnchangedLetVariableCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/UnchangedLetVariableCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/UselessExpressionStatementCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/UselessExpressionStatementCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/VariableNameCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/VariableNameCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/VariableShadowingCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/VariableShadowingCheckTest.java
@@ -20,7 +20,7 @@
 package org.sonar.javascript.checks;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/plugins/javascript/api/CustomRuleRepositoryTest.java
+++ b/javascript-checks/src/test/java/org/sonar/plugins/javascript/api/CustomRuleRepositoryTest.java
@@ -21,7 +21,7 @@ package org.sonar.plugins.javascript.api;
 
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javascript-checks/src/test/java/org/sonar/plugins/javascript/api/EslintBasedCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/plugins/javascript/api/EslintBasedCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.plugins.javascript.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/nodejs-utils/pom.xml
+++ b/nodejs-utils/pom.xml
@@ -20,13 +20,19 @@
       <artifactId>sonar-plugin-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/nodejs-utils/src/test/java/org/sonarsource/nodejs/ProcessWrapperImplTest.java
+++ b/nodejs-utils/src/test/java/org/sonarsource/nodejs/ProcessWrapperImplTest.java
@@ -20,7 +20,7 @@
 package org.sonarsource.nodejs;
 
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <gitRepositoryName>SonarJS</gitRepositoryName>
     <license.title>SonarQube JavaScript Plugin</license.title>
-    <sonarQubeMinVersion>7.9</sonarQubeMinVersion>
+    <sonarQubeMinVersion>8.9</sonarQubeMinVersion>
 
     <!-- override sonar-packaging plugin version from parent -->
     <version.sonar-packaging.plugin>1.20.0.405</version.sonar-packaging.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,10 @@
     <!-- override sonar-packaging plugin version from parent -->
     <version.sonar-packaging.plugin>1.20.0.405</version.sonar-packaging.plugin>
     <assertj.version>3.16.1</assertj.version>
-    <junit.version>4.13.1</junit.version>
+    <junit.version>5.7.2</junit.version>
     <mockito.version>3.5.0</mockito.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <sonar.version>7.9</sonar.version>
+    <sonar.version>8.9.0.43852</sonar.version>
     <sonar-orchestrator.version>3.35.0.2707</sonar-orchestrator.version>
     <sonarlint.version>6.2.0.34235</sonarlint.version>
     <gson.version>2.8.6</gson.version>
@@ -114,10 +114,11 @@
 
       <!-- Test dependencies -->
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
         <version>${junit.version}</version>
-        <scope>test</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -156,6 +157,12 @@
         <artifactId>sonar-plugin-api</artifactId>
         <version>${sonar.version}</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.sonarqube</groupId>
+        <artifactId>sonar-plugin-api-impl</artifactId>
+        <version>${sonar.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.sonarsource.javascript</groupId>

--- a/sonar-javascript-plugin/pom.xml
+++ b/sonar-javascript-plugin/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>sonar-plugin-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
     </dependency>
@@ -62,8 +66,9 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptChecksTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptChecksTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.plugins.javascript;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.javascript.checks.CheckList;
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptExclusionsFileFilterTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptExclusionsFileFilterTest.java
@@ -19,19 +19,17 @@
  */
 package org.sonar.plugins.javascript;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Function;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,12 +38,11 @@ public class JavaScriptExclusionsFileFilterTest {
 
   private static final String EXCLUSIONS_DEFAULT_VALUE = "**/node_modules/**,**/bower_components/**";
 
-  @Rule
-  public LogTester logTester = new LogTester();
+  @RegisterExtension
+  LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
+  @TempDir
+  Path tempDir;
 
   @Test
   public void should_exclude_node_modules_and_bower_components_by_default() throws Exception {
@@ -179,9 +176,8 @@ public class JavaScriptExclusionsFileFilterTest {
 
   @Test
   public void should_exclude_only_on_relative_path() throws Exception {
-    File tmp = temporaryFolder.newFolder();
     // **/vendor/** is excluded by default, however it should only be excluded under 'basedir', here it's above
-    Path basedirUnderVendor = tmp.toPath().resolve("vendor/basedir");
+    Path basedirUnderVendor = tempDir.resolve("vendor/basedir");
     Path file = basedirUnderVendor.resolve("file.js");
     InputFile inputFile = new TestInputFileBuilder("key", basedirUnderVendor.toFile(), file.toFile())
       .setContents("alert('hello');")

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptFilePredicateTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptFilePredicateTest.java
@@ -19,9 +19,15 @@
  */
 package org.sonar.plugins.javascript;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
@@ -30,25 +36,15 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class JavaScriptFilePredicateTest {
 
-  @ClassRule
-  public static TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public static Path baseDir;
 
   private static final String newLine = System.lineSeparator();
 
   @Test
   public void testJavaScriptPredicate() throws IOException {
-    File folder = temp.newFolder();
-    Path baseDir = folder.toPath();
 
     DefaultFileSystem fs = new DefaultFileSystem(baseDir);
     fs.add(createInputFile(baseDir, "a.js"));
@@ -100,8 +96,6 @@ public class JavaScriptFilePredicateTest {
 
   @Test
   public void testTypeScriptPredicate() throws IOException {
-    File folder = temp.newFolder();
-    Path baseDir = folder.toPath();
 
     DefaultFileSystem fs = new DefaultFileSystem(baseDir);
     fs.add(createInputFile(baseDir, "a.js"));

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptLanguageTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptLanguageTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.plugins.javascript;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.config.internal.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
@@ -21,7 +21,7 @@ package org.sonar.plugins.javascript;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinitionTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinitionTest.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rule.RuleStatus;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
@@ -57,7 +57,7 @@ public class JavaScriptProfilesDefinitionTest {
       .map(RulesDefinition.Rule::key)
       .collect(Collectors.toSet());
 
-  @Before
+  @BeforeEach
   public void setUp() {
     new JavaScriptProfilesDefinition().define(context);
   }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/SizeAssessorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/SizeAssessorTest.java
@@ -22,7 +22,7 @@ package org.sonar.plugins.javascript;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/TypeScriptChecksTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/TypeScriptChecksTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.check.Rule;
 import org.sonar.javascript.checks.CheckList;

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/TypeScriptLanguageTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/TypeScriptLanguageTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.plugins.javascript;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.config.internal.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/BundleImplTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/BundleImplTest.java
@@ -23,21 +23,19 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.sonar.api.utils.internal.JUnitTempFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BundleImplTest {
 
-  @Rule
-  public JUnitTempFolder tempFolder = new JUnitTempFolder();
+  @TempDir
+  Path deployLocation;
 
   @Test
   public void test() throws Exception {
     BundleImpl bundle = new BundleImpl("/test-bundle.tgz");
-    Path deployLocation = tempFolder.newDir().toPath();
     bundle.deploy(deployLocation);
     String script = bundle.startServerScript();
     File scriptFile = new File(script);
@@ -48,7 +46,6 @@ public class BundleImplTest {
 
   @Test
   public void should_not_fail_when_deployed_twice() throws Exception {
-    Path deployLocation = tempFolder.newDir().toPath();
     BundleImpl bundle = new BundleImpl("/test-bundle.tgz");
     bundle.deploy(deployLocation);
     bundle.deploy(deployLocation);

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/NodeDeprecationWarningTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/NodeDeprecationWarningTest.java
@@ -21,14 +21,14 @@ package org.sonar.plugins.javascript.eslint;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
-import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,8 +39,8 @@ public class NodeDeprecationWarningTest {
   private static final String MSG_10 = "You are using Node.js version 10, which reached end-of-life. Support for this version will be dropped in future release, please upgrade Node.js to more recent version.";
   private static final String UNSUPPORTED_MSG = "Node.js version 15 is not supported, you might experience issues. Please use a supported version of Node.js [12, 14, 16]";
 
-  @Rule
-  public final LogTester logTester = new LogTester();
+  @RegisterExtension
+  public final LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   @Test
   public void test() {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/RulesBundlesTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/RulesBundlesTest.java
@@ -21,9 +21,8 @@ package org.sonar.plugins.javascript.eslint;
 
 import java.nio.file.Path;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
-import org.sonar.api.utils.internal.JUnitTempFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.plugins.javascript.api.RulesBundle;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,14 +30,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class RulesBundlesTest {
 
-  @Rule
-  public JUnitTempFolder tempFolder = new JUnitTempFolder();
+  @TempDir
+  Path tempDir;
 
   @Test
   public void test() throws Exception {
     TestRulesBundle rulesBundle = new TestRulesBundle("/test-bundle.tgz");
     RulesBundles rulesBundles = new RulesBundles(new TestRulesBundle[]{rulesBundle});
-    List<Path> paths = rulesBundles.deploy(tempFolder.newDir().toPath());
+    List<Path> paths = rulesBundles.deploy(tempDir);
     assertThat(paths).hasSize(1);
     assertThat(paths.get(0)).exists();
     assertThat(paths.get(0).resolve("bin/server")).hasContent("#!/usr/bin/env node\n\n");
@@ -54,7 +53,7 @@ public class RulesBundlesTest {
   @Test
   public void test_empty() {
     RulesBundles rulesBundles = new RulesBundles();
-    assertThat(rulesBundles.deploy(tempFolder.newDir().toPath())).isEmpty();
+    assertThat(rulesBundles.deploy(tempDir)).isEmpty();
   }
 
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigFileTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigFileTest.java
@@ -23,10 +23,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LogTesterJUnit5;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -35,8 +36,8 @@ import static org.assertj.core.api.Assertions.entry;
 
 public class TsConfigFileTest {
 
-  @org.junit.Rule
-  public LogTester logTester = new LogTester();
+  @RegisterExtension
+  public LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   @Test
   public void test() {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigProviderTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigProviderTest.java
@@ -19,35 +19,40 @@
  */
 package org.sonar.plugins.javascript.eslint;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.impl.utils.DefaultTempFolder;
 import org.sonar.api.internal.SonarRuntimeImpl;
+import org.sonar.api.utils.TempFolder;
 import org.sonar.api.utils.Version;
-import org.sonar.api.utils.internal.JUnitTempFolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TsConfigProviderTest {
 
-  @Rule
-  public JUnitTempFolder tempFolder = new JUnitTempFolder();
+  @TempDir
+  Path baseDir;
 
-  private Path baseDir;
+  @TempDir
+  File tempDir;
 
-  @Before
-  public void setUp() {
-    baseDir = tempFolder.newDir().toPath();
+  TempFolder tempFolder;
+
+  @BeforeEach
+  void setUp() {
+    tempFolder = new DefaultTempFolder(tempDir, true);
   }
 
   @Test

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/EslintReportSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/EslintReportSensorTest.java
@@ -22,8 +22,8 @@ package org.sonar.plugins.javascript.external;
 import java.io.File;
 import java.util.Collection;
 import java.util.Iterator;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.DefaultTextPointer;
 import org.sonar.api.batch.fs.internal.DefaultTextRange;
@@ -31,7 +31,7 @@ import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.ExternalIssue;
 import org.sonar.api.rules.RuleType;
-import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.plugins.javascript.JavaScriptPlugin;
 
@@ -40,8 +40,8 @@ import static org.sonar.plugins.javascript.TestUtils.createInputFile;
 
 public class EslintReportSensorTest {
 
-  @Rule
-  public final LogTester logTester = new LogTester();
+  @RegisterExtension
+  public final LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   private static final File BASE_DIR = new File("src/test/resources/externalIssues/").getAbsoluteFile();
   private static final String CONTENT = "function addOne(i) {\n" +

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/TslintReportSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/TslintReportSensorTest.java
@@ -23,12 +23,13 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Iterator;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
@@ -41,7 +42,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.utils.Version;
-import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.plugins.javascript.JavaScriptPlugin;
 
@@ -51,11 +52,12 @@ import static org.sonar.plugins.javascript.TestUtils.createInputFile;
 public class TslintReportSensorTest {
 
   private static final String TSLINT_REPORT_FILE_NAME = "tslint-report.json";
-  @Rule
-  public TemporaryFolder tmpDir = new TemporaryFolder();
 
-  @Rule
-  public final LogTester logTester = new LogTester();
+  @TempDir
+  Path tmpDir;
+
+  @RegisterExtension
+  public final LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   private static final File BASE_DIR = new File("src/test/resources/externalIssues/").getAbsoluteFile();
   private static final String CONTENT = "foo('aaaaaaa')\nif (cond) \n{ }";
@@ -67,7 +69,7 @@ public class TslintReportSensorTest {
 
   private static final SonarRuntime RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     context.setRuntime(RUNTIME);
     context.fileSystem().add(inputFile);
@@ -119,7 +121,7 @@ public class TslintReportSensorTest {
       "  }\n" +
       "]";
 
-    File reportFile = tmpDir.newFile();
+    File reportFile = tmpDir.resolve("report").toFile();
     try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(reportFile), StandardCharsets.UTF_8)) {
       writer.write(String.format(report, inputFile.absolutePath()));
     }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/FileLocatorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/FileLocatorTest.java
@@ -21,7 +21,7 @@ package org.sonar.plugins.javascript.lcov;
 
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/minify/AverageLineLengthCalculatorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/minify/AverageLineLengthCalculatorTest.java
@@ -21,8 +21,7 @@ package org.sonar.plugins.javascript.minify;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 
@@ -32,8 +31,6 @@ public class AverageLineLengthCalculatorTest {
 
   private final static String DIR = "src/test/resources/minify/";
 
-  @org.junit.Rule
-  public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void noHeaderComment1() {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/minify/MinificationAssessorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/minify/MinificationAssessorTest.java
@@ -22,20 +22,18 @@ package org.sonar.plugins.javascript.minify;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import org.assertj.core.api.AbstractBooleanAssert;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MinificationAssessorTest {
 
   private final static String DIR = "src/test/resources/minify/";
 
-  @org.junit.Rule
-  public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void assessOnFileName() {
@@ -55,8 +53,8 @@ public class MinificationAssessorTest {
 
   @Test
   public void assessNonExistingFile() {
-    thrown.expect(IllegalStateException.class);
-    getAssert("file-does-not-exist.js").isFalse();
+    assertThatThrownBy(() ->  getAssert("file-does-not-exist.js").isFalse())
+      .isInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/EslintRulesDefinitionTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/EslintRulesDefinitionTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.plugins.javascript.rules;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.Repository;
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/JavaScriptRulesDefinitionTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/JavaScriptRulesDefinitionTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.plugins.javascript.rules;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.debt.DebtRemediationFunction.Type;
 import org.sonar.api.server.rule.RuleParamType;
@@ -38,7 +38,7 @@ public class JavaScriptRulesDefinitionTest {
   public void test() {
     RulesDefinition.Repository repository = TestUtils.buildRepository("javascript", new JavaScriptRulesDefinition());
 
-    assertThat(repository.name()).isEqualTo("SonarAnalyzer");
+    assertThat(repository.name()).isEqualTo("SonarQube");
     assertThat(repository.language()).isEqualTo("js");
     assertThat(repository.rules()).hasSize(CheckList.getJavaScriptChecks().size());
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/TslintRulesDefinitionTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/TslintRulesDefinitionTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.plugins.javascript.rules;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RulesDefinition;
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinitionTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinitionTest.java
@@ -26,7 +26,7 @@ import java.io.FileReader;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.debt.DebtRemediationFunction.Type;
 import org.sonar.api.server.rule.RulesDefinition.Param;
@@ -46,7 +46,7 @@ public class TypeScriptRulesDefinitionTest {
   public void test() {
     Repository repository = TestUtils.buildRepository("typescript", new TypeScriptRulesDefinition());
 
-    assertThat(repository.name()).isEqualTo("SonarAnalyzer");
+    assertThat(repository.name()).isEqualTo("SonarQube");
     assertThat(repository.language()).isEqualTo("ts");
     assertThat(repository.rules()).hasSize(CheckList.getTypeScriptChecks().size());
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/utils/RulesMetadataForSonarLintTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/utils/RulesMetadataForSonarLintTest.java
@@ -21,13 +21,10 @@ package org.sonar.plugins.javascript.utils;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.javascript.checks.StringLiteralsQuotesCheck;
 
 import static java.util.Arrays.asList;
@@ -35,12 +32,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RulesMetadataForSonarLintTest {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  Path tempDir;
 
   @Test
   public void test() throws Exception {
-    Path path = folder.newFile().toPath();
+    Path path = tempDir.resolve("sonarlint.json");
     new RulesMetadataForSonarLint("repo", asList(StringLiteralsQuotesCheck.class)).save(path);
     assertThat(path).hasContent("[\n" +
       "  {\n" +
@@ -83,7 +80,7 @@ public class RulesMetadataForSonarLintTest {
 
   @Test
   public void test_all() throws Exception {
-    Path path = folder.newFile().toPath();
+    Path path = tempDir.resolve("sonarlint.json");
     RulesMetadataForSonarLint.main(new String[]{path.toString()});
     JsonArray jsonArray = new Gson().fromJson(Files.newBufferedReader(path), JsonArray.class);
     assertThat(jsonArray.size()).isGreaterThan(470);


### PR DESCRIPTION
Most of the changes are boring such as changing

- annotation `org.junit.Test` to `org.junit.jupiter.api.Test`
- using `@TempDir` for temporary folders
- using `LogTesterJUnit5` for logtester (this required update of SQ API)

Plugin QA tests required a bit of rework because JUnit 5 doesn't support `@TestSuite` annotation which was required to start the Orchestrator only once for all QA tests. Now this is implemented with `@Extension` logic from JUnit 5 as described in https://stackoverflow.com/questions/43282798/in-junit-5-how-to-run-code-before-all-tests . Advantage of the new way is that we don't need to explicitly list test in the test suite anymore.

Ruling tests are using `@ParameterizedTest` and `@MethodSource` as described in https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests-sources-MethodSource 