### PR TITLE
Fix FP S4043 (`no-misleading-array-reverse`): Consider optional chaining

### DIFF
--- a/eslint-bridge/src/linting/eslint/rules/no-misleading-array-reverse.ts
+++ b/eslint-bridge/src/linting/eslint/rules/no-misleading-array-reverse.ts
@@ -127,8 +127,14 @@ function isForbiddenOperation(node: estree.Node) {
 }
 
 function isStandaloneExpression(node: estree.Node) {
-  const parent = (node as TSESTree.Node).parent;
-  return parent?.type === 'ExpressionStatement';
+  const ancestors = localAncestorsChain(node as TSESTree.Node);
+  const returnIdx = ancestors.findIndex(ancestor => ancestor.type === 'ExpressionStatement');
+  return (
+    returnIdx > -1 &&
+    ancestors
+      .slice(0, returnIdx)
+      .every(ancestor => ['ChainExpression', 'LogicalExpression'].includes(ancestor.type))
+  );
 }
 
 function isReturnedExpression(node: estree.Node) {

--- a/eslint-bridge/tests/linting/eslint/rules/no-misleading-array-reverse.test.ts
+++ b/eslint-bridge/tests/linting/eslint/rules/no-misleading-array-reverse.test.ts
@@ -30,7 +30,8 @@ ruleTester.run('Array-mutating methods should not be used misleadingly.', rule, 
       
         // ok
         a.reverse();
-
+        a?.reverse();
+        a && a.sort();
         // ok
         d = a.map(() => true).reverse();
         // ok, there is "slice"
@@ -101,6 +102,13 @@ ruleTester.run('Array-mutating methods should not be used misleadingly.', rule, 
     },
   ],
   invalid: [
+    {
+      code: `
+        let a = [];
+        const b = a?.sort();
+        `,
+      errors: 1,
+    },
     {
       code: `
         let a = [];


### PR DESCRIPTION
Fixes #2513 