### PR TITLE
Skip garbage collection test

### DIFF
--- a/tests/services/program/program.test.ts
+++ b/tests/services/program/program.test.ts
@@ -263,6 +263,7 @@ describe('program', () => {
     expect(cache.programs.get(tsConfig).files).toContain(mainFile);
   });
 
+  // skipping due to indeterminism. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry#avoid_where_possible
   it.skip('cache should only contain 2 elements and GC should clean up old programs', async () => {
     const cache = new ProgramCache(2);
     const file1Path = toUnixPath(path.join(__dirname, 'fixtures', 'file1.js'));

--- a/tests/services/program/program.test.ts
+++ b/tests/services/program/program.test.ts
@@ -263,7 +263,7 @@ describe('program', () => {
     expect(cache.programs.get(tsConfig).files).toContain(mainFile);
   });
 
-  it('cache should only contain 2 elements and GC should clean up old programs', async () => {
+  it.skip('cache should only contain 2 elements and GC should clean up old programs', async () => {
     const cache = new ProgramCache(2);
     const file1Path = toUnixPath(path.join(__dirname, 'fixtures', 'file1.js'));
     const file2Path = toUnixPath(path.join(__dirname, 'fixtures', 'file2.js'));


### PR DESCRIPTION
Skipping this tests as it very undeterministic. When running it alone locally is always passes, but on heavy load sometimes it failt due to FinalizationRegistry behaving in a 'best-effort' strategy. 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry#avoid_where_possible