### PR TITLE
Fix project structure for 'moose' in TS Ruling

### DIFF
--- a/its/ruling/src/test/expected/ts/moose/typescript-S1441.json
+++ b/its/ruling/src/test/expected/ts/moose/typescript-S1441.json
@@ -723,10 +723,6 @@
 10,
 12,
 ],
-'moose:shared/constants/CastDeviceType.ts':[
-2,
-3,
-],
 'moose:shared/constants/CastEvents.ts':[
 2,
 3,

--- a/its/ruling/src/test/expected/ts/moose/typescript-S1451.json
+++ b/its/ruling/src/test/expected/ts/moose/typescript-S1451.json
@@ -212,9 +212,6 @@
 'moose:sample/results.ts':[
 0,
 ],
-'moose:shared/constants/CastDeviceType.ts':[
-0,
-],
 'moose:shared/constants/CastEvents.ts':[
 0,
 ],

--- a/its/ruling/src/test/expected/ts/moose/typescript-S1537.json
+++ b/its/ruling/src/test/expected/ts/moose/typescript-S1537.json
@@ -214,9 +214,6 @@
 12,
 13,
 ],
-'moose:shared/constants/CastDeviceType.ts':[
-3,
-],
 'moose:shared/constants/CastEvents.ts':[
 10,
 ],


### PR DESCRIPTION
4 missing issues on the file 'CastDeviceType.ts' which is not seems to
be used


relates to #3194