### PR TITLE
Increase timeout so test won't fail in `build_win` CI check

### DIFF
--- a/eslint-bridge/tests/server.test.ts
+++ b/eslint-bridge/tests/server.test.ts
@@ -133,7 +133,7 @@ describe('server', () => {
   it('should timeout', async () => {
     console.log = jest.fn();
 
-    const server = await start(port, '127.0.0.1', 200);
+    const server = await start(port, '127.0.0.1', 500);
 
     await new Promise(r => setTimeout(r, 100));
     expect(server.listening).toBeTruthy();
@@ -143,7 +143,7 @@ describe('server', () => {
     expect(server.listening).toBeTruthy();
     await request(server, '/status', 'GET');
 
-    await new Promise(r => setTimeout(r, 300));
+    await new Promise(r => setTimeout(r, 600));
     expect(server.listening).toBeFalsy();
 
     expect(console.log).toHaveBeenCalledWith('DEBUG eslint-bridge server closed');


### PR DESCRIPTION
It fails often: https://gist.github.com/ilia-kebets-sonarsource/557cbdfa09d496c2dd28251b97336423#build_win