### PR TITLE
Update sonar-analyzer-commons to get rule scopes from JSON files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <sonar-orchestrator.version>3.35.0.2707</sonar-orchestrator.version>
     <sonarlint.version>6.3.0.36253</sonarlint.version>
     <gson.version>2.8.9</gson.version>
-    <analyzer-commons.version>1.26.0.1029</analyzer-commons.version>
+    <analyzer-commons.version>1.28.0.1058</analyzer-commons.version>
     <sslr.version>1.22</sslr.version>
     <sonarlint.plugin.api.version>6.3.0.36253</sonarlint.plugin.api.version>
 

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/utils/RulesMetadataForSonarLintTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/utils/RulesMetadataForSonarLintTest.java
@@ -23,6 +23,9 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.javascript.checks.StringLiteralsQuotesCheck;
@@ -84,6 +87,11 @@ class RulesMetadataForSonarLintTest {
     RulesMetadataForSonarLint.main(new String[]{path.toString()});
     JsonArray jsonArray = new Gson().fromJson(Files.newBufferedReader(path), JsonArray.class);
     assertThat(jsonArray.size()).isGreaterThan(470);
+
+    var scopes = StreamSupport.stream(jsonArray.spliterator(), false)
+      .map(element -> element.getAsJsonObject().get("scope").getAsString())
+      .collect(Collectors.toSet());
+    assertThat(scopes).isEqualTo(Set.of("ALL", "MAIN", "TEST"));
   }
 
 }


### PR DESCRIPTION
Fixes #3122
