### PR TITLE
Fix FP ('no-try-promise'): consider yield as an alternative to await

### DIFF
--- a/eslint-bridge/src/rules/no-try-promise.ts
+++ b/eslint-bridge/src/rules/no-try-promise.ts
@@ -71,13 +71,7 @@ function visitTryStatement(
         return;
       }
 
-      if (
-        (callLikeExpr.parent &&
-          (callLikeExpr.parent.type === 'AwaitExpression' ||
-            callLikeExpr.parent.type === 'YieldExpression')) ||
-        isThened(callLikeExpr) ||
-        isCatch(callLikeExpr)
-      ) {
+      if (isAwaitLike(callLikeExpr) || isThened(callLikeExpr) || isCatch(callLikeExpr)) {
         return;
       }
 
@@ -154,6 +148,13 @@ function checkForUselessCatch(
       loc: token!.loc,
     });
   }
+}
+
+function isAwaitLike(callExpr: CallLikeExpression) {
+  return (
+    callExpr.parent &&
+    (callExpr.parent.type === 'AwaitExpression' || callExpr.parent.type === 'YieldExpression')
+  );
 }
 
 function isThened(callExpr: CallLikeExpression) {

--- a/eslint-bridge/src/rules/no-try-promise.ts
+++ b/eslint-bridge/src/rules/no-try-promise.ts
@@ -72,7 +72,9 @@ function visitTryStatement(
       }
 
       if (
-        (callLikeExpr.parent && callLikeExpr.parent.type === 'AwaitExpression') ||
+        (callLikeExpr.parent &&
+          (callLikeExpr.parent.type === 'AwaitExpression' ||
+            callLikeExpr.parent.type === 'YieldExpression')) ||
         isThened(callLikeExpr) ||
         isCatch(callLikeExpr)
       ) {

--- a/eslint-bridge/tests/rules/no-try-promise.test.ts
+++ b/eslint-bridge/tests/rules/no-try-promise.test.ts
@@ -85,6 +85,18 @@ ruleTester.run(`Promise rejections should not be caught by 'try' block`, rule, {
       }
       `,
     },
+    {
+      code: `
+      function returningPromise() { return Promise.reject(); }
+      async function okWithYield() {
+        try {
+          yield returningPromise();
+        } catch (e) {
+          console.log(e);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {

--- a/eslint-bridge/tests/rules/no-try-promise.test.ts
+++ b/eslint-bridge/tests/rules/no-try-promise.test.ts
@@ -88,7 +88,7 @@ ruleTester.run(`Promise rejections should not be caught by 'try' block`, rule, {
     {
       code: `
       function returningPromise() { return Promise.reject(); }
-      async function okWithYield() {
+      async function * okWithYield() {
         try {
           yield returningPromise();
         } catch (e) {


### PR DESCRIPTION
Fixes #2683