### PR TITLE
Fix FP S3403 ('different-types-comparison'): Symbols should be comparable

### DIFF
--- a/eslint-bridge/tests/rules/different-types-comparison.test.ts
+++ b/eslint-bridge/tests/rules/different-types-comparison.test.ts
@@ -135,6 +135,23 @@ ruleTesterTs.run(`Strict equality operators should not be used with dissimilar t
           }
         }`,
     },
+    {
+      code: `
+        let str = 'str', obj = {};
+        str === obj;`,
+    },
+    {
+      code: `
+        let str = 'str', obj = {};
+        str !== obj;`,
+    },
+    {
+      code: `
+      const foo = Symbol('foo');
+      const symbols = [ foo ];
+      symbols.filter(symbol => symbol !== foo);
+      `,
+    },
   ],
   invalid: [
     {
@@ -183,18 +200,6 @@ ruleTesterTs.run(`Strict equality operators should not be used with dissimilar t
       code: `
         let str = 'str', bool = false;
         str !== bool;`,
-      errors: 1,
-    },
-    {
-      code: `
-        let str = 'str', obj = {};
-        str === obj;`,
-      errors: 1,
-    },
-    {
-      code: `
-        let str = 'str', obj = {};
-        str !== obj;`,
       errors: 1,
     },
     {

--- a/its/ruling/src/test/expected/js/p5.js/javascript-S3403.json
+++ b/its/ruling/src/test/expected/js/p5.js/javascript-S3403.json
@@ -5,7 +5,6 @@
 'p5.js:src/events/keyboard.js':[
 189,
 240,
-295,
 ],
 'p5.js:src/io/files.js':[
 1854,

--- a/its/ruling/src/test/expected/js/paper.js/javascript-S3403.json
+++ b/its/ruling/src/test/expected/js/paper.js/javascript-S3403.json
@@ -1,5 +1,5 @@
 {
-'paper.js:src/item/Item.js':[
-1637,
+'paper.js:src/core/Base.js':[
+183,
 ],
 }

--- a/its/ruling/src/test/expected/js/sizzle/javascript-S3403.json
+++ b/its/ruling/src/test/expected/js/sizzle/javascript-S3403.json
@@ -1,5 +1,6 @@
 {
 'sizzle:src/sizzle.js':[
 2227,
+2457,
 ],
 }


### PR DESCRIPTION
Fixes #3132 