### PR TITLE
Update "submit review" and "request review" actions to work for projectsV2

### DIFF
--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -9,9 +9,12 @@ jobs:
     name: Move card to review
     runs-on: ubuntu-latest
     # PRs from forks don't have required token authorization
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+        github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.review.author_association != 'NONE'
     steps:
-      - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@v1
+      - uses: sonarsource/gh-action-lt-backlog/MoveCardToReviewV2@use-until-merged
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          column-id: 16320793     # Kanban "In review" column
+          column-id: "14c3336d"     # Kanban "Review in progress" column
+          project-number: 8

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -8,6 +8,8 @@ jobs:
   MoveCardToReview_job:
     name: Move card to review
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     # PRs from forks don't have required token authorization
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
@@ -18,6 +20,7 @@ jobs:
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;
+
       - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@use-until-merged
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).kanban_token }}

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -1,4 +1,4 @@
-name: Request review for Project V2
+name: Request review
 
 on:
   pull_request:

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;
-
       - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@use-until-merged
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).kanban_token }}

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -13,8 +13,13 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
         && github.event.review.author_association != 'NONE'
     steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@2.4.3-1
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;
       - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@use-until-merged
         with:
-          github-token: ${{secrets.ILIA_TOKEN}}
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           column-id: "14c3336d"     # Kanban "Review in progress" column
           project-number: 8

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
         && github.event.review.author_association != 'NONE'
     steps:
-      - uses: sonarsource/gh-action-lt-backlog/MoveCardToReviewV2@use-until-merged
+      - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@use-until-merged
         with:
           github-token: ${{secrets.GH_TOKEN}}
           column-id: "14c3336d"     # Kanban "Review in progress" column

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardToReviewV2@use-until-merged
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.GH_TOKEN}}
           column-id: "14c3336d"     # Kanban "Review in progress" column
           project-number: 8

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -20,6 +20,6 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;
       - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@use-until-merged
         with:
-          github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).kanban_token }}
           column-id: "14c3336d"     # Kanban "Review in progress" column
           project-number: 8

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -1,4 +1,4 @@
-name: Request review
+name: Request review for Project V2
 
 on:
   pull_request:

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -16,7 +16,7 @@ jobs:
         && github.event.review.author_association != 'NONE'
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@2.4.3-1
+        uses: SonarSource/vault-action-wrapper@2.5.0-4
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@use-until-merged
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{secrets.ILIA_TOKEN}}
           column-id: "14c3336d"     # Kanban "Review in progress" column
           project-number: 8

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -31,6 +31,8 @@ jobs:
   ReviewApproved_job:
     name: Move card to review approved
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
         && github.event.review.author_association != 'NONE'

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@use-until-merged
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{secrets.ILIA_TOKEN}}
           column-id: "47fc9ee4"     # Kanban "In progress" column
           project-number: 8
 
@@ -31,6 +31,6 @@ jobs:
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@use-until-merged
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{secrets.ILIA_TOKEN}}
           column-id: "dd10adad"     # Kanban "Review approved" column
           project-number: 8

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -1,4 +1,4 @@
-name: Submit Review
+name: Submit Review for Project V2
 
 on:
   pull_request_review:

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -1,4 +1,4 @@
-name: Submit Review for Project V2
+name: Submit Review
 
 on:
   pull_request_review:

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReviewV2@use-until-merged
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.GH_TOKEN}}
           column-id: "47fc9ee4"     # Kanban "In progress" column
           project-number: 8
 
@@ -31,6 +31,6 @@ jobs:
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReviewV2@use-until-merged
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.GH_TOKEN}}
           column-id: "dd10adad"     # Kanban "Review approved" column
           project-number: 8

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -15,7 +15,7 @@ jobs:
         && github.event.review.author_association != 'NONE'
         && github.event.review.state == 'changes_requested'
     steps:
-      - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReviewV2@use-until-merged
+      - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@use-until-merged
         with:
           github-token: ${{secrets.GH_TOKEN}}
           column-id: "47fc9ee4"     # Kanban "In progress" column
@@ -29,7 +29,7 @@ jobs:
         && github.event.review.author_association != 'NONE'
         && github.event.review.state == 'approved'
     steps:
-      - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReviewV2@use-until-merged
+      - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@use-until-merged
         with:
           github-token: ${{secrets.GH_TOKEN}}
           column-id: "dd10adad"     # Kanban "Review approved" column

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -8,6 +8,8 @@ jobs:
   MoveCardToProgress_job:
     name: Move card to progress
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     # Single quotes must be used here https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#literals
     # PRs from forks don't have required token authorization
     if: |
@@ -15,9 +17,14 @@ jobs:
         && github.event.review.author_association != 'NONE'
         && github.event.review.state == 'changes_requested'
     steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@2.5.0-4
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;
       - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@use-until-merged
         with:
-          github-token: ${{secrets.ILIA_TOKEN}}
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).kanban_token }}
           column-id: "47fc9ee4"     # Kanban "In progress" column
           project-number: 8
 
@@ -29,8 +36,13 @@ jobs:
         && github.event.review.author_association != 'NONE'
         && github.event.review.state == 'approved'
     steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@2.5.0-4
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;
       - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@use-until-merged
         with:
-          github-token: ${{secrets.ILIA_TOKEN}}
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).kanban_token }}
           column-id: "dd10adad"     # Kanban "Review approved" column
           project-number: 8

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -12,21 +12,25 @@ jobs:
     # PRs from forks don't have required token authorization
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.review.author_association != 'NONE'
         && github.event.review.state == 'changes_requested'
     steps:
-      - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@v1
+      - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReviewV2@use-until-merged
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          column-id: 16320787     # Kanban "In progress" column
+          column-id: "47fc9ee4"     # Kanban "In progress" column
+          project-number: 8
 
   ReviewApproved_job:
     name: Move card to review approved
     runs-on: ubuntu-latest
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.review.author_association != 'NONE'
         && github.event.review.state == 'approved'
     steps:
-      - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@v1
+      - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReviewV2@use-until-merged
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          column-id: 16320799     # Kanban "Resolved" column
+          column-id: "dd10adad"     # Kanban "Review approved" column
+          project-number: 8


### PR DESCRIPTION
When merged, we would need to change the branches to @V1 like:

```yaml
      - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@V1
```

instead of 

```yaml
      - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@ use-until-merged
```
