### PR TITLE
Update rule S3758 (`values-not-covertable-to-numbers`) to allow ES2020 BigInt

### DIFF
--- a/src/linting/eslint/rules/values-not-convertible-to-numbers.ts
+++ b/src/linting/eslint/rules/values-not-convertible-to-numbers.ts
@@ -98,7 +98,10 @@ function isConvertibleToNumber(typ: ts.Type, checker: ts.TypeChecker) {
   const valueOfSignatures = getValueOfSignatures(typ, checker);
   return (
     valueOfSignatures.length === 0 ||
-    valueOfSignatures.some(signature => isNumberLike(signature.getReturnType()))
+    valueOfSignatures.some(signature => {
+      const returnType = signature.getReturnType();
+      return isNumberLike(returnType) || isBigIntLike(returnType);
+    })
   );
 }
 
@@ -115,4 +118,8 @@ function getValueOfSignatures(typ: ts.Type, checker: ts.TypeChecker) {
 
 function isNumberLike(typ: ts.Type) {
   return (typ.getFlags() & ts.TypeFlags.NumberLike) !== 0;
+}
+
+function isBigIntLike(typ: ts.Type) {
+  return (typ.getFlags() & ts.TypeFlags.BigIntLike) !== 0;
 }

--- a/tests/linting/eslint/rules/values-not-convertible-to-numbers.test.ts
+++ b/tests/linting/eslint/rules/values-not-convertible-to-numbers.test.ts
@@ -86,6 +86,27 @@ ruleTesterTs.run(
         let x = { };
         x.a >= 42;`, // FN
       },
+      {
+        code: `
+        const a = BigInt("42");
+        const b = BigInt("41");
+        a > b;
+        `,
+      },
+      {
+        code: `
+        const a = 42n;
+        const b = 41n;
+        a > b;
+        `,
+      },
+      {
+        code: `
+        const a = BigInt("42");
+        const b = 41n;
+        a > b;
+        `,
+      },
     ],
     invalid: [
       {


### PR DESCRIPTION
# Description 

Currently, [S3758](https://sonarsource.github.io/rspec/#/rspec/S3758) only allow comparisons between two NumberLike types, but ES2020 added BigInt ([ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)), which can validly use the `comparisonOperators` defined in the implementation, but is incompatible since they are not `NumberLike` (instead, they are `BigIntLike`).

This PR modified the implementation to allow the operands to be either `NumberLike` or `BigIntLike`, and related test cases are also added.

This is the first time that I contributed to this project, plz let me know if any improvements can be made to this PR!