### PR TITLE
Enable quick fix for S2757 ('non-existent-operator')

### DIFF
--- a/eslint-bridge/src/quickfix.ts
+++ b/eslint-bridge/src/quickfix.ts
@@ -47,6 +47,7 @@ const quickFixRules = new Set([
 
   // eslint-plugin-sonarjs
   'no-inverted-boolean-check',
+  'non-existent-operator',
   'prefer-immediate-return',
   'prefer-while',
 


### PR DESCRIPTION
Fixes #3010
Depends on https://github.com/SonarSource/eslint-plugin-sonarjs/pull/336