### PR TITLE
Fix handling of forward slash when parsing regexp

### DIFF
--- a/eslint-bridge/src/utils/utils-regex.ts
+++ b/eslint-bridge/src/utils/utils-regex.ts
@@ -142,7 +142,7 @@ export function getRegexpLocation(
   return loc;
 }
 
-function getRegexpRange(node: estree.Node, regexpNode: regexpp.AST.Node): AST.Range {
+export function getRegexpRange(node: estree.Node, regexpNode: regexpp.AST.Node): AST.Range {
   if (isRegexLiteral(node)) {
     return [regexpNode.start, regexpNode.end];
   }
@@ -169,13 +169,17 @@ function getRegexpRange(node: estree.Node, regexpNode: regexpp.AST.Node): AST.Ra
     }
     // regexpNode positions are 1 - based, we need to -1 to report as 0 - based
     // it's possible for node start to be outside of range, e.g. `a` in new RegExp('//a')
-    const startToken = Math.min(regexpNode.start - 1, tokens.length - 1);
+    const startToken = regexpNode.start - 1;
     const start = tokens[startToken].range[0];
     // it's possible for node end to be outside of range, e.g. new RegExp('\n(|)')
     const endToken = Math.min(regexpNode.end - 2, tokens.length - 1);
     const end = tokens[endToken].range[1];
     // +1 is needed to account for string quotes
     return [start + 1, end + 1];
+  }
+  if (node.type === 'TemplateLiteral') {
+    // we don't support these properly
+    return node.range!;
   }
   throw new Error(`Expected regexp or string literal, got ${node.type}`);
 }

--- a/eslint-bridge/src/utils/utils-string-literal.ts
+++ b/eslint-bridge/src/utils/utils-string-literal.ts
@@ -27,6 +27,7 @@ const UNICODE_ESCAPE_LENGTH = 4;
 const HEX_ESCAPE_LENGTH = 2;
 
 const CP_BACK_SLASH = cp('\\');
+const CP_FORWARD_SLASH = cp('/');
 const CP_CR = cp('\r');
 const CP_LF = cp('\n');
 const CP_n = cp('n');
@@ -143,6 +144,13 @@ export function tokenizeString(s: string): StringLiteralToken[] {
       if (value !== '') {
         tokens.push({ value, range: [start, pos] });
       }
+    } else if (c === CP_FORWARD_SLASH) {
+      const forwardSlash: StringLiteralToken = {
+        value: String.fromCodePoint(c),
+        range: [start, pos],
+      };
+      tokens.push(forwardSlash);
+      tokens.push(forwardSlash);
     } else {
       tokens.push({ value: String.fromCodePoint(c), range: [start, pos] });
     }

--- a/eslint-bridge/tests/rules/regex-complexity.test.ts
+++ b/eslint-bridge/tests/rules/regex-complexity.test.ts
@@ -322,6 +322,56 @@ ruleTesterThreshold0.run(
         errors: 1,
         options: [0],
       },
+      {
+        code: `
+        RegExp('/s*')
+        `,
+        options: [0],
+        errors: [
+          {
+            message: JSON.stringify({
+              message:
+                'Simplify this regular expression to reduce its complexity from 1 to the 0 allowed.',
+              cost: 1,
+              secondaryLocations: [
+                {
+                  message: '+1',
+                  column: 18,
+                  line: 2,
+                  endColumn: 19,
+                  endLine: 2,
+                },
+              ],
+            }),
+          },
+        ],
+      },
+      {
+        code: `
+        RegExp('|/?[a-z]')
+        `,
+        options: [0],
+        errors: [
+          {
+            message: JSON.stringify({
+              message:
+                'Simplify this regular expression to reduce its complexity from 4 to the 0 allowed.',
+              cost: 4,
+              secondaryLocations: [
+                { message: '+1', column: 16, line: 2, endColumn: 17, endLine: 2 },
+                {
+                  message: '+2 (incl 1 for nesting)',
+                  column: 18,
+                  line: 2,
+                  endColumn: 19,
+                  endLine: 2,
+                },
+                { message: '+1', column: 19, line: 2, endColumn: 20, endLine: 2 },
+              ],
+            }),
+          },
+        ],
+      },
     ],
   },
 );

--- a/eslint-bridge/tests/utils/utils-regex.test.ts
+++ b/eslint-bridge/tests/utils/utils-regex.test.ts
@@ -1,0 +1,42 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as esprima from 'esprima';
+import * as estree from 'estree';
+import { getRegexpRange } from 'utils';
+import * as regexpp from 'regexpp';
+
+it('should get range for regexp /s*', () => {
+  const program = esprima.parse(`'/s*'`);
+  const literal: estree.Literal = program.body[0].expression;
+  const regexNode = regexpp.parseRegExpLiteral(new RegExp(literal.value as string));
+  const quantifier = regexNode.pattern.alternatives[0].elements[1]; // s*
+  const range = getRegexpRange(literal, quantifier);
+  expect(range).toStrictEqual([2, 4]);
+});
+
+it('should get range for regexp |/?[a-z]', () => {
+  const program = esprima.parse(`'|/?[a-z]'`);
+  const literal: estree.Literal = program.body[0].expression;
+  const regexNode = regexpp.parseRegExpLiteral(new RegExp(literal.value as string));
+  const alternative = regexNode.pattern.alternatives[1]; // /?[a-z]
+  const range = getRegexpRange(literal, alternative);
+  expect(range).toStrictEqual([2, 9]);
+});


### PR DESCRIPTION
Fixes #2788 

The improvement makes two changes
 - in string tokenizer, when we process `/` we insert an additional token to correct for the implicit escape
 - when computing offsets for secondary locations, this should be done in the coordinates of the regexp, which will account for / thanks to the previous point

Computation of offsets will not work if the regexp spans multiple lines. I believe we can ignore such corner case.