### PR TITLE
fix path for comment-based test generation

### DIFF
--- a/eslint-bridge/tools/newRule.ts
+++ b/eslint-bridge/tools/newRule.ts
@@ -80,7 +80,7 @@ function run() {
       ruleMetadata,
     );
 
-    const testPath = path.join(rootFolder, `eslint-bridge/tests/rules/fixtures`);
+    const testPath = path.join(rootFolder, `eslint-bridge/tests/rules/comment-based`);
     try {
       fs.mkdirSync(testPath);
     } catch {


### PR DESCRIPTION
`npm new-rule` script still generates test on `fixtures` path, instead of the correct `comment-based`
