### PR TITLE
Fix FP S1172 ('no-unused-function-argument'): Ignore parameters referenced as JSX identifiers

### DIFF
--- a/eslint-bridge/tests/linting/eslint/rules/no-unused-function-argument.test.ts
+++ b/eslint-bridge/tests/linting/eslint/rules/no-unused-function-argument.test.ts
@@ -22,7 +22,7 @@ import { isParameterProperty, rule } from 'linting/eslint/rules/no-unused-functi
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
-  parserOptions: { ecmaVersion: 2018 },
+  parserOptions: { ecmaVersion: 2018, ecmaFeatures: { jsx: true } },
 });
 
 ruleTester.run('Unused function parameters should be removed', rule, {
@@ -90,6 +90,12 @@ ruleTester.run('Unused function parameters should be removed', rule, {
     },
     {
       code: `function fun(this: void) {}`,
+    },
+    {
+      code: `
+        function f(Tag) {
+          return <Tag />
+        }`,
     },
   ],
   invalid: [


### PR DESCRIPTION
Fixes #3117 

The false positive originally reported is no longer raised. Upgrading ESLint at some points probably included a bugfix in the scope analysis, but I was not able to identify which release fixed it. In any case, I added a test case to track any regression.
