### PR TITLE
Count JS/TS files using java API to determine if project is beyond limit

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/SonarLintProjectChecker.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/SonarLintProjectChecker.java
@@ -35,7 +35,8 @@ public class SonarLintProjectChecker implements ProjectChecker {
 
   private static final Logger LOG = Loggers.get(SonarLintProjectChecker.class);
   static final String MAX_FILES_PROPERTY = "sonar.javascript.sonarlint.typechecking.maxfiles";
-  static final int DEFAULT_MAX_FILES_FOR_TYPE_CHECKING = 10_000;
+  static final int DEFAULT_MAX_FILES_FOR_TYPE_CHECKING = 20_000;
+  private static final int FILE_WALK_MAX_DEPTH = 20;
 
   private boolean beyondLimit = true;
 
@@ -81,7 +82,7 @@ public class SonarLintProjectChecker implements ProjectChecker {
   private static long countFiles(SensorContext context, int maxFilesForTypeChecking) {
     var isPluginFile = Pattern.compile("\\.(js|cjs|mjs|jsx|ts|cts|mts|tsx|vue)$").asPredicate();
 
-    try (var files = Files.walk(context.fileSystem().baseDir().toPath())) {
+    try (var files = Files.walk(context.fileSystem().baseDir().toPath(), FILE_WALK_MAX_DEPTH)) {
       return files.filter(Files::isRegularFile)
         .map(path -> path.getFileName().toString())
         .filter(isPluginFile)
@@ -93,7 +94,7 @@ public class SonarLintProjectChecker implements ProjectChecker {
   }
 
   private static int getMaxFilesForTypeChecking(SensorContext context) {
-    return context.config().getInt(MAX_FILES_PROPERTY).orElse(DEFAULT_MAX_FILES_FOR_TYPE_CHECKING);
+    return Math.max(context.config().getInt(MAX_FILES_PROPERTY).orElse(DEFAULT_MAX_FILES_FOR_TYPE_CHECKING), 0);
   }
 
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/utils/PathWalker.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/utils/PathWalker.java
@@ -1,0 +1,88 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.javascript.utils;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class PathWalker implements Iterator<Path> {
+
+  private final Deque<Path> paths = new ArrayDeque<>();
+  private final long rootDepth;
+  private final int maxDepth;
+
+  private PathWalker(Path root, int maxDepth) {
+    this.rootDepth = depth(root);
+    this.maxDepth = Math.max(0, maxDepth);
+    addPath(root);
+  }
+
+  public static Stream<Path> stream(Path root, int maxDepth) {
+    var pathWalker = new PathWalker(root, maxDepth);
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(pathWalker, Spliterator.ORDERED), false);
+  }
+
+  private static long depth(Path path) {
+    return StreamSupport.stream(path.spliterator(), false).count();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !paths.isEmpty();
+  }
+
+  @Override
+  public Path next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    var path = paths.removeFirst();
+    if (Files.isDirectory(path)) {
+      Stream.ofNullable(path.toFile().listFiles())
+        .flatMap(Arrays::stream)
+        .map(File::toPath)
+        .forEach(this::addPath);
+    }
+    return path;
+  }
+
+  private void addPath(Path path) {
+    if (!Files.isSymbolicLink(path) && !isTooDeep(path)) {
+      paths.addFirst(path);
+    }
+  }
+
+  private boolean isTooDeep(Path path) {
+    var pathDepth = depth(path);
+    return pathDepth - rootDepth > maxDepth;
+  }
+
+}

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/SonarLintProjectCheckerTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/SonarLintProjectCheckerTest.java
@@ -20,15 +20,9 @@
 package org.sonar.plugins.javascript.eslint;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,9 +31,7 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
-import org.sonar.plugins.javascript.utils.PathWalker;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -85,74 +77,6 @@ class SonarLintProjectCheckerTest {
 
     assertThat(checker.isBeyondLimit()).isTrue();
     assertThat(logTester.logs()).containsExactly("Project type checking for JavaScript files deactivated because of unexpected error");
-  }
-
-  @Test
-  void should_walk_files() {
-    var root = baseDir.resolve("walk");
-    var depth = 5;
-    var width = 2;
-
-    var folders = createFolder(root, depth, width).collect(toList());
-    var createdPaths = getPaths(folders.stream(), 5);
-    var iteratedPaths = getPaths(PathWalker.stream(root, depth), 5);
-    assertThat(createdPaths).containsExactlyElementsOf(iteratedPaths);
-  }
-
-  @Test
-  void should_walk_files_until_max_depth() {
-    var root = baseDir.resolve("walk");
-    var depth = 5;
-    var width = 2;
-
-    var folders = createFolder(root, depth, width).collect(toList());
-    var createdPaths = getPaths(folders.stream(), depth - 1);
-    var iteratedPaths = getPaths(PathWalker.stream(root, depth), depth - 1);
-    assertThat(createdPaths).containsExactlyElementsOf(iteratedPaths);
-  }
-
-  @NotNull
-  private List<String> getPaths(Stream<Path> folder, int maxDepth) {
-    return folder.map(path -> baseDir.relativize(path))
-      .filter(path -> StreamSupport.stream(path.spliterator(), false).count() <= maxDepth)
-      .map(Path::toString)
-      .sorted()
-      .collect(toList());
-  }
-
-  private Stream<Path> createFolder(Path path, int depth, int width) {
-    try {
-      Stream.Builder<Path> streamBuilder = Stream.builder();
-      streamBuilder.add(path);
-
-      Files.createDirectory(path);
-
-      if (depth > 0) {
-        IntStream.range(0, width)
-          .mapToObj(n -> path.resolve(String.format("folder-%d", n)))
-          .flatMap(folder -> createFolder(folder, depth - 1, width))
-          .forEach(streamBuilder::add);
-
-        Files.createSymbolicLink(path.resolve("folder"), path.resolve(String.format("folder-%d", width - 1)));
-
-        IntStream.range(0, width)
-          .mapToObj(n -> path.resolve(String.format("file-%d.js", n)))
-          .peek(SonarLintProjectCheckerTest::createFile)
-          .forEach(streamBuilder::add);
-      }
-
-      return streamBuilder.build();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-  }
-
-  private static void createFile(Path path) {
-    try {
-      Files.writeString(path, "File Content");
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
   }
 
   private SonarLintProjectChecker sonarLintJavaScriptProjectChecker(int maxFiles) {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/SonarLintProjectCheckerTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/SonarLintProjectCheckerTest.java
@@ -20,8 +20,8 @@
 package org.sonar.plugins.javascript.eslint;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,6 @@ import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.plugins.javascript.JavaScriptLanguage;
 import org.sonar.plugins.javascript.css.CssLanguage;
-import org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileSystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -51,25 +50,11 @@ class SonarLintProjectCheckerTest {
   @TempDir
   Path baseDir;
 
-  private static ModuleFileSystem moduleFileSystem(InputFile... inputFiles) {
-    var moduleFileSystem = mock(ModuleFileSystem.class);
-    when(moduleFileSystem.files()).thenReturn(Arrays.stream(inputFiles));
-    return moduleFileSystem;
-  }
-
-  private static ModuleFileSystem moduleFileSystem(RuntimeException error) {
-    var moduleFileSystem = mock(ModuleFileSystem.class);
-    when(moduleFileSystem.files()).thenThrow(error);
-    return moduleFileSystem;
-  }
-
   @Test
   void should_check_javascript_files() throws IOException {
-    var checker = sonarLintJavaScriptProjectChecker(
-      2,
-      inputFile("file.js", "function foo() {}", JavaScriptLanguage.KEY),
-      inputFile("file.css", "h1 {\n  font-weight: bold;\n}", CssLanguage.KEY)
-    );
+    inputFile("file.js", "function foo() {}", JavaScriptLanguage.KEY);
+    inputFile("file.css", "h1 {\n  font-weight: bold;\n}", CssLanguage.KEY);
+    var checker = sonarLintJavaScriptProjectChecker(2);
 
     assertThat(checker.isBeyondLimit()).isFalse();
     assertThat(logTester.logs()).contains("Project type checking for JavaScript files activated as project size (total number of files is 1, maximum is 2)");
@@ -78,20 +63,19 @@ class SonarLintProjectCheckerTest {
   @Test
   void should_detect_too_big_projects() throws IOException {
     logTester.setLevel(LoggerLevel.DEBUG);
-    var checker = sonarLintJavaScriptProjectChecker(
-      2,
-      inputFile("file.js", "function foo() {}", JavaScriptLanguage.KEY),
-      inputFile("file.cjs", "function foo() {}", JavaScriptLanguage.KEY),
-      inputFile("file.ts", "function foo() {}", JavaScriptLanguage.KEY)
-    );
+    inputFile("file1.js", "function foo() {}", JavaScriptLanguage.KEY);
+    inputFile("file2.ts", "function foo() {}", JavaScriptLanguage.KEY);
+    inputFile("file3.cjs", "function foo() {}", JavaScriptLanguage.KEY);
+    inputFile("file4.cts", "function foo() {}", JavaScriptLanguage.KEY);
+    var checker = sonarLintJavaScriptProjectChecker(3);
 
     assertThat(checker.isBeyondLimit()).isTrue();
-    assertThat(logTester.logs()).contains("Project type checking for JavaScript files deactivated due to project size (maximum is 2 files)",
+    assertThat(logTester.logs()).contains("Project type checking for JavaScript files deactivated due to project size (maximum is 3 files)",
       "Update \"sonar.javascript.sonarlint.typechecking.maxfiles\" to set a different limit.");
   }
 
   @Test
-  void should_detect_errors() throws IOException {
+  void should_detect_errors() {
     logTester.setLevel(LoggerLevel.DEBUG);
     var checker = sonarLintJavaScriptProjectChecker(new IllegalArgumentException());
 
@@ -99,15 +83,17 @@ class SonarLintProjectCheckerTest {
     assertThat(logTester.logs()).containsExactly("Project type checking for JavaScript files deactivated because of unexpected error");
   }
 
-  private SonarLintProjectChecker sonarLintJavaScriptProjectChecker(int maxFiles, InputFile... inputFiles) {
-    var checker = new SonarLintProjectChecker(moduleFileSystem(inputFiles));
+  private SonarLintProjectChecker sonarLintJavaScriptProjectChecker(int maxFiles) {
+    var checker = new SonarLintProjectChecker();
     checker.checkOnce(sensorContext(maxFiles));
     return checker;
   }
 
   private SonarLintProjectChecker sonarLintJavaScriptProjectChecker(RuntimeException error) {
-    var checker = new SonarLintProjectChecker(moduleFileSystem(error));
-    checker.checkOnce(sensorContext());
+    var checker = new SonarLintProjectChecker();
+    var context = sensorContext();
+    when(context.fileSystem().baseDir()).thenThrow(error);
+    checker.checkOnce(context);
     return checker;
   }
 
@@ -125,15 +111,19 @@ class SonarLintProjectCheckerTest {
     return context;
   }
 
-  private InputFile inputFile(String filename, @Nullable String contents, String language) throws IOException {
+  private void inputFile(String filename, @Nullable String contents, String language) throws IOException {
     var file = mock(InputFile.class);
-    var uri = baseDir.resolve(filename).toUri();
+    var path = baseDir.resolve(filename);
+    var uri = path.toUri();
+
+    if (contents != null) {
+      Files.writeString(path, contents);
+    }
 
     when(file.language()).thenReturn(language);
     when(file.contents()).thenReturn(contents);
     when(file.filename()).thenReturn(filename);
     when(file.uri()).thenReturn(uri);
-    return file;
   }
 
 }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/utils/PathWalkerTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/utils/PathWalkerTest.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.plugins.javascript.utils;
 
 import java.io.IOException;

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/utils/PathWalkerTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/utils/PathWalkerTest.java
@@ -1,0 +1,91 @@
+package org.sonar.plugins.javascript.utils;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PathWalkerTest {
+
+  @TempDir
+  Path baseDir;
+
+  @Test
+  void should_walk_files() {
+    var root = baseDir.resolve("walk");
+    var depth = 5;
+    var width = 2;
+
+    var folders = createFolder(root, depth, width).collect(toList());
+    var createdPaths = getPaths(folders.stream(), 5);
+    var iteratedPaths = getPaths(PathWalker.stream(root, depth), 5);
+    assertThat(createdPaths).containsExactlyElementsOf(iteratedPaths);
+  }
+
+  @Test
+  void should_walk_files_until_max_depth() {
+    var root = baseDir.resolve("walk");
+    var depth = 5;
+    var width = 2;
+
+    var folders = createFolder(root, depth, width).collect(toList());
+    var createdPaths = getPaths(folders.stream(), depth - 1);
+    var iteratedPaths = getPaths(PathWalker.stream(root, depth), depth - 1);
+    assertThat(createdPaths).containsExactlyElementsOf(iteratedPaths);
+  }
+
+  @NotNull
+  private List<String> getPaths(Stream<Path> folder, int maxDepth) {
+    return folder.map(path -> baseDir.relativize(path))
+      .filter(path -> StreamSupport.stream(path.spliterator(), false).count() <= maxDepth)
+      .map(Path::toString)
+      .sorted()
+      .collect(toList());
+  }
+
+  private Stream<Path> createFolder(Path path, int depth, int width) {
+    try {
+      Stream.Builder<Path> streamBuilder = Stream.builder();
+      streamBuilder.add(path);
+
+      Files.createDirectory(path);
+
+      if (depth > 0) {
+        IntStream.range(0, width)
+          .mapToObj(n -> path.resolve(String.format("folder-%d", n)))
+          .flatMap(folder -> createFolder(folder, depth - 1, width))
+          .forEach(streamBuilder::add);
+
+        Files.createSymbolicLink(path.resolve("folder"), path.resolve(String.format("folder-%d", width - 1)));
+
+        IntStream.range(0, width)
+          .mapToObj(n -> path.resolve(String.format("file-%d.js", n)))
+          .peek(PathWalkerTest::createFile)
+          .forEach(streamBuilder::add);
+      }
+
+      return streamBuilder.build();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static void createFile(Path path) {
+    try {
+      Files.writeString(path, "File Content");
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+}


### PR DESCRIPTION
The PR uses the Java API to count the analyzed project JS/TS files. This metric is used to determine if the default generation of a tsconfig.json file specifying the project files with a general wildcard expression will be fast enough for SonarLint. The use of the Java API is best suited for this use case as it counts the same files that the TypeScript compiler will parse.