### PR TITLE
Update comment-based testing framework: fix secondary location encoding

### DIFF
--- a/eslint-bridge/src/linter.ts
+++ b/eslint-bridge/src/linter.ts
@@ -319,7 +319,7 @@ export function getRuleConfig(ruleModule: ESLintRule.RuleModule | undefined, inp
   return options;
 }
 
-function hasSonarRuntimeOption(
+export function hasSonarRuntimeOption(
   ruleModule: ESLintRule.RuleModule | undefined,
   ruleId: string,
 ): boolean {

--- a/eslint-bridge/src/utils/utils-location.ts
+++ b/eslint-bridge/src/utils/utils-location.ts
@@ -26,7 +26,7 @@ export type LocationHolder = AST.Token | TSESTree.Node | estree.Node | { loc: AS
 
 export function toEncodedMessage(
   message: string,
-  secondaryLocationsHolder: Array<LocationHolder>,
+  secondaryLocationsHolder: Array<LocationHolder> = [],
   secondaryMessages?: (string | undefined)[],
   cost?: number,
 ): string {

--- a/eslint-bridge/tests/rules/rule-test-launcher.test.ts
+++ b/eslint-bridge/tests/rules/rule-test-launcher.test.ts
@@ -26,6 +26,7 @@ import { readAssertions } from '../testing-framework/assertions';
 import { buildSourceCode } from 'parser';
 import { readFileSync } from 'fs';
 import { FileType } from '../../src/analyzer';
+import { hasSonarRuntimeOption } from '../../src/linter';
 
 /**
  * Return test files for specific rule based on rule key
@@ -61,12 +62,14 @@ function runRuleTests(rules: Record<string, Rule.RuleModule>, ruleTester: RuleTe
     }
     describe(`Running tests for rule ${rule}`, () => {
       files.forEach(filename => {
+        const ruleModule = rules[rule];
         const code = readFileSync(filename, { encoding: 'utf8' });
+        const errors = readAssertions(code, hasSonarRuntimeOption(ruleModule, rule));
         const tests = {
           valid: [],
-          invalid: [{ code, errors: readAssertions(code), filename }],
+          invalid: [{ code, errors, filename }],
         };
-        ruleTester.run(filename, rules[rule], tests);
+        ruleTester.run(filename, ruleModule, tests);
       });
     });
   }

--- a/eslint-bridge/tests/testing-framework/assertions.ts
+++ b/eslint-bridge/tests/testing-framework/assertions.ts
@@ -41,22 +41,26 @@ function convertToTestCaseErrors(
   issue: LineIssues,
   usesSecondaryLocations: boolean,
 ): RuleTester.TestCaseError[] {
-  const toMessage = usesSecondaryLocations ? toEncodedMessage : message => message;
+  const encodeMessageIfNeeded = usesSecondaryLocations ? toEncodedMessage : message => message;
   const line = issue.line;
   const primary = issue.primaryLocation;
   const messages = [...issue.messages.values()];
   if (primary === null) {
-    return messages.map(message => (message ? { line, message: toMessage(message) } : { line }));
+    return messages.map(message =>
+      message ? { line, message: encodeMessageIfNeeded(message) } : { line },
+    );
   } else {
     const secondary = primary.secondaryLocations;
     if (secondary.length === 0) {
       return messages.map(message =>
-        message ? { ...primary.range, message: toMessage(message) } : { ...primary.range },
+        message
+          ? { ...primary.range, message: encodeMessageIfNeeded(message) }
+          : { ...primary.range },
       );
     } else {
       return messages.map(message => ({
         ...primary.range,
-        message: toMessage(
+        message: encodeMessageIfNeeded(
           message,
           secondary.map(s => s.range.toLocationHolder()),
           secondary.map(s => s.message),

--- a/eslint-bridge/tests/testing-framework/assertions.ts
+++ b/eslint-bridge/tests/testing-framework/assertions.ts
@@ -24,31 +24,39 @@ import { FileIssues, LineIssues } from './issues';
 /**
  * Produces array of errors for the ESLint RuleTester from the file contents of a comment-based test file
  * @param fileContent The comment-based file as a string
+ * @param usesSonarRuntime A flag that indicates if the tested rule uses sonar-runtime parameter
  * @returns array of errors
  */
-export function readAssertions(fileContent: string): RuleTester.TestCaseError[] {
+export function readAssertions(
+  fileContent: string,
+  usesSonarRuntime: boolean,
+): RuleTester.TestCaseError[] {
   const expectedIssues = new FileIssues(fileContent).getExpectedIssues();
   const errors: RuleTester.TestCaseError[] = [];
-  expectedIssues.forEach(issue => errors.push(...convertToTestCaseErrors(issue)));
+  expectedIssues.forEach(issue => errors.push(...convertToTestCaseErrors(issue, usesSonarRuntime)));
   return errors;
 }
 
-function convertToTestCaseErrors(issue: LineIssues): RuleTester.TestCaseError[] {
+function convertToTestCaseErrors(
+  issue: LineIssues,
+  usesSecondaryLocations: boolean,
+): RuleTester.TestCaseError[] {
+  const toMessage = usesSecondaryLocations ? toEncodedMessage : message => message;
   const line = issue.line;
   const primary = issue.primaryLocation;
   const messages = [...issue.messages.values()];
   if (primary === null) {
-    return messages.map(message => (message ? { line, message } : { line }));
+    return messages.map(message => (message ? { line, message: toMessage(message) } : { line }));
   } else {
     const secondary = primary.secondaryLocations;
     if (secondary.length === 0) {
       return messages.map(message =>
-        message ? { ...primary.range, message } : { ...primary.range },
+        message ? { ...primary.range, message: toMessage(message) } : { ...primary.range },
       );
     } else {
       return messages.map(message => ({
         ...primary.range,
-        message: toEncodedMessage(
+        message: toMessage(
           message,
           secondary.map(s => s.range.toLocationHolder()),
           secondary.map(s => s.message),

--- a/eslint-bridge/tests/testing-framework/fixtures/missing_secondary.js
+++ b/eslint-bridge/tests/testing-framework/fixtures/missing_secondary.js
@@ -1,0 +1,6 @@
+alert(msg);
+//    ^^^> {{Secondary location message}}
+alert(msg); // Noncompliant {{Rule message}}
+//    ^^^
+
+console.log(msg); // Noncompliant {{Rule message}}

--- a/eslint-bridge/tests/testing-framework/testing-framework.test.ts
+++ b/eslint-bridge/tests/testing-framework/testing-framework.test.ts
@@ -24,10 +24,10 @@ import { readFileSync } from 'fs';
 describe('Comment-based Testing Framework', () => {
   const baseDir = path.resolve(`${__dirname}/fixtures`);
 
-  function assertions(filename: string) {
+  function assertions(filename: string, usesSecondaryLocations = false) {
     const filePath = path.join(baseDir, filename);
     const code = readFileSync(filePath, { encoding: 'utf8' });
-    return readAssertions(code);
+    return readAssertions(code, usesSecondaryLocations);
   }
 
   it('non compliant', () => {
@@ -69,7 +69,7 @@ describe('Comment-based Testing Framework', () => {
   });
 
   it('secondary', () => {
-    expect(assertions('secondary.js')).toEqual([
+    expect(assertions('secondary.js', true)).toEqual([
       {
         column: 7,
         line: 3,
@@ -98,8 +98,22 @@ describe('Comment-based Testing Framework', () => {
     ]);
   });
 
+  it('missing secondary', () => {
+    expect(assertions('missing_secondary.js', true)).toEqual(
+      expect.arrayContaining([
+        {
+          line: 6,
+          message: JSON.stringify({
+            message: 'Rule message',
+            secondaryLocations: [],
+          }),
+        },
+      ]),
+    );
+  });
+
   it('line adjustment', () => {
-    expect(assertions('adjustment.js')).toEqual([
+    expect(assertions('adjustment.js', true)).toEqual([
       {
         line: 2,
       },


### PR DESCRIPTION
When a rule enables the support of secondary locations with the internal `sonar-runtime` parameter, it forces the encoding of issue messages even if an issue does not always include secondary locations. On the other hand, the comment-based testing framework only considers local comments in test files when extracting issue expectations. Therefore, if an issue expectation does not include secondary locations, the extraction process considers it a regular issue and bypasses the encoding of the issue message. This prevents the comment-based testing framework from correctly testing issues without secondary locations reported by a rule enabling the support of secondary locations.