### PR TITLE
Fix css:S5362 ('function-calc-no-invalid'): Correctly detect the division operator

### DIFF
--- a/eslint-bridge/src/rules/stylelint/function-calc-no-invalid.ts
+++ b/eslint-bridge/src/rules/stylelint/function-calc-no-invalid.ts
@@ -104,7 +104,7 @@ export const rule = stylelint.createPlugin(ruleName, function () {
       }
 
       function isDivision(node: postcssValueParser.Node) {
-        return (node.type === 'word' && node.value === '/') || node.type === 'div';
+        return (node.type === 'word' || node.type === 'div') && node.value === '/';
       }
 
       function isZero(node: postcssValueParser.Node) {

--- a/eslint-bridge/tests/rules/stylint/function-calc-no-invalid.test.ts
+++ b/eslint-bridge/tests/rules/stylint/function-calc-no-invalid.test.ts
@@ -43,6 +43,10 @@ tester.run('function-calc-no-invalid', {
       description: 'division by 1px',
       code: '.foo {width: calc(100% / 1px);}',
     },
+    {
+      description: 'comma divider',
+      code: '.foo {width: calc(100% + var(--text-color, 0px));}',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
While rewriting S5362 ('function-calc-no-invalid') as part of #3089, the detection of a division by zero assumed that the division operator could be represented by one of the two forms:

- a `word` node with a `/` value
- a `div` node

The latter turns out to be not accurate enough because such a node can actually be used for other contexts than divisions (see ['div' semantics](https://github.com/TrySound/postcss-value-parser#div)). This wrong assumption leads to false positives like [this one](https://peach.sonarsource.com/project/issues?id=directus_nodev14&issues=AYAghd7-CAMBr5DXUslu&open=AYAghd7-CAMBr5DXUslu).

To sum up, the division operator is either represented with: a `word` node _or_ a `div` node, _with_ a `/` value.