### PR TITLE
Fix Windows build

### DIFF
--- a/eslint-bridge/package.json
+++ b/eslint-bridge/package.json
@@ -10,7 +10,7 @@
     "ctest": "jest tests/tools/testers/comment-based/launcher.test.ts --verbose=false",
     "format": "prettier --write \"{src,tests,tools}/**/!(*.lint).ts\"",
     "compile": "tsc -b src tests",
-    "jar": "npm pack && mkdirp target/classes && mv eslint-bridge-1.0.0.tgz target/classes && ./tools/check-distribution-filepath-length.sh",
+    "jar": "npm pack && mkdirp target/classes && mv eslint-bridge-1.0.0.tgz target/classes && bash tools/check-distribution-filepath-length.sh",
     "new-rule": "ts-node tools/newRule.ts"
   },
   "repository": {


### PR DESCRIPTION
Fixes Windows build. Needs cygwin to have higher precedence over Windows binaries (ie. sort)