### PR TITLE
Improve S3 Bucket rule template: make rule metadata parameterizable

### DIFF
--- a/eslint-bridge/src/utils/s3-rule-template.ts
+++ b/eslint-bridge/src/utils/s3-rule-template.ts
@@ -24,16 +24,10 @@ import { getModuleAndCalledMethod, isIdentifier } from '.';
 
 export function S3BucketTemplate(
   callback: (node: estree.NewExpression, context: Rule.RuleContext) => void,
+  metadata: { meta: Rule.RuleMetaData } = { meta: {} },
 ): Rule.RuleModule {
   return {
-    meta: {
-      schema: [
-        {
-          // internal parameter for rules having secondary locations
-          enum: ['sonar-runtime'],
-        },
-      ],
-    },
+    ...metadata,
     create(context: Rule.RuleContext) {
       return {
         NewExpression: (node: estree.NewExpression) => {


### PR DESCRIPTION
A rule's metadata needs to be parameterizable. Otherwise, if we were to force the support of secondary locations, rules that don't it would still have to use the secondary location API when reporting issues, that is, calling `toEncodedMessage`.
