### PR TITLE
Fix Parsing of reserved keywords that should not throw, because it could be used on legacy JavaScript

### DIFF
--- a/eslint-bridge/tests/services/analysis/analyzers/js/analyzer.test.ts
+++ b/eslint-bridge/tests/services/analysis/analyzers/js/analyzer.test.ts
@@ -746,4 +746,18 @@ describe('analyzeJSTS', () => {
       APIError.parsingError('Unexpected token (3:0)', { line: 3 }),
     );
   });
+
+  it('should parse code with reserved keywords as variable names for S1527 (future-reserved-words)', async () => {
+    const rules = [
+      { key: 'future-reserved-words', configurations: [], fileTypeTarget: ['MAIN'] },
+    ] as RuleConfig[];
+    initializeLinter(rules);
+
+    const filePath = path.join(__dirname, 'fixtures', 's1527.js');
+    const language = 'js';
+
+    const { issues } = analyzeJSTS(await jsTsInput({ filePath }), language) as JsTsAnalysisOutput;
+
+    expect(issues).toHaveLength(7);
+  });
 });

--- a/eslint-bridge/tests/services/analysis/analyzers/js/fixtures/s1527.js
+++ b/eslint-bridge/tests/services/analysis/analyzers/js/fixtures/s1527.js
@@ -1,0 +1,12 @@
+var implements; // NOK
+
+implements = 42; // ok, usage
+var implements; // ok, second declaration
+
+var interface; // NOK
+var public = 42; // NOK
+function foo(static) {} // NOK
+var await; // NOK
+function yield() { // NOK
+  var extends; // NOK
+}


### PR DESCRIPTION
Fixes #2990
