### PR TITLE
Fix Babel fallback for JS files

### DIFF
--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S106.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S106.json
@@ -326,6 +326,26 @@
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/models/plugins/pagination.js": [
 180
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+35,
+36,
+38,
+61,
+63,
+92,
+93,
+94,
+136,
+137,
+138,
+158,
+159,
+160,
+205,
+206,
+207,
+208
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/test/functional/base.js": [
 337
 ],
@@ -376,6 +396,12 @@
 16,
 17,
 20
+],
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
+6,
+10,
+16,
+36
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/7-rest-params/js/rest-spread.js": [
 18,

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S109.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S109.json
@@ -92306,6 +92306,9 @@
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/index.js": [
 93
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+147
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/test/functional/base.js": [
 154,
 160,
@@ -93643,6 +93646,12 @@
 11,
 12,
 21
+],
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
+13,
+13,
+13,
+13
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/8-iterators.js": [
 37

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1117.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1117.json
@@ -1693,6 +1693,9 @@
 15,
 23
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+174
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/test/functional/base.js": [
 179,
 456,

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1314.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1314.json
@@ -1,0 +1,5 @@
+{
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
+13
+]
+}

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S139.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S139.json
@@ -1032,6 +1032,13 @@
 13,
 19
 ],
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
+6,
+10,
+15,
+16,
+36
+],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/7-rest-params/Gruntfile.js": [
 8
 ],

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1441.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1441.json
@@ -54737,6 +54737,15 @@
 20,
 20
 ],
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
+5,
+5,
+6,
+10,
+13,
+24,
+36
+],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/7-rest-params/js/rest-spread.js": [
 22,
 23,

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1451.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1451.json
@@ -3968,6 +3968,9 @@
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/sequence.js": [
 0
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+0
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/validate-themes.js": [
 0
 ],
@@ -4482,6 +4485,9 @@
 0
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/5-set.js": [
+0
+],
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
 0
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/7-rest-params/Gruntfile.js": [

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1541.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1541.json
@@ -631,6 +631,9 @@
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/downzero.js": [
 18
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+167
+],
 "javascript-test-sources:src/ecmascript6/expressionist.js/test/parser.spec.js": [
 66,
 393

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1774.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1774.json
@@ -1722,6 +1722,10 @@
 10,
 14
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+5,
+192
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/shared/ghost-url.js": [
 56,
 57,

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S2260.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S2260.json
@@ -10,11 +10,5 @@
 ],
 "javascript-test-sources:src/ace/tool/templates/theme.js": [
 32
-],
-"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
-37
-],
-"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
-13
 ]
 }

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S3504.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S3504.json
@@ -15865,6 +15865,15 @@
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/sequence.js": [
 1
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+1,
+30,
+46,
+76,
+105,
+146,
+172
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/validate-themes.js": [
 5,
 17,
@@ -17504,6 +17513,11 @@
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/5-set.js": [
 7
+],
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
+5,
+15,
+33
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/7-rest-params/js/rest-spread.js": [
 1,

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S3512.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S3512.json
@@ -1192,6 +1192,10 @@
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/downzero.js": [
 14
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+36,
+61
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/shared/ghost-url.js": [
 20
 ],
@@ -1337,6 +1341,12 @@
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/4-default-params.js": [
 4
+],
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
+6,
+10,
+16,
+36
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/7-rest-params/js/rest-spread.js": [
 25

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S3533.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S3533.json
@@ -4912,6 +4912,12 @@
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/sequence.js": [
 1
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+1,
+2,
+3,
+4
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/validate-themes.js": [
 5,
 6,

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S3723.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S3723.json
@@ -12811,6 +12811,10 @@
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/read-directory.js": [
 38
 ],
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+15,
+212
+],
 "javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/validate-themes.js": [
 19,
 33,
@@ -14403,6 +14407,10 @@
 9,
 13,
 31
+],
+"javascript-test-sources:src/ecmascript6/ecmascript6-today/6-destructuring.js": [
+28,
+29
 ],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/7-rest-params/Gruntfile.js": [
 8,

--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S6657.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S6657.json
@@ -1,0 +1,14 @@
+{
+"javascript-test-sources:src/ecmascript6/Ghost/core/server/utils/startup-check.js": [
+37,
+38,
+62,
+64,
+92,
+94,
+110,
+112,
+205,
+208
+]
+}

--- a/its/ruling/src/test/expected/js/jshint/javascript-S2260.json
+++ b/its/ruling/src/test/expected/js/jshint/javascript-S2260.json
@@ -15,7 +15,7 @@
 2
 ],
 "jshint:tests/unit/fixtures/es6-template-literal-tagged.js": [
-24
+23
 ],
 "jshint:tests/unit/fixtures/es6-template-literal.js": [
 14

--- a/its/ruling/src/test/expected/js/mootools-core/javascript-S2260.json
+++ b/its/ruling/src/test/expected/js/mootools-core/javascript-S2260.json
@@ -1,5 +1,0 @@
-{
-"mootools-core:Specs/Types/Number.js": [
-20
-]
-}

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractAnalysis.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AbstractAnalysis.java
@@ -70,5 +70,9 @@ abstract class AbstractAnalysis {
     this.analysisMode = analysisMode;
   }
 
+  protected boolean isJavaScript(InputFile file) {
+    return inputFileLanguage(file).equals(JavaScriptLanguage.KEY);
+  }
+
   abstract void analyzeFiles(List<InputFile> inputFiles, List<String> tsConfigs) throws IOException;
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWithProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWithProgram.java
@@ -160,7 +160,11 @@ public class AnalysisWithProgram extends AbstractAnalysis {
         monitoring.startFile(file);
         var fileContent = contextUtils.shouldSendFileContent(file) ? file.contents() : null;
         var request = getJsAnalysisRequest(file, tsProgram, fileContent);
-        var response = bridgeServer.analyzeWithProgram(request);
+
+        var response = isJavaScript(file)
+          ? bridgeServer.analyzeJavaScript(request)
+          : bridgeServer.analyzeTypeScript(request);
+
         analysisProcessor.processResponse(context, checks, file, response);
         cacheStrategy.writeAnalysisToCache(
           CacheAnalysis.fromResponse(response.ucfgPaths, response.cpdTokens),

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWithWatchProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/AnalysisWithWatchProgram.java
@@ -166,8 +166,4 @@ public class AnalysisWithWatchProgram extends AbstractAnalysis {
       analysisProcessor.processCacheAnalysis(context, file, cacheAnalysis);
     }
   }
-
-  private boolean isJavaScript(InputFile file) {
-    return inputFileLanguage(file).equals(JavaScriptLanguage.KEY);
-  }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/BridgeServer.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/BridgeServer.java
@@ -48,8 +48,6 @@ public interface BridgeServer extends Startable {
 
   AnalysisResponse analyzeTypeScript(JsAnalysisRequest request) throws IOException;
 
-  AnalysisResponse analyzeWithProgram(JsAnalysisRequest request) throws IOException;
-
   AnalysisResponse analyzeCss(CssAnalysisRequest request) throws IOException;
 
   AnalysisResponse analyzeYaml(JsAnalysisRequest request) throws IOException;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/BridgeServerImpl.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/eslint/BridgeServerImpl.java
@@ -348,11 +348,6 @@ public class BridgeServerImpl implements BridgeServer {
   }
 
   @Override
-  public AnalysisResponse analyzeWithProgram(JsAnalysisRequest request) throws IOException {
-    return response(request(GSON.toJson(request), "analyze-with-program"), request.filePath);
-  }
-
-  @Override
   public AnalysisResponse analyzeCss(CssAnalysisRequest request) throws IOException {
     String json = GSON.toJson(request);
     return response(request(json, "analyze-css"), request.filePath);

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImplTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/EslintBridgeServerImplTest.java
@@ -298,7 +298,7 @@ class BridgeServerImplTest {
       programCreated.programId,
       DEFAULT_LINTER_ID
     );
-    assertThat(bridgeServer.analyzeWithProgram(request).issues).isEmpty();
+    assertThat(bridgeServer.analyzeTypeScript(request).issues).isEmpty();
 
     assertThat(bridgeServer.deleteProgram(programCreated)).isTrue();
   }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JavaScriptEslintBasedSensorTest.java
@@ -130,7 +130,7 @@ class JavaScriptEslintBasedSensorTest {
     tempFolder = new DefaultTempFolder(tempDir, true);
     when(bridgeServerMock.isAlive()).thenReturn(true);
     when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(new AnalysisResponse());
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(new AnalysisResponse());
+    when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(new AnalysisResponse());
     when(bridgeServerMock.getCommandInfo()).thenReturn("bridgeServerMock command info");
     when(bridgeServerMock.createTsConfigFile(any()))
       .thenReturn(
@@ -172,7 +172,7 @@ class JavaScriptEslintBasedSensorTest {
       "{\"line\":0,\"column\":1,\"ruleId\":\"file-header\",\"message\":\"File issue message\", \"secondaryLocations\": []}" +
       "]}"
     );
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(responseIssues);
+    when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(responseIssues);
 
     var sensor = createSensor();
     DefaultInputFile inputFile = createInputFile(context);
@@ -221,7 +221,7 @@ class JavaScriptEslintBasedSensorTest {
       "}" +
       "]}"
     );
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(responseIssues);
+    when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(responseIssues);
 
     var sensor = createSensor();
     createInputFile(context);
@@ -250,7 +250,7 @@ class JavaScriptEslintBasedSensorTest {
 
   @Test
   void should_report_secondary_issue_locations() throws Exception {
-    when(bridgeServerMock.analyzeWithProgram(any()))
+    when(bridgeServerMock.analyzeJavaScript(any()))
       .thenReturn(
         response(
           "{ issues: [{\"line\":1,\"column\":2,\"endLine\":3,\"endColumn\":4,\"ruleId\":\"no-all-duplicated-branches\",\"message\":\"Issue message\", " +
@@ -291,7 +291,7 @@ class JavaScriptEslintBasedSensorTest {
 
   @Test
   void should_not_report_secondary_when_location_are_null() throws Exception {
-    when(bridgeServerMock.analyzeWithProgram(any()))
+    when(bridgeServerMock.analyzeJavaScript(any()))
       .thenReturn(
         response(
           "{ issues: [{\"line\":1,\"column\":3,\"endLine\":3,\"endColumn\":5,\"ruleId\":\"no-all-duplicated-branches\",\"message\":\"Issue message\", " +
@@ -315,7 +315,7 @@ class JavaScriptEslintBasedSensorTest {
 
   @Test
   void should_report_cost() throws Exception {
-    when(bridgeServerMock.analyzeWithProgram(any()))
+    when(bridgeServerMock.analyzeJavaScript(any()))
       .thenReturn(
         response(
           "{ issues: [{\"line\":1,\"column\":2,\"endLine\":3,\"endColumn\":4,\"ruleId\":\"no-all-duplicated-branches\",\"message\":\"Issue message\", " +
@@ -349,7 +349,7 @@ class JavaScriptEslintBasedSensorTest {
     AnalysisResponse responseMetrics = response(
       "{ metrics: {\"ncloc\":[1, 2, 3],\"commentLines\":[4, 5, 6],\"nosonarLines\":[7, 8, 9],\"executableLines\":[10, 11, 12],\"functions\":1,\"statements\":2,\"classes\":3,\"complexity\":4,\"cognitiveComplexity\":5} }"
     );
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(responseMetrics);
+    when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(responseMetrics);
 
     var sensor = createSensor();
     DefaultInputFile inputFile = createInputFile(context);
@@ -391,7 +391,7 @@ class JavaScriptEslintBasedSensorTest {
   @Test
   void should_save_only_nosonar_metric_for_test() throws Exception {
     AnalysisResponse responseMetrics = response("{ metrics: {\"nosonarLines\":[7, 8, 9]} }");
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(responseMetrics);
+    when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(responseMetrics);
 
     var sensor = createSensor();
 
@@ -413,7 +413,7 @@ class JavaScriptEslintBasedSensorTest {
     AnalysisResponse responseCpdTokens = response(
       "{ highlights: [{\"location\": { \"startLine\":1,\"startCol\":0,\"endLine\":1,\"endCol\":4},\"textType\":\"KEYWORD\"},{\"location\": { \"startLine\":2,\"startCol\":1,\"endLine\":2,\"endCol\":5},\"textType\":\"CONSTANT\"}] }"
     );
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(responseCpdTokens);
+    when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(responseCpdTokens);
 
     var sensor = createSensor();
     DefaultInputFile inputFile = createInputFile(context);
@@ -432,7 +432,7 @@ class JavaScriptEslintBasedSensorTest {
   @Test
   void should_save_cpd() throws Exception {
     AnalysisResponse responseCpdTokens = response(CacheTestUtils.CPD_TOKENS);
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(responseCpdTokens);
+    when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(responseCpdTokens);
 
     var sensor = createSensor();
     DefaultInputFile inputFile = createInputFile(context);
@@ -459,7 +459,7 @@ class JavaScriptEslintBasedSensorTest {
 
   @Test
   void should_not_explode_if_no_response() throws Exception {
-    when(bridgeServerMock.analyzeWithProgram(any())).thenThrow(new IOException("error"));
+    when(bridgeServerMock.analyzeJavaScript(any())).thenThrow(new IOException("error"));
     var sensor = createSensor();
     DefaultInputFile inputFile = createInputFile(context);
     sensor.execute(context);
@@ -583,7 +583,7 @@ class JavaScriptEslintBasedSensorTest {
 
   @Test
   void should_raise_a_parsing_error() throws IOException {
-    when(bridgeServerMock.analyzeWithProgram(any()))
+    when(bridgeServerMock.analyzeJavaScript(any()))
       .thenReturn(
         new Gson()
           .fromJson(
@@ -605,7 +605,7 @@ class JavaScriptEslintBasedSensorTest {
 
   @Test
   void should_not_create_parsing_issue_when_no_rule() throws IOException {
-    when(bridgeServerMock.analyzeWithProgram(any()))
+    when(bridgeServerMock.analyzeJavaScript(any()))
       .thenReturn(
         new Gson()
           .fromJson(
@@ -661,7 +661,7 @@ class JavaScriptEslintBasedSensorTest {
     createInputFile(ctx);
 
     createSensor().execute(ctx);
-    verify(bridgeServerMock).analyzeWithProgram(captor.capture());
+    verify(bridgeServerMock).analyzeJavaScript(captor.capture());
     assertThat(captor.getValue().fileContent).isNull();
   }
 
@@ -685,13 +685,13 @@ class JavaScriptEslintBasedSensorTest {
 
     ArgumentCaptor<JsAnalysisRequest> captor = ArgumentCaptor.forClass(JsAnalysisRequest.class);
     createSensor().execute(ctx);
-    verify(bridgeServerMock).analyzeWithProgram(captor.capture());
+    verify(bridgeServerMock).analyzeJavaScript(captor.capture());
     assertThat(captor.getValue().fileContent).isEqualTo(content);
   }
 
   @Test
   void should_fail_fast() throws Exception {
-    when(bridgeServerMock.analyzeWithProgram(any())).thenThrow(new IOException("error"));
+    when(bridgeServerMock.analyzeJavaScript(any())).thenThrow(new IOException("error"));
     var sensor = createSensor();
     MapSettings settings = new MapSettings().setProperty("sonar.internal.analysis.failFast", true);
     context.setSettings(settings);

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JsTsSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/eslint/JsTsSensorTest.java
@@ -328,11 +328,11 @@ class JsTsSensorTest {
     var inputFile = createInputFile(ctx);
     var tsProgram = new TsProgram("1", List.of(inputFile.absolutePath()), List.of());
     when(bridgeServerMock.createProgram(any())).thenReturn(tsProgram);
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(new AnalysisResponse());
+    when(bridgeServerMock.analyzeTypeScript(any())).thenReturn(new AnalysisResponse());
     createTsConfigFile();
     createSensor().execute(ctx);
     var captor = ArgumentCaptor.forClass(JsAnalysisRequest.class);
-    verify(bridgeServerMock).analyzeWithProgram(captor.capture());
+    verify(bridgeServerMock).analyzeTypeScript(captor.capture());
     assertThat(captor.getValue().fileContent).isNull();
 
     var deleteCaptor = ArgumentCaptor.forClass(TsProgram.class);
@@ -444,11 +444,11 @@ class JsTsSensorTest {
         )
       );
 
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(new AnalysisResponse());
+    when(bridgeServerMock.analyzeTypeScript(any())).thenReturn(new AnalysisResponse());
 
     ArgumentCaptor<JsAnalysisRequest> captor = ArgumentCaptor.forClass(JsAnalysisRequest.class);
     createSensor().execute(context);
-    verify(bridgeServerMock, times(1)).analyzeWithProgram(captor.capture());
+    verify(bridgeServerMock, times(1)).analyzeTypeScript(captor.capture());
     assertThat(captor.getAllValues())
       .extracting(req -> req.filePath)
       .containsExactlyInAnyOrder(file1.absolutePath());
@@ -496,11 +496,11 @@ class JsTsSensorTest {
         )
       );
 
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(new AnalysisResponse());
+    when(bridgeServerMock.analyzeTypeScript(any())).thenReturn(new AnalysisResponse());
 
     ArgumentCaptor<JsAnalysisRequest> captor = ArgumentCaptor.forClass(JsAnalysisRequest.class);
     createSensor().execute(context);
-    verify(bridgeServerMock, times(4)).analyzeWithProgram(captor.capture());
+    verify(bridgeServerMock, times(4)).analyzeTypeScript(captor.capture());
     assertThat(captor.getAllValues())
       .extracting(req -> req.filePath)
       .containsExactlyInAnyOrder(
@@ -547,7 +547,7 @@ class JsTsSensorTest {
         )
       );
 
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(new AnalysisResponse());
+    when(bridgeServerMock.analyzeTypeScript(any())).thenReturn(new AnalysisResponse());
 
     ArgumentCaptor<TsProgramRequest> captorProgram = ArgumentCaptor.forClass(
       TsProgramRequest.class
@@ -658,7 +658,7 @@ class JsTsSensorTest {
   @Test
   void should_fail_fast() throws Exception {
     createTsConfigFile();
-    when(bridgeServerMock.analyzeWithProgram(any())).thenThrow(new IOException("error"));
+    when(bridgeServerMock.analyzeTypeScript(any())).thenThrow(new IOException("error"));
     JsTsSensor sensor = createSensor();
     MapSettings settings = new MapSettings().setProperty("sonar.internal.analysis.failFast", true);
     context.setSettings(settings);
@@ -723,7 +723,7 @@ class JsTsSensorTest {
     DefaultInputFile inputFile = createInputFile(context);
     var tsProgram = new TsProgram("1", List.of(inputFile.absolutePath()), List.of());
     when(bridgeServerMock.createProgram(any())).thenReturn(tsProgram);
-    when(bridgeServerMock.analyzeWithProgram(any())).thenReturn(new AnalysisResponse());
+    when(bridgeServerMock.analyzeTypeScript(any())).thenReturn(new AnalysisResponse());
 
     sensor.execute(context);
     assertThat(logTester.logs(LoggerLevel.DEBUG)).contains("Analyzing file: " + inputFile.uri());


### PR DESCRIPTION
Babel fallback is only used in SonarLint or in Vue projects at the moment. Always fallback to it for JS files when TypeScript fails to parse the file.