### PR TITLE
Remove again node_modules on ruling tests

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -36,11 +36,10 @@ mvn clean install
 
 ### Ruling Tests
 
-The "Ruling Test" is an integration test which launches the analysis of a large code base (stored as submodules), saves the issues created by the plugin in report files, and then compares those results to the set of expected issues (stored as JSON files). You need to set the environment variable `SONARJS_LIMIT_DEPS_RESOLUTION` to `1` in order to avoid your dev environment affect the expected results of the tests. By having `node_modules` of the project installed, Typescript type-checking will behave differently compared to a clean setup, where the expected results of the tests were created.
+The "Ruling Test" is an integration test which launches the analysis of a large code base (stored as submodules), saves the issues created by the plugin in report files, and then compares those results to the set of expected issues (stored as JSON files).
 
 ```sh
 cd its/ruling
-export SONARJS_LIMIT_DEPS_RESOLUTION=1
 mvn verify -Dtest=JavaScriptRulingTest -Dmaven.test.redirectTestOutputToFile=false
 mvn verify -Dtest=TypeScriptRulingTest -Dmaven.test.redirectTestOutputToFile=false
 mvn verify -Dtest=CssRulingTest -Dmaven.test.redirectTestOutputToFile=false

--- a/src/services/program/program.ts
+++ b/src/services/program/program.ts
@@ -74,8 +74,15 @@ export function getProgramForFile(
   cache = programCache,
   tsconfigs?: ProjectTSConfigs,
 ): ts.Program {
+  /**
+   * SONARJS_LIMIT_DEPS_RESOLUTION is available to limit TS resolution to current baseDir.
+   * However, this does not apply when we rely on typescript-eslint to create watchPrograms.
+   * If we are ever able to provide our own compilerHost to typescript-eslint, we can generalize
+   * for all projects and avoid removing node_modules for ruling tests
+   */
   const topDir =
     process.env['SONARJS_LIMIT_DEPS_RESOLUTION'] === '1' ? toUnixPath(input.baseDir) : undefined;
+
   if (!tsconfigs) {
     tsconfigs = getDefaultTSConfigs(input.baseDir, input.tsConfigs);
   }


### PR DESCRIPTION
SONARJS_LIMIT_DEPS_RESOLUTION was available to limit TS resolution to current baseDir. However, this does not apply when we rely on typescript-eslint to create watchPrograms. If we are ever able to provide our own compilerHost to typescript-eslint, we can generalize for all projects and avoid removing node_modules for ruling tests