### PR TITLE
Remove empty leading line from documentation.md

### DIFF
--- a/sonar-javascript-plugin/src/main/resources/static/documentation.md
+++ b/sonar-javascript-plugin/src/main/resources/static/documentation.md
@@ -1,4 +1,3 @@
-
 ---
 title: JavaScript/TypeScript/CSS
 key: javascript


### PR DESCRIPTION
Due to this empty line (introduced in SonarJS 9.0 https://github.com/SonarSource/SonarJS/blob/d53e654f102f8ef106bbaee34d82da3c3ba67585/sonar-javascript-plugin/src/main/resources/static/documentation.md?plain=1#L1) the documentation is badly displayed at docs.sonarqube.org