### PR TITLE
Explicitly specify that we use commonjs modules

### DIFF
--- a/eslint-bridge/package.json
+++ b/eslint-bridge/package.json
@@ -24,6 +24,7 @@
   "engines": {
     "node": ">=10"
   },
+  "type": "commonjs",
   "devDependencies": {
     "@types/bytes": "3.1.0",
     "@types/eslint": "7.28.0",


### PR DESCRIPTION
This is to make sure that we avoid loading code with ESM. See https://nodejs.org/api/packages.html#determining-module-system

