### PR TITLE
BUILD-2178 Use Vault

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,21 +1,25 @@
 gcp_credentials: ENCRYPTED[!149d4005ecdba4cdd78bb5ba22756ebb98bf8e3367ee2e9ab08c5a1608c0d3e3b501904b67a1d67c0b63085e469d7dde!]
 
 env:
-  ARTIFACTORY_URL: ENCRYPTED[!2f8fa307d3289faa0aa6791f18b961627ae44f1ef46b136e1a1e63b0b4c86454dbb25520d49b339e2d50a1e1e5f95c88!]
-  ARTIFACTORY_PRIVATE_USERNAME: repox-private-reader-lt-1a7e1f
-  ARTIFACTORY_PRIVATE_PASSWORD: ENCRYPTED[!4890acae4038fb09d3921b1126aad6af4c0bc3984e603cf1639766e44cc987c3f2b7d529b5420b2e3eca0f354b938bf8!]
-  ARTIFACTORY_DEPLOY_USERNAME: repox-qa-deployer-lt-1a7e1f
-  ARTIFACTORY_DEPLOY_PASSWORD: ENCRYPTED[!91fd8560ac00c4661c3161af1bd6e74ed8de8799e9d6ddc2f07bbcf154703adfb54d197ec2286c25f481fca7aba18c76!]
+  CIRRUS_VAULT_URL: https://vault.sonar.build:8200
+  CIRRUS_VAULT_AUTH_PATH: jwt-cirrusci
+  CIRRUS_VAULT_ROLE: cirrusci-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}
+
+  ARTIFACTORY_URL: VAULT[development/kv/data/repox data.url]
+  ARTIFACTORY_PRIVATE_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader
+  ARTIFACTORY_PRIVATE_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
+  ARTIFACTORY_DEPLOY_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer
+  ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer access_token]
   ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
-  ARTIFACTORY_API_KEY: ENCRYPTED[!4890acae4038fb09d3921b1126aad6af4c0bc3984e603cf1639766e44cc987c3f2b7d529b5420b2e3eca0f354b938bf8!]
+  ARTIFACTORY_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
+  GITHUB_TOKEN: VAULT[development/github/token/licenses-ro token]
   # burgr notification
-  BURGR_URL: ENCRYPTED[!c7e294da94762d7bac144abef6310c5db300c95979daed4454ca977776bfd5edeb557e1237e3aa8ed722336243af2d78!]
-  BURGR_USERNAME: ENCRYPTED[!b29ddc7610116de511e74bec9a93ad9b8a20ac217a0852e94a96d0066e6e822b95e7bc1fe152afb707f16b70605fddd3!]
-  BURGR_PASSWORD: ENCRYPTED[!83e130718e92b8c9de7c5226355f730e55fb46e45869149a9223e724bb99656878ef9684c5f8cfef434aa716e87f4cf2!]
+  BURGR_URL: VAULT[development/kv/data/burgr data.url]
+  BURGR_USERNAME: VAULT[development/kv/data/burgr data.cirrus_username]
+  BURGR_PASSWORD: VAULT[development/kv/data/burgr data.cirrus_password]
 
   # Use bash (instead of sh on linux or cmd.exe on windows)
   CIRRUS_SHELL: bash
-  GITHUB_TOKEN: ENCRYPTED[!f458126aa9ed2ac526f220c5acb51dd9cc255726b34761a56fc78d4294c11089502a882888cef0ca7dd4085e72e611a5!]
 
 container_definition: &CONTAINER_DEFINITION
   builder_image_project: release-engineering-ci-prod
@@ -80,13 +84,13 @@ build_task:
     memory: 30G
   env:
     # analysis on next
-    SONAR_TOKEN: ENCRYPTED[!b6fd814826c51e64ee61b0b6f3ae621551f6413383f7170f73580e2e141ac78c4b134b506f6288c74faa0dd564c05a29!]
+    SONAR_TOKEN: VAULT[development/kv/data/next data.token]
     SONAR_HOST_URL: https://next.sonarqube.com/sonarqube
     #allow deployment of pull request artifacts to repox
     DEPLOY_PULL_REQUEST: true
     #sign artifacts
-    SIGN_KEY: ENCRYPTED[!cc216dfe592f79db8006f2a591f8f98b40aa2b078e92025623594976fd32f6864c1e6b6ba74b50647f608e2418e6c336!]
-    PGP_PASSPHRASE: ENCRYPTED[!314a8fc344f45e462dd5e8dccd741d7562283a825e78ebca27d4ae9db8e65ce618e7f6aece386b2782a5abe5171467bd!]
+    SIGN_KEY: VAULT[development/kv/data/sign data.key]
+    PGP_PASSPHRASE: VAULT[development/kv/data/sign data.passphrase]
   <<: *MAVEN_CACHE
   sonar_cache:
     folder: ${HOME}/.sonar/cache
@@ -123,7 +127,7 @@ ws_scan_task:
   # run only on master and long-term branches
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*")
   env:
-    WS_APIKEY: ENCRYPTED[!3929c6148b9dfc751a2d17c590b15d755f82cd9c108f2de5f24a5b32f2a0c26144e921fab7e2c959fc2824d6d6d1550d!]
+    WS_APIKEY: VAULT[development/kv/data/mend data.apikey]
   <<: *MAVEN_CACHE
   whitesource_script:
     - source cirrus-env QA
@@ -228,8 +232,9 @@ promote_task:
     memory: 1G
   env:
     #promotion cloud function
-    GCF_ACCESS_TOKEN: ENCRYPTED[!1fb91961a5c01e06e38834e55755231d649dc62eca354593105af9f9d643d701ae4539ab6a8021278b8d9348ae2ce8be!]
-    PROMOTE_URL: ENCRYPTED[!e22ed2e34a8f7a1aea5cff653585429bbd3d5151e7201022140218f9c5d620069ec2388f14f83971e3fd726215bc0f5e!]
+    GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
+    PROMOTE_URL: VAULT[development/kv/data/promote data.url]
+    GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
     #artifacts that will have downloadable links in burgr
     ARTIFACTS: org.sonarsource.javascript:sonar-javascript-plugin:jar
   <<: *MAVEN_CACHE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
+---
 name: sonar-release
-
+# This workflow is triggered when publishing a new github release
+# yamllint disable-line rule:truthy
 on:
   release:
     types:
@@ -7,80 +9,11 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    name: Release
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.BINARIES_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.BINARIES_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.BINARIES_AWS_REGION }}
-      - name: Release
-        id: release
-        env:
-          ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
-          BINARIES_AWS_DEPLOY: ${{ secrets.BINARIES_AWS_DEPLOY }}
-          BURGRX_USER: ${{ secrets.BURGRX_USER }}
-          BURGRX_PASSWORD: ${{ secrets.BURGRX_PASSWORD }}
-          CIRRUS_TOKEN: ${{ secrets.CIRRUS_TOKEN }}
-          PATH_PREFIX: ${{ secrets.BINARIES_PATH_PREFIX }}
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          RELEASE_SSH_USER: ${{ secrets.RELEASE_SSH_USER }}
-          RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
-          SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
-        uses: SonarSource/gh-action_release/main@v4
-        with:
-          publish_to_binaries: true
-          slack_channel: team-lang-js-ts-css
-      - name: Release action results
-        if: always()
-        run: |
-          echo "${{ steps.release.outputs.releasability }}"
-          echo "${{ steps.release.outputs.promote }}"
-          echo "${{ steps.release.outputs.publish_to_binaries }}"
-          echo "${{ steps.release.outputs.release }}"
-
-  maven-central-sync:
-    runs-on: ubuntu-latest
-    name: Maven Central Sync
-    needs:
-      - release
-    steps:
-      - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v1
-      - name: JFrog config
-        run: jfrog rt config repox --url https://repox.jfrog.io/artifactory/ --apikey $ARTIFACTORY_API_KEY --basic-auth-only
-        env:
-          ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
-      - name: Get the version
-        id: get_version
-        run: |
-          IFS=. read major minor patch build <<< "${{ github.event.release.tag_name }}"
-          echo ::set-output name=build::"${build}"
-      - name: Create local repository directory
-        id: local_repo
-        run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
-      - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@v4
-        with:
-          build-number: ${{ steps.get_version.outputs.build }}
-          local-repo-dir: ${{ steps.local_repo.outputs.dir }}
-      - name: Maven Central Sync
-        id: maven-central-sync
-        continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@v4
-        with:
-          local-repo-dir: ${{ steps.local_repo.outputs.dir }}
-        env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-      - name: Notify on failure
-        if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          text: 'Maven sync failed'
-          status: failure
-          fields: repo,author,eventName
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILD_WEBHOOK }}
+    permissions:
+      id-token: write
+      contents: write
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    with:
+      publishToBinaries: true
+      mavenCentralSync: true
+      slackChannel:  team-lang-js-ts-css


### PR DESCRIPTION
- [x] depends on https://github.com/SonarSource/re-terraform-aws-vault/pull/272
- [x] `.cirrus.yml`
   - [x] rebuild docker image
   - [x] `its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/PRAnalysisTest.java` uses `Edition.DEVELOPER` and hence requires `GITHUB_TOKEN` to obtain license
- [x] `.github/workflows/release.yml`
- [ ] `.github/workflows/dogfood.yml`

Nothing to do for
* `.github/workflows/CreatePullRequest.yml`
* `.github/workflows/RequestReview.yml`
* `.github/workflows/StartProgress.yml`
* `.github/workflows/SubmitReview.yml`
