### PR TITLE
Generate wildcard TSConfig for JavaScript in SonarLint

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
@@ -143,22 +143,20 @@ class SonarLintTest {
   }
 
   @Test
-  void should_analyze_with_typed_rules() throws IOException {
-    var language = "javascript";
-    var extension = "js";
+  void should_analyze_js_with_typed_rules() throws IOException {
     String fileName;
     String content;
     List<Issue> issues;
 
-    fileName = "file." + extension;
-    content = Files.readString(TestUtils.projectDir(extension + "-sonarlint-project").toPath().resolve(fileName));
+    fileName = "file.js";
+    content = Files.readString(TestUtils.projectDir("js-sonarlint-project").toPath().resolve(fileName));
     issues = analyze(fileName, content);
-    assertThat(issues).extracting(Issue::getRuleKey).contains(language + ":S2870", language + ":S3504");
+    assertThat(issues).extracting(Issue::getRuleKey).contains("javascript:S2870", "javascript:S3504");
 
     fileName = "file.vue";
-    content = Files.readString(TestUtils.projectDir(extension + "-sonarlint-project").toPath().resolve(fileName));
+    content = Files.readString(TestUtils.projectDir("js-sonarlint-project").toPath().resolve(fileName));
     issues = analyze(fileName, content);
-    assertThat(issues).extracting(Issue::getRuleKey).contains(language + ":S2870", language + ":S3504");
+    assertThat(issues).extracting(Issue::getRuleKey).contains("javascript:S2870", "javascript:S3504");
   }
 
   @Test

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarLintTest.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.sonarsource.sonarlint.core.NodeJsHelper;
 import org.sonarsource.sonarlint.core.StandaloneSonarLintEngineImpl;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
@@ -144,9 +142,10 @@ class SonarLintTest {
     assertThat(issues).extracting(Issue::getRuleKey).containsExactly("css:S1128", "css:S1116", "css:S4660");
   }
 
-  @ParameterizedTest
-  @CsvSource({"javascript,js", "typescript,ts"})
-  void should_analyze_with_typed_rules(String language, String extension) throws IOException {
+  @Test
+  void should_analyze_with_typed_rules() throws IOException {
+    var language = "javascript";
+    var extension = "js";
     String fileName;
     String content;
     List<Issue> issues;

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -284,16 +284,16 @@ public class JavaScriptPlugin implements Plugin {
           .build());
     } else {
       var sonarLintPluginAPIManager = new SonarLintPluginAPIManager();
-      sonarLintPluginAPIManager.addSonarlintJavaScriptIndexer(context, new SonarLintPluginAPIVersion());
+      sonarLintPluginAPIManager.addSonarlintJavaScriptProjectChecker(context, new SonarLintPluginAPIVersion());
     }
   }
 
   static class SonarLintPluginAPIManager {
-    public void addSonarlintJavaScriptIndexer(Context context, SonarLintPluginAPIVersion sonarLintPluginAPIVersion) {
+    public void addSonarlintJavaScriptProjectChecker(Context context, SonarLintPluginAPIVersion sonarLintPluginAPIVersion) {
       if (sonarLintPluginAPIVersion.isDependencyAvailable()) {
         context.addExtension(SonarLintJavaScriptProjectChecker.class);
       } else {
-        LOG.debug("Error while trying to inject SonarLintJavaScriptIndexer");
+        LOG.debug("Error while trying to inject SonarLintJavaScriptProjectChecker");
       }
     }
   }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -24,6 +24,8 @@ import org.sonar.api.PropertyType;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.javascript.css.CssLanguage;
 import org.sonar.plugins.javascript.css.CssProfileDefinition;
 import org.sonar.plugins.javascript.css.CssRulesDefinition;
@@ -40,6 +42,7 @@ import org.sonar.plugins.javascript.eslint.JavaScriptEslintBasedSensor;
 import org.sonar.plugins.javascript.eslint.Monitoring;
 import org.sonar.plugins.javascript.eslint.NodeDeprecationWarning;
 import org.sonar.plugins.javascript.eslint.RulesBundles;
+import org.sonar.plugins.javascript.eslint.SonarLintJavaScriptProjectChecker;
 import org.sonar.plugins.javascript.eslint.TypeScriptChecks;
 import org.sonar.plugins.javascript.eslint.TypeScriptSensor;
 import org.sonar.plugins.javascript.eslint.YamlSensor;
@@ -56,6 +59,7 @@ import org.sonarsource.nodejs.ProcessWrapperImpl;
 
 public class JavaScriptPlugin implements Plugin {
 
+  private static final Logger LOG = Loggers.get(JavaScriptPlugin.class);
 
   // Subcategories
 
@@ -278,7 +282,30 @@ public class JavaScriptPlugin implements Plugin {
           .subCategory("CSS")
           .multiValues(true)
           .build());
+    } else {
+      var sonarLintPluginAPIManager = new SonarLintPluginAPIManager();
+      sonarLintPluginAPIManager.addSonarlintJavaScriptIndexer(context, new SonarLintPluginAPIVersion());
     }
   }
 
+  static class SonarLintPluginAPIManager {
+    public void addSonarlintJavaScriptIndexer(Context context, SonarLintPluginAPIVersion sonarLintPluginAPIVersion) {
+      if (sonarLintPluginAPIVersion.isDependencyAvailable()) {
+        context.addExtension(SonarLintJavaScriptProjectChecker.class);
+      } else {
+        LOG.debug("Error while trying to inject SonarLintJavaScriptIndexer");
+      }
+    }
+  }
+
+  static class SonarLintPluginAPIVersion {
+    boolean isDependencyAvailable() {
+      try {
+        Class.forName("org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileSystem");
+      } catch (ClassNotFoundException e) {
+        return false;
+      }
+      return true;
+    }
+  }
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
@@ -43,8 +43,6 @@ import org.sonar.plugins.javascript.eslint.cache.CacheStrategies;
 import org.sonar.plugins.javascript.eslint.cache.CacheStrategy;
 import org.sonar.plugins.javascript.utils.ProgressReport;
 
-import static org.sonar.plugins.javascript.eslint.TsConfigProvider.GeneratedTsConfigFileProvider.getDefaultCompilerOptions;
-
 public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
 
   private static final Logger LOG = Loggers.get(JavaScriptEslintBasedSensor.class);
@@ -52,7 +50,7 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
   private final TempFolder tempFolder;
   private final JavaScriptChecks checks;
   private final AnalysisProcessor processAnalysis;
-  private final JavaScriptProjectChecker javascriptProjectChecker;
+  private final JavaScriptProjectChecker javaScriptProjectChecker;
   private AnalysisMode analysisMode;
   private TsConfigProvider.Provider tsConfigProvider;
 
@@ -64,7 +62,7 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
     this.tempFolder = folder;
     this.checks = checks;
     this.processAnalysis = processAnalysis;
-    this.javascriptProjectChecker = javaScriptProjectChecker;
+    this.javaScriptProjectChecker = javaScriptProjectChecker;
   }
 
   @Override
@@ -74,12 +72,12 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
   }
 
   private TsConfigProvider.Provider getTsConfigProvider() {
-    JavaScriptProjectChecker.checkOnce(javascriptProjectChecker, context);
+    JavaScriptProjectChecker.checkOnce(javaScriptProjectChecker, context);
 
-    if (isSonarLint()) {
-      return new TsConfigProvider.SonarLintProvider(javascriptProjectChecker);
+    if (context.runtime().getProduct() == SonarProduct.SONARLINT) {
+      return new TsConfigProvider.SonarLintTsConfigProvider(javaScriptProjectChecker);
     } else {
-      return new DefaultTsConfigProvider(tempFolder, JavaScriptFilePredicate::getJavaScriptPredicate, getDefaultCompilerOptions());
+      return new DefaultTsConfigProvider(tempFolder, JavaScriptFilePredicate::getJavaScriptPredicate);
     }
   }
 
@@ -144,10 +142,6 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
     descriptor
       .onlyOnLanguage(JavaScriptLanguage.KEY)
       .name("JavaScript analysis");
-  }
-
-  private boolean isSonarLint() {
-    return context.runtime().getProduct() == SonarProduct.SONARLINT;
   }
 
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
@@ -70,9 +70,8 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
   }
 
   private TsConfigProvider.Provider getTsConfigProvider() {
-    JavaScriptProjectChecker.checkOnce(javaScriptProjectChecker, context);
-
     if (context.runtime().getProduct() == SonarProduct.SONARLINT) {
+      JavaScriptProjectChecker.checkOnce(javaScriptProjectChecker, context);
       return new TsConfigProvider.WildcardTsConfigProvider(javaScriptProjectChecker);
     } else {
       return new DefaultTsConfigProvider(tempFolder, JavaScriptFilePredicate::getJavaScriptPredicate);
@@ -116,8 +115,7 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
       LOG.debug("Analyzing file: {}", file.uri());
       String fileContent = contextUtils.shouldSendFileContent(file) ? file.contents() : null;
       JsAnalysisRequest jsAnalysisRequest = new JsAnalysisRequest(file.absolutePath(), file.type().toString(),
-        fileContent, contextUtils.ignoreHeaderComments(), tsConfigs, null,
-        analysisMode.getLinterIdFor(file));
+        fileContent, contextUtils.ignoreHeaderComments(), tsConfigs, null, analysisMode.getLinterIdFor(file));
       AnalysisResponse response = eslintBridgeServer.analyzeJavaScript(jsAnalysisRequest);
       processAnalysis.processResponse(context, checks, file, response);
       cacheStrategy.writeGeneratedFilesToCache(response.ucfgPaths);

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptProjectChecker.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptProjectChecker.java
@@ -1,0 +1,34 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.javascript.eslint;
+
+import javax.annotation.Nullable;
+import org.sonar.api.batch.sensor.SensorContext;
+
+public interface JavaScriptProjectChecker {
+  static void checkOnce(@Nullable JavaScriptProjectChecker javascriptProjectChecker, SensorContext context) {
+    if (javascriptProjectChecker != null) {
+      javascriptProjectChecker.checkOnce(context);
+    }
+  }
+
+  void checkOnce(SensorContext context);
+  boolean isBeyondLimit();
+}

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/SonarLintJavaScriptProjectChecker.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/SonarLintJavaScriptProjectChecker.java
@@ -96,6 +96,8 @@ public class SonarLintJavaScriptProjectChecker implements JavaScriptProjectCheck
         LOG.debug("Update \"{}\" to set a different limit.", MAX_LINES_PROPERTY);
       }
     } catch (RuntimeException e) {
+      // Any runtime error raised by the SonarLint API would be caught here to let the analyzer proceed with the rules that don't require
+      // type checking.
       LOG.debug("Project type checking for JavaScript files deactivated because of unexpected error", e);
     }
   }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/SonarLintJavaScriptProjectChecker.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/SonarLintJavaScriptProjectChecker.java
@@ -59,16 +59,16 @@ public class SonarLintJavaScriptProjectChecker implements JavaScriptProjectCheck
 
   private final ModuleFileSystem moduleFileSystem;
 
-  public boolean isBeyondLimit() {
-    return beyondLimit;
-  }
-
   private boolean beyondLimit = true;
 
   private boolean shouldCheck = true;
 
   public SonarLintJavaScriptProjectChecker(ModuleFileSystem moduleFileSystem) {
     this.moduleFileSystem = moduleFileSystem;
+  }
+
+  public boolean isBeyondLimit() {
+    return beyondLimit;
   }
 
   public void checkOnce(SensorContext context) {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
@@ -22,6 +22,7 @@ package org.sonar.plugins.javascript;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
@@ -29,8 +30,12 @@ import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
+import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.utils.log.LoggerLevel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class JavaScriptPluginTest {
 
@@ -41,6 +46,9 @@ class JavaScriptPluginTest {
   private static final int SONARLINT_ADDITIONAL_EXTENSIONS = 1;
 
   public static final Version LTS_VERSION = Version.create(7, 9);
+
+  @RegisterExtension
+  public LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   @Test
   void count_extensions_lts() throws Exception {
@@ -57,6 +65,17 @@ class JavaScriptPluginTest {
   void count_extensions_for_sonarlint() throws Exception {
     Plugin.Context context = setupContext(SonarRuntimeImpl.forSonarLint(LTS_VERSION));
     assertThat(context.getExtensions()).hasSize(BASE_EXTENSIONS + SONARLINT_ADDITIONAL_EXTENSIONS);
+  }
+
+  @Test
+  void classNotAvailable() {
+    var sonarLintPluginAPIVersion = mock(JavaScriptPlugin.SonarLintPluginAPIVersion.class);
+    when(sonarLintPluginAPIVersion.isDependencyAvailable()).thenReturn(false);
+    var sonarLintPluginAPIManager = new JavaScriptPlugin.SonarLintPluginAPIManager();
+    var context = mock(Plugin.Context.class);
+
+    sonarLintPluginAPIManager.addSonarlintJavaScriptProjectChecker(context, sonarLintPluginAPIVersion);
+    assertThat(logTester.logs(LoggerLevel.DEBUG)).containsExactly("Error while trying to inject SonarLintJavaScriptProjectChecker");
   }
 
   private List<PropertyDefinition> properties() {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
@@ -38,6 +38,7 @@ class JavaScriptPluginTest {
   private static final int JS_ADDITIONAL_EXTENSIONS = 4;
   private static final int TS_ADDITIONAL_EXTENSIONS = 3;
   private static final int CSS_ADDITIONAL_EXTENSIONS = 3;
+  private static final int SONARLINT_ADDITIONAL_EXTENSIONS = 1;
 
   public static final Version LTS_VERSION = Version.create(7, 9);
 
@@ -55,7 +56,7 @@ class JavaScriptPluginTest {
   @Test
   void count_extensions_for_sonarlint() throws Exception {
     Plugin.Context context = setupContext(SonarRuntimeImpl.forSonarLint(LTS_VERSION));
-    assertThat(context.getExtensions()).hasSize(BASE_EXTENSIONS);
+    assertThat(context.getExtensions()).hasSize(BASE_EXTENSIONS + SONARLINT_ADDITIONAL_EXTENSIONS);
   }
 
   private List<PropertyDefinition> properties() {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/SonarLintJavaScriptProjectCheckerTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/SonarLintJavaScriptProjectCheckerTest.java
@@ -70,7 +70,7 @@ class SonarLintJavaScriptProjectCheckerTest {
     );
 
     assertThat(checker.isBeyondLimit()).isFalse();
-    assertThat(logTester.logs()).containsExactly("Project type checking for JavaScript files activated as project size (total number of lines is 1, maximum is 1000000)");
+    assertThat(logTester.logs()).containsExactly("Project type checking for JavaScript files activated as project size (total number of lines is 1, maximum is 500000)");
   }
 
   @Test
@@ -81,8 +81,8 @@ class SonarLintJavaScriptProjectCheckerTest {
     );
 
     assertThat(checker.isBeyondLimit()).isTrue();
-    assertThat(logTester.logs()).containsExactly("Project type checking for JavaScript files deactivated due to project size (maximum is 1000000)",
-      "Update \"sonar.javascript.sonarlint.type.maxlines\" to set a different limit.");
+    assertThat(logTester.logs()).containsExactly("Project type checking for JavaScript files deactivated due to project size (maximum is 500000)",
+      "Update \"sonar.javascript.sonarlint.typechecking.maxlines\" to set a different limit.");
   }
 
   private SonarLintJavaScriptProjectChecker sonarLintJavaScriptProjectChecker(InputFile... inputFiles) {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/SonarLintJavaScriptProjectCheckerTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/SonarLintJavaScriptProjectCheckerTest.java
@@ -1,0 +1,114 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.javascript.eslint;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.plugins.javascript.JavaScriptLanguage;
+import org.sonar.plugins.javascript.css.CssLanguage;
+import org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileSystem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.sonar.plugins.javascript.eslint.SonarLintJavaScriptProjectChecker.MAX_LINES_PROPERTY;
+
+class SonarLintJavaScriptProjectCheckerTest {
+
+  @RegisterExtension
+  LogTesterJUnit5 logTester = new LogTesterJUnit5();
+
+  @TempDir
+  Path baseDir;
+
+  private static ModuleFileSystem moduleFileSystem(InputFile... inputFiles) {
+    var moduleFileSystem = mock(ModuleFileSystem.class);
+    when(moduleFileSystem.files()).thenReturn(Arrays.stream(inputFiles));
+    return moduleFileSystem;
+  }
+
+  @BeforeEach
+  void setUp() {
+    logTester.setLevel(LoggerLevel.DEBUG);
+  }
+
+  @Test
+  void should_check_javascript_files() throws IOException {
+    var checker = sonarLintJavaScriptProjectChecker(
+      inputFile("file.js", "function foo() {}", JavaScriptLanguage.KEY, 1),
+      inputFile("file.css", "h1 {\n  font-weight: bold;\n}", CssLanguage.KEY, 3)
+    );
+
+    assertThat(checker.isBeyondLimit()).isFalse();
+    assertThat(logTester.logs()).containsExactly("Project type checking for JavaScript files activated as project size (total number of lines is 1, maximum is 1000000)");
+  }
+
+  @Test
+  void should_check_detect_too_big_projects() throws IOException {
+    var checker = sonarLintJavaScriptProjectChecker(
+      inputFile("file.js", "function foo() {}", JavaScriptLanguage.KEY, 1000000),
+      inputFile("file.css", "h1 {\n  font-weight: bold;\n}", CssLanguage.KEY, 3)
+    );
+
+    assertThat(checker.isBeyondLimit()).isTrue();
+    assertThat(logTester.logs()).containsExactly("Project type checking for JavaScript files deactivated due to project size (maximum is 1000000)",
+      "Update \"sonar.javascript.sonarlint.type.maxlines\" to set a different limit.");
+  }
+
+  private SonarLintJavaScriptProjectChecker sonarLintJavaScriptProjectChecker(InputFile... inputFiles) {
+    var checker = new SonarLintJavaScriptProjectChecker(moduleFileSystem(inputFiles));
+    checker.checkOnce(sensorContext());
+    return checker;
+  }
+
+  private SensorContext sensorContext() {
+    var config = mock(Configuration.class);
+    when(config.get(MAX_LINES_PROPERTY)).thenReturn(Optional.of("10"));
+
+    var context = mock(SensorContext.class);
+    when(context.config()).thenReturn(config);
+    when(context.fileSystem()).thenReturn(new DefaultFileSystem(baseDir));
+    return context;
+  }
+
+  private InputFile inputFile(String filename, @Nullable String contents, String language, Integer lines) throws IOException {
+    var file = mock(InputFile.class);
+    when(file.language()).thenReturn(language);
+    when(file.contents()).thenReturn(contents);
+    when(file.filename()).thenReturn(filename);
+    when(file.uri()).thenReturn(baseDir.resolve(filename).toUri());
+    when(file.lines()).thenReturn(lines);
+    return file;
+  }
+
+}

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigProviderTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/TsConfigProviderTest.java
@@ -175,7 +175,7 @@ class TsConfigProviderTest {
     List<String> tsconfigs = new TsConfigProvider(tempFolder).tsconfigs(ctx);
     assertThat(tsconfigs).hasSize(1);
     String tsconfig = new String(Files.readAllBytes(Paths.get(tsconfigs.get(0))), StandardCharsets.UTF_8);
-    assertThat(tsconfig).isEqualTo("{\"files\":[\"moduleKey/file1.ts\",\"moduleKey/file2.ts\"],\"compilerOptions\":{}}");
+    assertThat(tsconfig).isEqualTo("{\"files\":[\"moduleKey/file1.ts\",\"moduleKey/file2.ts\"],\"compilerOptions\":{\"allowJs\":true,\"noImplicitAny\":true}}");
   }
 
   @Test
@@ -190,7 +190,7 @@ class TsConfigProviderTest {
     assertThat(tsconfigs)
       .hasSize(1)
       .extracting(path -> Files.readString(Paths.get(path)))
-      .contains(String.format("{\"compilerOptions\":{\"noImplicitAny\":true,\"allowJs\":true},\"include\":[\"%s/**/*\"]}", baseDir.toFile().getAbsolutePath().replace(File.separator, "/")));
+      .contains(String.format("{\"compilerOptions\":{\"allowJs\":true,\"noImplicitAny\":true},\"include\":[\"%s/**/*\"]}", baseDir.toFile().getAbsolutePath().replace(File.separator, "/")));
   }
 
   @Test
@@ -206,11 +206,11 @@ class TsConfigProviderTest {
     assertThat(provider.getTsConfigsForFile(tsconfigs, file1))
       .hasSize(1)
       .extracting(path -> Files.readString(Paths.get(path)))
-      .contains("{\"files\":[\"moduleKey/file1.js\"],\"compilerOptions\":{\"noImplicitAny\":true,\"allowJs\":true}}");
+      .contains("{\"files\":[\"moduleKey/file1.js\"],\"compilerOptions\":{\"allowJs\":true,\"noImplicitAny\":true}}");
     assertThat(provider.getTsConfigsForFile(tsconfigs, file2))
       .hasSize(1)
       .extracting(path -> Files.readString(Paths.get(path)))
-      .contains("{\"files\":[\"moduleKey/file2.js\"],\"compilerOptions\":{\"noImplicitAny\":true,\"allowJs\":true}}");
+      .contains("{\"files\":[\"moduleKey/file2.js\"],\"compilerOptions\":{\"allowJs\":true,\"noImplicitAny\":true}}");
   }
 
   @Test
@@ -222,21 +222,21 @@ class TsConfigProviderTest {
     var checker = mock(JavaScriptProjectChecker.class);
     when(checker.isBeyondLimit()).thenReturn(false);
 
-    var wildcardProvider = new TsConfigProvider.SonarLintProvider(checker);
+    var wildcardProvider = new TsConfigProvider.SonarLintTsConfigProvider(checker);
     assertThat(wildcardProvider.tsconfigs(ctx))
       .hasSize(1)
       .extracting(path -> Files.readString(Paths.get(path)))
-      .contains(String.format("{\"compilerOptions\":{\"noImplicitAny\":true,\"allowJs\":true},\"include\":[\"%s/**/*\"]}", baseDir.toFile().getAbsolutePath().replace(File.separator, "/")));
+      .contains(String.format("{\"compilerOptions\":{\"allowJs\":true,\"noImplicitAny\":true},\"include\":[\"%s/**/*\"]}", baseDir.toFile().getAbsolutePath().replace(File.separator, "/")));
 
     when(checker.isBeyondLimit()).thenReturn(true);
-    var analysedFileTsConfigProvider = new TsConfigProvider.SonarLintProvider(checker);
+    var analysedFileTsConfigProvider = new TsConfigProvider.SonarLintTsConfigProvider(checker);
     assertThat(analysedFileTsConfigProvider.tsconfigs(ctx)).isEmpty();
     assertThat(analysedFileTsConfigProvider.getTsConfigsForFile(analysedFileTsConfigProvider.tsconfigs(ctx), file1))
       .hasSize(1)
       .extracting(path -> Files.readString(Paths.get(path)))
-      .contains("{\"files\":[\"moduleKey/file1.js\"],\"compilerOptions\":{\"noImplicitAny\":true,\"allowJs\":true}}");
+      .contains("{\"files\":[\"moduleKey/file1.js\"],\"compilerOptions\":{\"allowJs\":true,\"noImplicitAny\":true}}");
 
-    var deactivatedProvider = new TsConfigProvider.SonarLintProvider(null);
+    var deactivatedProvider = new TsConfigProvider.SonarLintTsConfigProvider(null);
     assertThat(deactivatedProvider.tsconfigs(ctx)).isEmpty();
     assertThat(deactivatedProvider.getTsConfigsForFile(deactivatedProvider.tsconfigs(ctx), file1)).isEmpty();
   }


### PR DESCRIPTION
Fixes #3562

This PR generates temporary `tsconfig.json` files for every project for files analyzed with the JavaScript sensor. It also uses the SonarLint API `ModuleFileSystem` to determine if the project is not exceeding a configured limit by setting the max number of lines with `sonar.javascript.sonarlint.type.maxlines`.
