### PR TITLE
Fix FP S1128 (`unused-import`): Cover Vue elements with dot in the name

### DIFF
--- a/packages/jsts/src/rules/S1128/cb.fixture.vue
+++ b/packages/jsts/src/rules/S1128/cb.fixture.vue
@@ -5,6 +5,7 @@
   <Foo v-four-five-six />
   <something/>
   <another-THING/>
+  <library.item/>
 </template>
 <script lang="ts">
   import Comp from './some.vue'; // Noncompliant
@@ -16,4 +17,5 @@
   import fourFiveSix from './OneTwoThree.vue';
   import something from './something';
   import AnotherTHING from './another';
+  import * as Library from './library';
 </script>

--- a/packages/jsts/src/rules/S1128/rule.ts
+++ b/packages/jsts/src/rules/S1128/rule.ts
@@ -211,8 +211,9 @@ export const rule: Rule.RuleModule = {
         {
           VElement: (node: AST.VElement) => {
             const { rawName } = node;
-            vueIdentifiers.add(toCamelCase(rawName));
-            vueIdentifiers.add(toPascalCase(rawName));
+            const name = rawName.split('.')[0];
+            vueIdentifiers.add(toCamelCase(name));
+            vueIdentifiers.add(toPascalCase(name));
           },
           VDirectiveKey: (node: AST.VDirectiveKey) => {
             const {


### PR DESCRIPTION
add one more case to #4047 - Vue component names like `library.item`
