### PR TITLE
Fix S6535 (unnecessary-character-escapes): Disambiguate conflicting message ids

### DIFF
--- a/packages/jsts/src/rules/S6535/cb.fixture.js
+++ b/packages/jsts/src/rules/S6535/cb.fixture.js
@@ -1,5 +1,9 @@
-const quote = "\'"; // Noncompliant {{Unnecessary escape character: \'.}}
+const quote = "\'"; // Noncompliant [[qf3,qf4=0]] {{Unnecessary escape character: \'.}}
 //             ^
+// fix@qf3 {{Remove the `\`. This maintains the current functionality.}}
+// edit@qf3 {{const quote = "'";}}
+// fix@qf4 {{Replace the `\` with `\\` to include the actual backslash character.}}
+// edit@qf4 {{const quote = "\\'";}}
 
 const octal  = "\8"; // Noncompliant [[qf1,qf2=0]] {{Don't use '\8' escape sequence.}}
 //              ^^
@@ -7,3 +11,4 @@ const octal  = "\8"; // Noncompliant [[qf1,qf2=0]] {{Don't use '\8' escape seque
 // edit@qf1 {{const octal  = "8";}}
 // fix@qf2 {{Replace '\8' with '\\8' to include the actual backslash character.}}
 // edit@qf2 {{const octal  = "\\8";}}
+

--- a/packages/jsts/src/rules/S6535/rule.ts
+++ b/packages/jsts/src/rules/S6535/rule.ts
@@ -35,14 +35,14 @@ const noUselessEscapeRule = eslintRules['no-useless-escape'];
 const noNonoctalDecimalEscapeRule = eslintRules['no-nonoctal-decimal-escape'];
 
 /**
- * We replace the message id 'escapeBackslash' of 'no-nonoctal-decimal-escape' with 'otherEscapeBackslash'.
+ * We replace the message id 'escapeBackslash' of 'no-nonoctal-decimal-escape' with 'nonOctalEscapeBacklash'.
  */
-noNonoctalDecimalEscapeRule.meta!.messages!['otherEscapeBackslash'] =
+noNonoctalDecimalEscapeRule.meta!.messages!['nonOctalEscapeBacklash'] =
   noNonoctalDecimalEscapeRule.meta!.messages!['escapeBackslash'];
 delete noNonoctalDecimalEscapeRule.meta!.messages!['escapeBackslash'];
 
 /**
- * We decorate 'no-nonoctal-decimal-escape' to map suggestions with the message id 'escapeBackslash' to 'otherEscapeBackslash'.
+ * We decorate 'no-nonoctal-decimal-escape' to map suggestions with the message id 'escapeBackslash' to 'nonOctalEscapeBacklash'.
  */
 const decoratedNoNonoctalDecimalEscapeRule = decorateNoNonoctalDecimalEscape(
   noNonoctalDecimalEscapeRule,
@@ -53,7 +53,7 @@ function decorateNoNonoctalDecimalEscape(rule: Rule.RuleModule): Rule.RuleModule
     suggest?.forEach(s => {
       const suggestion = s as { messageId: string };
       if (suggestion.messageId === 'escapeBackslash') {
-        suggestion.messageId = 'otherEscapeBackslash';
+        suggestion.messageId = 'nonOctalEscapeBacklash';
       }
     });
     context.report({ suggest, ...rest });


### PR DESCRIPTION
Fixes #3987 

S6535 implementation consists of merging ESLint rules `no-useless-escape` and `no-nonoctal-decimal-escape`. However, both share a common message id `escapeBackslash` with a different description for their respective suggestions. Because this wasn't noticed at the time of merging the rules, the message id `escapeBackslash` from `no-nonoctal-decimal-escape` used to overwrite the one from `no-useless-escape`. This is why not only the suggestion messages were sometimes confusing but also why the data interpolation of some suggestions didn't occur.