### PR TITLE
Remove latest SonarQube 8.9 testing from QA

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,7 +121,6 @@ plugin_qa_task:
     CIRRUS_CLONE_DEPTH: 10
     SONARSOURCE_QA: true
     matrix:
-      - SQ_VERSION: LATEST_RELEASE[8.9]
       - SQ_VERSION: LATEST_RELEASE
       - SQ_VERSION: DEV
   maven_cache:

--- a/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
@@ -128,7 +128,8 @@ class JavaScriptRulingTest {
       .restoreProfile(FileLocation.ofClasspath("/empty-js-profile.xml"))
       .restoreProfile(FileLocation.ofClasspath("/empty-css-profile.xml"))
       .restoreProfile(FileLocation.ofClasspath("/empty-terraform-profile.xml"))
-      .restoreProfile(FileLocation.ofClasspath("/empty-cloudformation-profile.xml"));
+      .restoreProfile(FileLocation.ofClasspath("/empty-cloudformation-profile.xml"))
+      .restoreProfile(FileLocation.ofClasspath("/empty-kubernetes-profile.xml"));
 
     instantiateTemplateRule("js", "rules",
       "S124",
@@ -161,6 +162,7 @@ class JavaScriptRulingTest {
     orchestrator.getServer().associateProjectToQualityProfile(projectKey, "css", "empty-profile");
     orchestrator.getServer().associateProjectToQualityProfile(projectKey, "terraform", "empty-profile");
     orchestrator.getServer().associateProjectToQualityProfile(projectKey, "cloudformation", "empty-profile");
+    orchestrator.getServer().associateProjectToQualityProfile(projectKey, "kubernetes", "empty-profile");
 
     File sourcesLocation = FileLocation.of(sources).getFile();
 

--- a/its/ruling/src/test/resources/empty-kubernetes-profile.xml
+++ b/its/ruling/src/test/resources/empty-kubernetes-profile.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile>
+  <name>empty-profile</name>
+  <language>kubernetes</language>
+  <rules>
+  </rules>
+</profile>
+


### PR DESCRIPTION
Testing with LTS is no longer required, since current plugin version is never going to be part of LTS