### PR TITLE
Fix FP S4660 ('selector-pseudo-element-no-unknown'): Ignore Blazor '::deep' combinator

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/css/rules/SelectorPseudoElementNoUnknown.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/css/rules/SelectorPseudoElementNoUnknown.java
@@ -29,7 +29,7 @@ import static org.sonar.plugins.javascript.css.rules.RuleUtils.splitAndTrim;
 @Rule(key = "S4660")
 public class SelectorPseudoElementNoUnknown implements CssRule {
 
-  private static final String DEFAULT_IGNORE_PSEUDO_ELEMENTS = "ng-deep,v-deep";
+  private static final String DEFAULT_IGNORE_PSEUDO_ELEMENTS = "ng-deep,v-deep,deep";
 
   @Override
   public String stylelintKey() {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/css/rules/CssRuleTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/css/rules/CssRuleTest.java
@@ -94,7 +94,7 @@ class CssRuleTest {
   @Test
   void selector_pseudo_element_no_unknown_default() {
     String optionsAsJson = new Gson().toJson(new SelectorPseudoElementNoUnknown().stylelintOptions());
-    assertThat(optionsAsJson).isEqualTo("[true,{\"ignorePseudoElements\":[\"ng-deep\",\"v-deep\"]}]");
+    assertThat(optionsAsJson).isEqualTo("[true,{\"ignorePseudoElements\":[\"ng-deep\",\"v-deep\",\"deep\"]}]");
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/SonarSource/sonar-css/issues/373
Fixes https://github.com/SonarSource/sonar-css/pull/361