### PR TITLE
Fix dependency injection of JavaScriptProjectChecker for SonarCloud

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
@@ -53,6 +53,9 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
   private final JavaScriptProjectChecker javaScriptProjectChecker;
   private AnalysisMode analysisMode;
 
+  // This constructor is required to avoid an error in SonarCloud because there's no implementation available for the interface
+  // JavaScriptProjectChecker. The implementation for that interface is available only in SonarLint. Unlike SonarCloud,
+  // SonarQube is simply passing null and doesn't throw any error.
   public JavaScriptEslintBasedSensor(JavaScriptChecks checks, EslintBridgeServer eslintBridgeServer,
                                      AnalysisWarningsWrapper analysisWarnings, TempFolder folder, Monitoring monitoring,
                                      AnalysisProcessor processAnalysis) {

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensor.java
@@ -55,6 +55,12 @@ public class JavaScriptEslintBasedSensor extends AbstractEslintSensor {
 
   public JavaScriptEslintBasedSensor(JavaScriptChecks checks, EslintBridgeServer eslintBridgeServer,
                                      AnalysisWarningsWrapper analysisWarnings, TempFolder folder, Monitoring monitoring,
+                                     AnalysisProcessor processAnalysis) {
+    this(checks, eslintBridgeServer, analysisWarnings, folder, monitoring, processAnalysis, null);
+  }
+
+  public JavaScriptEslintBasedSensor(JavaScriptChecks checks, EslintBridgeServer eslintBridgeServer,
+                                     AnalysisWarningsWrapper analysisWarnings, TempFolder folder, Monitoring monitoring,
                                      AnalysisProcessor processAnalysis,
                                      @Nullable JavaScriptProjectChecker javaScriptProjectChecker) {
     super(eslintBridgeServer, analysisWarnings, monitoring);

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensorTest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -425,8 +426,7 @@ class JavaScriptEslintBasedSensorTest {
       new AnalysisWarningsWrapper(),
       tempFolder,
       monitoring,
-      analysisProcessor,
-      null
+      analysisProcessor
     );
     javaScriptEslintBasedSensor.execute(context);
     assertThat(logTester.logs(LoggerLevel.INFO)).contains("No input files found for analysis");
@@ -442,8 +442,7 @@ class JavaScriptEslintBasedSensorTest {
       analysisWarnings,
       tempFolder,
       monitoring,
-      analysisProcessor,
-      null
+      analysisProcessor
     );
     createInputFile(context);
     javaScriptEslintBasedSensor.execute(context);
@@ -494,7 +493,7 @@ class JavaScriptEslintBasedSensorTest {
       .thenReturn(new Gson().fromJson("{ parsingError: { line: 3, message: \"Parse error message\", code: \"Parsing\"} }", AnalysisResponse.class));
     createInputFile(context);
     new JavaScriptEslintBasedSensor(checks(ESLINT_BASED_RULE),
-      eslintBridgeServerMock, null, tempFolder, monitoring, analysisProcessor, null).execute(context);
+      eslintBridgeServerMock, null, tempFolder, monitoring, analysisProcessor).execute(context);
     Collection<Issue> issues = context.allIssues();
     assertThat(issues).isEmpty();
     assertThat(context.allAnalysisErrors()).hasSize(1);
@@ -627,7 +626,7 @@ class JavaScriptEslintBasedSensorTest {
     return createSensor(null);
   }
 
-  private JavaScriptEslintBasedSensor createSensor(JavaScriptProjectChecker javaScriptProjectChecker) {
+  private JavaScriptEslintBasedSensor createSensor(@Nullable JavaScriptProjectChecker javaScriptProjectChecker) {
     return new JavaScriptEslintBasedSensor(checks(ESLINT_BASED_RULE, "S2260", "S1451"),
       eslintBridgeServerMock, new AnalysisWarningsWrapper(), tempFolder, monitoring, analysisProcessor, javaScriptProjectChecker
     );


### PR DESCRIPTION
SonarCloud is failing to load the SonarJS plugin because the JavaScript sensor depends on an interface that only has an implementation in SonarLint. Currently, the sensor receives null for the missing implementation class in our integration tests. But on SonarCloud, it raises an exception. The solution here is to provide a second constructor to the JavaScript sensor without this dependency. SonarCloud doesn't throw an exception if there's a constructor that it can invoke.