### PR TITLE
Fix FP S1128 (`unused-import`): Consider all names of Vue.js elements

### DIFF
--- a/packages/jsts/src/rules/S1128/cb.fixture.vue
+++ b/packages/jsts/src/rules/S1128/cb.fixture.vue
@@ -2,10 +2,14 @@
   <Foo />
   <Foo v-one-two-three />
   <Foo v-four-five-six />
+  <something/>
+  <another-THING/>
 </template>
 <script setup lang="ts">
   import Foo from './Foo.vue';
   import Bar from './Bar.vue'; // Noncompliant
   import OneTwoThree from './OneTwoThree.vue';
   import fourFiveSix from './OneTwoThree.vue';
+  import something from './something';
+  import AnotherTHING from './another';
 </script>

--- a/packages/jsts/src/rules/S1128/cb.fixture.vue
+++ b/packages/jsts/src/rules/S1128/cb.fixture.vue
@@ -1,10 +1,14 @@
 <template>
+  <Comp />
   <Foo />
   <Foo v-one-two-three />
   <Foo v-four-five-six />
   <something/>
   <another-THING/>
 </template>
+<script lang="ts">
+  import Comp from './some.vue'; // Noncompliant
+</script>
 <script setup lang="ts">
   import Foo from './Foo.vue';
   import Bar from './Bar.vue'; // Noncompliant

--- a/packages/jsts/src/rules/S1128/rule.ts
+++ b/packages/jsts/src/rules/S1128/rule.ts
@@ -207,11 +207,8 @@ export const rule: Rule.RuleModule = {
         {
           VElement: (node: AST.VElement) => {
             const { rawName } = node;
-            if (startsWithUpper(rawName)) {
-              vueIdentifiers.add(rawName);
-            } else if (isKebabCase(rawName)) {
-              vueIdentifiers.add(toPascalCase(rawName));
-            }
+            vueIdentifiers.add(toCamelCase(rawName));
+            vueIdentifiers.add(toPascalCase(rawName));
           },
           VDirectiveKey: (node: AST.VDirectiveKey) => {
             const {
@@ -233,23 +230,14 @@ export const rule: Rule.RuleModule = {
   },
 };
 
-function startsWithUpper(str: string) {
-  return str.charAt(0) === str.charAt(0).toUpperCase();
-}
-
-function isKebabCase(str: string) {
-  return str.includes('-');
-}
-
+// vue only capitalizes the char after '-'
 function toCamelCase(str: string) {
-  const pascalized = toPascalCase(str);
-  return pascalized[0].toLowerCase() + pascalized.slice(1);
+  return str.replace(/-\w/g, s => s[1].toUpperCase());
 }
 
 function toPascalCase(str: string) {
-  return str
-    .replace(/\w+/g, word => word[0].toUpperCase() + word.slice(1).toLowerCase())
-    .replace(/-/g, '');
+  const camelized = toCamelCase(str);
+  return camelized[0].toUpperCase() + camelized.slice(1);
 }
 
 function getSuggestion(

--- a/packages/jsts/src/rules/S1128/rule.ts
+++ b/packages/jsts/src/rules/S1128/rule.ts
@@ -23,7 +23,11 @@ import { Rule, Scope } from 'eslint';
 import * as estree from 'estree';
 import { AST } from 'vue-eslint-parser';
 import { TSESTree } from '@typescript-eslint/experimental-utils';
-import { isRequiredParserServices, removeNodeWithLeadingWhitespaces } from '../helpers';
+import {
+  isRequiredParserServices,
+  removeNodeWithLeadingWhitespaces,
+  isInsideVueSetupScript,
+} from '../helpers';
 
 const EXCLUDED_IMPORTS = ['React'];
 const JSDOC_TAGS = [
@@ -184,7 +188,7 @@ export const rule: Rule.RuleModule = {
             ({ id: unused }) =>
               !jsxIdentifiers.includes(unused.name) &&
               !tsTypeIdentifiers.has(unused.name) &&
-              !vueIdentifiers.has(unused.name) &&
+              !(vueIdentifiers.has(unused.name) && isInsideVueSetupScript(unused, context)) &&
               !jsxFactories.has(unused.name) &&
               !jsDocComments.some(comment => comment.value.includes(unused.name)),
           )


### PR DESCRIPTION
Fixes #4047
