### PR TITLE
Fix FP S109 ('no-magic-numbers'): Ignore numeric literal types

### DIFF
--- a/its/ruling/src/test/expected/ts/ant-design/typescript-S109.json
+++ b/its/ruling/src/test/expected/ts/ant-design/typescript-S109.json
@@ -280,9 +280,6 @@
 8,
 ],
 'ant-design:components/result/index.tsx':[
-28,
-28,
-28,
 63,
 ],
 'ant-design:components/segmented/__tests__/index.test.tsx':[

--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/NoMagicNumbersCheck.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/NoMagicNumbersCheck.java
@@ -45,5 +45,6 @@ public class NoMagicNumbersCheck implements EslintBasedCheck {
     int[] ignore = { 0, 1, -1};
     boolean ignoreEnums = true;
     boolean ignoreReadonlyClassProperties = true;
+    boolean ignoreNumericLiteralTypes = true;
   }
 }

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/NoMagicNumbersCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/NoMagicNumbersCheckTest.java
@@ -29,6 +29,6 @@ class NoMagicNumbersCheckTest {
   @Test
   void config() {
     String configAsString = new Gson().toJson(new NoMagicNumbersCheck().configurations());
-    assertThat(configAsString).isEqualTo("[{\"ignore\":[0,1,-1],\"ignoreEnums\":true,\"ignoreReadonlyClassProperties\":true}]");
+    assertThat(configAsString).isEqualTo("[{\"ignore\":[0,1,-1],\"ignoreEnums\":true,\"ignoreReadonlyClassProperties\":true,\"ignoreNumericLiteralTypes\":true}]");
   }
 }


### PR DESCRIPTION
Fixes #3401 
