### PR TITLE
Do not rely on external browserlists files

### DIFF
--- a/src/parsing/jsts/parsers/options.ts
+++ b/src/parsing/jsts/parsers/options.ts
@@ -74,7 +74,7 @@ function babelParserOptions(options: Linter.ParserOptions) {
   const babelOptions = {
     targets: 'defaults',
     presets: [
-      [`${pluginPath}/@babel/preset-react`, { ignoreBrowserslistConfig: true }],
+      `${pluginPath}/@babel/preset-react`,
       `${pluginPath}/@babel/preset-flow`,
       `${pluginPath}/@babel/preset-env`,
     ],

--- a/src/parsing/jsts/parsers/options.ts
+++ b/src/parsing/jsts/parsers/options.ts
@@ -72,8 +72,9 @@ export function buildParserOptions(initialOptions: Linter.ParserOptions, usingBa
 function babelParserOptions(options: Linter.ParserOptions) {
   const pluginPath = `${__dirname}/../../../../node_modules`;
   const babelOptions = {
+    targets: 'defaults',
     presets: [
-      `${pluginPath}/@babel/preset-react`,
+      [`${pluginPath}/@babel/preset-react`, { ignoreBrowserslistConfig: true }],
       `${pluginPath}/@babel/preset-flow`,
       `${pluginPath}/@babel/preset-env`,
     ],


### PR DESCRIPTION
As mentioned in https://babeljs.io/docs/babel-preset-env#browserslist-integration:

> By default @babel/preset-env will use [browserslist config sources](https://github.com/ai/browserslist#queries) unless either the [targets](https://babeljs.io/docs/babel-preset-env#targets) or [ignoreBrowserslistConfig](https://babeljs.io/docs/babel-preset-env#ignorebrowserslistconfig) options are set.

Babel will walk the tree looking for browserlist files. Some external browserlists will make babel fail, as Python squad saw with django-cms peach analysis.

This will avoid babel to look for those files.