### PR TITLE
Add syntax highlighting for TypeScript "as" and "type" keywords

### DIFF
--- a/packages/jsts/src/linter/visitors/syntax-highlighting.ts
+++ b/packages/jsts/src/linter/visitors/syntax-highlighting.ts
@@ -53,6 +53,8 @@ export function getSyntaxHighlighting(sourceCode: SourceCode) {
   const { tokens, comments } = extractTokensAndComments(sourceCode);
   const highlights: SyntaxHighlight[] = [];
   for (const token of tokens) {
+    const node = sourceCode.getNodeByRangeIndex(token.range[0]);
+    node;
     switch (token.type as any) {
       case 'HTMLTagOpen':
       case 'HTMLTagClose':
@@ -69,6 +71,17 @@ export function getSyntaxHighlighting(sourceCode: SourceCode) {
         break;
       case 'Numeric':
         highlight(token, 'CONSTANT', highlights);
+        break;
+      case 'Identifier':
+        const node = sourceCode.getNodeByRangeIndex(token.range[0]);
+        // @ts-ignore
+        if (token.value === 'type' && node?.type === 'TSTypeAliasDeclaration') {
+          highlight(token, 'KEYWORD', highlights);
+        }
+        // @ts-ignore
+        if (token.value === 'as' && node?.type === 'TSAsExpression') {
+          highlight(token, 'KEYWORD', highlights);
+        }
         break;
     }
   }

--- a/packages/jsts/src/linter/visitors/syntax-highlighting.ts
+++ b/packages/jsts/src/linter/visitors/syntax-highlighting.ts
@@ -53,8 +53,6 @@ export function getSyntaxHighlighting(sourceCode: SourceCode) {
   const { tokens, comments } = extractTokensAndComments(sourceCode);
   const highlights: SyntaxHighlight[] = [];
   for (const token of tokens) {
-    const node = sourceCode.getNodeByRangeIndex(token.range[0]);
-    node;
     switch (token.type as any) {
       case 'HTMLTagOpen':
       case 'HTMLTagClose':

--- a/packages/jsts/tests/linter/visitors/fixtures/syntax-highlighting/typescript.ts
+++ b/packages/jsts/tests/linter/visitors/fixtures/syntax-highlighting/typescript.ts
@@ -1,0 +1,11 @@
+type T = number;
+42 as any;
+class A {
+  public  b() {}
+  private c() {}
+}
+class B implements C {}
+interface D {}
+enum E {}
+const type = 'hello';
+const as = 42;

--- a/packages/jsts/tests/linter/visitors/syntax-highlighting.test.ts
+++ b/packages/jsts/tests/linter/visitors/syntax-highlighting.test.ts
@@ -23,7 +23,7 @@ import {
   TextType,
 } from '../../../src/linter/visitors/syntax-highlighting';
 import path from 'path';
-import { parseJavaScriptSourceFile } from '../../tools/helpers';
+import { parseTypeScriptSourceFile } from '../../tools/helpers';
 
 describe('getSyntaxHighlighting', () => {
   it('should highlight keywords', async () => {
@@ -96,11 +96,25 @@ describe('getSyntaxHighlighting', () => {
       ]),
     );
   });
+
+  it('should highlight TypeScript-specific keywords', async () => {
+    expect(await highlighting('typescript.ts')).toEqual(
+      expect.arrayContaining([
+        highlight(1, 0, 1, 4, 'KEYWORD'), // type
+        highlight(2, 3, 2, 5, 'KEYWORD'), // as
+        highlight(4, 2, 4, 8, 'KEYWORD'), // public
+        highlight(5, 2, 5, 9, 'KEYWORD'), // private
+        highlight(7, 8, 7, 18, 'KEYWORD'), // implements
+        highlight(8, 0, 8, 9, 'KEYWORD'), // interface
+        highlight(9, 0, 9, 4, 'KEYWORD'), // enum
+      ]),
+    );
+  });
 });
 
 async function highlighting(filename: string): Promise<SyntaxHighlight[]> {
   const filePath = path.join(__dirname, 'fixtures', 'syntax-highlighting', filename);
-  const sourceCode = await parseJavaScriptSourceFile(filePath);
+  const sourceCode = await parseTypeScriptSourceFile(filePath, []);
   return getSyntaxHighlighting(sourceCode).highlights;
 }
 


### PR DESCRIPTION
While working on #4078, I noticed on SonarCloud that TypeScript keywords `as` and `any` were not highlighted as keywords. The corresponding tokens processed by the bridge and coming from TypeScript ESLint are wrongly described as "identifier" tokens for some obscure reason. After further investigation, I am not entirely sure whether the cause is coming from TypeScript ESLint or TypeScript itself.

__Before__

<img width="462" alt="Screenshot 2023-08-22 at 15 03 17" src="https://github.com/SonarSource/SonarJS/assets/52890329/3a27ceab-980d-4ebe-9052-cf22f8aa2ccf">

__After__

<img width="462" alt="Screenshot 2023-08-22 at 15 07 19" src="https://github.com/SonarSource/SonarJS/assets/52890329/1bb8482c-eace-4e2b-a9a5-9609bb27be6d">

I double-checked all other TypeScript-specific keywords, and only `as` and `any` were not properly highlighted.
