### PR TITLE
Fix S1313: Consider IPv4 addresses mapped to IPv6 with the ::ffff:0: prefix

### DIFF
--- a/eslint-bridge/tests/linting/eslint/rules/no-hardcoded-ip.test.ts
+++ b/eslint-bridge/tests/linting/eslint/rules/no-hardcoded-ip.test.ts
@@ -25,8 +25,9 @@ const ruleTesterTs = new TypeScriptRuleTester();
 ruleTesterTs.run('Hardcoded ip addresses should be avoided', rule, {
   valid: [
     {
-      code: `        
+      code: `
       address = "127.0.0.0";
+      address = "::ffff:0:127.0.0.0";
       address = "127.0.255.0";
       address = "255.255.255.255";
       address = "2.5.1.1";
@@ -45,6 +46,7 @@ ruleTesterTs.run('Hardcoded ip addresses should be avoided', rule, {
       address = 42,
       address = "192.0.2.5",
       address = "198.51.100.5",
+      address = "::ffff:0:198.51.100.5",
       address = "203.0.113.5",
       address = "2001:db8:acad:1::ff"`,
     },
@@ -76,6 +78,10 @@ ruleTesterTs.run('Hardcoded ip addresses should be avoided', rule, {
     },
     {
       code: `address = "10.10.10.1/32";`,
+      errors: 1,
+    },
+    {
+      code: `address = "::ffff:0:10.10.10.1";`,
       errors: 1,
     },
   ],


### PR DESCRIPTION
Fixes #3208
