### PR TITLE
Fix handling of escape characters when tokenizing regexp

### DIFF
--- a/eslint-bridge/src/utils/utils-string-literal.ts
+++ b/eslint-bridge/src/utils/utils-string-literal.ts
@@ -142,6 +142,7 @@ export function tokenizeString(s: string): StringLiteralToken[] {
     if (c === CP_BACK_SLASH) {
       const value = readEscape();
       if (value !== '') {
+        tokens.push({ value: String.fromCodePoint(CP_BACK_SLASH), range: [start, start + 1] });
         tokens.push({ value, range: [start, pos] });
       }
     } else if (c === CP_FORWARD_SLASH) {

--- a/eslint-bridge/tests/utils/utils-regex.test.ts
+++ b/eslint-bridge/tests/utils/utils-regex.test.ts
@@ -40,3 +40,12 @@ it('should get range for regexp |/?[a-z]', () => {
   const range = getRegexpRange(literal, alternative);
   expect(range).toStrictEqual([2, 9]);
 });
+
+it('should get range for regexp \ns', () => {
+  const program = esprima.parse(`'\\ns'`);
+  const literal: estree.Literal = program.body[0].expression;
+  const regexNode = regexpp.parseRegExpLiteral(new RegExp(literal.value as string));
+  const quantifier = regexNode.pattern.alternatives[0].elements[1]; // s
+  const range = getRegexpRange(literal, quantifier);
+  expect(range).toStrictEqual([3, 4]);
+});


### PR DESCRIPTION
Basically the same problem as #2798 but for escape characters (backward slashes).