### PR TITLE
Improve SonarLint integration test

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
@@ -43,7 +43,6 @@ import org.sonarsource.sonarlint.core.commons.Version;
 import org.sonarsource.sonarlint.core.commons.log.ClientLogOutput;
 
 import static com.sonar.javascript.it.plugin.TestUtils.sonarLintInputFile;
-import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestUtils.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/TestUtils.java
@@ -19,6 +19,7 @@
  */
 package com.sonar.javascript.it.plugin;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -84,56 +85,62 @@ public class TestUtils {
     }
   }
 
-  static ClientInputFile prepareInputFile(File baseDir, String relativePath, String content) throws IOException {
-    Path file = baseDir.toPath().resolve(relativePath);
-    Files.write(file, content.getBytes(StandardCharsets.UTF_8));
-    return createInputFile(file);
+  static ClientInputFile sonarLintInputFile(Path path, String content) throws IOException {
+    return createInputFile(path, content);
   }
 
-  private static ClientInputFile createInputFile(final Path path) {
-    return new ClientInputFile() {
+  private static ClientInputFile createInputFile(Path file, String content) {
+    return new TestClientInputFile(file, content);
+  }
 
-      @Override
-      public String getPath() {
-        return path.toString();
-      }
+  static class TestClientInputFile implements ClientInputFile {
+    private final String content;
+    private final Path path;
 
-      @Override
-      public boolean isTest() {
-        return false;
-      }
+    TestClientInputFile(Path path, String content) {
+      this.content = content;
+      this.path = path;
+    }
 
-      @Override
-      public Charset getCharset() {
-        return StandardCharsets.UTF_8;
-      }
+    @Override
+    public String getPath() {
+      return path.toString();
+    }
 
-      @Override
-      public <G> G getClientObject() {
-        return null;
-      }
+    @Override
+    public boolean isTest() {
+      return false;
+    }
 
-      @Override
-      public String contents() throws IOException {
-        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
-      }
+    @Override
+    public Charset getCharset() {
+      return StandardCharsets.UTF_8;
+    }
 
-      @Override
-      public String relativePath() {
-        return path.toString();
-      }
+    @Override
+    public <G> G getClientObject() {
+      return null;
+    }
 
-      @Override
-      public URI uri() {
-        return path.toUri();
-      }
+    @Override
+    public String contents() {
+      return content;
+    }
 
-      @Override
-      public InputStream inputStream() throws IOException {
-        return Files.newInputStream(path);
-      }
+    @Override
+    public String relativePath() {
+      return path.toString();
+    }
 
-    };
+    @Override
+    public URI uri() {
+      return path.toUri();
+    }
+
+    @Override
+    public InputStream inputStream() {
+      return new ByteArrayInputStream(content.getBytes(getCharset()));
+    }
   }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,11 @@
     <sonar.version>9.6.1.59531</sonar.version>
     <sonar.api.version>9.10.0.269</sonar.api.version>
     <sonar-orchestrator.version>3.35.0.2707</sonar-orchestrator.version>
-    <sonarlint.version>8.7.0.52152</sonarlint.version>
+    <sonarlint.version>8.9.0.54830</sonarlint.version>
     <gson.version>2.8.9</gson.version>
     <analyzer-commons.version>2.0.0.1075</analyzer-commons.version>
     <sslr.version>1.22</sslr.version>
-    <sonarlint.plugin.api.version>6.3.0.36253</sonarlint.plugin.api.version>
+    <sonarlint.plugin.api.version>8.9.0.54830</sonarlint.plugin.api.version>
 
     <artifactsToPublish>${project.groupId}:sonar-javascript-plugin:jar</artifactsToPublish>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>


### PR DESCRIPTION
Clean-up and small improvements to SonarLint integration tests. We avoid writing to filesystem when not required. Motivation is to fix spurious failures, however I failed to find the root cause of failure.
