### PR TITLE
Fix FP S4328: Ignore `data:` and `file:` imports

### DIFF
--- a/eslint-bridge/src/linting/eslint/rules/no-implicit-dependencies.ts
+++ b/eslint-bridge/src/linting/eslint/rules/no-implicit-dependencies.ts
@@ -117,7 +117,7 @@ function raiseOnImplicitImport(
     return;
   }
 
-  if (moduleName.startsWith('node:')) {
+  if (['node:', 'data:', 'file:'].some(prefix => moduleName.startsWith(prefix))) {
     return;
   }
 

--- a/eslint-bridge/tests/linting/eslint/rules/no-implicit-dependencies.test.ts
+++ b/eslint-bridge/tests/linting/eslint/rules/no-implicit-dependencies.test.ts
@@ -107,6 +107,16 @@ ruleTester.run('Dependencies should be explicit', rule, {
       filename,
       options,
     },
+    {
+      code: `import 'data:text/javascript,console.log("hello, world!");';`,
+      filename,
+      options,
+    },
+    {
+      code: `import 'file:/some/file.js'`,
+      filename,
+      options,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #3414 
