### PR TITLE
Fix FP S1128 (`unused-import`): Ignore imported symbols used as Vue.js directives

### DIFF
--- a/src/linting/eslint/rules/unused-import.ts
+++ b/src/linting/eslint/rules/unused-import.ts
@@ -138,6 +138,13 @@ export const rule: Rule.RuleModule = {
               vueIdentifiers.add(toPascalCase(rawName));
             }
           },
+          VDirectiveKey: (node: AST.VDirectiveKey) => {
+            const {
+              name: { name },
+            } = node;
+            vueIdentifiers.add(toCamelCase(name));
+            vueIdentifiers.add(toPascalCase(name));
+          },
           Identifier: (node: AST.ESLintIdentifier) => {
             vueIdentifiers.add(node.name);
           },
@@ -157,6 +164,11 @@ function startsWithUpper(str: string) {
 
 function isKebabCase(str: string) {
   return str.includes('-');
+}
+
+function toCamelCase(str: string) {
+  const pascalized = toPascalCase(str);
+  return pascalized[0].toLowerCase() + pascalized.slice(1);
 }
 
 function toPascalCase(str: string) {

--- a/tests/linting/eslint/rules/comment-based/unused-import.vue
+++ b/tests/linting/eslint/rules/comment-based/unused-import.vue
@@ -1,7 +1,11 @@
 <template>
   <Foo />
+  <Foo v-one-two-three />
+  <Foo v-four-five-six />
 </template>
 <script setup lang="ts">
   import Foo from './Foo.vue';
   import Bar from './Bar.vue'; // Noncompliant
+  import OneTwoThree from './OneTwoThree.vue';
+  import fourFiveSix from './OneTwoThree.vue';
 </script>


### PR DESCRIPTION
Fixes #3790 
