### PR TITLE
Fix decorator S6661: Report on the callee instead of computed location

### DIFF
--- a/packages/jsts/src/rules/S6661/decorator.ts
+++ b/packages/jsts/src/rules/S6661/decorator.ts
@@ -20,24 +20,18 @@
 // https://sonarsource.github.io/rspec/#/rspec/S6661/javascript
 
 import { Rule } from 'eslint';
+import { CallExpression } from 'estree';
 import { interceptReport } from '../helpers';
 
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
   return interceptReport(rule, (context, reportDescriptor) => {
     if ('node' in reportDescriptor) {
       const { node, ...rest } = reportDescriptor;
-
-      if (node.type === 'CallExpression' && node.loc) {
-        const { start } = node.loc;
-
-        context.report({
-          loc: {
-            start,
-            end: { line: start.line, column: start.column + 'Object.assign'.length },
-          },
-          ...rest,
-        });
-      }
+      const call = node as CallExpression;
+      context.report({
+        node: call.callee,
+        ...rest,
+      });
     }
   });
 }

--- a/packages/jsts/src/rules/S6661/unit.test.ts
+++ b/packages/jsts/src/rules/S6661/unit.test.ts
@@ -22,7 +22,7 @@ import { rule } from './';
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
 
-ruleTester.run('Object spread syntax should be used instead of Object.assign', rule, {
+ruleTester.run('Object spread syntax should be used instead of "Object.assign"', rule, {
   valid: [
     {
       code: `Object.assign(foo, bar);`,
@@ -50,6 +50,22 @@ ruleTester.run('Object spread syntax should be used instead of Object.assign', r
           endLine: 1,
           column: 11,
           endColumn: 24,
+        },
+      ],
+    },
+    {
+      code: `
+var assign = Object.assign;
+const b = assign({}, foo, bar);`,
+      output: `
+var assign = Object.assign;
+const b = { ...foo, ...bar};`,
+      errors: [
+        {
+          line: 3,
+          endLine: 3,
+          column: 11,
+          endColumn: 17,
         },
       ],
     },

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6661.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6661.json
@@ -1,5 +1,5 @@
 {
-  "title": "Object spread syntax should be used instead of Object.assign",
+  "title": "Object spread syntax should be used instead of \"Object.assign\"",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
#4024 enabled ESLint's [prefer-object-spread](https://eslint.org/docs/latest/rules/prefer-object-spread) and decorated it for readability purposes so that reported issues don't spread over multiple lines. However, the decoration is flawed and produces runtime errors when SonarJS tries to save an issue on SonarQube for certain cases as illustrated by [Peach/react-native](https://cirrus-ci.com/task/5462490562166784?logs=analyze#L633).

The decorator wrongly assumes that the node that is reported by the rule has always the shape `Object.assign(...)` and relies on that assumption to adjust the location of the reported issue. As a result, the following snippet would report an issue with inconsistent location:

```javascript
var assign = Object.assign;
const b = assign(
//        ~~~~~~~~~~~~~
  something,
  somethingElse
);
```

The end column of the issue exceeds the last column of the snippet (or file). This is why SonarQube throws a runtime exception due to an invalid offset.