### PR TITLE
Add rule S1534 (`no-dupe-keys`) for TypeScript

### DIFF
--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/DuplicatePropertyNameCheck.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/DuplicatePropertyNameCheck.java
@@ -22,9 +22,11 @@ package org.sonar.javascript.checks;
 import org.sonar.check.Rule;
 import org.sonar.plugins.javascript.api.EslintBasedCheck;
 import org.sonar.plugins.javascript.api.JavaScriptRule;
+import org.sonar.plugins.javascript.api.TypeScriptRule;
 import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 
 @JavaScriptRule
+@TypeScriptRule
 @Rule(key = "S1534")
 @DeprecatedRuleKey(ruleKey = "DuplicatePropertyName")
 public class DuplicatePropertyNameCheck implements EslintBasedCheck {

--- a/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1534.json
+++ b/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1534.json
@@ -15,6 +15,7 @@
   "scope": "Main",
   "quickfix": "covered",
   "compatibleLanguages": [
-    "JAVASCRIPT"
+    "JAVASCRIPT",
+    "TYPESCRIPT"
   ]
 }


### PR DESCRIPTION
S1534 does not cover Typescript due to TS compiler proactively reporting it on JS objects. Now that the rule covers JSX, Typescript should also be added