### PR TITLE
Deprecate S2814 (`no-redeclare`) for TypeScript

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinition.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinition.java
@@ -76,6 +76,8 @@ public class JavaScriptProfilesDefinition implements BuiltInQualityProfilesDefin
 
     keys.stream()
       .filter(activeKeysForBothLanguages::contains)
+      // deprecated for Typescript: https://github.com/SonarSource/SonarJS/issues/3580
+      .filter(key -> !TypeScriptLanguage.KEY.equals(language) || !"S2814".equals(key))
       .forEach(key -> newProfile.activateRule(repositoryKey, key));
 
     addSecurityRules(newProfile, language);

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinition.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinition.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.javascript.rules;
 
 import java.util.Collections;
 import org.sonar.api.SonarRuntime;
+import org.sonar.api.rule.RuleStatus;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.javascript.checks.CheckList;
 import org.sonar.plugins.javascript.JavaScriptProfilesDefinition;
@@ -49,7 +50,10 @@ public class TypeScriptRulesDefinition implements RulesDefinition {
     NewRule commentRegularExpression = repository.rule("S124");
     commentRegularExpression.setTemplate(true);
 
+    // deprecated for Typescript: https://github.com/SonarSource/SonarJS/issues/3580
+    NewRule redeclaredVariables = repository.rule("S2814");
+    redeclaredVariables.setStatus(RuleStatus.DEPRECATED);
+
     repository.done();
   }
-
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinition.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinition.java
@@ -51,8 +51,8 @@ public class TypeScriptRulesDefinition implements RulesDefinition {
     commentRegularExpression.setTemplate(true);
 
     // deprecated for Typescript: https://github.com/SonarSource/SonarJS/issues/3580
-    NewRule redeclaredVariables = repository.rule("S2814");
-    redeclaredVariables.setStatus(RuleStatus.DEPRECATED);
+    NewRule redeclaredSymbol = repository.rule("S2814");
+    redeclaredSymbol.setStatus(RuleStatus.DEPRECATED);
 
     repository.done();
   }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinitionTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinitionTest.java
@@ -95,6 +95,7 @@ class JavaScriptProfilesDefinitionTest {
     assertThat(profile.rules()).extracting("repoKey").containsOnly(CheckList.TS_REPOSITORY_KEY);
     assertThat(profile.rules().size()).isGreaterThan(100);
     assertThat(profile.rules()).extracting(BuiltInQualityProfilesDefinition.BuiltInActiveRule::ruleKey).contains("S5122");
+    assertThat(profile.rules()).extracting(BuiltInQualityProfilesDefinition.BuiltInActiveRule::ruleKey).doesNotContain("S2814");
 
     assertThat(deprecatedRulesInProfile(profile, deprecatedTsRules)).isEmpty();
   }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinitionTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinitionTest.java
@@ -75,6 +75,7 @@ class JavaScriptProfilesDefinitionTest {
     assertThat(profile.name()).isEqualTo(JavaScriptProfilesDefinition.SONAR_WAY);
     assertThat(profile.rules()).extracting("repoKey").containsOnly(CheckList.JS_REPOSITORY_KEY);
     assertThat(profile.rules().size()).isGreaterThan(100);
+    assertThat(profile.rules()).extracting(BuiltInQualityProfilesDefinition.BuiltInActiveRule::ruleKey).contains("S2814");
 
     assertThat(deprecatedRulesInProfile(profile, deprecatedJsRules)).isEmpty();
   }

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinitionTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinitionTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.internal.SonarRuntimeImpl;
+import org.sonar.api.rule.RuleStatus;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.debt.DebtRemediationFunction.Type;
 import org.sonar.api.server.rule.RulesDefinition.Param;
@@ -120,6 +121,7 @@ class TypeScriptRulesDefinitionTest {
     assertThat(rule.debtRemediationFunction().type()).isEqualTo(Type.CONSTANT_ISSUE);
     assertThat(rule.type()).isEqualTo(RuleType.BUG);
     assertThat(repository.rule("S124").template()).isTrue();
+    assertThat(repository.rule("S2814").status()).isEqualTo(RuleStatus.DEPRECATED);
   }
 
   private void assertAllRuleParametersHaveDescription(Repository repository) {


### PR DESCRIPTION
Fixes #3580 

Note: we failed to add `Deprecated` section to the rule description