### PR TITLE
Fix FP for S1874 (`deprecation`): only flag symbols if all their declarations are deprecated

### DIFF
--- a/packages/jsts/src/rules/S1874/cb.fixture.ts
+++ b/packages/jsts/src/rules/S1874/cb.fixture.ts
@@ -228,3 +228,6 @@ const a = {
     this.y // OK
 	},
 };
+
+// edge case: contains a declaration with no body and no jsDoc that we should not consider.
+window.pageXOffset // OK, I can't write a discriminant logic for this one that wouldn't conflict with others

--- a/packages/jsts/src/rules/S1874/cb.fixture.ts
+++ b/packages/jsts/src/rules/S1874/cb.fixture.ts
@@ -45,7 +45,7 @@ d.m(); // Noncompliant
  * @deprecated since version 42
  */
 export class MyClass {
-    /** @deprecated */ 
+    /** @deprecated */
     deprecatedProperty: any;
     /** @deprecated with message */ oneMoreDeprecated: any;
     notDeprecated;
@@ -60,7 +60,7 @@ foo(myObj.notDeprecated);
 interface MyInterface extends MyClass {} // Noncompliant
 let myInterface: MyInterface;
 foo(myInterface.deprecatedProperty); // Noncompliant
-foo(myInterface.notDeprecated); 
+foo(myInterface.notDeprecated);
 
 (function ({deprecatedProperty, notDeprecated, oneMoreDeprecated: tmp}: MyInterface) {})  // Noncompliant 2
 (function ({foo: {deprecatedProperty, notDeprecated}}: {foo: MyInterface}) {}) // Noncompliant
@@ -72,7 +72,7 @@ let {deprecatedProperty, notDeprecated, oneMoreDeprecated} = myObj; // Noncompli
 let obj = { deprecatedProperty: 42, notDeprecated };
 
 /** @deprecated */
-let deprecatedVar; 
+let deprecatedVar;
 ({deprecatedProperty: deprecatedVar} = myObj);  // Noncompliant 2
 
 /* separator */
@@ -170,9 +170,9 @@ function someDeprecated(a: number | string): number | string {
     return a;
 }
 
-//someDeprecated('yolo'); // Noncompliant
-//someDeprecated(42); // OK
-//someDeprecated: // OK
+someDeprecated('yolo'); // Noncompliant
+someDeprecated(42); // OK
+someDeprecated: // OK
 
 /** @deprecated */ function allDeprecated(a: string): string;
 /** @deprecated */ function allDeprecated(a: number): number;
@@ -181,6 +181,6 @@ function allDeprecated(a: number | string): number | string {
     return a;
 }
 
-//allDeprecated('yolo'); // Noncompliant
-//allDeprecated(42); // Noncompliant
+allDeprecated('yolo'); // Noncompliant
+allDeprecated(42); // Noncompliant
 allDeprecated; // Noncompliant

--- a/packages/jsts/src/rules/S1874/cb.fixture.ts
+++ b/packages/jsts/src/rules/S1874/cb.fixture.ts
@@ -160,3 +160,27 @@ const myObj2: DeprecatedClass = new DeprecatedClass();  // Noncompliant 2
 const myObj3: DeprecatedConstructorClass = new ClassWithDeprecatedConstructor(); // Noncompliant
 new ClassWithOneDeprecatedConstructor();
 new ClassWithOneDeprecatedConstructor(1); // Noncompliant
+
+// fixes issue #4008
+
+/** @deprecated */ function someDeprecated(a: string): string;
+/** @param a */ function someDeprecated(a: number): number;
+function someDeprecated(a: number | string): number | string {
+    if (typeof a === 'number') return a + 1;
+    return a;
+}
+
+//someDeprecated('yolo'); // Noncompliant
+//someDeprecated(42); // OK
+//someDeprecated: // OK
+
+/** @deprecated */ function allDeprecated(a: string): string;
+/** @deprecated */ function allDeprecated(a: number): number;
+function allDeprecated(a: number | string): number | string {
+    if (typeof a === 'number') return a + 1;
+    return a;
+}
+
+//allDeprecated('yolo'); // Noncompliant
+//allDeprecated(42); // Noncompliant
+allDeprecated; // Noncompliant

--- a/packages/jsts/src/rules/S1874/cb.fixture.ts
+++ b/packages/jsts/src/rules/S1874/cb.fixture.ts
@@ -206,3 +206,6 @@ function multipleDeclarationsWithUnrelatedTags(a: string | number): void {
 }
 multipleDeclarationsWithUnrelatedTags;
 
+(function() {
+	return undefined; // OK
+}() );

--- a/packages/jsts/src/rules/S1874/cb.fixture.ts
+++ b/packages/jsts/src/rules/S1874/cb.fixture.ts
@@ -199,3 +199,10 @@ multipleDeclarationsWithoutJsDoc;
 }
 multipleDeclarationsWithoutTags;
 
+/** @param */ function multipleDeclarationsWithUnrelatedTags(a: string): void;
+/** @yolo */function multipleDeclarationsWithUnrelatedTags(a: number): void;
+function multipleDeclarationsWithUnrelatedTags(a: string | number): void {
+    a;
+}
+multipleDeclarationsWithUnrelatedTags;
+

--- a/packages/jsts/src/rules/S1874/cb.fixture.ts
+++ b/packages/jsts/src/rules/S1874/cb.fixture.ts
@@ -206,6 +206,25 @@ function multipleDeclarationsWithUnrelatedTags(a: string | number): void {
 }
 multipleDeclarationsWithUnrelatedTags;
 
+// edge case of implementation: symbol with a declarations array of length 0
 (function() {
 	return undefined; // OK
 }() );
+
+// edge case of implementation: symbol with 2 declarations containing a body
+const a = {
+	_: {
+		y: 0,
+	},
+
+	set y (value) {
+	},
+	get y () {
+		return this._.y;
+	},
+
+	// Method for creating a clone of this object
+	clone: function () {
+    this.y // OK
+	},
+};

--- a/packages/jsts/src/rules/S1874/cb.fixture.ts
+++ b/packages/jsts/src/rules/S1874/cb.fixture.ts
@@ -93,7 +93,7 @@ function fn() { }
 
 fn<number>();
 fn(1); // Noncompliant
-h(fn); // Noncompliant
+h(fn); // OK, not deprecated anymore because it has non-deprecated declarations
 
 /* separator */
 
@@ -142,7 +142,7 @@ deprecatedCallSignature2(); // Noncompliant
 /* separator */
 
 import * as allDeprecations from './cb.fixture.deprecations';
-z(allDeprecations.deprecatedFunction);// Noncompliant
+z(allDeprecations.deprecatedFunction); // OK, not deprecated anymore because it has non-deprecated declarations
 
 import defaultImport, {deprecatedFunction, anotherDeprecatedFunction as aliasForDeprecated, notDeprecated1, notDeprecated2} from './cb.fixture.deprecations';
 defaultImport(); // Noncompliant
@@ -184,3 +184,18 @@ function allDeprecated(a: number | string): number | string {
 allDeprecated('yolo'); // Noncompliant
 allDeprecated(42); // Noncompliant
 allDeprecated; // Noncompliant
+
+function multipleDeclarationsWithoutJsDoc(a: string): void;
+function multipleDeclarationsWithoutJsDoc(a: number): void;
+function multipleDeclarationsWithoutJsDoc(a: string | number): void {
+    a;
+}
+multipleDeclarationsWithoutJsDoc;
+
+/** hello */ function multipleDeclarationsWithoutTags(a: string): void;
+/** I have no tags */function multipleDeclarationsWithoutTags(a: number): void;
+/** me neither */ function multipleDeclarationsWithoutTags(a: string | number): void {
+    a;
+}
+multipleDeclarationsWithoutTags;
+

--- a/packages/jsts/src/rules/S1874/rule.ts
+++ b/packages/jsts/src/rules/S1874/rule.ts
@@ -195,12 +195,16 @@ function getJsDocDeprecationFromSymbol(symbol: ts.Symbol) {
     return getJsDocDeprecation(symbol.getJsDocTags());
   }
 
-  if (!symbol.declarations) return undefined;
+  if (!symbol.declarations) {
+    return undefined;
+  }
 
   for (const declaration of symbol.declarations as any) {
-    for (const jsdoc of declaration?.jsDoc || []) {
+    for (const jsdoc of declaration.jsDoc || []) {
       // if a declaration has no JS doc or tags, it can't be deprecated
-      if (!jsdoc || !jsdoc.tags) return undefined;
+      if (!jsdoc?.tags) {
+        return undefined;
+      }
       if (!(jsdoc.tags as Array<any>).some(tag => tag.tagName.escapedText === 'deprecated')) {
         return undefined;
       }

--- a/packages/jsts/src/rules/S1874/rule.ts
+++ b/packages/jsts/src/rules/S1874/rule.ts
@@ -200,9 +200,13 @@ function getJsDocDeprecationFromSymbol(symbol: ts.Symbol) {
   }
 
   for (const declaration of symbol.declarations as any) {
-    for (const jsdoc of declaration.jsDoc || []) {
-      // if a declaration has no JS doc or tags, it can't be deprecated
-      if (!jsdoc?.tags) {
+    // if a declaration has no JS doc, it can't be deprecated
+    if (!declaration.jsDoc) {
+      return undefined;
+    }
+    for (const jsdoc of declaration.jsDoc) {
+      // if a declaration has no or tags, it can't be deprecated
+      if (!jsdoc.tags) {
         return undefined;
       }
       if (!(jsdoc.tags as Array<any>).some(tag => tag.tagName.escapedText === 'deprecated')) {

--- a/packages/jsts/src/rules/S1874/rule.ts
+++ b/packages/jsts/src/rules/S1874/rule.ts
@@ -205,7 +205,7 @@ function getJsDocDeprecationFromSymbol(symbol: ts.Symbol) {
       return undefined;
     }
     for (const jsdoc of declaration.jsDoc) {
-      // if a declaration has no or tags, it can't be deprecated
+      // if a declaration has no tags, it can't be deprecated
       if (!jsdoc.tags) {
         return undefined;
       }

--- a/packages/jsts/src/rules/S1874/rule.ts
+++ b/packages/jsts/src/rules/S1874/rule.ts
@@ -195,7 +195,7 @@ function getJsDocDeprecationFromSymbol(symbol: ts.Symbol) {
     return getJsDocDeprecation(symbol.getJsDocTags());
   }
 
-  if (!symbol.declarations) {
+  if (!symbol.declarations || symbol.declarations.length === 0) {
     return undefined;
   }
 


### PR DESCRIPTION
Fixes #4008 
