### PR TITLE
Require Node.js v10 and update documentation about supported Node.js versions

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImpl.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImpl.java
@@ -65,7 +65,7 @@ public class EslintBridgeServerImpl implements EslintBridgeServer {
   private static final String MAX_OLD_SPACE_SIZE_PROPERTY = "sonar.javascript.node.maxspace";
   private static final String ALLOW_TS_PARSER_JS_FILES = "sonar.javascript.allowTsParserJsFiles";
   private static final Gson GSON = new Gson();
-  private static final int MIN_NODE_VERSION = 8;
+
   private static final String DEPLOY_LOCATION = "eslint-bridge-bundle";
 
   private final OkHttpClient client;
@@ -171,7 +171,7 @@ public class EslintBridgeServerImpl implements EslintBridgeServer {
         }
       })
       .pathResolver(bundle)
-      .minNodeVersion(MIN_NODE_VERSION)
+      .minNodeVersion(NodeDeprecationWarning.MIN_NODE_VERSION)
       .configuration(context.config())
       .script(scriptFile.getAbsolutePath())
       .scriptArgs(String.valueOf(port), hostAddress, workDir.getAbsolutePath(), String.valueOf(allowTsParserJsFiles), String.valueOf(isSonarLint), bundles);

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/NodeDeprecationWarning.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/NodeDeprecationWarning.java
@@ -36,6 +36,7 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
 public class NodeDeprecationWarning {
 
   private static final Logger LOG = Loggers.get(NodeDeprecationWarning.class);
+  static final int MIN_NODE_VERSION = 10;
   private static final int MIN_RECOMMENDED_NODE_VERSION = 12;
   private static final List<Integer> SUPPORTED_NODE_VERSIONS = Arrays.asList(12, 14, 16);
   private final SonarRuntime sonarRuntime;

--- a/sonar-javascript-plugin/src/main/resources/static/documentation.md
+++ b/sonar-javascript-plugin/src/main/resources/static/documentation.md
@@ -11,11 +11,12 @@ key: javascript
 ## Prerequisites
 
 In order to analyze JavaScript or TypeScript code, you need to have supported version of Node.js installed on the
-machine running the scan. Supported versions are current LTS versions (v10, v12, v14) and latest version v15. Odd
+machine running the scan. Supported versions are current LTS versions (v12, v14) and the latest version - v16. Odd
 (non LTS) versions might work, but are not actively tested. We recommend using the latest available LTS version 
-(v14 as of today) for optimal stability and performance.
+(v14 as of today) for optimal stability and performance. v10 is still supported, but it already reached end-of-life and 
+is deprecated.
 
-If standard `node` is not available, you have to set property `sonar.nodejs.executable` to an absolute path to
+If `node` is not available in the PATH, you can use property `sonar.nodejs.executable` to set an absolute path to
 Node.js executable.
  
 ## Language-Specific Properties


### PR DESCRIPTION
Fix #2771 

I moved all constants to NodeDeprecationWarning, so they are in one place.