### PR TITLE
Fix rule-specs path in CSS sonarpedia

### DIFF
--- a/css-sonarpedia/sonarpedia.json
+++ b/css-sonarpedia/sonarpedia.json
@@ -1,5 +1,5 @@
 {
-  "rules-metadata-path": "sonar-javascript-plugin/src/main/resources/org/sonar/l10n/css/rules/css",
+  "rules-metadata-path": "../sonar-javascript-plugin/src/main/resources/org/sonar/l10n/css/rules/css",
   "languages": [
     "CSS"
   ],


### PR DESCRIPTION
Fixes the failure when running rule-api:
```
SonarJS/css-sonarpedia $ java -jar ../../sonar-rule-api/target/rule-api-2.2.0-SNAPSHOT.jar generate -rule S5362
NOTE: the rules are generated based on GitHub "rspec" repository from branch 'master'.

Exception in thread "main" java.lang.IllegalArgumentException: directory does not exist
	at com.sonarsource.ruleapi.utilities.Utilities.assertBaseDir(Utilities.java:68)
	at com.sonarsource.ruleapi.services.RuleFilesService.create(RuleFilesService.java:76)
	at com.sonarsource.ruleapi.services.SonarPediaFileService.lambda$create$0(SonarPediaFileService.java:69)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at com.sonarsource.ruleapi.services.SonarPediaFileService.create(SonarPediaFileService.java:75)
	at com.sonarsource.ruleapi.Main.handleGenerate(Main.java:117)
	at com.sonarsource.ruleapi.Main.doRequestedOption(Main.java:98)
	at com.sonarsource.ruleapi.Main.main(Main.java:65)
```
And should also fix the RSPEC coverage-tool test:
```
css-sonarpedia/sonarpedia.json
SonarJS master checkout failed: [Errno 2] No such file or directory: 'css-sonarpedia/sonar-javascript-plugin/src/main/resources/org/sonar/l10n/css/rules/css'
```