### PR TITLE
Improve test coverage for file hash in cache

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/cache/FileMetadata.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/cache/FileMetadata.java
@@ -27,9 +27,9 @@ import org.sonar.api.batch.fs.InputFile;
 
 public class FileMetadata {
 
-  private long size;
+  private final long size;
 
-  private byte[] hash;
+  private final byte[] hash;
 
   FileMetadata(long size, byte[] hash) {
     this.size = size;

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/cache/FileMetadataTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/cache/FileMetadataTest.java
@@ -1,0 +1,61 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.javascript.eslint.cache;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileMetadataTest {
+
+
+  @Test
+  void test() throws Exception {
+    var file = TestInputFileBuilder.create("module", "file.ts")
+      .setContents("abc")
+      .setCharset(StandardCharsets.UTF_8)
+      .build();
+
+    var same = TestInputFileBuilder.create("module", "file.ts")
+      .setContents("abc")
+      .setCharset(StandardCharsets.UTF_8)
+      .build();
+
+    var metadata = FileMetadata.from(file);
+    assertThat(metadata.compareTo(same)).isTrue();
+
+    var diffSize = TestInputFileBuilder.create("module", "file.ts")
+      .setContents("a")
+      .setCharset(StandardCharsets.UTF_8)
+      .build();
+    assertThat(metadata.compareTo(diffSize)).isFalse();
+
+    var diffContent = TestInputFileBuilder.create("module", "file.ts")
+      .setContents("def")
+      .setCharset(StandardCharsets.UTF_8)
+      .build();
+    assertThat(metadata.compareTo(diffContent)).isFalse();
+  }
+
+}


### PR DESCRIPTION
I am still not 100% happy with it because of extended usage of mocks, we would need to refactor the code to make it more testable