### PR TITLE
Fix S6327 ('aws-sns-unencrypted-topics'): Report on the property value

### DIFF
--- a/eslint-bridge/src/linting/eslint/rules/aws-sns-unencrypted-topics.ts
+++ b/eslint-bridge/src/linting/eslint/rules/aws-sns-unencrypted-topics.ts
@@ -68,7 +68,7 @@ function checkTopic(key: string) {
 
     const masterKeyValue = getUniqueWriteUsageOrNode(ctx, masterKey.value);
     if (isUndefined(masterKeyValue)) {
-      report(masterKey);
+      report(masterKey.value);
       return;
     }
 

--- a/eslint-bridge/tests/linting/eslint/rules/comment-based/aws-sns-unencrypted-topics.js
+++ b/eslint-bridge/tests/linting/eslint/rules/comment-based/aws-sns-unencrypted-topics.js
@@ -59,10 +59,14 @@ function non_compliant() {
   const undefinedKey = undefined;
 
   new Topic(this, 'UnencryptedTopic'); // Noncompliant {{Omitting "masterKey" disables SNS topics encryption. Make sure it is safe here.}}
+//    ^^^^^
   new Topic(this, 'UnencryptedTopic', undefined); // Noncompliant
+//    ^^^^^
   new Topic(this, 'UnencryptedTopic', {}); // Noncompliant
+//                                    ^^
   new Topic(this, 'UnencryptedTopic', {
     masterKey: undefined // Noncompliant
+//             ^^^^^^^^^
   });
   new Topic(this, 'UnencryptedTopic', {
     'masterKey': undefined // Noncompliant
@@ -84,10 +88,14 @@ function non_compliant() {
   const undefinedKeyId = undefined;
 
   new CfnTopic(this, 'UnencryptedCfnTopic'); // Noncompliant {{Omitting "kmsMasterKeyId" disables SNS topics encryption. Make sure it is safe here.}}
+//    ^^^^^^^^
   new CfnTopic(this, 'UnencryptedCfnTopic', undefined); // Noncompliant
+//    ^^^^^^^^
   new CfnTopic(this, 'UnencryptedCfnTopic', {}); // Noncompliant
+//                                          ^^
   new CfnTopic(this, 'UnencryptedCfnTopic', {
     kmsMasterKeyId: undefined // Noncompliant
+//                  ^^^^^^^^^
   });
   new CfnTopic(this, 'UnencryptedCfnTopic', {
     'kmsMasterKeyId': undefined // Noncompliant


### PR DESCRIPTION
I used to report on the whole property rather than the property value, which happens to be inconsistent with the implemented reporting of other rules.