### PR TITLE
Analyze files without tsconfig also when using AnalysisWithWatchProgram

### DIFF
--- a/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/JavaScriptRulingTest.java
@@ -67,7 +67,7 @@ class JavaScriptRulingTest {
   public static final Orchestrator orchestrator = Orchestrator
     .builderEnv()
     .useDefaultAdminCredentialsForBuilds(true)
-    .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE[9.9]"))
+    .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE"))
     .addPlugin(
       FileLocation.byWildcardMavenFilename(
         new File("../../sonar-plugin/sonar-javascript-plugin/target"),
@@ -256,6 +256,7 @@ class JavaScriptRulingTest {
       .setTestDirs(testDir)
       .setSourceEncoding("utf-8")
       .setScannerVersion(SCANNER_VERSION)
+      .setDebugLogs(true)
       .setProperty(
         "sonar.lits.dump.old",
         FileLocation

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractAnalysis.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractAnalysis.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.javascript.JavaScriptFilePredicate;
 import org.sonar.plugins.javascript.JavaScriptLanguage;
 import org.sonar.plugins.javascript.TypeScriptLanguage;
@@ -31,6 +33,7 @@ import org.sonar.plugins.javascript.utils.ProgressReport;
 
 abstract class AbstractAnalysis {
 
+  private static final Logger LOG = Loggers.get(AbstractAnalysis.class);
   static final String PROGRESS_REPORT_TITLE = "Progress of JavaScript/TypeScript analysis";
   static final long PROGRESS_REPORT_PERIOD = TimeUnit.SECONDS.toMillis(10);
 
@@ -60,6 +63,7 @@ abstract class AbstractAnalysis {
   }
 
   void initialize(SensorContext context, JsTsChecks checks, AnalysisMode analysisMode) {
+    LOG.debug("Initializing " + getClass().getName());
     this.context = context;
     contextUtils = new ContextUtils(context);
     this.checks = checks;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractEslintSensor.java
@@ -22,6 +22,7 @@ package org.sonar.plugins.javascript.eslint;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -114,9 +115,16 @@ public abstract class AbstractEslintSensor implements Sensor {
   protected abstract List<InputFile> getInputFiles();
 
   protected boolean shouldAnalyzeWithProgram(List<InputFile> inputFiles) {
-    return (
-      inputFiles.stream().noneMatch(f -> f.filename().endsWith(".vue")) &&
-      !contextUtils.isSonarLint()
-    );
+    if (contextUtils.isSonarLint()) {
+      LOG.debug("Will use AnalysisWithWatchProgram because we are in SonarLint context");
+      return false;
+    }
+    var vueFile = inputFiles.stream().filter(f -> f.filename().endsWith(".vue")).findAny();
+    if (vueFile.isPresent()) {
+      LOG.debug("Will use AnalysisWithWatchProgram because we have vue file");
+      return false;
+    }
+    LOG.debug("Will use AnalysisWithProgram");
+    return true;
   }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWithWatchProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWithWatchProgram.java
@@ -73,15 +73,12 @@ public class AnalysisWithWatchProgram extends AbstractAnalysis {
           TsConfigFile tsConfigFile = entry.getKey();
           List<InputFile> files = entry.getValue();
           if (TsConfigFile.UNMATCHED_CONFIG.equals(tsConfigFile)) {
-            LOG.info("Skipping {} files with no tsconfig.json", files.size());
-            LOG.debug(
-              "Skipped files: " +
-              files.stream().map(InputFile::toString).collect(Collectors.joining("\n"))
-            );
-            continue;
+            LOG.info("Analyzing {} files without tsconfig", files.size());
+            analyzeTsConfig(null, files);
+          } else {
+            LOG.info("Analyzing {} files using tsconfig: {}", files.size(), tsConfigFile);
+            analyzeTsConfig(tsConfigFile, files);
           }
-          LOG.info("Analyzing {} files using tsconfig: {}", files.size(), tsConfigFile);
-          analyzeTsConfig(tsConfigFile, files);
           // Clear Watch Program Cache. Useful only for SonarQube with Vue files. To be removed when only in SonarLint. Test Out of memory
           eslintBridgeServer.newTsConfig();
         }

--- a/src/helpers/context.ts
+++ b/src/helpers/context.ts
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { debug } from './debug';
+
 /**
  * A container of contextual information
  *
@@ -55,5 +57,6 @@ export function getContext(): Context {
  * @param ctx the new global context
  */
 export function setContext(ctx: Context) {
+  debug(`Context set with ${JSON.stringify(ctx)}`);
   context = { ...ctx };
 }

--- a/src/services/program/program.ts
+++ b/src/services/program/program.ts
@@ -46,7 +46,14 @@ import { ProgramCache } from 'helpers/cache';
 import { JsTsAnalysisInput } from 'services/analysis';
 
 export const programCache = new ProgramCache();
-const projectTSConfigs = new ProjectTSConfigs();
+let projectTSConfigs: ProjectTSConfigs;
+
+function getDefaultTSConfigs() {
+  if (!projectTSConfigs) {
+    projectTSConfigs = new ProjectTSConfigs();
+  }
+  return projectTSConfigs;
+}
 
 /**
  * Creates or gets the proper existing TypeScript's Program containing a given source file.
@@ -58,8 +65,11 @@ const projectTSConfigs = new ProjectTSConfigs();
 export function getProgramForFile(
   input: JsTsAnalysisInput,
   cache = programCache,
-  tsconfigs = projectTSConfigs,
+  tsconfigs?: ProjectTSConfigs,
 ): ts.Program {
+  if (!tsconfigs) {
+    tsconfigs = getDefaultTSConfigs();
+  }
   let newTsConfigs = false;
   if (input.tsConfigs) {
     newTsConfigs = tsconfigs.upsertTsConfigs(input.tsConfigs, input.forceUpdateTSConfigs);

--- a/tests/parsing/jsts/builders/build.test.ts
+++ b/tests/parsing/jsts/builders/build.test.ts
@@ -62,7 +62,6 @@ describe('buildSourceCode', () => {
     } = buildSourceCode(await jsTsInput({ filePath }), 'js');
 
     expect(stmt.type).toEqual('VariableDeclaration');
-    expect(console.log).not.toHaveBeenCalled();
   });
 
   it('should build JavaScript Vue.js source code', async () => {


### PR DESCRIPTION
- `ProjectTsConfigs` need to be initialized lazily
- Analyze files without tsconfig also when using analysis with watch program

Fixes #3883 
