### PR TITLE
Remove compilerHost to handle vue files in program creation

### DIFF
--- a/src/services/program/program.ts
+++ b/src/services/program/program.ts
@@ -34,34 +34,6 @@ import { addTsConfigIfDirectory, debug, toUnixPath } from 'helpers';
 import tmp from 'tmp';
 import { promisify } from 'util';
 import fs from 'fs/promises';
-import { parsers } from 'parsing/jsts';
-
-/**
- * Empty AST to be sent to Vue parser, as we just use it to provide us with the JS/TS code,
- * no need for it to make further actions with the AST result.
- */
-const emptySourceCode = {
-  ast: {
-    type: 'Program',
-    start: 0,
-    end: 0,
-    loc: {
-      start: {
-        line: 1,
-        column: 0,
-      },
-      end: {
-        line: 1,
-        column: 0,
-      },
-    },
-    range: [0, 0],
-    comments: [],
-    tokens: [],
-    sourceType: 'module',
-    body: [],
-  },
-};
 
 /**
  * A cache of created TypeScript's Program instances
@@ -199,27 +171,6 @@ export async function createProgram(tsConfig: string): Promise<{
   missingTsConfig: boolean;
 }> {
   const programOptions = createProgramOptions(tsConfig);
-
-  programOptions.host = ts.createCompilerHost(programOptions.options);
-
-  const originalReadFile = programOptions.host.readFile;
-  // Patch readFile to be able to read only JS/TS from vue files
-  programOptions.host.readFile = fileName => {
-    const contents = originalReadFile(fileName);
-    if (contents && fileName.endsWith('.vue')) {
-      const codes: string[] = [];
-      parsers.vuejs.parse(contents, {
-        parser: {
-          parseForESLint: (code: string) => {
-            codes.push(code);
-            return emptySourceCode;
-          },
-        },
-      });
-      return codes.join('');
-    }
-    return contents;
-  };
 
   const program = ts.createProgram(programOptions);
   const inputProjectReferences = program.getProjectReferences() || [];


### PR DESCRIPTION
It can only work with watchProgram. This reverts https://github.com/SonarSource/SonarJS/pull/3743
