### PR TITLE
Update rule count

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This SonarSource project is a [static code analyzer](https://en.wikipedia.org/wi
 # Features
 
 - Advanced rules based on pattern matching and control flow analysis
-- [340 JS rules](https://rules.sonarsource.com/javascript) and [340+ TS rules](https://rules.sonarsource.com/typescript)
+- [370 JS rules](https://rules.sonarsource.com/javascript) and [375 TS rules](https://rules.sonarsource.com/typescript)
 - [25 CSS rules](https://rules.sonarsource.com/css)
 - Compatible with ECMAScript 2015-2020
 - React JSX, Flow, Vue, and AWS lambda functions support for JavaScript and TypeScript


### PR DESCRIPTION
The updated numbers are based on those on Peach, i.e., the current master. Those from [rules.sonarsource.com](rules.sonarsource.com) will be updated once SonarJS is released.