### PR TITLE
Set BROWSERSLIST_IGNORE_OLD_DATA to true to avoid error logs

### DIFF
--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImplTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImplTest.java
@@ -151,6 +151,7 @@ class EslintBridgeServerImplTest {
     assertThat(logTester.logs(DEBUG)).contains("testing debug log");
     assertThat(logTester.logs(WARN)).contains("testing warn log");
     assertThat(logTester.logs(INFO)).contains("testing info log");
+    assertThat(logTester.logs(INFO)).contains("BROWSERSLIST_IGNORE_OLD_DATA is set to true");
   }
 
   @Test

--- a/sonar-javascript-plugin/src/test/resources/mock-eslint-bridge/logging.js
+++ b/sonar-javascript-plugin/src/test/resources/mock-eslint-bridge/logging.js
@@ -8,6 +8,10 @@ console.log(`DEBUG testing debug log`)
 console.log(`WARN testing warn log`)
 console.log(`testing info log`)
 
+if (process.env.BROWSERSLIST_IGNORE_OLD_DATA) {
+  console.log("BROWSERSLIST_IGNORE_OLD_DATA is set to true");
+}
+
 const server = http.createServer((req, res) => {
   if (req.url === "/close") {
     res.end();


### PR DESCRIPTION
Fixes #2803 

Tested manually by changing the date on local machine 1 year in future.