### PR TITLE
Remove unneeded direct dependency `decompress-targz`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
         "@types/tmp": "0.2.3",
         "cpy-cli": "4.2.0",
         "decompress": "4.2.1",
-        "decompress-targz": "4.1.1",
         "extract-zip": "2.0.1",
         "fs-extra": "11.1.1",
         "husky": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@types/tmp": "0.2.3",
     "cpy-cli": "4.2.0",
     "decompress": "4.2.1",
-    "decompress-targz": "4.1.1",
     "extract-zip": "2.0.1",
     "fs-extra": "11.1.1",
     "husky": "8.0.3",

--- a/tools/fetch-node/scripts/fetch-node.mjs
+++ b/tools/fetch-node/scripts/fetch-node.mjs
@@ -21,7 +21,6 @@ import fetch from 'node-fetch';
 import fs from 'fs-extra';
 import extract from 'extract-zip';
 import decompress from 'decompress';
-import decompressTargz from 'decompress-targz';
 import * as path from 'node:path';
 import * as stream from 'node:stream';
 import * as crypto from 'node:crypto';
@@ -186,7 +185,6 @@ async function extractFile(file, dir) {
     // decompress tar gz doesn't support overwrites
     deleteFolderIfExists(removeExtension(file));
     await decompress(file, dir, {
-      plugins: [decompressTargz()],
       /**
        * There are symlinks in the unix distros that raise an exception when running this on Windows
        * So we filter them out. We only need the binary which is in {distroFullName}/bin/node
@@ -235,7 +233,7 @@ function removeExtension(filename) {
  */
 function retrieveArtifactoryKey() {
   const devKey = retrieveForDevMachine();
-  return devKey ? devKey : retrieveForCI();
+  return devKey || retrieveForCI();
 
   function retrieveForCI() {
     return process.env.ARTIFACTORY_ACCESS_TOKEN;


### PR DESCRIPTION
Mend reports [CVE-2020-12265](https://www.mend.io/vulnerability-database/CVE-2020-12265) for `decompress-targz` because it has "vulnerable" version 4.1.1 . `decompress-targz` is not needed directly, it's included transitively by `decompress` which has "non-vulnerable" version `4.2.1`