### PR TITLE
Update css:S4653 ('unit-no-unknown'): Drop obsolete hardcoded configuration

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/css/rules/UnitNoUnknown.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/css/rules/UnitNoUnknown.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.plugins.javascript.css.rules;
 
-import java.util.Arrays;
-import java.util.List;
 import org.sonar.check.Rule;
 
 @Rule(key = "S4653")
@@ -29,15 +27,5 @@ public class UnitNoUnknown implements CssRule {
   @Override
   public String stylelintKey() {
     return "unit-no-unknown";
-  }
-
-  @Override
-  public List<Object> stylelintOptions() {
-    return Arrays.asList(true, new StylelintIgnoreOption());
-  }
-
-  private static class StylelintIgnoreOption {
-    // Used by GSON serialization
-    private final String[] ignoreUnits = {"x"};
   }
 }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/css/rules/CssRuleTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/css/rules/CssRuleTest.java
@@ -48,8 +48,7 @@ class CssRuleTest {
       PropertyNoUnknown.class,
       SelectorPseudoClassNoUnknown.class,
       SelectorPseudoElementNoUnknown.class,
-      SelectorTypeNoUnknown.class,
-      UnitNoUnknown.class);
+      SelectorTypeNoUnknown.class);
 
     for (Class ruleClass : CssRules.getRuleClasses()) {
       CssRule rule = (CssRule)ruleClass.getConstructor().newInstance();
@@ -104,12 +103,6 @@ class CssRuleTest {
     selectorPseudoElementNoUnknown.ignorePseudoElements =  "ng-deep, /^custom-/";
     String optionsAsJson = new Gson().toJson(selectorPseudoElementNoUnknown.stylelintOptions());
     assertThat(optionsAsJson).isEqualTo("[true,{\"ignorePseudoElements\":[\"ng-deep\",\"/^custom-/\"]}]");
-  }
-
-  @Test
-  void units_no_unknown_options() {
-    String optionsAsJson = new Gson().toJson(new UnitNoUnknown().stylelintOptions());
-    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreUnits\":[\"x\"]}]");
   }
 
   @Test


### PR DESCRIPTION
The exception was introduced a while ago because the rule was raising false positives, but it has been now fixed with https://github.com/stylelint/stylelint/pull/4427.