### PR TITLE
Fix FP S4023 (`no-empty-interface`): Exclude extensions of TypeScript utility types

### DIFF
--- a/its/ruling/src/test/expected/ts/ant-design/typescript-S4023.json
+++ b/its/ruling/src/test/expected/ts/ant-design/typescript-S4023.json
@@ -1,10 +1,4 @@
 {
-'ant-design:components/skeleton/Image.tsx':[
-6,
-],
-'ant-design:components/skeleton/Skeleton.tsx':[
-16,
-],
 'ant-design:components/tree/Tree.tsx':[
 54,
 ],

--- a/its/ruling/src/test/expected/ts/eigen/typescript-S4023.json
+++ b/its/ruling/src/test/expected/ts/eigen/typescript-S4023.json
@@ -59,9 +59,6 @@
 'eigen:src/app/Components/ArtworkFilter/Filters/YearOptions.tsx':[
 21,
 ],
-'eigen:src/app/Components/ArtworkFilter/components/ArtworkFilterOptionCheckboxItem.tsx':[
-7,
-],
 'eigen:src/app/Scenes/Onboarding/ForgotPassword.tsx':[
 20,
 ],

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4023.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4023.html
@@ -3,12 +3,23 @@ contains more properties than are specified in the type. But in the case of an e
 successful. The result is highly likely to confuse maintainers.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
-interface MyFace {}  // Noncompliant
+interface A {}  // Noncompliant
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
-interface MyFace {
+interface A {
   foo: number;
 }
+</pre>
+<h2>Exceptions</h2>
+<p>No issue is raised if the empty interface extends a <a href="https://www.typescriptlang.org/docs/handbook/utility-types.html">TypeScript utility
+type</a>.</p>
+<pre>
+interface A {
+  foo: number;
+  bar: string;
+}
+
+interface B extends Pick&lt;A, 'foo'&gt; {}
 </pre>
 

--- a/src/linting/eslint/rules/decorators/index.ts
+++ b/src/linting/eslint/rules/decorators/index.ts
@@ -28,6 +28,7 @@ import { decorateNoDupeKeys } from './no-dupe-keys-decorator';
 import { decorateNoDuplicateImports } from './no-duplicate-imports-decorator';
 import { decorateNoEmpty } from './no-empty-decorator';
 import { decorateNoEmptyFunction } from './no-empty-function-decorator';
+import { decorateNoEmptyInterface } from './no-empty-interface-decorator';
 import { decorateNoExtraSemi } from './no-extra-semi-decorator';
 import { decorateNoRedeclare } from './no-redeclare-decorator';
 import { decorateNoThisAlias } from './no-this-alias-decorator';
@@ -69,6 +70,7 @@ export const decorators: Record<string, RuleDecorator> = {
   'no-duplicate-imports': decorateNoDuplicateImports,
   'no-empty': decorateNoEmpty,
   'no-empty-function': decorateNoEmptyFunction,
+  'no-empty-interface': decorateNoEmptyInterface,
   'no-extra-semi': decorateNoExtraSemi,
   'no-redeclare': decorateNoRedeclare,
   'no-this-alias': decorateNoThisAlias,

--- a/src/linting/eslint/rules/decorators/no-empty-interface-decorator.ts
+++ b/src/linting/eslint/rules/decorators/no-empty-interface-decorator.ts
@@ -1,0 +1,68 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+// https://sonarsource.github.io/rspec/#/rspec/S4023/javascript
+
+import { Rule } from 'eslint';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { interceptReport } from './helpers';
+
+// core implementation of this rule raises issues on empty interface extending TypeScript utility types
+export function decorateNoEmptyInterface(rule: Rule.RuleModule): Rule.RuleModule {
+  return interceptReport(rule, (context, reportDescriptor) => {
+    const id = (reportDescriptor as any).node as TSESTree.Identifier;
+    const decl = id.parent as TSESTree.TSInterfaceDeclaration;
+    if (decl.extends?.length === 1 && isUtilityType(decl.extends[0])) {
+      return;
+    }
+    context.report(reportDescriptor);
+  });
+}
+
+/**
+ * TypeScript provides a set of utility types to facilitate type transformations.
+ * @see https://www.typescriptlang.org/docs/handbook/utility-types.html
+ */
+const UtilityTypes = new Set([
+  'Awaited',
+  'Partial',
+  'Required',
+  'Readonly',
+  'Record',
+  'Pick',
+  'Omit',
+  'Exclude',
+  'Extract',
+  'NonNullable',
+  'Parameters',
+  'ConstructorParameters',
+  'ReturnType',
+  'InstanceType',
+  'ThisParameterType',
+  'OmitThisParameter',
+  'ThisType',
+  'Uppercase',
+  'Lowercase',
+  'Capitalize',
+  'Uncapitalize',
+]);
+
+function isUtilityType(node: TSESTree.TSInterfaceHeritage) {
+  return node.expression.type === 'Identifier' && UtilityTypes.has(node.expression.name);
+}

--- a/tests/linting/eslint/rules/decorators/no-empty-interface-decorator.test.ts
+++ b/tests/linting/eslint/rules/decorators/no-empty-interface-decorator.test.ts
@@ -1,0 +1,51 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { rules as typescriptESLintRules } from '@typescript-eslint/eslint-plugin';
+import { decorateNoEmptyInterface } from 'linting/eslint/rules/decorators/no-empty-interface-decorator';
+import { TypeScriptRuleTester } from '../../../../tools';
+
+const ruleTester = new TypeScriptRuleTester();
+const rule = decorateNoEmptyInterface(typescriptESLintRules['no-empty-interface']);
+ruleTester.run(`Decorated rule should provide suggestion`, rule, {
+  valid: [
+    {
+      code: 'interface A { x: string }',
+    },
+    {
+      code: 'interface A { x: string, y: string }; interface B extends Pick<A, "x"> {}',
+    },
+  ],
+  invalid: [
+    {
+      code: 'interface A {}',
+      errors: 1,
+    },
+    {
+      code: 'interface A extends "foo" {}',
+      errors: 1,
+      output: 'type A = "foo"',
+    },
+    {
+      code: 'interface A extends Z {}',
+      errors: 1,
+      output: 'type A = Z',
+    },
+  ],
+});


### PR DESCRIPTION
Fixes #3634 
