### PR TITLE
Fix dev docs: Point to the correct comment-based fixtures path

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -105,7 +105,7 @@ This script:
 
 #### Comment-based testing
 
-These tests are located in `eslint-bridge/tests/rules/fixtures/`, they follow the following structure:
+These tests are located in `eslint-bridge/tests/rules/comment-based/`, they follow the following structure:
 
 ```javascript
 some.clean.code();


### PR DESCRIPTION
The refactoring done in https://github.com/SonarSource/SonarJS/pull/3171 moved some files. The new directory structure is not up to date in the docs.