### PR TITLE
Fix FP S5860 (`unused-named-groups`): Consider accesses via the index syntax

### DIFF
--- a/eslint-bridge/src/linting/eslint/rules/helpers/ast.ts
+++ b/eslint-bridge/src/linting/eslint/rules/helpers/ast.ts
@@ -564,6 +564,12 @@ export function isDotNotation(
   return node.type === 'MemberExpression' && !node.computed && node.property.type === 'Identifier';
 }
 
+export function isIndexNotation(
+  node: estree.Node,
+): node is estree.MemberExpression & { property: StringLiteral } {
+  return node.type === 'MemberExpression' && node.computed && isStringLiteral(node.property);
+}
+
 export function isObjectDestructuring(
   node: estree.Node,
 ): node is

--- a/eslint-bridge/tests/linting/eslint/rules/unused-named-groups.test.ts
+++ b/eslint-bridge/tests/linting/eslint/rules/unused-named-groups.test.ts
@@ -203,6 +203,15 @@ typeAwareRuleTester.run('Regular expressions named groups should be used', rule,
         }
       `,
     },
+    {
+      code: `
+        const pattern = /(?<foo>\\w)/;
+        const matched = pattern.exec('str');
+        if (matched) {
+          matched.indices.groups['foo'];
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -567,6 +576,16 @@ typeAwareRuleTester.run('Regular expressions named groups should be used', rule,
         const matched = 'str'.match(pattern);
         if (matched) {
           matched.groups['bar'];
+        }
+      `,
+      errors: 1,
+    },
+    {
+      code: `
+        const pattern = /(?<foo>\\w)(?<bar>\\w)/; // Noncompliant: unused 'foo'
+        const matched = pattern.exec('str');
+        if (matched) {
+          matched.indices.groups['bar'];
         }
       `,
       errors: 1,

--- a/eslint-bridge/tests/linting/eslint/rules/unused-named-groups.test.ts
+++ b/eslint-bridge/tests/linting/eslint/rules/unused-named-groups.test.ts
@@ -194,6 +194,15 @@ typeAwareRuleTester.run('Regular expressions named groups should be used', rule,
       }
       `,
     },
+    {
+      code: `
+        const pattern = /(?<foo>\\w)/;
+        const matched = 'str'.matchAll(pattern);
+        if (matched) {
+          matched.groups['foo'];
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -551,6 +560,16 @@ typeAwareRuleTester.run('Regular expressions named groups should be used', rule,
       }
       `,
       errors: 2,
+    },
+    {
+      code: `
+        const pattern = /(?<foo>\\w)(?<bar>\\w)/; // Noncompliant: unused 'foo'
+        const matched = 'str'.match(pattern);
+        if (matched) {
+          matched.groups['bar'];
+        }
+      `,
+      errors: 1,
     },
   ],
 });


### PR DESCRIPTION
Fixes #3683 