### PR TITLE
Fix scope for sonar-ws

### DIFF
--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-ws</artifactId>
-      <version>${sonar.version}</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarlint.core</groupId>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-ws</artifactId>
-      <version>7.9.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.sonarsource.sonarqube</groupId>
+        <artifactId>sonar-ws</artifactId>
+        <version>${sonar.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>4.0.3</version>


### PR DESCRIPTION
I had this small change locally and it was annoying me :) It's for WhiteSource to not consider this dependency, because we don't actually ship it.