### PR TITLE
Improve S1874 (`deprecation`): Report deprecations from TypeScript compiler

### DIFF
--- a/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1874.json
+++ b/its/ruling/src/test/expected/js/javascript-test-sources/javascript-S1874.json
@@ -94,11 +94,6 @@
 "javascript-test-sources:src/ace/src/mouse/touch_handler.js": [
 59
 ],
-"javascript-test-sources:src/ace/src/scrollbar.js": [
-125,
-130,
-223
-],
 "javascript-test-sources:src/ace/src/scrollbar_test.js": [
 13
 ],
@@ -106,12 +101,7 @@
 270
 ],
 "javascript-test-sources:src/ace/src/test/all_browser.js": [
-11,
 116
-],
-"javascript-test-sources:src/ace/src/virtual_renderer.js": [
-1159,
-1167
 ],
 "javascript-test-sources:src/ace/static.js": [
 33
@@ -139,15 +129,6 @@
 123,
 124
 ],
-"javascript-test-sources:src/ecmascript6/Ghost/core/server/models/post.js": [
-329
-],
-"javascript-test-sources:src/ecmascript6/Ghost/core/server/models/tag.js": [
-68
-],
-"javascript-test-sources:src/ecmascript6/Ghost/core/server/models/user.js": [
-184
-],
 "javascript-test-sources:src/ecmascript6/ecmascript6-today/7-rest-params/js/rest-spread.js": [
 25
 ],
@@ -160,8 +141,6 @@
 ],
 "javascript-test-sources:src/ecmascript6/router/third_party/brick/brick-1.0.1.byob.js": [
 337,
-572,
-575,
 877,
 1412,
 1637,

--- a/its/ruling/src/test/expected/js/p5.js/javascript-S1874.json
+++ b/its/ruling/src/test/expected/js/p5.js/javascript-S1874.json
@@ -2,6 +2,8 @@
 "p5.js:docs/yuidoc-p5-theme/assets/js/reference.js": [
 2433,
 2433,
+2535,
+3895,
 4316,
 4316,
 4503,

--- a/its/ruling/src/test/expected/ts/ant-design/typescript-S1874.json
+++ b/its/ruling/src/test/expected/ts/ant-design/typescript-S1874.json
@@ -21,6 +21,7 @@
 15
 ],
 "ant-design:components/statistic/Statistic.tsx": [
+5,
 74
 ],
 "ant-design:components/table/hooks/useSelection.tsx": [

--- a/its/ruling/src/test/expected/ts/eigen/typescript-S1874.json
+++ b/its/ruling/src/test/expected/ts/eigen/typescript-S1874.json
@@ -1,19 +1,23 @@
 {
 "eigen:src/app/Components/ArticleCard.tests.tsx": [
+1,
 19
 ],
 "eigen:src/app/Components/Artist/ArtistAbout/ArtistAbout.tests.tsx": [
+5,
 55,
 69,
 85
 ],
 "eigen:src/app/Components/Artist/ArtistAbout/ArtistAboutShows.tests.tsx": [
+3,
 48,
 67,
 88,
 107
 ],
 "eigen:src/app/Components/Artist/ArtistConsignButton.tests.tsx": [
+7,
 81,
 96,
 114,
@@ -24,50 +28,61 @@
 236
 ],
 "eigen:src/app/Components/Artist/ArtistHeader.tests.tsx": [
+8,
 42,
 52,
 64
 ],
 "eigen:src/app/Components/Artist/ArtistInsights/ArtistInsights.tests.tsx": [
+3,
 52,
 58
 ],
 "eigen:src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tests.tsx": [
+9,
 74,
 89,
 104,
 120
 ],
 "eigen:src/app/Components/Artist/ArtistInsights/MarketStats.tests.tsx": [
+4,
 26,
 34,
 64,
 110
 ],
 "eigen:src/app/Components/Artist/ArtistShows/ArtistShow.tests.tsx": [
+3,
 39,
 48
 ],
 "eigen:src/app/Components/Artist/ArtistShows/Metadata.tests.tsx": [
+3,
 22
 ],
 "eigen:src/app/Components/Artist/ArtistShows/SmallList.tests.tsx": [
+3,
 16
 ],
 "eigen:src/app/Components/Artist/ArtistShows/VariableSizeShowsList.tests.tsx": [
+1,
 14
 ],
 "eigen:src/app/Components/ArtistListItem.tests.tsx": [
+2,
 40,
 46
 ],
 "eigen:src/app/Components/ArtsyWebView.tests.tsx": [
+5,
 37,
 48,
 239,
 257
 ],
 "eigen:src/app/Components/ArtworkFilter/Filters/AggregationOptionCommonValidation.tsx": [
+12,
 68,
 74,
 81,
@@ -75,6 +90,7 @@
 120
 ],
 "eigen:src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx": [
+10,
 91,
 119,
 154,
@@ -82,6 +98,7 @@
 219
 ],
 "eigen:src/app/Components/ArtworkFilter/Filters/ColorsSwatch.tests.tsx": [
+1,
 8,
 20,
 34,
@@ -89,9 +106,11 @@
 59
 ],
 "eigen:src/app/Components/ArtworkFilter/Filters/KeywordFilter.tests.tsx": [
+2,
 27
 ],
 "eigen:src/app/Components/ArtworkFilter/Filters/SortOptions.tests.tsx": [
+5,
 47,
 53,
 87,
@@ -102,15 +121,18 @@
 240
 ],
 "eigen:src/app/Components/ArtworkFilter/Filters/YearOptions.tests.tsx": [
+9,
 74,
 83
 ],
 "eigen:src/app/Components/ArtworkFilter/Filters/useMultiSelect.tests.tsx": [
+9,
 76,
 102,
 128
 ],
 "eigen:src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx": [
+6,
 30,
 40,
 128,
@@ -124,9 +146,11 @@
 236
 ],
 "eigen:src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tests.tsx": [
+3,
 70
 ],
 "eigen:src/app/Components/AuctionResult/AuctionResultMidEstimate.tests.tsx": [
+1,
 8,
 16,
 24,
@@ -134,15 +158,18 @@
 30
 ],
 "eigen:src/app/Components/Bidding/BidFlow.tests.tsx": [
+5,
 50,
 85
 ],
 "eigen:src/app/Components/Bidding/Components/PaymentInfo.tests.tsx": [
+1,
 24,
 28,
 41
 ],
 "eigen:src/app/Components/Bidding/Components/Timer.tests.tsx": [
+1,
 66,
 71,
 76,
@@ -158,12 +185,19 @@
 173
 ],
 "eigen:src/app/Components/Bidding/Components/Title.tests.tsx": [
+1,
 8
 ],
+"eigen:src/app/Components/Bidding/Components/Title.tsx": [
+1,
+5
+],
 "eigen:src/app/Components/Bidding/Helpers/FakeNavigator.tsx": [
+1,
 37
 ],
 "eigen:src/app/Components/Bidding/Screens/BidResult.tests.tsx": [
+4,
 60,
 86,
 107,
@@ -172,25 +206,51 @@
 180
 ],
 "eigen:src/app/Components/Bidding/Screens/BillingAddress.tests.tsx": [
+2,
 14
 ],
 "eigen:src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx": [
+13,
+16,
 66,
 104,
 168,
 955
 ],
 "eigen:src/app/Components/Bidding/Screens/ConfirmBid/PriceSummary.tsx": [
+1,
+19,
+21,
 92
 ],
+"eigen:src/app/Components/Bidding/Screens/ConfirmBid/index.tsx": [
+26,
+515,
+520,
+521,
+523,
+525,
+538,
+544,
+546,
+608,
+616
+],
 "eigen:src/app/Components/Bidding/Screens/CreditCardForm.tests.tsx": [
+1,
 26,
 33,
 56,
 75,
 99
 ],
+"eigen:src/app/Components/Bidding/Screens/CreditCardForm.tsx": [
+2,
+102,
+104
+],
 "eigen:src/app/Components/Bidding/Screens/Registration.tests.tsx": [
+9,
 47,
 99,
 113,
@@ -219,6 +279,7 @@
 534
 ],
 "eigen:src/app/Components/Bidding/Screens/RegistrationResult.tests.tsx": [
+1,
 16,
 32,
 49,
@@ -229,6 +290,7 @@
 95
 ],
 "eigen:src/app/Components/Bidding/Screens/SelectMaxBid.tests.tsx": [
+5,
 78,
 89,
 105,
@@ -238,37 +300,52 @@
 160
 ],
 "eigen:src/app/Components/Buttons/CaretButton.tests.tsx": [
+1,
 11
 ],
 "eigen:src/app/Components/Buttons/DarkNavigationButton.tests.tsx": [
+3,
 10
 ],
+"eigen:src/app/Components/Buttons/DarkNavigationButton.tsx": [
+2,
+21,
+23
+],
 "eigen:src/app/Components/Buttons/InfoButton.tests.tsx": [
+3,
 11,
 23,
 37
 ],
 "eigen:src/app/Components/ConnectivityBanner.tests.tsx": [
+1,
 7
 ],
 "eigen:src/app/Components/Disappearable.tests.tsx": [
+2,
 10
 ],
 "eigen:src/app/Components/EventTiming.tests.tsx": [
+2,
 10,
 21,
 32
 ],
 "eigen:src/app/Components/Gene/About.tests.tsx": [
+5,
 46
 ],
 "eigen:src/app/Components/Gene/Biography.tests.tsx": [
+3,
 12
 ],
 "eigen:src/app/Components/Gene/Header.tests.tsx": [
+1,
 14
 ],
 "eigen:src/app/Components/HeaderArtworksFilter/HeaderArtworksFilter.tests.tsx": [
+3,
 29,
 33,
 38,
@@ -276,12 +353,15 @@
 50
 ],
 "eigen:src/app/Components/HeaderArtworksFilter/HeaderArtworksFilterWithTotalArtworks.tests.tsx": [
+7,
 42
 ],
 "eigen:src/app/Components/Home/ArtistRails/ArtistCard.tests.tsx": [
+1,
 8
 ],
 "eigen:src/app/Components/Lists/AuctionResultListItem.tests.tsx": [
+3,
 52,
 81,
 110,
@@ -289,32 +369,40 @@
 161
 ],
 "eigen:src/app/Components/Lists/SavedItemRow.tests.tsx": [
+1,
 13
 ],
 "eigen:src/app/Components/LocationMap/LocationMap.tests.tsx": [
+1,
 7
 ],
 "eigen:src/app/Components/LotsByArtistsYouFollowRail/LotsByFollowedArtistsRail.tests.tsx": [
+5,
 42,
 52
 ],
 "eigen:src/app/Components/Markdown.tests.tsx": [
+1,
 13,
 32,
 56,
 83
 ],
 "eigen:src/app/Components/Modals/LoadingModal.tests.tsx": [
+1,
 8,
 12
 ],
 "eigen:src/app/Components/ParentAwareScrollView.tests.tsx": [
+1,
 30
 ],
 "eigen:src/app/Components/PartnerEntityHeader.tests.tsx": [
+3,
 41
 ],
 "eigen:src/app/Components/PopoverMessage/PopoverMessage.tests.tsx": [
+2,
 22,
 40,
 59,
@@ -328,48 +416,59 @@
 223
 ],
 "eigen:src/app/Components/RetryErrorBoundary.tests.tsx": [
+2,
 68,
 76,
 89
 ],
 "eigen:src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tests.tsx": [
+3,
 57,
 74,
 81
 ],
 "eigen:src/app/Components/SectionTitle.tests.tsx": [
+2,
 9,
 17,
 26
 ],
 "eigen:src/app/Components/Show/ShowArtistsPreview.tests.tsx": [
+9,
 45,
 67
 ],
 "eigen:src/app/Components/Show/ShowArtworksPreview.tests.tsx": [
+7,
 35
 ],
 "eigen:src/app/Components/Tag/About.tests.tsx": [
+4,
 13
 ],
 "eigen:src/app/Components/Toast/Toast.tests.tsx": [
+1,
 33,
 45,
 58
 ],
 "eigen:src/app/Containers/Inbox.tests.tsx": [
+4,
 54
 ],
 "eigen:src/app/Containers/Inquiry.tests.tsx": [
+1,
 8
 ],
 "eigen:src/app/Containers/Inquiry.tsx": [
 292
 ],
 "eigen:src/app/Containers/RegistrationFlow.tests.tsx": [
+1,
 11
 ],
 "eigen:src/app/Containers/WorksForYou.tests.tsx": [
+2,
 15,
 28,
 36
@@ -378,44 +477,55 @@
 201
 ],
 "eigen:src/app/Scenes/About/About.tests.tsx": [
+2,
 8,
 16,
 24,
 32
 ],
 "eigen:src/app/Scenes/ArtistArticles/ArtistArticles.tests.tsx": [
+2,
 40
 ],
 "eigen:src/app/Scenes/ArtistSeries/ArtistSeries.tests.tsx": [
+8,
 52
 ],
 "eigen:src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tests.tsx": [
+7,
 48
 ],
 "eigen:src/app/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tests.tsx": [
+6,
 44
 ],
 "eigen:src/app/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx": [
 94
 ],
 "eigen:src/app/Scenes/ArtistSeries/ArtistSeriesHeader.tests.tsx": [
+4,
 42
 ],
 "eigen:src/app/Scenes/ArtistSeries/ArtistSeriesListItem.tests.tsx": [
+6,
 15,
 31
 ],
 "eigen:src/app/Scenes/ArtistSeries/ArtistSeriesMeta.tests.tsx": [
+8,
 51
 ],
 "eigen:src/app/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tests.tsx": [
+8,
 62
 ],
 "eigen:src/app/Scenes/ArtistShows/ArtistShows2.tests.tsx": [
+4,
 44,
 57
 ],
 "eigen:src/app/Scenes/Artwork/Artwork.tests.tsx": [
+19,
 111,
 120,
 133,
@@ -433,29 +543,38 @@
 457
 ],
 "eigen:src/app/Scenes/Artwork/Components/ArtworkHeader.tests.tsx": [
+2,
 17,
 22,
 27
 ],
 "eigen:src/app/Scenes/Artwork/Components/ArtworksInSeriesRail.tests.tsx": [
+5,
 48
 ],
 "eigen:src/app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tests.tsx": [
+6,
 49,
 58,
 68,
 75
 ],
 "eigen:src/app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tests.tsx": [
+5,
 60
 ],
 "eigen:src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx": [
+10,
+20,
 121,
 152,
 183,
 205
 ],
 "eigen:src/app/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tests.tsx": [
+4,
+9,
+9,
 14,
 38,
 43,
@@ -466,6 +585,7 @@
 77
 ],
 "eigen:src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tests.tsx": [
+3,
 226
 ],
 "eigen:src/app/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx": [
@@ -475,21 +595,25 @@
 76
 ],
 "eigen:src/app/Scenes/AuctionResult/AuctionResult.tests.tsx": [
+7,
 57,
 83,
 96,
 106
 ],
 "eigen:src/app/Scenes/AuctionResultsForArtistsYouFollow/AuctionResultsForArtistsYouFollow.tests.tsx": [
+2,
 40
 ],
 "eigen:src/app/Scenes/BottomTabs/BottomTabs.tests.tsx": [
+6,
 64,
 78,
 100,
 121
 ],
 "eigen:src/app/Scenes/BottomTabs/BottomTabsButton.tests.tsx": [
+6,
 26,
 36,
 52,
@@ -497,13 +621,22 @@
 66
 ],
 "eigen:src/app/Scenes/BottomTabs/BottomTabsNavigator.tests.tsx": [
+5,
 25
 ],
 "eigen:src/app/Scenes/City/CityBMWList.tsx": [
 167
 ],
 "eigen:src/app/Scenes/City/CityFairList.tsx": [
+9,
+75,
+75,
 182
+],
+"eigen:src/app/Scenes/City/CityPicker.tsx": [
+6,
+64,
+70
 ],
 "eigen:src/app/Scenes/City/CitySavedList.tsx": [
 175
@@ -511,16 +644,51 @@
 "eigen:src/app/Scenes/City/CitySectionList.tsx": [
 275
 ],
+"eigen:src/app/Scenes/City/Components/AllEvents.tsx": [
+5,
+219,
+219
+],
+"eigen:src/app/Scenes/City/Components/BMWEventSection/index.tsx": [
+6,
+79,
+79,
+86,
+88
+],
+"eigen:src/app/Scenes/City/Components/Event/index.tsx": [
+7,
+154,
+156
+],
+"eigen:src/app/Scenes/City/Components/EventList.tsx": [
+7,
+101,
+101
+],
+"eigen:src/app/Scenes/City/Components/EventSection/index.tsx": [
+4,
+48,
+48
+],
+"eigen:src/app/Scenes/City/Components/FairEventSection/index.tsx": [
+4,
+45,
+47
+],
 "eigen:src/app/Scenes/Collection/Collection.tests.tsx": [
+4,
 45
 ],
 "eigen:src/app/Scenes/Collection/Collection.tsx": [
 146
 ],
 "eigen:src/app/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/CollectionArtistSeriesRail.tests.tsx": [
+24,
 65
 ],
 "eigen:src/app/Scenes/Collection/Components/CollectionHubsRails/FeaturedCollections/FeaturedCollectionsRail.tests.tsx": [
+9,
 60,
 105,
 111,
@@ -529,6 +697,7 @@
 140
 ],
 "eigen:src/app/Scenes/Collection/Components/CollectionHubsRails/OtherCollections/OtherCollectionsRail.tests.tsx": [
+3,
 17,
 26,
 34
@@ -537,42 +706,53 @@
 100
 ],
 "eigen:src/app/Scenes/Collection/Screens/CollectionArtworks.tests.tsx": [
+12,
 49
 ],
 "eigen:src/app/Scenes/Fair/Fair.tests.tsx": [
+4,
 51
 ],
 "eigen:src/app/Scenes/Fair/FairAllFollowedArtists.tests.tsx": [
+2,
 52
 ],
 "eigen:src/app/Scenes/Fair/FairArticles.tsx": [
 208
 ],
 "eigen:src/app/Scenes/Fair/FairArtworks.tests.tsx": [
+7,
 18
 ],
 "eigen:src/app/Scenes/Fair/FairBMWArtActivation.tsx": [
 132
 ],
 "eigen:src/app/Scenes/Fair/FairCollections.tests.tsx": [
+3,
 18
 ],
 "eigen:src/app/Scenes/Fair/FairEditorial.tests.tsx": [
+3,
 18
 ],
 "eigen:src/app/Scenes/Fair/FairExhibitorRail.tests.tsx": [
+5,
 20
 ],
 "eigen:src/app/Scenes/Fair/FairExhibitors.tests.tsx": [
+3,
 16
 ],
 "eigen:src/app/Scenes/Fair/FairFollowedArtistsRail.tests.tsx": [
+3,
 51
 ],
 "eigen:src/app/Scenes/Fair/FairHeader.tests.tsx": [
+6,
 46
 ],
 "eigen:src/app/Scenes/Fair/FairMoreInfo.tests.tsx": [
+3,
 21
 ],
 "eigen:src/app/Scenes/Fair/FairMoreInfo.tsx": [
@@ -588,30 +768,37 @@
 172
 ],
 "eigen:src/app/Scenes/Feature/Feature.tests.tsx": [
+3,
 18
 ],
 "eigen:src/app/Scenes/Feature/components/FeatureMarkdown.tests.tsx": [
+2,
 8
 ],
 "eigen:src/app/Scenes/Gene/Gene.tests.tsx": [
+7,
 67,
 72
 ],
 "eigen:src/app/Scenes/Home/Components/AuctionResultsRail.tests.tsx": [
+11,
 45,
 61,
 72
 ],
 "eigen:src/app/Scenes/Home/Components/CollectionsRail.tests.tsx": [
+13,
 57,
 76,
 90,
 107
 ],
 "eigen:src/app/Scenes/Home/Components/EmailConfirmationBanner.tests.tsx": [
+11,
 43
 ],
 "eigen:src/app/Scenes/Home/Components/FairsRail.tests.tsx": [
+1,
 72,
 82,
 93,
@@ -622,11 +809,13 @@
 174
 ],
 "eigen:src/app/Scenes/Home/Components/HomeHero.tests.tsx": [
+6,
 39,
 60,
 80
 ],
 "eigen:src/app/Scenes/Home/Components/SalesRail.tests.tsx": [
+8,
 61,
 78,
 94,
@@ -635,74 +824,99 @@
 212
 ],
 "eigen:src/app/Scenes/Home/Components/ShowsRail.tests.tsx": [
+2,
 74,
 90
 ],
 "eigen:src/app/Scenes/Home/Components/Trove.tests.tsx": [
+5,
 39,
 59
 ],
 "eigen:src/app/Scenes/Home/TabBar.tests.tsx": [
+1,
 8
 ],
 "eigen:src/app/Scenes/Inbox/Components/ActiveBids/ActiveBid.tests.tsx": [
+1,
 9,
 13
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Composer.tests.tsx": [
+5,
 54
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tests.tsx": [
+4,
 73
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/ConversationSnippet.tests.tsx": [
+1,
 9,
 15
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Conversations.tests.tsx": [
+3,
 41
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tests.tsx": [
+3,
 60
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tests.tsx": [
+5,
 114
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx": [
 127
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Message.tests.tsx": [
+1,
 28
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx": [
+3,
 63
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx": [
+6,
 82
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Preview/ArtworkPreview.tests.tsx": [
+1,
 11,
 18
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Preview/Attachment/FileDownload.tests.tsx": [
+2,
 13
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Preview/Attachment/ImagePreview.tests.tsx": [
+1,
 8
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Preview/Attachment/PDFPreview.tests.tsx": [
+1,
 8
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Preview/ShowPreview.tests.tsx": [
+1,
 8
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx": [
 126
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tests.tsx": [
+4,
 30
 ],
+"eigen:src/app/Scenes/Inbox/Components/Conversations/ZeroStateInbox.tsx": [
+1,
+47,
+47
+],
 "eigen:src/app/Scenes/Inbox/Screens/Conversation.tests.tsx": [
+5,
 61
 ],
 "eigen:src/app/Scenes/Inbox/Screens/Conversation.tsx": [
@@ -712,6 +926,7 @@
 105
 ],
 "eigen:src/app/Scenes/MyAccount/MyAccount.tests.tsx": [
+5,
 67,
 89,
 115,
@@ -721,9 +936,11 @@
 164
 ],
 "eigen:src/app/Scenes/MyAccount/MyAccountEditPassword.tests.tsx": [
+1,
 8
 ],
 "eigen:src/app/Scenes/MyBids/ActiveLotStanding.tests.tsx": [
+5,
 38,
 50,
 64,
@@ -733,6 +950,7 @@
 115
 ],
 "eigen:src/app/Scenes/MyBids/ClosedLotStanding.tests.tsx": [
+3,
 38,
 50,
 62,
@@ -741,13 +959,16 @@
 98
 ],
 "eigen:src/app/Scenes/MyBids/MyBids.tests.tsx": [
+3,
 59,
 70
 ],
 "eigen:src/app/Scenes/MyBids/SaleCard.tests.tsx": [
+3,
 45
 ],
 "eigen:src/app/Scenes/MyBids/SaleInfo.tests.tsx": [
+2,
 14,
 29,
 39,
@@ -756,27 +977,34 @@
 158
 ],
 "eigen:src/app/Scenes/MyCollection/Components/ScreenMargin.tests.tsx": [
+2,
 9
 ],
 "eigen:src/app/Scenes/MyCollection/MyCollection.tests.tsx": [
+14,
 72
 ],
 "eigen:src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tests.tsx": [
+7,
 53,
 69,
 76,
 87
 ],
 "eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArrowDetails.tests.tsx": [
+1,
 10
 ],
 "eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tests.tsx": [
+1,
 25
 ],
 "eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/MediumPicker.tests.tsx": [
+1,
 22
 ],
 "eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tests.tsx": [
+3,
 36,
 44,
 50,
@@ -785,6 +1013,7 @@
 73
 ],
 "eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tests.tsx": [
+5,
 90,
 123,
 168,
@@ -792,18 +1021,27 @@
 235
 ],
 "eigen:src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tests.tsx": [
+6,
 65,
 75,
 87,
 113
 ],
 "eigen:src/app/Scenes/MyProfile/LoggedInUserInfo.tests.tsx": [
+4,
+5,
 16,
 21,
 38,
 44
 ],
+"eigen:src/app/Scenes/MyProfile/LoggedInUserInfo.tsx": [
+5,
+17,
+17
+],
 "eigen:src/app/Scenes/MyProfile/MyProfilePushNotifications.tests.tsx": [
+5,
 32,
 46,
 55,
@@ -814,16 +1052,20 @@
 166
 ],
 "eigen:src/app/Scenes/MyProfile/MyProfileSettings.tests.tsx": [
+3,
 13
 ],
 "eigen:src/app/Scenes/NewWorksForYou/NewWorksForYou.tests.tsx": [
+3,
 36
 ],
 "eigen:src/app/Scenes/Onboarding/ForgotPassword.tests.tsx": [
+2,
 43,
 49
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingCreateAccount/Onboarding.tests.tsx": [
+2,
 14,
 19,
 26,
@@ -831,10 +1073,12 @@
 40
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tests.tsx": [
+4,
 19,
 115
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountEmail.tests.tsx": [
+3,
 37,
 47,
 51,
@@ -843,6 +1087,7 @@
 73
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountName.tests.tsx": [
+3,
 49,
 59,
 65,
@@ -851,6 +1096,7 @@
 90
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountPassword.tests.tsx": [
+3,
 38,
 48,
 52,
@@ -858,6 +1104,7 @@
 65
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingSocialPick.tests.tsx": [
+3,
 15,
 24,
 32,
@@ -870,6 +1117,7 @@
 91
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingLogin.tests.tsx": [
+1,
 43,
 52,
 57,
@@ -881,17 +1129,21 @@
 123
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tests.tsx": [
+7,
 57,
 74
 ],
 "eigen:src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalizationModal.tests.tsx": [
+3,
 48,
 72
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/ArtworkInfoSection.tests.tsx": [
+2,
 36
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/OrderDetails.tests.tsx": [
+3,
 55,
 65,
 78,
@@ -900,6 +1152,7 @@
 125
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/OrderDetailsHeader.tests.tsx": [
+3,
 46,
 59,
 67,
@@ -915,18 +1168,22 @@
 196
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/OrderDetailsPayment.tests.tsx": [
+3,
 43
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/ShipsToSection.tests.tsx": [
+3,
 51,
 63,
 76
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/SoldBySection.tests.tsx": [
+3,
 36,
 72
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/TrackOrderSection.tests.tsx": [
+3,
 86,
 104,
 125,
@@ -935,11 +1192,13 @@
 202
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderHistory.tests.tsx": [
+3,
 18,
 48,
 63
 ],
 "eigen:src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx": [
+3,
 67,
 88,
 99,
@@ -958,6 +1217,7 @@
 315
 ],
 "eigen:src/app/Scenes/OrderHistory/SummarySection.tests.tsx": [
+2,
 37,
 56,
 79,
@@ -965,29 +1225,46 @@
 121
 ],
 "eigen:src/app/Scenes/Partner/Components/PartnerArtwork.tests.tsx": [
+2,
 36
 ],
 "eigen:src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx": [
+3,
 37,
 51,
 65,
 79
 ],
+"eigen:src/app/Scenes/Partner/Components/PartnerMap.tsx": [
+8,
+60,
+62,
+65,
+67,
+70,
+72
+],
 "eigen:src/app/Scenes/Partner/Components/PartnerOverview.tests.tsx": [
+5,
 69,
 89,
 109,
 128
 ],
 "eigen:src/app/Scenes/Partner/Screens/PartnerLocations.tsx": [
+7,
+45,
+45,
 112
 ],
 "eigen:src/app/Scenes/Sale/RegisterToBidButton.tests.tsx": [
+4,
 49,
 64,
 84
 ],
 "eigen:src/app/Scenes/Sale/Sale.tests.tsx": [
+4,
 37,
 64,
 91,
@@ -999,6 +1276,7 @@
 211
 ],
 "eigen:src/app/Scenes/Sale/SaleActiveBidItem.tests.tsx": [
+5,
 78,
 100,
 120,
@@ -1007,28 +1285,34 @@
 192
 ],
 "eigen:src/app/Scenes/Sale/SaleActiveBids.tests.tsx": [
+2,
 41,
 54
 ],
 "eigen:src/app/Scenes/Sale/SaleArtworksRail.tests.tsx": [
+4,
 42,
 55
 ],
 "eigen:src/app/Scenes/Sale/SaleHeader.tests.tsx": [
+7,
 48,
 71,
 126
 ],
 "eigen:src/app/Scenes/Sale/SaleLotsList.tests.tsx": [
+10,
 98,
 115,
 133,
 151
 ],
 "eigen:src/app/Scenes/SaleFAQ/SaleFAQ.tests.tsx": [
+1,
 8
 ],
 "eigen:src/app/Scenes/SaleInfo/SaleInfo.tests.tsx": [
+4,
 42,
 54,
 81,
@@ -1036,13 +1320,16 @@
 105
 ],
 "eigen:src/app/Scenes/Sales/Components/ZeroState/index.tests.tsx": [
+1,
 7
 ],
 "eigen:src/app/Scenes/SavedAddresses/SavedAddressesForm.tests.tsx": [
+3,
 41,
 62
 ],
 "eigen:src/app/Scenes/Search/AutosuggestResults.tests.tsx": [
+7,
 168,
 173,
 189,
@@ -1053,14 +1340,17 @@
 294
 ],
 "eigen:src/app/Scenes/Search/RecentSearches.tests.tsx": [
+3,
 86,
 95,
 109
 ],
 "eigen:src/app/Scenes/Search/SearchModel.tests.tsx": [
+2,
 107
 ],
 "eigen:src/app/Scenes/Search/components/AutosuggestSearchResult.tests.tsx": [
+5,
 91,
 114,
 125,
@@ -1073,19 +1363,23 @@
 237
 ],
 "eigen:src/app/Scenes/Search/components/CityGuideCTA.tests.tsx": [
+3,
 10,
 16
 ],
 "eigen:src/app/Scenes/Search/components/CityGuideCTANew.tests.tsx": [
+3,
 10,
 16
 ],
 "eigen:src/app/Scenes/SellWithArtsy/Components/ArtistList.tests.tsx": [
+9,
 32,
 38,
 63
 ],
 "eigen:src/app/Scenes/SellWithArtsy/Components/RecentlySold.tests.tsx": [
+10,
 34,
 40,
 58,
@@ -1093,6 +1387,7 @@
 112
 ],
 "eigen:src/app/Scenes/SellWithArtsy/index.tests.tsx": [
+3,
 24,
 33,
 49
@@ -1101,38 +1396,49 @@
 229
 ],
 "eigen:src/app/Scenes/Show/Show.tests.tsx": [
+5,
 44
 ],
 "eigen:src/app/Scenes/Show/ShowArtworks.tests.tsx": [
+5,
 16
 ],
 "eigen:src/app/Scenes/Show/ShowArtworksEmptyState.tests.tsx": [
+3,
 41
 ],
 "eigen:src/app/Scenes/Show/ShowContextCard.tests.tsx": [
+7,
 46
 ],
 "eigen:src/app/Scenes/Show/ShowHours.tests.tsx": [
+3,
 41
 ],
 "eigen:src/app/Scenes/Show/ShowLocation.tests.tsx": [
+3,
 65
 ],
 "eigen:src/app/Scenes/Show/ShowMoreInfo.tests.tsx": [
+3,
 43
 ],
 "eigen:src/app/Scenes/Show/ShowViewingRoom.tests.tsx": [
+4,
 43
 ],
 "eigen:src/app/Scenes/Tag/Tag.tests.tsx": [
+6,
 62,
 67,
 75
 ],
 "eigen:src/app/Scenes/Tag/TagHeader.tests.tsx": [
+1,
 11
 ],
 "eigen:src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx": [
+5,
 48,
 61,
 69,
@@ -1142,6 +1448,7 @@
 134
 ],
 "eigen:src/app/Scenes/VanityURL/VanityURLPossibleRedirect.tests.tsx": [
+7,
 26,
 36,
 58,
@@ -1152,12 +1459,14 @@
 125
 ],
 "eigen:src/app/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tests.tsx": [
+5,
 28,
 38,
 47,
 69
 ],
 "eigen:src/app/Scenes/ViewingRoom/Components/ViewingRoomHeader.tests.tsx": [
+4,
 25,
 33,
 44,
@@ -1169,18 +1478,22 @@
 112
 ],
 "eigen:src/app/Scenes/ViewingRoom/Components/ViewingRoomSubsections.tests.tsx": [
+2,
 25,
 32
 ],
 "eigen:src/app/Scenes/ViewingRoom/Components/ViewingRoomViewWorksButton.tests.tsx": [
+3,
 26,
 35
 ],
 "eigen:src/app/Scenes/ViewingRoom/Components/ViewingRoomsListFeatured.tests.tsx": [
+2,
 26,
 36
 ],
 "eigen:src/app/Scenes/ViewingRoom/ViewingRoom.tests.tsx": [
+4,
 30,
 40,
 57,
@@ -1194,9 +1507,11 @@
 273
 ],
 "eigen:src/app/Scenes/ViewingRoom/ViewingRoomArtwork.tests.tsx": [
+3,
 28
 ],
 "eigen:src/app/Scenes/ViewingRoom/ViewingRoomArtworks.tests.tsx": [
+4,
 32,
 39,
 49,
@@ -1206,12 +1521,15 @@
 232
 ],
 "eigen:src/app/Scenes/ViewingRoom/ViewingRoomsList.tests.tsx": [
+2,
 24
 ],
 "eigen:src/app/tests/MockRelayRenderer.tests.tsx": [
+9,
 15
 ],
 "eigen:src/app/tests/MockRelayRenderer.tsx": [
+14,
 169,
 212
 ],
@@ -1222,23 +1540,48 @@
 105
 ],
 "eigen:src/app/tests/renderUntil.tsx": [
-38,
 38
 ],
 "eigen:src/app/tests/renderWithLayout.tsx": [
+1,
 6
 ],
 "eigen:src/app/tests/setupTestWrapper.tsx": [
+8,
 78
 ],
 "eigen:src/app/utils/getTestWrapper.tsx": [
+10,
 15,
 41
 ],
 "eigen:src/app/utils/placeholders.tests.tsx": [
+1,
 8,
 15,
 25
+],
+"eigen:src/app/utils/renderMarkdown.tests.tsx": [
+6,
+66,
+68,
+92,
+94,
+121,
+123
+],
+"eigen:src/app/utils/renderMarkdown.tsx": [
+4,
+99,
+101,
+113,
+115,
+140,
+140,
+148,
+150,
+159,
+161
 ],
 "eigen:src/app/utils/renderWithLoadProgress.tests.tsx": [
 6,
@@ -1246,14 +1589,17 @@
 17
 ],
 "eigen:src/app/utils/track/tracking.tests.tsx": [
+1,
 32,
 65
 ],
 "eigen:src/palette/elements/Checkbox/Checkbox.tests.tsx": [
+1,
 8,
 18
 ],
 "eigen:src/palette/elements/Input/PhoneInput/PhoneInput.tests.tsx": [
+2,
 20,
 41,
 54,
@@ -1261,15 +1607,18 @@
 111
 ],
 "eigen:src/palette/elements/Radio/RadioButton.tests.tsx": [
+1,
 8,
 18
 ],
 "eigen:src/palette/elements/Select/Select.tests.tsx": [
+2,
 23,
 40,
 61
 ],
 "eigen:src/palette/elements/Tabs/Tabs.tests.tsx": [
+1,
 29,
 37,
 47,
@@ -1277,11 +1626,16 @@
 93
 ],
 "eigen:src/palette/helpers/color.tests.tsx": [
+1,
 15,
 26
 ],
 "eigen:src/palette/helpers/space.tests.tsx": [
+1,
 16,
 28
+],
+"eigen:src/palette/organisms/screenStructure/Screen.tsx": [
+288
 ]
 }

--- a/its/ruling/src/test/expected/ts/vuetify/typescript-S1874.json
+++ b/its/ruling/src/test/expected/ts/vuetify/typescript-S1874.json
@@ -1,14 +1,14 @@
 {
 "vuetify:packages/docs/src/App.vue": [
-61,
-64
+55,
+58
 ],
 "vuetify:packages/docs/src/components/app/Markup.vue": [
-128,
-129
+77,
+79
 ],
 "vuetify:packages/docs/src/components/app/Toc.vue": [
-143
+54
 ],
 "vuetify:packages/docs/src/util/helpers.ts": [
 10,

--- a/packages/jsts/src/rules/S1874/cb.fixture.ts
+++ b/packages/jsts/src/rules/S1874/cb.fixture.ts
@@ -9,7 +9,7 @@ function foo(strings: TemplateStringsArray, ...values: any[]): string {
 foo``;
 foo`${'foo'}`;
 foo`${42}`;
-foo`${[1, 2, 3]}`; // Noncompliant FN
+foo`${[1, 2, 3]}`; // Noncompliant
 
 /* separator */
 
@@ -18,7 +18,7 @@ interface X {
     foo(pp: string): number;
 }
 function bar(x: X, p: string) {
-    x.foo(p); // Noncompliant {{'foo' is deprecated. use bar instead}}
+    x.foo(p); // Noncompliant {{The signature '(pp: string): number' of 'x.foo' is deprecated.}}
 //    ^^^
 }
 
@@ -81,7 +81,7 @@ let deprecatedVar;
 const const1 = 1,
     const2 = 2;
 
-h(const1 + const2); // Noncompliant
+h(const1 + const2); // Noncompliant 2
 export default const1;// Noncompliant
 
 /* separator */
@@ -93,7 +93,7 @@ function fn() { }
 
 fn<number>();
 fn(1); // Noncompliant
-h(fn); // Noncompliant
+h(fn);
 
 /* separator */
 
@@ -142,9 +142,9 @@ deprecatedCallSignature2(); // Noncompliant
 /* separator */
 
 import * as allDeprecations from './cb.fixture.deprecations';
-z(allDeprecations.deprecatedFunction);// Noncompliant
+z(allDeprecations.deprecatedFunction);
 
-import defaultImport, {deprecatedFunction, anotherDeprecatedFunction as aliasForDeprecated, notDeprecated1, notDeprecated2} from './cb.fixture.deprecations';
+import defaultImport, {deprecatedFunction, anotherDeprecatedFunction as aliasForDeprecated, notDeprecated1, notDeprecated2} from './cb.fixture.deprecations'; // Noncompliant 2
 defaultImport(); // Noncompliant
 deprecatedFunction(); // Noncompliant
 deprecatedFunction(1);
@@ -155,8 +155,32 @@ noDeprecated2(); // OK
 import * as deprecationsExport from './cb.fixture.deprecationsExport';
 z(deprecationsExport); // Noncompliant
 
-import {DeprecatedClass, ClassWithDeprecatedConstructor, ClassWithOneDeprecatedConstructor} from "./cb.fixture.deprecations"
+import {DeprecatedClass, ClassWithDeprecatedConstructor, ClassWithOneDeprecatedConstructor} from "./cb.fixture.deprecations" // Noncompliant
 const myObj2: DeprecatedClass = new DeprecatedClass();  // Noncompliant 2
 const myObj3: DeprecatedConstructorClass = new ClassWithDeprecatedConstructor(); // Noncompliant
 new ClassWithOneDeprecatedConstructor();
 new ClassWithOneDeprecatedConstructor(1); // Noncompliant
+
+/* i4008 */
+
+/** @deprecated */ function someDeprecated(a: string): string;
+/** @param a */ function someDeprecated(a: number): number;
+function someDeprecated(a: number | string): number | string {
+    if (typeof a === 'number') return a + 1;
+    return a;
+}
+
+someDeprecated('yolo'); // Noncompliant
+someDeprecated(42); // OK
+someDeprecated; // OK
+
+/** @deprecated */ function allDeprecated(a: string): string;
+/** @deprecated */ function allDeprecated(a: number): number;
+function allDeprecated(a: number | string): number | string {
+    if (typeof a === 'number') return a + 1;
+    return a;
+}
+
+allDeprecated('yolo'); // Noncompliant
+allDeprecated(42); // Noncompliant
+allDeprecated; // OK

--- a/packages/jsts/src/rules/S1874/rule.ts
+++ b/packages/jsts/src/rules/S1874/rule.ts
@@ -20,15 +20,13 @@
 // https://sonarsource.github.io/rspec/#/rspec/S1874/javascript
 
 import { Rule } from 'eslint';
-import { TSESTree } from '@typescript-eslint/experimental-utils';
-import * as estree from 'estree';
-import { getParent, isRequiredParserServices, RequiredParserServices } from '../helpers';
+import { isRequiredParserServices } from '../helpers';
 import * as ts from 'typescript';
 
 export const rule: Rule.RuleModule = {
   meta: {
     messages: {
-      deprecation: "'{{symbol}}' is deprecated. {{reason}}",
+      deprecation: '{{deprecation}}',
     },
   },
   create(context: Rule.RuleContext) {
@@ -37,202 +35,29 @@ export const rule: Rule.RuleModule = {
       return {};
     }
     return {
-      Identifier: (node: estree.Node) => {
-        const parent = getParent(context);
-        if (isShortHandProperty(parent) && parent.key === node) {
-          // to not report twice
-          return;
-        }
-        if (isObjectExpressionProperty(node, context)) {
-          return;
-        }
-        const id = node as estree.Identifier;
-        const insideImportExport = context.getAncestors().some(anc => anc.type.includes('Import'));
-        if (insideImportExport || isDeclaration(id, context)) {
-          return;
-        }
-
-        const deprecation = getDeprecation(id, services, context);
-        if (deprecation) {
-          context.report({
-            node,
-            messageId: 'deprecation',
-            data: {
-              symbol: id.name,
-              reason: deprecation.reason,
-            },
-          });
+      Program: () => {
+        const program = services.program;
+        const checker = program.getTypeChecker();
+        const sourceFile = program.getSourceFile(context.filename);
+        const diagnostics: ts.DiagnosticWithLocation[] =
+          // @ts-ignore: TypeChecker#getSuggestionDiagnostics is not publicly exposed
+          checker.getSuggestionDiagnostics(sourceFile);
+        for (const diagnostic of diagnostics) {
+          if (diagnostic.reportsDeprecated === true) {
+            const sourceCode = context.sourceCode;
+            const start = sourceCode.getLocFromIndex(diagnostic.start);
+            const end = sourceCode.getLocFromIndex(diagnostic.start + diagnostic.length);
+            const loc = { start, end };
+            context.report({
+              loc,
+              messageId: 'deprecation',
+              data: {
+                deprecation: diagnostic.messageText as string,
+              },
+            });
+          }
         }
       },
     };
   },
 };
-
-function isDeclaration(id: estree.Identifier, context: Rule.RuleContext) {
-  const parent = getParent(context);
-  if (isShortHandProperty(parent) && parent.value === id) {
-    return false;
-  }
-
-  const variable = context.getScope().variables.find(v => v.name === id.name);
-  if (variable) {
-    return variable.defs.some(def => def.name === id);
-  }
-
-  const declarationTypes = [
-    'PropertyDefinition',
-    'TSPropertySignature',
-    'TSDeclareFunction',
-    'FunctionDeclaration',
-    'MethodDefinition',
-    'TSMethodSignature',
-  ];
-  return parent && declarationTypes.includes(parent.type);
-}
-
-function getDeprecation(
-  id: estree.Identifier,
-  services: RequiredParserServices,
-  context: Rule.RuleContext,
-): Deprecation | undefined {
-  const tc = services.program.getTypeChecker();
-  const callExpression = getCallExpression(context, id);
-
-  if (callExpression) {
-    const tsCallExpression = services.esTreeNodeToTSNodeMap.get(callExpression as TSESTree.Node);
-    const signature = tc.getResolvedSignature(tsCallExpression as ts.CallLikeExpression);
-    if (signature) {
-      const deprecation = getJsDocDeprecation(signature.getJsDocTags());
-      if (deprecation) {
-        return deprecation;
-      }
-    }
-  }
-  const symbol = getSymbol(id, services, context, tc);
-
-  if (!symbol) {
-    return undefined;
-  }
-  if (callExpression && isFunction(symbol)) {
-    return undefined;
-  }
-
-  return getJsDocDeprecation(symbol.getJsDocTags());
-}
-
-function getSymbol(
-  id: estree.Identifier,
-  services: RequiredParserServices,
-  context: Rule.RuleContext,
-  tc: ts.TypeChecker,
-) {
-  let symbol: ts.Symbol | undefined;
-  const tsId = services.esTreeNodeToTSNodeMap.get(id as TSESTree.Node) as ts.Identifier;
-  const parent = services.esTreeNodeToTSNodeMap.get(getParent(context) as TSESTree.Node) as ts.Node;
-  if (parent.kind === ts.SyntaxKind.BindingElement) {
-    symbol = tc.getTypeAtLocation(parent.parent).getProperty(tsId.text);
-  } else if (
-    (isPropertyAssignment(parent) && parent.name === tsId) ||
-    (isShorthandPropertyAssignment(parent) && parent.name === tsId)
-  ) {
-    try {
-      symbol = tc.getPropertySymbolOfDestructuringAssignment(tsId);
-    } catch (e) {
-      // do nothing, we are in object literal, not destructuring
-      // no obvious easy way to check that in advance
-    }
-  } else {
-    symbol = tc.getSymbolAtLocation(tsId);
-  }
-
-  if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
-    return tc.getAliasedSymbol(symbol);
-  }
-  return symbol;
-}
-
-function getCallExpression(
-  context: Rule.RuleContext,
-  id: estree.Node,
-): estree.CallExpression | estree.TaggedTemplateExpression | undefined {
-  const ancestors = context.getAncestors();
-  let callee = id;
-  let parent = ancestors.length > 0 ? ancestors[ancestors.length - 1] : undefined;
-
-  if (parent && parent.type === 'MemberExpression' && parent.property === id) {
-    callee = parent;
-    parent = ancestors.length > 1 ? ancestors[ancestors.length - 2] : undefined;
-  }
-
-  if (isCallExpression(parent, callee)) {
-    return parent;
-  }
-}
-
-function isCallExpression(
-  node: estree.Node | undefined,
-  callee: estree.Node,
-): node is estree.CallExpression | estree.TaggedTemplateExpression {
-  if (node) {
-    if (node.type === 'NewExpression' || node.type === 'CallExpression') {
-      return node.callee === callee;
-    } else if (node.type === 'TaggedTemplateExpression') {
-      return node.tag === callee;
-    }
-  }
-  return false;
-}
-
-function getJsDocDeprecation(tags: ts.JSDocTagInfo[]): Deprecation | undefined {
-  for (const tag of tags) {
-    if (tag.name === 'deprecated') {
-      return tag.text ? { reason: tag.text.map(e => e.text).join(' ') } : new Deprecation();
-    }
-  }
-  return undefined;
-}
-
-function isFunction(symbol: ts.Symbol) {
-  const { declarations } = symbol;
-  if (declarations === undefined || declarations.length === 0) {
-    return false;
-  }
-  switch (declarations[0].kind) {
-    case ts.SyntaxKind.MethodDeclaration:
-    case ts.SyntaxKind.FunctionDeclaration:
-    case ts.SyntaxKind.FunctionExpression:
-    case ts.SyntaxKind.MethodSignature:
-      return true;
-    default:
-      return false;
-  }
-}
-
-function isPropertyAssignment(node: ts.Node): node is ts.PropertyAssignment {
-  return node.kind === ts.SyntaxKind.PropertyAssignment;
-}
-
-function isShorthandPropertyAssignment(node: ts.Node): node is ts.ShorthandPropertyAssignment {
-  return node.kind === ts.SyntaxKind.ShorthandPropertyAssignment;
-}
-
-function isShortHandProperty(parent: estree.Node | undefined): parent is estree.Property {
-  return !!parent && parent.type === 'Property' && parent.shorthand;
-}
-
-function isObjectExpressionProperty(node: estree.Node, context: Rule.RuleContext) {
-  const ancestors = context.getAncestors();
-  const parent = ancestors.pop();
-  const grandparent = ancestors.pop();
-  return (
-    parent?.type === 'Property' &&
-    !parent.computed &&
-    !parent.shorthand &&
-    parent.key === node &&
-    grandparent?.type === 'ObjectExpression'
-  );
-}
-
-class Deprecation {
-  reason = '';
-}


### PR DESCRIPTION
Fixes #4008 

Building from #4064, it turns out quite tricky to cover every single case of deprecated symbols that are used. In fact, after looking at TypeScript's codebase, there are many places where usages of deprecated APIs are detected and reported. This is due to several edge cases. Instead of replicating the logic for every single one, we propose to extract and propagate deprecation suggestions emitted by TypeScript's type checker. There are minor functional differences compared to our current implementation, like the fact that TypeScript reports on import statements. However, with these changes, we behave precisely like TypeScript compilers, thus reducing false positives and negatives.