### PR TITLE
Allow Stylelint imports for projects without CSS files

### DIFF
--- a/sonar-plugin/css/src/main/java/org/sonar/css/StylelintReportSensor.java
+++ b/sonar-plugin/css/src/main/java/org/sonar/css/StylelintReportSensor.java
@@ -75,7 +75,6 @@ public class StylelintReportSensor implements Sensor {
   @Override
   public void describe(SensorDescriptor descriptor) {
     descriptor
-      .onlyOnLanguage(CssLanguage.KEY)
       .onlyWhenConfiguration(conf -> conf.hasKey(STYLELINT_REPORT_PATHS))
       .name("Import of stylelint issues");
   }

--- a/sonar-plugin/css/src/test/java/org/sonar/css/StylelintReportSensorTest.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/StylelintReportSensorTest.java
@@ -223,7 +223,6 @@ class StylelintReportSensorTest {
     DefaultSensorDescriptor sensorDescriptor = new DefaultSensorDescriptor();
     stylelintReportSensor.describe(sensorDescriptor);
     assertThat(sensorDescriptor.name()).isEqualTo("Import of stylelint issues");
-    assertThat(sensorDescriptor.languages()).containsOnly(CssLanguage.KEY);
   }
 
   private void setReport(String reportFileName) {


### PR DESCRIPTION
Users without css files in their project are not able to import stylelint reports, when the report may be well be referring to other kinds of files for which we don't analyze CSS (`.tsx`)

Fixes #4105 