### PR TITLE
Fix S107 ('sonar-max-params'): Fix location reporting of empty functions

### DIFF
--- a/eslint-bridge/src/linting/eslint/rules/sonar-max-params.ts
+++ b/eslint-bridge/src/linting/eslint/rules/sonar-max-params.ts
@@ -72,7 +72,7 @@ export const rule: Rule.RuleModule = {
           if (functionLike.params.length > maxParams) {
             context.report({
               messageId: 'exceed',
-              loc: getFunctionHeaderLocation(node),
+              loc: getFunctionHeaderLocation(functionLike),
               data: {
                 name: getFunctionNameWithKind(functionLike),
                 count: numParams.toString(),
@@ -81,10 +81,15 @@ export const rule: Rule.RuleModule = {
             });
           }
 
-          function getFunctionHeaderLocation(node: estree.Node) {
+          function getFunctionHeaderLocation(functionLike: TSESTree.FunctionLike) {
             const sourceCode = context.getSourceCode();
-            const headerStart = sourceCode.getFirstToken(node)!;
-            const headerEnd = sourceCode.getFirstToken(node, token => token.value === '(')!;
+            const functionNode = (
+              functionLike.type === 'TSEmptyBodyFunctionExpression'
+                ? functionLike.parent!
+                : functionLike
+            ) as estree.Node;
+            const headerStart = sourceCode.getFirstToken(functionNode)!;
+            const headerEnd = sourceCode.getFirstToken(functionNode, token => token.value === '(')!;
             return {
               start: headerStart.loc.start,
               end: headerEnd.loc.start,

--- a/eslint-bridge/src/linting/eslint/rules/sonar-max-params.ts
+++ b/eslint-bridge/src/linting/eslint/rules/sonar-max-params.ts
@@ -69,7 +69,7 @@ export const rule: Rule.RuleModule = {
           const functionLike = node as unknown as TSESTree.FunctionLike;
           const maxParams = context.options[0] as number;
           const numParams = functionLike.params.length;
-          if (functionLike.params.length > maxParams) {
+          if (numParams > maxParams) {
             context.report({
               messageId: 'exceed',
               loc: getFunctionHeaderLocation(functionLike),

--- a/eslint-bridge/tests/linting/eslint/rules/sonar-max-params.test.ts
+++ b/eslint-bridge/tests/linting/eslint/rules/sonar-max-params.test.ts
@@ -85,9 +85,23 @@ ruleTester.run(``, rule, {
         {
           message: "Empty function 'm' has too many parameters (5). Maximum allowed is 3.",
           line: 1,
-          column: 12,
+          column: 11,
           endLine: 1,
           endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: `class C { constructor(a: any, b: any, c: any, d: any, e: any); }`,
+      options: [MAX_PARAMS_3],
+      errors: [
+        {
+          message:
+            "Empty function 'constructor' has too many parameters (5). Maximum allowed is 3.",
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 22,
         },
       ],
     },


### PR DESCRIPTION
Cirrus jobs for TypeScript and material2 projects are failing when trying to save an issue:

> 16:14:12.368 ERROR: Failure during analysis, Node.js command to start eslint-bridge was:/some/long/path
java.lang.IllegalArgumentException: Start pointer [line=1305, lineOffset=19] should be before end pointer [line=1305, lineOffset=19]
  ...
	at org.sonar.plugins.javascript.eslint.AnalysisProcessor.saveIssue(AnalysisProcessor.java:224)

This is caused by the recent extension of S107 ('sonar-max-params'), which now considers function signatures as well. For example, given the definition:

```typescript
class C {
  constructor(/* too many parameters */);
}
```

the rule is currently raising an issue at a location where the starting and ending columns overlap, which causes the failure:

> java.lang.IllegalArgumentException: Start pointer [line=199, lineOffset=13] should be before end pointer [line=199, lineOffset=13]
	at org.sonar.api.utils.Preconditions.checkArgument(Preconditions.java:43)
	at org.sonar.api.batch.fs.internal.DefaultInputFile.newRangeValidPointers(DefaultInputFile.java:360)
	at org.sonar.api.batch.fs.internal.DefaultInputFile.newRange(DefaultInputFile.java:301)
	at org.sonar.plugins.javascript.eslint.AnalysisProcessor.saveIssue(AnalysisProcessor.java:224)

Due to how TypeScript ESLint represents function signatures in the AST, the rule should reports issues based on the parent node to get the tokens of the function header, that is, everything before the opening parenthesis:

```typescript
class C {
  constructor(/* too many parameters */);
//^^^^^^^^^^^
}
```

