### PR TITLE
Remove implements AnalysisWarnings to not expose component to other plugins which dont expect it

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
@@ -67,7 +67,7 @@ abstract class AbstractEslintSensor implements Sensor {
   private final NoSonarFilter noSonarFilter;
   private final FileLinesContextFactory fileLinesContextFactory;
   final EslintBridgeServer eslintBridgeServer;
-  private final AnalysisWarnings analysisWarnings;
+  private final AnalysisWarningsWrapper analysisWarnings;
   // Visible for testing
   final List<Rule> rules;
   final AbstractChecks checks;

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWarningsWrapper.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWarningsWrapper.java
@@ -26,7 +26,7 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @ScannerSide
 @SonarLintSide
-public class AnalysisWarningsWrapper implements AnalysisWarnings {
+public class AnalysisWarningsWrapper {
 
   private final AnalysisWarnings analysisWarnings;
 
@@ -41,7 +41,6 @@ public class AnalysisWarningsWrapper implements AnalysisWarnings {
     this.analysisWarnings = analysisWarnings;
   }
 
-  @Override
   public void addUnique(String text) {
     if (analysisWarnings != null) {
       analysisWarnings.addUnique(text);


### PR DESCRIPTION
Apparently if we declare such component, it will become available for other plugins which might not expect it to be available in SonarLint context.

See more https://discuss.sonarsource.com/t/dogfooding-python-analyzer-from-next-fails-to-load-in-eclipse/8875/4 (internal link)