### PR TITLE
Fix integration unit tests failing for OS-dependent paths format

### DIFF
--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
@@ -230,11 +230,14 @@ class TypeScriptSensorTest {
     verify(eslintBridgeServerMock, never()).analyzeTypeScript(any());
     verify(eslintBridgeServerMock, never()).analyzeWithProgram(any());
 
+    String errorLog;
     if (isWindows()) {
-      assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Provided tsconfig.json path doesn't exist. Path: '" + baseDir.toRealPath().resolve("wrong.json") + "'"); // toRealPath avoids 8.3 paths on Windows
+      // toRealPath avoids 8.3 paths on Windows
+      errorLog = "Provided tsconfig.json path doesn't exist. Path: '" + baseDir.toRealPath().resolve("wrong.json") + "'";
     } else {
-      assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Provided tsconfig.json path doesn't exist. Path: '" + baseDir.resolve("wrong.json") + "'"); // toRealPath avoids 8.3 paths on Windows
+      errorLog = "Provided tsconfig.json path doesn't exist. Path: '" + baseDir.resolve("wrong.json") + "'";
     }
+    assertThat(logTester.logs(LoggerLevel.ERROR)).contains(errorLog);
     
   }
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TypeScriptSensorTest.java
@@ -230,12 +230,12 @@ class TypeScriptSensorTest {
     verify(eslintBridgeServerMock, never()).analyzeTypeScript(any());
     verify(eslintBridgeServerMock, never()).analyzeWithProgram(any());
 
-    String errorLog;
+    String errorLog = "Provided tsconfig.json path doesn't exist. Path: '%s'";
     if (isWindows()) {
       // toRealPath avoids 8.3 paths on Windows
-      errorLog = "Provided tsconfig.json path doesn't exist. Path: '" + baseDir.toRealPath().resolve("wrong.json") + "'";
+      errorLog = String.format(errorLog, baseDir.toRealPath().resolve("wrong.json"));
     } else {
-      errorLog = "Provided tsconfig.json path doesn't exist. Path: '" + baseDir.resolve("wrong.json") + "'";
+      errorLog = String.format(errorLog, baseDir.resolve("wrong.json"));
     }
     assertThat(logTester.logs(LoggerLevel.ERROR)).contains(errorLog);
     


### PR DESCRIPTION
Fixes #3175 

The test was failing because the following line was returning false: 

https://github.com/SonarSource/SonarJS/blob/ecafd2e7faf96dc708f16495edf5d5334926866c/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWithProgram.java#L121

A better fix would be:
1. finding a way to express file paths that works for all OSes
2. applying it in all the codebase

I suggest leaving this for a deeper refactoring sprint.