### PR TITLE
Fix FP S4328: Ignore `node:` imports

### DIFF
--- a/eslint-bridge/src/linting/eslint/rules/no-implicit-dependencies.ts
+++ b/eslint-bridge/src/linting/eslint/rules/no-implicit-dependencies.ts
@@ -117,6 +117,10 @@ function raiseOnImplicitImport(
     return;
   }
 
+  if (moduleName.startsWith('node:')) {
+    return;
+  }
+
   if (baseUrl) {
     const underBaseUrlPath = path.join(baseUrl, moduleName);
     const extensions = ['', '.ts', '.d.ts', '.tsx', '.js', '.jsx', '.vue', '.mjs'];

--- a/eslint-bridge/tests/linting/eslint/rules/no-implicit-dependencies.test.ts
+++ b/eslint-bridge/tests/linting/eslint/rules/no-implicit-dependencies.test.ts
@@ -97,6 +97,16 @@ ruleTester.run('Dependencies should be explicit', rule, {
       ),
       options,
     },
+    {
+      code: `const fs = require("node:fs/promises");`,
+      filename,
+      options,
+    },
+    {
+      code: `import fs from 'node:fs/promises';`,
+      filename,
+      options,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #3334 
