### PR TITLE
Enable quick fix for S1126 ('prefer-single-boolean-return')

### DIFF
--- a/eslint-bridge/src/quickfix.ts
+++ b/eslint-bridge/src/quickfix.ts
@@ -48,6 +48,7 @@ const quickFixRules = new Set([
   // eslint-plugin-sonarjs
   'no-inverted-boolean-check',
   'prefer-immediate-return',
+  'prefer-single-boolean-return',
   'prefer-while',
 
   // @typescript-eslint plugin


### PR DESCRIPTION
Fixes #3003
Depends on https://github.com/SonarSource/eslint-plugin-sonarjs/pull/337
