### PR TITLE
Fix typedoc script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "plugin:build-no-bridge": "mvn install",
     "plugin:build:fast": "npm run plugin:build-no-bridge -- -DskipTests",
     "pbf": "npm run plugin:build:fast",
-    "td": "node typedoc/scripts/setup-plugins.js && ./node-modules/.bin/typedoc --options typedoc/typedoc.js",
+    "td": "node typedoc/scripts/setup-plugins.js && ./node_modules/.bin/typedoc --options typedoc/typedoc.js",
     "prepare": "husky install",
     "precommit": "pretty-quick --staged",
     "_:bridge:clear": "rimraf lib/*",


### PR DESCRIPTION
the checks on the [`master`](https://github.com/SonarSource/SonarJS/commits/master) branch fail since I broke the script by replacing characters in https://github.com/SonarSource/SonarJS/pull/4203. This fixes it.