### PR TITLE
Fix FP S2639 (`sonar-no-empty-character-class`): Ignore `[^]` matching any character

### DIFF
--- a/src/linting/eslint/rules/sonar-no-empty-character-class.ts
+++ b/src/linting/eslint/rules/sonar-no-empty-character-class.ts
@@ -27,7 +27,7 @@ export const rule: Rule.RuleModule = createRegExpRule(
   context => {
     return {
       onCharacterClassEnter: (node: CharacterClass) => {
-        if (node.elements.length === 0) {
+        if (node.elements.length === 0 && !node.negate) {
           context.reportRegExpNode({
             messageId: 'issue',
             node: context.node,

--- a/tests/linting/eslint/rules/comment-based/sonar-no-empty-character-class.js
+++ b/tests/linting/eslint/rules/comment-based/sonar-no-empty-character-class.js
@@ -4,6 +4,7 @@
 /[foo]/;
 /[\[\]]/;
 /[   ]/;
+/[^]/;
 /foo[]/;                    // Noncompliant {{Rework this empty character class that doesn't match anything.}}
 //  ^^
 /foo[]bar/;                 // Noncompliant


### PR DESCRIPTION
While validating the rule on Peach, there are many false positives for this specific pattern `[^]` which matches any character. Unfortunately, this was not detected with the projects we use on ruling.
