### PR TITLE
Enable quick fix for S3626 ('no-redundant-jump')

### DIFF
--- a/eslint-bridge/src/quickfix.ts
+++ b/eslint-bridge/src/quickfix.ts
@@ -47,6 +47,7 @@ const quickFixRules = new Set([
 
   // eslint-plugin-sonarjs
   'no-inverted-boolean-check',
+  'no-redundant-jump',
   'prefer-immediate-return',
   'prefer-while',
 


### PR DESCRIPTION
Fixes #3016
Depends on https://github.com/SonarSource/eslint-plugin-sonarjs/pull/338