### PR TITLE
Run plugin QA in parallel

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,6 +34,8 @@ win_vm_definition: &WINDOWS_VM_DEFINITION
     disk: 128
     type: c2-standard-8
     use_ssd: true
+  maven_cache:
+    folder: ${CIRRUS_WORKING_DIR}/.m2/repository
     
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
@@ -102,9 +104,6 @@ build_win_task:
     - build
   <<: *WINDOWS_VM_DEFINITION
   <<: *ONLY_SONARSOURCE_QA
-  maven_cache:
-    #windows cache is buggy if using ${CIRRUS_WORKING_DIR}
-    folder: ~/.m2/repository
   build_script:
     - source cirrus-env CI
     - npm config set registry "${ARTIFACTORY_URL}/api/npm/npm"
@@ -166,9 +165,6 @@ plugin_qa_win_task:
     matrix:
       - TEST: "!CoverageTest,!TypeScriptAnalysisTest,!EslintBasedRulesTest,!SonarLintTest"
       - TEST: "CoverageTest,TypeScriptAnalysisTest,EslintBasedRulesTest,SonarLintTest"
-  maven_cache:
-    #windows cache is buggy if using ${CIRRUS_WORKING_DIR}
-    folder: ~/.m2/repository
   qa_script:
     - source /c/buildTools-docker/bin/cirrus-env QA
     - source /c/buildTools-docker/bin/set_maven_build_version $BUILD_NUMBER

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,13 +38,41 @@ win_vm_definition: &WINDOWS_VM_DEFINITION
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
 
+plugin_qa_body: &PLUGIN_QA_BODY
+  depends_on:
+    - build
+  <<: *ONLY_SONARSOURCE_QA
+  gke_container:
+    dockerfile: .cirrus/nodejs.Dockerfile
+    <<: *CONTAINER_DEFINITION
+    cpu: 15
+    memory: 30G
+  env:
+    CIRRUS_CLONE_DEPTH: 10
+    SONARSOURCE_QA: true
+  maven_cache:
+    folder: ${CIRRUS_WORKING_DIR}/.m2/repository
+  node_version_script:
+    - node -v
+  qa_script:
+    - source cirrus-env QA
+    - source set_maven_build_version $BUILD_NUMBER
+    - mvn -f its/plugin/pom.xml -Dsonar.runtimeVersion=${SQ_VERSION} -B -e -V verify surefire-report:report
+  cleanup_before_cache_script: cleanup_maven_repository
+  always:
+    surefire_report_artifacts:
+      path: "its/plugin/tests/target/site/**/*"
+      type: text/html
+    surefire_artifacts:
+      path: "its/plugin/tests/target/surefire-reports/**/*"
+      type: text/xml
 
 build_task:
   gke_container:
     dockerfile: .cirrus/nodejs.Dockerfile
     <<: *CONTAINER_DEFINITION
     cpu: 15
-    memory: 24G
+    memory: 30G
   env:
     GITHUB_TOKEN: ENCRYPTED[!f458126aa9ed2ac526f220c5acb51dd9cc255726b34761a56fc78d4294c11089502a882888cef0ca7dd4085e72e611a5!]
     # analysis on next
@@ -109,56 +137,22 @@ ws_scan_task:
       path: "whitesource/**/*"
 
 plugin_qa_task:
-  depends_on:
-    - build
-  <<: *ONLY_SONARSOURCE_QA
+  <<: *PLUGIN_QA_BODY
   gke_container:
-    dockerfile: .cirrus/nodejs.Dockerfile
-    <<: *CONTAINER_DEFINITION
-    cpu: 3
-    memory: 8G
-  env:
-    CIRRUS_CLONE_DEPTH: 10
-    SONARSOURCE_QA: true
-    matrix:
-      - SQ_VERSION: LATEST_RELEASE
-      - SQ_VERSION: DEV
-  maven_cache:
-    folder: ${CIRRUS_WORKING_DIR}/.m2/repository
-  qa_script:
-    - source cirrus-env QA
-    - source set_maven_build_version $BUILD_NUMBER
-    - mvn -f its/plugin/pom.xml -Dsonar.runtimeVersion=${SQ_VERSION} -Dmaven.test.redirectTestOutputToFile=false -B -e -V verify
-  cleanup_before_cache_script: cleanup_maven_repository
-
-plugin_qa_nodejs_task:
-  depends_on:
-    - build
-  <<: *ONLY_SONARSOURCE_QA
-  gke_container:
-    dockerfile: .cirrus/nodejs.Dockerfile
     docker_arguments:
       matrix:
         - NODE_VERSION: v12.22.12
         - NODE_VERSION: v14.20.0
         - NODE_VERSION: v16.16.0
         - NODE_VERSION: v18.6.0
-    <<: *CONTAINER_DEFINITION
-    cpu: 3
-    memory: 8G
   env:
-    CIRRUS_CLONE_DEPTH: 10
-    SONARSOURCE_QA: true
     SQ_VERSION: LATEST_RELEASE
-  maven_cache:
-    folder: ${CIRRUS_WORKING_DIR}/.m2/repository
-  node_version_script:
-    - node -v
-  qa_script:
-    - source cirrus-env QA
-    - source set_maven_build_version $BUILD_NUMBER
-    - mvn -f its/plugin/pom.xml -Dsonar.runtimeVersion=${SQ_VERSION} -Dmaven.test.redirectTestOutputToFile=false -B -e -V verify
-  cleanup_before_cache_script: cleanup_maven_repository
+
+
+plugin_qa_sq_dev_task:
+  <<: *PLUGIN_QA_BODY
+  env:
+    SQ_VERSION: DEV
 
 # Plugin QA for Windows is splint into 2 parts to make it faster
 plugin_qa_win_task:
@@ -180,8 +174,15 @@ plugin_qa_win_task:
     - source /c/buildTools-docker/bin/set_maven_build_version $BUILD_NUMBER
   # building the custom plugin required for the further tests
     - mvn clean package -f its/plugin/plugins/pom.xml
-    - mvn -f its/plugin/tests/pom.xml -Dsonar.runtimeVersion=${SQ_VERSION} -Dmaven.test.redirectTestOutputToFile=false "-Dtest=${TEST}" -B -e -V verify
+    - mvn -f its/plugin/tests/pom.xml -Dsonar.runtimeVersion=${SQ_VERSION} "-Dtest=${TEST}" -B -e -V verify surefire-report:report
   cleanup_before_cache_script: cleanup_maven_repository
+  always:
+    surefire_report_artifacts:
+      path: "its/plugin/tests/target/site/**/*"
+      type: text/html
+    surefire_artifacts:
+      path: "its/plugin/tests/target/surefire-reports/**/*"
+      type: text/xml
 
 ruling_task:
   depends_on:
@@ -220,8 +221,8 @@ promote_task:
     - ws_scan
     - build_win
     - plugin_qa
+    - plugin_qa_sq_dev
     - plugin_qa_win
-    - plugin_qa_nodejs
     - ruling
   <<: *ONLY_SONARSOURCE_QA
   gke_container:

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -75,6 +75,7 @@
           <includes>
             <include>**/*Test.java</include>
           </includes>
+          <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
         </configuration>
       </plugin>
     </plugins>

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssIssuesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssIssuesTest.java
@@ -22,8 +22,6 @@ package com.sonar.javascript.it.plugin;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
-import com.sonar.orchestrator.locator.FileLocation;
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,10 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.SearchRequest;
-import org.sonarsource.analyzer.commons.ProfileGenerator;
-import org.sonarsource.analyzer.commons.ProfileGenerator.RulesConfiguration;
 
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -50,13 +47,11 @@ class CssIssuesTest {
 
   @BeforeAll
   public static void prepare() {
-    RulesConfiguration rulesConfiguration = new RulesConfiguration();
+    ProfileGenerator.RulesConfiguration rulesConfiguration = new ProfileGenerator.RulesConfiguration();
     rulesConfiguration.add("S4660", "ignorePseudoElements", "ng-deep, /^custom-/");
-    File profile = ProfileGenerator.generateProfile(orchestrator.getServer().getUrl(), "css", "css", rulesConfiguration, Collections.emptySet());
-    orchestrator.getServer().restoreProfile(FileLocation.of(profile));
-
+    var profile = ProfileGenerator.generateProfile(orchestrator, "css", "css", rulesConfiguration, emptySet());
     orchestrator.getServer().provisionProject(PROJECT_KEY, PROJECT_KEY);
-    orchestrator.getServer().associateProjectToQualityProfile(PROJECT_KEY, "css", "rules");
+    orchestrator.getServer().associateProjectToQualityProfile(PROJECT_KEY, "css", profile);
 
     SonarScanner scanner = CssTestsUtils.createScanner(PROJECT_KEY);
     scanner.setProperty("sonar.exclusions", "**/file-with-parsing-error-excluded.css");

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssNonStandardPathTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssNonStandardPathTest.java
@@ -21,8 +21,6 @@ package com.sonar.javascript.it.plugin;
 
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
-import com.sonar.orchestrator.locator.FileLocation;
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,10 +29,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.SearchRequest;
-import org.sonarsource.analyzer.commons.ProfileGenerator;
-import org.sonarsource.analyzer.commons.ProfileGenerator.RulesConfiguration;
 
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -47,14 +45,12 @@ class CssNonStandardPathTest {
 
   @BeforeAll
   public static void prepare() {
-    RulesConfiguration rulesConfiguration = new RulesConfiguration();
-    File profile = ProfileGenerator.generateProfile(orchestrator.getServer().getUrl(), "css", "css", rulesConfiguration, Collections.emptySet());
-    orchestrator.getServer().restoreProfile(FileLocation.of(profile));
-
+    var rulesConfiguration = new ProfileGenerator.RulesConfiguration();
+    var profile = ProfileGenerator.generateProfile(orchestrator, "css", "css", rulesConfiguration, emptySet());
     orchestrator.getServer().provisionProject(PROJECT_KEY, PROJECT_KEY);
-    orchestrator.getServer().associateProjectToQualityProfile(PROJECT_KEY, "css", "rules");
+    orchestrator.getServer().associateProjectToQualityProfile(PROJECT_KEY, "css", profile);
 
-    SonarScanner scanner = SonarScanner.create()
+    SonarScanner scanner = getSonarScanner()
       .setSourceEncoding("UTF-8")
       .setProjectDir(TestUtils.projectDir("css-(dir with paren)"))
       .setProjectKey(PROJECT_KEY)

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssTestsUtils.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssTestsUtils.java
@@ -25,7 +25,7 @@ import com.sonar.orchestrator.build.SonarScanner;
 class CssTestsUtils {
 
   static SonarScanner createScanner(String projectKey) {
-    return SonarScanner.create()
+    return OrchestratorStarter.getSonarScanner()
       .setSourceEncoding("UTF-8")
       .setProjectDir(TestUtils.projectDir(projectKey))
       .setProjectKey(projectKey)

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ECMAScriptModulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ECMAScriptModulesTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(OrchestratorStarter.class)
@@ -40,7 +41,7 @@ class ECMAScriptModulesTest {
   @Test
   void test() {
     String projectKey = "esm-project";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
@@ -64,7 +64,10 @@ class EslintCustomRulesTest {
       .restoreProfileAtStartup(FileLocation.ofClasspath("/profile-typescript-custom-rules.xml"))
       .restoreProfileAtStartup(FileLocation.ofClasspath("/nosonar.xml"))
       .build();
-    orchestrator.start();
+    // Installation of SQ server in orchestrator is not thread-safe, so we need to synchronize
+    synchronized (OrchestratorStarter.class) {
+      orchestrator.start();
+    }
     return orchestrator;
   }
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MultiTsconfigTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/MultiTsconfigTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -40,7 +41,7 @@ class MultiTsconfigTest {
 
   @Test
   void test() throws Exception {
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(PROJECT)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/NoSonarTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/NoSonarTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +42,7 @@ class NoSonarTest {
   @BeforeAll
   public static void startServer() {
     String projectKey = "nosonar-project";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1")
@@ -58,7 +59,7 @@ class NoSonarTest {
   void test() {
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList("nosonar-project")).setSeverities(singletonList("INFO")).setRules(singletonList("javascript:S1116"));
-    assertThat(newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList()).hasSize(1);
+    assertThat(newWsClient(orchestrator).issues().search(request).getIssuesList()).hasSize(1);
   }
 
 }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProfileGenerator.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProfileGenerator.java
@@ -1,0 +1,180 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2012-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.javascript.it.plugin;
+
+import com.google.gson.Gson;
+import com.sonar.orchestrator.Orchestrator;
+import com.sonar.orchestrator.locator.FileLocation;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * This class is a copy of ProfileGenerator from sonar-analyzer-commons, but it uses Gson parser which is thread-safe
+ * @see https://github.com/SonarSource/sonar-analyzer-commons/blob/master/commons/src/main/java/org/sonarsource/analyzer/commons/ProfileGenerator.java
+ */
+public class ProfileGenerator {
+
+  private static final Gson gson = new Gson();
+  private static final int QUERY_PAGE_SIZE = 500;
+
+  private ProfileGenerator() {
+  }
+
+  public static String generateProfile(Orchestrator orchestrator, String language, String repository, RulesConfiguration rulesConfiguration, Set<String> excludedRules) {
+    try {
+      Set<String> ruleKeys = getRuleKeys(orchestrator.getServer().getUrl(), language, repository);
+      ruleKeys.removeAll(excludedRules);
+      var name = "rules-" + UUID.randomUUID();
+      var profileFile = generateProfile(name, language, repository, rulesConfiguration, ruleKeys);
+      orchestrator.getServer().restoreProfile(FileLocation.of(profileFile));
+      return name;
+    } catch (IOException | XMLStreamException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static File generateProfile(String name, String language, String repository, RulesConfiguration rulesConfiguration, Set<String> ruleKeys) throws XMLStreamException, IOException {
+    XMLOutputFactory output = XMLOutputFactory.newInstance();
+    StringWriter stringWriter = new StringWriter();
+    XMLStreamWriter xml = output.createXMLStreamWriter(stringWriter);
+
+    xml.writeStartDocument("UTF-8", "1.0");
+    xml.writeStartElement("profile");
+    el(xml, "name", name);
+    el(xml, "language", language);
+
+    xml.writeStartElement("rules");
+    for (String key : ruleKeys) {
+      xml.writeStartElement("rule");
+      el(xml, "repositoryKey", repository);
+      el(xml, "key", key);
+      el(xml, "priority", "INFO");
+      Collection<Parameter> parameters = rulesConfiguration.config.getOrDefault(key, Collections.emptyList());
+      if (!parameters.isEmpty()) {
+        xml.writeStartElement("parameters");
+        for (Parameter parameter : parameters) {
+          xml.writeStartElement("parameter");
+          el(xml, "key", parameter.parameterKey);
+          el(xml, "value", parameter.parameterValue);
+          xml.writeEndElement();
+        }
+        xml.writeEndElement();
+      }
+      xml.writeEndElement();
+    }
+    xml.writeEndElement();
+    xml.writeEndElement();
+    xml.writeEndDocument();
+
+    File file = File.createTempFile("profile", ".xml");
+    Files.write(file.toPath(), stringWriter.toString().getBytes(StandardCharsets.UTF_8));
+    file.deleteOnExit();
+    return file;
+
+  }
+
+  private static void el(XMLStreamWriter xml, String name, String text) throws XMLStreamException {
+    xml.writeStartElement(name);
+    xml.writeCharacters(text);
+    xml.writeEndElement();
+  }
+
+  private static Set<String> getRuleKeys(String serverUrl, String language, String repository) throws IOException {
+    Set<String> ruleKeys = new HashSet<>();
+    long total;
+    int processed = 0;
+    int page = 1;
+    do {
+      Map<String, Object> response = queryRules(serverUrl, language, repository, page);
+      total = ((Double) response.get("total")).longValue();
+      @SuppressWarnings("unchecked")
+      List<Map<String, String>> jsonRules = (List<Map<String, String>>) response.get("rules");
+      for (Map<String, String> jsonRule : jsonRules) {
+        String key = jsonRule.get("key").split(":")[1];
+        ruleKeys.add(key);
+        processed++;
+      }
+      page++;
+    } while (processed < total);
+
+    return ruleKeys;
+  }
+
+  private static Map<String, Object> queryRules(String serverUrl, String language, String repository, int page) throws IOException {
+    Map<String, Object> queryParams = new HashMap<>();
+    queryParams.put("languages", language);
+    queryParams.put("repositories", repository);
+    queryParams.put("ps", QUERY_PAGE_SIZE);
+    queryParams.put("p", page);
+    String params = queryParams.entrySet().stream()
+      .map(e -> e.getKey() + "=" + e.getValue())
+      .collect(Collectors.joining("&"));
+
+    URL url = new URL(serverUrl + "/api/rules/search?" + params);
+    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+    con.setRequestMethod("GET");
+    con.connect();
+    String response = new BufferedReader(new InputStreamReader(con.getInputStream()))
+      .lines().collect(Collectors.joining("\n"));
+    con.disconnect();
+    return gson.fromJson(response, Map.class);
+  }
+
+  public static class RulesConfiguration {
+    private Map<String, List<Parameter>> config = new HashMap<>();
+
+    public RulesConfiguration add(String ruleKey, String parameterKey, String parameterValue) {
+      List<Parameter> ruleConfiguration = this.config.computeIfAbsent(ruleKey, k -> new ArrayList<>());
+      ruleConfiguration.add(new Parameter(parameterKey, parameterValue));
+      return this;
+    }
+  }
+
+  private static class Parameter {
+    String parameterKey;
+    String parameterValue;
+
+    Parameter(String parameterKey, String parameterValue) {
+      this.parameterKey = parameterKey;
+      this.parameterValue = parameterValue;
+    }
+  }
+
+}

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithBOMTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithBOMTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +42,7 @@ class ProjectWithBOMTest {
   @Test
   void test() {
     String projectKey = "project-with-bom";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -53,7 +54,7 @@ class ProjectWithBOMTest {
 
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList(projectKey)).setRules(singletonList("javascript:S3923"));
-    List<Issues.Issue> issuesList = newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList();
+    List<Issues.Issue> issuesList = newWsClient(orchestrator).issues().search(request).getIssuesList();
     assertThat(issuesList).extracting(Issues.Issue::getLine, Issues.Issue::getComponent, Issues.Issue::getRule)
       .containsExactly(tuple(1, "project-with-bom:fileWithBom.js", "javascript:S3923"));
   }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithDifferentEncodingTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ProjectWithDifferentEncodingTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +42,7 @@ class ProjectWithDifferentEncodingTest {
   @Test
   void test() {
     String projectKey = "project-with-different-encoding";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-16")
       .setSourceDirs(".")
@@ -53,7 +54,7 @@ class ProjectWithDifferentEncodingTest {
 
     SearchRequest request = new SearchRequest();
     request.setComponentKeys(singletonList(projectKey)).setRules(singletonList("javascript:S3923"));
-    List<Issues.Issue> issuesList = newWsClient(OrchestratorStarter.ORCHESTRATOR).issues().search(request).getIssuesList();
+    List<Issues.Issue> issuesList = newWsClient(orchestrator).issues().search(request).getIssuesList();
     assertThat(issuesList).extracting(Issues.Issue::getLine, Issues.Issue::getComponent, Issues.Issue::getRule)
       .containsExactly(tuple(2, projectKey + ":fileWithUtf16.js", "javascript:S3923"));
   }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestCodeAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestCodeAnalysisTest.java
@@ -22,7 +22,6 @@ package com.sonar.javascript.it.plugin;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
-import com.sonar.orchestrator.locator.FileLocation;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.SearchRequest;
-import org.sonarsource.analyzer.commons.ProfileGenerator;
 import org.sonarsource.sonarlint.core.NodeJsHelper;
 import org.sonarsource.sonarlint.core.StandaloneSonarLintEngineImpl;
 import org.sonarsource.sonarlint.core.client.api.common.Language;
@@ -45,6 +43,7 @@ import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneAnalysisCo
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneGlobalConfiguration;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneSonarLintEngine;
 
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,18 +63,17 @@ class TestCodeAnalysisTest {
     String sourceDir = "src";
     String testDir = "test";
 
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(project)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(sourceDir)
       .setTestDirs(testDir)
       .setProjectDir(TestUtils.projectDir(project));
 
-    File jsProfile = ProfileGenerator.generateProfile(
-      orchestrator.getServer().getUrl(), "js", "javascript", new ProfileGenerator.RulesConfiguration(), new HashSet<>());
-    orchestrator.getServer().restoreProfile(FileLocation.of(jsProfile));
+    var jsProfile = ProfileGenerator.generateProfile(
+      orchestrator, "js", "javascript", new ProfileGenerator.RulesConfiguration(), new HashSet<>());
 
-    OrchestratorStarter.setProfile(project, "rules", "js");
+    OrchestratorStarter.setProfile(project, jsProfile, "js");
 
     BuildResult buildResult = orchestrator.executeBuild(build);
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TypeScriptAnalysisTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -44,7 +45,7 @@ class TypeScriptAnalysisTest {
   @Test
   void test() throws Exception {
     String projectKey = "tsproject";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -79,7 +80,7 @@ class TypeScriptAnalysisTest {
   @Test
   void should_use_custom_tsconfig() throws Exception {
     String projectKey = "tsproject-custom";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -106,7 +107,7 @@ class TypeScriptAnalysisTest {
     File dir = TestUtils.projectDir("missing-tsconfig");
 
     String projectKey = "missing-tsconfig";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -131,7 +132,7 @@ class TypeScriptAnalysisTest {
     File dir = TestUtils.projectDir("missing-tsconfig-vue");
 
     String projectKey = "missing-tsconfig-vue";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -155,7 +156,7 @@ class TypeScriptAnalysisTest {
     File dir = TestUtils.projectDir("tsproject-extended");
 
     String projectKey = "tsproject-extended";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -179,7 +180,7 @@ class TypeScriptAnalysisTest {
     String projectKey = "solution-tsconfig";
     File dir = TestUtils.projectDir(projectKey);
 
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -202,7 +203,7 @@ class TypeScriptAnalysisTest {
     String projectKey = "solution-tsconfig-custom";
     File dir = TestUtils.projectDir(projectKey);
 
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/VueAnalysisTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues;
 
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(OrchestratorStarter.class)
@@ -38,7 +39,7 @@ class VueAnalysisTest {
   @Test
   void sonarqube() {
     String projectKey = "vue-js-project";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -63,7 +64,7 @@ class VueAnalysisTest {
   @Test
   void jsWithinVueAsJavaScript() {
     String projectKey = "vue-js-project-with-lang-js";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
@@ -80,7 +81,7 @@ class VueAnalysisTest {
   @Test
   void tsWithinVueAsTypeScript() {
     String projectKey = "vue-js-project-with-lang-ts";
-    SonarScanner build = SonarScanner.create()
+    SonarScanner build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/YamlAnalysisTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/YamlAnalysisTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.javascript.it.plugin.OrchestratorStarter.getIssues;
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -39,7 +40,7 @@ public class YamlAnalysisTest {
   @Test
   void singleLineInlineAwsLambdaForJs() {
     var projectKey = "yaml-aws-lambda";
-    var build = SonarScanner.create()
+    var build = getSonarScanner()
       .setProjectKey(projectKey)
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")

--- a/its/plugin/tests/src/test/resources/junit-platform.properties
+++ b/its/plugin/tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.platform.output.capture.stdout=true
+junit.platform.output.capture.stderr=true

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <!-- override sonar-packaging plugin version from parent -->
     <version.sonar-packaging.plugin>1.20.0.405</version.sonar-packaging.plugin>
     <assertj.version>3.16.1</assertj.version>
-    <junit.version>5.7.2</junit.version>
+    <junit.version>5.8.1</junit.version>
     <mockito.version>3.5.0</mockito.version>
     <slf4j.version>1.7.21</slf4j.version>
     <sonar.version>9.3.0.51899</sonar.version>
@@ -71,6 +71,7 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <maven.compiler.release>11</maven.compiler.release>
     <jdk.min.version>11</jdk.min.version>
+    <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
 
     <!-- FIXME fix javadoc errors -->
     <doclint>none</doclint>


### PR DESCRIPTION
This was a bit complicated mostly because I needed to workaround couple of race conditions in orchestrator and scanner, which are not really ready to be run in parallel:

- Installation of SQ before the test suite needs to be synchronized 
- I explicitly set scanner version to a fixed version (4.7) and this is also installed before tests are executed to avoid race condition
- Creation of profile for tests needs to be adjusted to create unique profile for each test

Unrelated changes is fix for Windows maven cache.

It seems that capturing stdout/stderr is not working really well between JUnit 5 and maven surefire. In case we will need it we would need to disable parallel execution.