### PR TITLE
fix tests on Windows

### DIFF
--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
@@ -230,10 +230,12 @@ class TypeScriptSensorTest {
     verify(eslintBridgeServerMock, never()).analyzeTypeScript(any());
     verify(eslintBridgeServerMock, never()).analyzeWithProgram(any());
 
-    assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Provided tsconfig.json path doesn't exist. Path: '" + baseDir.toRealPath().resolve("wrong.json") + "'");
+    assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Provided tsconfig.json path doesn't exist. Path: '" + baseDir.toRealPath().resolve("wrong.json") + "'"); // toRealPath avoids 8.3 paths on Windows
   }
 
   private SensorContextTester createSensorContext(Path baseDir) throws IOException {
+    // toRealPath avoids 8.3 paths on Windows, which clashes with tests where test file location is checked
+    // https://en.wikipedia.org/wiki/8.3_filename
     SensorContextTester ctx = SensorContextTester.create(baseDir.toRealPath());
     ctx.fileSystem().setWorkDir(workDir);
     return ctx;

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
@@ -230,11 +230,11 @@ class TypeScriptSensorTest {
     verify(eslintBridgeServerMock, never()).analyzeTypeScript(any());
     verify(eslintBridgeServerMock, never()).analyzeWithProgram(any());
 
-    assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Provided tsconfig.json path doesn't exist. Path: '" + baseDir.resolve("wrong.json") + "'");
+    assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Provided tsconfig.json path doesn't exist. Path: '" + baseDir.toRealPath().resolve("wrong.json") + "'");
   }
 
-  private SensorContextTester createSensorContext(Path baseDir) {
-    SensorContextTester ctx = SensorContextTester.create(baseDir);
+  private SensorContextTester createSensorContext(Path baseDir) throws IOException {
+    SensorContextTester ctx = SensorContextTester.create(baseDir.toRealPath());
     ctx.fileSystem().setWorkDir(workDir);
     return ctx;
   }
@@ -411,7 +411,7 @@ class TypeScriptSensorTest {
   }
 
   @Test
-  void should_do_nothing_when_no_tsconfig_when_analysis_with_program() {
+  void should_do_nothing_when_no_tsconfig_when_analysis_with_program() throws IOException {
     var ctx = createSensorContext(baseDir);
     createInputFile(ctx);
     createSensor().execute(ctx);


### PR DESCRIPTION
basePath contained tilde path (C:\Users\VICTOR~1.DIE\AppData\...) instead of full path (C:/Users/victor.diez/AppData/...)

Using `baseDir.toRealPath()` fixes the issue, but to seems it actually checks FS