### PR TITLE
Update S6571 (`no-redundant-type-constituents`): Limit unknown detection to the `unknown` type annotation

### DIFF
--- a/src/linting/eslint/rules/decorators/no-redundant-type-constituents.ts
+++ b/src/linting/eslint/rules/decorators/no-redundant-type-constituents.ts
@@ -17,6 +17,8 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+// https://sonarsource.github.io/rspec/#/rspec/S6571/javascript
+
 import { Rule } from 'eslint';
 import { interceptReport } from './helpers';
 import { TSESTree } from '@typescript-eslint/experimental-utils';
@@ -36,7 +38,11 @@ function reportExempting(context: Rule.RuleContext, descriptor: Rule.ReportDescr
 }
 
 // We ignore issues where typeName is 'any' but not raised for the 'any' keyword as they are due to unresolved types.
+// The same exception applies for the 'unknown' type.
 function exemptionCondition(node: TSESTree.Node, descriptor: Rule.ReportDescriptor) {
   const data = descriptor.data;
-  return data?.['typeName'] === 'any' && node.type !== 'TSAnyKeyword';
+  return (
+    (data?.['typeName'] === 'any' && node.type !== 'TSAnyKeyword') ||
+    (data?.['typeName'] === 'unknown' && node.type !== 'TSUnknownKeyword')
+  );
 }

--- a/tests/linting/eslint/rules/comment-based/no-redundant-type-constituents.ts
+++ b/tests/linting/eslint/rules/comment-based/no-redundant-type-constituents.ts
@@ -23,3 +23,8 @@ type H = 0 & number; // Noncompliant
 type I = ZERO & number; // Noncompliant
 type J = '' & string; // Noncompliant
 type K = 0n & bigint; // Noncompliant
+
+const x: unknown | string = '42'; // Noncompliant
+
+type hidden = unknown;
+const y: hidden | string = '42'; // Compliant - FP


### PR DESCRIPTION
I noticed that we already reduced the scope of the rule for `any` to simple cases. I did the same for the case of `unknown` since we are facing the same issue as François did when he first implemented the rule and limited the scope.