### PR TITLE
Update S4139 (`no-for-in-array`): Cover cases from TypeScript ESLint implementation

### DIFF
--- a/src/linting/eslint/rules/helpers/type.ts
+++ b/src/linting/eslint/rules/helpers/type.ts
@@ -65,6 +65,10 @@ export function isUnion(node: estree.Node, services: RequiredParserServices) {
   return type.isUnion();
 }
 
+export function getUnionTypes(type: ts.Type): ts.Type[] {
+  return type.isUnion() ? type.types : [type];
+}
+
 export function isUndefinedOrNull(node: estree.Node, services: RequiredParserServices) {
   const checker = services.program.getTypeChecker();
   const typ = checker.getTypeAtLocation(services.esTreeNodeToTSNodeMap.get(node as TSESTree.Node));
@@ -103,5 +107,31 @@ export function getSignatureFromCallee(node: estree.Node, services: RequiredPars
   const checker = services.program.getTypeChecker();
   return checker.getResolvedSignature(
     services.esTreeNodeToTSNodeMap.get(node as TSESTree.Node) as ts.CallLikeExpression,
+  );
+}
+
+export function isArrayLikeType(type: ts.Type, services: RequiredParserServices) {
+  const checker = services.program.getTypeChecker();
+  const constrained = checker.getBaseConstraintOfType(type);
+  return isArrayOrUnionOfArrayType(constrained ?? type, services);
+}
+
+function isArrayOrUnionOfArrayType(type: ts.Type, services: RequiredParserServices): boolean {
+  for (const part of getUnionTypes(type)) {
+    if (!isArrayType(part, services)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Internal TS API
+function isArrayType(type: ts.Type, services: RequiredParserServices): type is ts.TypeReference {
+  const checker = services.program.getTypeChecker();
+  return (
+    'isArrayType' in checker &&
+    typeof checker.isArrayType === 'function' &&
+    checker.isArrayType(type)
   );
 }

--- a/src/linting/eslint/rules/helpers/type.ts
+++ b/src/linting/eslint/rules/helpers/type.ts
@@ -110,6 +110,12 @@ export function getSignatureFromCallee(node: estree.Node, services: RequiredPars
   );
 }
 
+/**
+ * This function checks if a type may correspond to an array type. Beyond simple array types, it will also
+ * consider the union of array types and generic types extending an array type.
+ * @param type A type to check
+ * @param services The services used to get access to the TypeScript type checker
+ */
 export function isArrayLikeType(type: ts.Type, services: RequiredParserServices) {
   const checker = services.program.getTypeChecker();
   const constrained = checker.getBaseConstraintOfType(type);

--- a/src/linting/eslint/rules/no-for-in-iterable.ts
+++ b/src/linting/eslint/rules/no-for-in-iterable.ts
@@ -35,6 +35,7 @@ export const rule: Rule.RuleModule = {
     if (!isRequiredParserServices(services)) {
       return {};
     }
+    const checker = services.program.getTypeChecker();
     return {
       ForInStatement: (node: estree.Node) => {
         const type = getTypeFromTreeNode((node as estree.ForInStatement).right, services);
@@ -48,12 +49,36 @@ export const rule: Rule.RuleModule = {
         }
       },
     };
+
+    function isIterable(type: ts.Type) {
+      return isCollection(type) || isString(type) || isArrayLikeType(type);
+    }
+
+    function isArrayLikeType(type: ts.Type) {
+      const constrained = checker.getBaseConstraintOfType(type);
+      return isArrayOrUnionOfArrayType(constrained ?? type);
+    }
+
+    function isArrayOrUnionOfArrayType(type: ts.Type): boolean {
+      for (const part of getUnionTypes(type)) {
+        if (!isArrayType(part)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    // Internal TS API
+    function isArrayType(type: ts.Type): type is ts.TypeReference {
+      return (
+        'isArrayType' in checker &&
+        typeof checker.isArrayType === 'function' &&
+        checker.isArrayType(type)
+      );
+    }
   },
 };
-
-function isIterable(type: ts.Type) {
-  return isCollection(type) || isString(type);
-}
 
 function isCollection(type: ts.Type) {
   return (
@@ -82,4 +107,12 @@ function isString(type: ts.Type) {
     (type.symbol !== undefined && type.symbol.name === 'String') ||
     (type.flags & ts.TypeFlags.StringLike) !== 0
   );
+}
+
+function getUnionTypes(type: ts.Type): ts.Type[] {
+  return isUnionType(type) ? type.types : [type];
+}
+
+function isUnionType(type: ts.Type): type is ts.UnionType {
+  return (type.flags & ts.TypeFlags.Union) !== 0;
 }

--- a/tests/linting/eslint/rules/no-alphabetical-sort.test.ts
+++ b/tests/linting/eslint/rules/no-alphabetical-sort.test.ts
@@ -142,6 +142,9 @@ ruleTester.run(`A compare function should be provided when using "Array.prototyp
       }
     `,
     },
+    {
+      code: `Array.prototype.sort.apply([1, 2, 10])`,
+    },
   ],
   invalid: [
     {

--- a/tests/linting/eslint/rules/no-for-in-iterable.test.ts
+++ b/tests/linting/eslint/rules/no-for-in-iterable.test.ts
@@ -29,6 +29,13 @@ ruleTesterJs.run('"for in" should not be used with iterables [js]', rule, {
         const array = [1, 2, 3];
         for (let value in array) console.log(value); // not reported if type information is missing`,
     },
+    {
+      code: `
+        for (const x of [3, 4, 5]) {
+          console.log(x);
+        }
+    `,
+    },
   ],
   invalid: [],
 });
@@ -85,6 +92,53 @@ ruleTesterTs.run('"for in" should not be used with iterables [ts]', rule, {
       code: `
         const string = new String('Hello');
         for (let value in string) console.log(value);`,
+      errors: 1,
+    },
+    {
+      code: `
+for (const x in [3, 4, 5]) {
+  console.log(x);
+}
+      `,
+      errors: 1,
+    },
+    {
+      code: `
+const z = [3, 4, 5];
+for (const x in z) {
+  console.log(x);
+}
+      `,
+      errors: 1,
+    },
+    {
+      code: `
+const fn = (arr: number[]) => {
+  for (const x in arr) {
+    console.log(x);
+  }
+};
+      `,
+      errors: 1,
+    },
+    {
+      code: `
+const fn = (arr: number[] | string[]) => {
+  for (const x in arr) {
+    console.log(x);
+  }
+};
+      `,
+      errors: 1,
+    },
+    {
+      code: `
+const fn = <T extends any[]>(arr: T) => {
+  for (const x in arr) {
+    console.log(x);
+  }
+};
+      `,
       errors: 1,
     },
   ],


### PR DESCRIPTION
This PR reuses the logic from `no-alphabetical-sort` which is now shared in `type.ts` to cover cases where the array is a union type or a generic parameter extending an array type as in:

```typescript
const fn = (arr: number[] | string[]) => {
  for (const x in arr) {
    console.log(x);
  }
};
```

and 

```typescript
const fn = <T extends any[]>(arr: T) => {
  for (const x in arr) {
    console.log(x);
  }
};
```

Fixes #3796 
