### PR TITLE
Update S3758 (`values-not-convertible-to-numbers`): Allow ES2020 BigInt

### DIFF
--- a/packages/jsts/src/rules/S3758/rule.ts
+++ b/packages/jsts/src/rules/S3758/rule.ts
@@ -27,6 +27,8 @@ import {
   RequiredParserServices,
   getTypeFromTreeNode,
   isStringType,
+  isNumberType,
+  isBigIntType,
 } from '../helpers';
 
 const comparisonOperators = new Set(['>', '<', '>=', '<=']);
@@ -100,7 +102,7 @@ function isConvertibleToNumber(typ: ts.Type, checker: ts.TypeChecker) {
     valueOfSignatures.length === 0 ||
     valueOfSignatures.some(signature => {
       const returnType = signature.getReturnType();
-      return isNumberLike(returnType) || isBigIntLike(returnType);
+      return isNumberType(returnType) || isBigIntType(returnType);
     })
   );
 }
@@ -114,12 +116,4 @@ function getValueOfSignatures(typ: ts.Type, checker: ts.TypeChecker) {
   return declarations
     .map(declaration => checker.getTypeAtLocation(declaration).getCallSignatures())
     .reduce((result, decl) => result.concat(decl), []);
-}
-
-function isNumberLike(typ: ts.Type) {
-  return (typ.getFlags() & ts.TypeFlags.NumberLike) !== 0;
-}
-
-function isBigIntLike(typ: ts.Type) {
-  return (typ.getFlags() & ts.TypeFlags.BigIntLike) !== 0;
 }

--- a/packages/jsts/src/rules/S3758/rule.ts
+++ b/packages/jsts/src/rules/S3758/rule.ts
@@ -98,7 +98,10 @@ function isConvertibleToNumber(typ: ts.Type, checker: ts.TypeChecker) {
   const valueOfSignatures = getValueOfSignatures(typ, checker);
   return (
     valueOfSignatures.length === 0 ||
-    valueOfSignatures.some(signature => isNumberLike(signature.getReturnType()))
+    valueOfSignatures.some(signature => {
+      const returnType = signature.getReturnType();
+      return isNumberLike(returnType) || isBigIntLike(returnType);
+    })
   );
 }
 
@@ -115,4 +118,8 @@ function getValueOfSignatures(typ: ts.Type, checker: ts.TypeChecker) {
 
 function isNumberLike(typ: ts.Type) {
   return (typ.getFlags() & ts.TypeFlags.NumberLike) !== 0;
+}
+
+function isBigIntLike(typ: ts.Type) {
+  return (typ.getFlags() & ts.TypeFlags.BigIntLike) !== 0;
 }

--- a/packages/jsts/src/rules/S3758/unit.test.ts
+++ b/packages/jsts/src/rules/S3758/unit.test.ts
@@ -86,6 +86,27 @@ ruleTesterTs.run(
         let x = { };
         x.a >= 42;`, // FN
       },
+      {
+        code: `
+        const a = BigInt("42");
+        const b = BigInt("41");
+        a > b;
+        `,
+      },
+      {
+        code: `
+        const a = 42n;
+        const b = 41n;
+        a > b;
+        `,
+      },
+      {
+        code: `
+        const a = BigInt("42");
+        const b = 41n;
+        a > b;
+        `,
+      },
     ],
     invalid: [
       {


### PR DESCRIPTION
Fixes #4028 