### PR TITLE
Improve S3504 (`no-var`): Highlight only `var` keyword and identifier.

### DIFF
--- a/eslint-bridge/src/linting/eslint/rules/decorators/index.ts
+++ b/eslint-bridge/src/linting/eslint/rules/decorators/index.ts
@@ -38,6 +38,7 @@ import { decoratePreferForOf } from './prefer-for-of-decorator';
 import { decoratePreferTemplate } from './prefer-template-decorator';
 import { decorateSemi } from './semi-decorator';
 import { decorateUseIsNan } from './use-isnan-decorator';
+import { decorateNoVar } from './no-var-decorator';
 
 /**
  * A decorator of an ESLint rule
@@ -70,6 +71,7 @@ export const decorators: Record<string, RuleDecorator> = {
   'no-throw-literal': decorateNoThrowLiteral,
   'no-unreachable': decorateNoUnreachable,
   'no-unused-expressions': decorateNoUnusedExpressions,
+  'no-var': decorateNoVar,
   'object-shorthand': decorateObjectShorthand,
   'prefer-for-of': decoratePreferForOf,
   'prefer-template': decoratePreferTemplate,

--- a/eslint-bridge/src/linting/eslint/rules/decorators/no-var-decorator.ts
+++ b/eslint-bridge/src/linting/eslint/rules/decorators/no-var-decorator.ts
@@ -30,8 +30,8 @@ export function decorateNoVar(rule: Rule.RuleModule): Rule.RuleModule {
       } = node as estree.VariableDeclaration;
 
       const varToken = context.getSourceCode().getTokenBefore(firstDecl.id);
-      const identifierEnd = firstDecl.id.loc?.end;
-      if (varToken == null || identifierEnd == undefined) {
+      const identifierEnd = firstDecl.id.loc!.end;
+      if (varToken == null) {
         // impossible
         return;
       }

--- a/eslint-bridge/src/linting/eslint/rules/decorators/no-var-decorator.ts
+++ b/eslint-bridge/src/linting/eslint/rules/decorators/no-var-decorator.ts
@@ -1,0 +1,47 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { Rule } from 'eslint';
+import { interceptReport } from './helpers';
+import estree from 'estree';
+
+export function decorateNoVar(rule: Rule.RuleModule): Rule.RuleModule {
+  return interceptReport(rule, (context, reportDescriptor) => {
+    if ('node' in reportDescriptor) {
+      const { node, ...rest } = reportDescriptor;
+      const {
+        declarations: [firstDecl, ..._],
+      } = node as estree.VariableDeclaration;
+
+      const varToken = context.getSourceCode().getTokenBefore(firstDecl.id);
+      const identifierEnd = firstDecl.id.loc?.end;
+      if (varToken == null || identifierEnd == undefined) {
+        // impossible
+        return;
+      }
+      context.report({
+        loc: {
+          start: varToken.loc.start,
+          end: identifierEnd,
+        },
+        ...rest,
+      });
+    }
+  });
+}

--- a/eslint-bridge/tests/linting/eslint/rules/comment-based/no-var.js
+++ b/eslint-bridge/tests/linting/eslint/rules/comment-based/no-var.js
@@ -1,0 +1,10 @@
+
+function bar() {
+  var foo = 42; // Noncompliant [[qf1!]]
+//^^^^^^^
+// edit@qf1 {{  let foo = 42;}}
+
+  var x, y = qz(); // Noncompliant [[qf2!]]
+//^^^^^
+// edit@qf2 {{  let x, y = qz();}}
+}


### PR DESCRIPTION
Fixes #3507 
