### PR TITLE
Update S4649 ('font-family-no-missing-generic-family-keyword'): Support 'ignoreFontFamilies' option

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/css/rules/FontFamilyNoMissingGenericFamilyKeyword.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/css/rules/FontFamilyNoMissingGenericFamilyKeyword.java
@@ -19,13 +19,41 @@
  */
 package org.sonar.plugins.javascript.css.rules;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+
+import static org.sonar.plugins.javascript.css.rules.RuleUtils.splitAndTrim;
 
 @Rule(key = "S4649")
 public class FontFamilyNoMissingGenericFamilyKeyword implements CssRule {
 
+  private static final String DEFAULT_IGNORE_FONT_FAMILIES = "custom-font";
+
+  @RuleProperty(
+    key = "ignoreFontFamilies",
+    description = "Comma-separated list of regular expressions for font families exempt from this rule.",
+    defaultValue = "" + DEFAULT_IGNORE_FONT_FAMILIES)
+  String ignoreFontFamilies = DEFAULT_IGNORE_FONT_FAMILIES;
+
   @Override
   public String stylelintKey() {
     return "font-family-no-missing-generic-family-keyword";
+  }
+
+  @Override
+  public List<Object> stylelintOptions() {
+    return Arrays.asList(true, new StylelintIgnoreOption(splitAndTrim(ignoreFontFamilies)));
+  }
+
+  private static class StylelintIgnoreOption {
+    // Used by GSON serialization
+    private final List<String> ignoreFontFamilies;
+
+    StylelintIgnoreOption(List<String> ignoreFontFamilies) {
+      this.ignoreFontFamilies = ignoreFontFamilies;
+    }
   }
 }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/css/rules/CssRuleTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/css/rules/CssRuleTest.java
@@ -44,6 +44,7 @@ class CssRuleTest {
     Set<Class> rulesWithStylelintOptions = Sets.newSet(
       AtRuleNoUnknown.class,
       DeclarationBlockNoDuplicateProperties.class,
+      FontFamilyNoMissingGenericFamilyKeyword.class,
       PropertyNoUnknown.class,
       SelectorPseudoClassNoUnknown.class,
       SelectorPseudoElementNoUnknown.class,
@@ -136,5 +137,19 @@ class CssRuleTest {
     DeclarationBlockNoDuplicateProperties instance = new DeclarationBlockNoDuplicateProperties();
     instance.ignoreFallbacks = false;
     assertThat(instance.stylelintOptions()).isEmpty();
+  }
+
+  @Test
+  void font_family_no_missing_generic_family_keyword_default() {
+    String optionsAsJson = new Gson().toJson(new FontFamilyNoMissingGenericFamilyKeyword().stylelintOptions());
+    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreFontFamilies\":[\"custom-font\"]}]");
+  }
+
+  @Test
+  void font_family_no_missing_generic_family_keyword_custom() {
+    FontFamilyNoMissingGenericFamilyKeyword instance = new FontFamilyNoMissingGenericFamilyKeyword();
+    instance.ignoreFontFamilies = "Icon Font, /icon$/";
+    String optionsAsJson = new Gson().toJson(instance.stylelintOptions());
+    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreFontFamilies\":[\"Icon Font\",\"/icon$/\"]}]");
   }
 }


### PR DESCRIPTION
Fixes https://github.com/SonarSource/sonar-css/issues/356
Fixes https://github.com/SonarSource/sonar-css/pull/357