### PR TITLE
Update ansi-regex dependency to 5.0.1

### DIFF
--- a/eslint-bridge/yarn.lock
+++ b/eslint-bridge/yarn.lock
@@ -1591,9 +1591,9 @@ ansi-escapes@^4.2.1:
     type-fest "^0.21.3"
 
 ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://repox.jfrog.io/repox/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=
+  version "5.0.1"
+  resolved "https://repox.jfrog.io/repox/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This is from WhiteSource scan to fix CVE-2021-3807


