### PR TITLE
Enable quick fix for S3981 ('no-collection-size-mischeck')

### DIFF
--- a/eslint-bridge/src/quickfix.ts
+++ b/eslint-bridge/src/quickfix.ts
@@ -46,6 +46,7 @@ const quickFixRules = new Set([
   'use-isnan',
 
   // eslint-plugin-sonarjs
+  'no-collection-size-mischeck',
   'no-inverted-boolean-check',
   'prefer-immediate-return',
   'prefer-while',


### PR DESCRIPTION
Fixes #3021
Depends on https://github.com/SonarSource/eslint-plugin-sonarjs/pull/340
