### PR TITLE
FP S1128 (unused-import): consider imported symbols used in Vue.js SFC templates

### DIFF
--- a/eslint-bridge/package-lock.json
+++ b/eslint-bridge/package-lock.json
@@ -52,7 +52,7 @@
         "scslre": "0.1.6",
         "stylelint": "13.13.1",
         "typescript": "4.4.3",
-        "vue-eslint-parser": "7.6.0"
+        "vue-eslint-parser": "7.11.0"
       },
       "devDependencies": {
         "@types/bytes": "3.1.0",
@@ -11118,16 +11118,19 @@
       }
     },
     "node_modules/vue-eslint-parser": {
-      "version": "7.6.0",
+      "version": "7.11.0",
+      "resolved": "https://repox.jfrog.io/repox/api/npm/npm/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
+      "integrity": "sha1-IUtd6pYQB/z/su5luJEjB2KNDa8=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "eslint-scope": "^5.0.0",
+        "eslint-scope": "^5.1.1",
         "eslint-visitor-keys": "^1.1.0",
         "espree": "^6.2.1",
         "esquery": "^1.4.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21",
+        "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=8.10"
@@ -18018,14 +18021,17 @@
       }
     },
     "vue-eslint-parser": {
-      "version": "7.6.0",
+      "version": "7.11.0",
+      "resolved": "https://repox.jfrog.io/repox/api/npm/npm/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
+      "integrity": "sha1-IUtd6pYQB/z/su5luJEjB2KNDa8=",
       "requires": {
         "debug": "^4.1.1",
-        "eslint-scope": "^5.0.0",
+        "eslint-scope": "^5.1.1",
         "eslint-visitor-keys": "^1.1.0",
         "espree": "^6.2.1",
         "esquery": "^1.4.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {

--- a/eslint-bridge/package.json
+++ b/eslint-bridge/package.json
@@ -63,7 +63,7 @@
     "scslre": "0.1.6",
     "stylelint": "13.13.1",
     "typescript": "4.4.3",
-    "vue-eslint-parser": "7.6.0"
+    "vue-eslint-parser": "7.11.0"
   },
   "bundledDependencies": [
     "@typescript-eslint/eslint-plugin",

--- a/eslint-bridge/tests/rules/unused-import.test.ts
+++ b/eslint-bridge/tests/rules/unused-import.test.ts
@@ -338,3 +338,66 @@ ruleTesterJsxFactory.run('Unused imports denoting jsx factory should be ignored'
     },
   ],
 });
+
+const ruleTesterVue = new RuleTester({
+  parserOptions: { ecmaVersion: 2018, sourceType: 'module' },
+  parser: require.resolve('vue-eslint-parser'),
+});
+
+ruleTesterVue.run('Unnecessary imports should be removed', rule, {
+  valid: [
+    {
+      code: `
+      <script setup>
+        import Foo from './Foo.vue'
+      </script>      
+      <template>
+        <Foo />
+      </template>
+      `,
+    },
+    {
+      code: `
+      <script setup>
+        import MyFoo from './MyFoo.vue'
+      </script>      
+      <template>
+        <my-foo />
+      </template>
+      `,
+    },
+    {
+      code: `
+      <script setup>
+        import {foo} from './foo'
+      </script>      
+      <template>
+        <div @click="foo()" />
+      </template>
+      `,
+    },
+    {
+      code: `
+      <script setup>
+        import {isFoo} from './foo'
+      </script>      
+      <template>
+        <div v-if="isFoo" />
+      </template>
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      <script setup>
+        import Foo from './Foo.vue'
+      </script>      
+      <template>
+        <div />
+      </template>
+      `,
+      errors: 1,
+    },
+  ],
+});


### PR DESCRIPTION
Fixes #2818

vue-eslint-parsing supports the new feature [<script setup>](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0040-script-setup.md) only on the syntactic level. There is no changes regarding scope information, especially for variable references between `<script>` and `<template>` sections of Vue.js Single File components. Therefore, and as a workaround, we consider any identifiers in the `<template>` section as possible references of imported symbols in the `<script>` section as well as tag names.