### PR TITLE
Fix FP S6606 (`prefer-nullish-coalescing`): When the first argument is `boolean | undefined`

### DIFF
--- a/its/sources/jsts/custom/S6606.ts
+++ b/its/sources/jsts/custom/S6606.ts
@@ -1,0 +1,3 @@
+function foo(bar: boolean | undefined, baz: string) {
+  return bar || baz; // FP
+}

--- a/its/sources/jsts/custom/tsconfig.json
+++ b/its/sources/jsts/custom/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "allowJs": true
+    "allowJs": true,
+    "strict": true
   }
 }

--- a/sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/PreferNullishCoalescingCheck.java
+++ b/sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/PreferNullishCoalescingCheck.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.javascript.checks;
 
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.check.Rule;
@@ -45,5 +46,18 @@ public class PreferNullishCoalescingCheck implements EslintBasedCheck {
     boolean ignoreTernaryTests = false;
     boolean ignoreMixedLogicalExpressions = true;
     boolean allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = true;
+
+    IgnorePrimitives ignorePrimitives = new IgnorePrimitives();
+
+    private static class IgnorePrimitives {
+
+      boolean string = false;
+
+      @SerializedName(value = "boolean")
+      boolean bool = true;
+
+      boolean number = false;
+      boolean bigint = false;
+    }
   }
 }


### PR DESCRIPTION
Fixes #3936 
This fix only works after upgrading typescript-eslint, as the parameter used here (IgnorePrimitives) was [added in August 2023](https://github.com/typescript-eslint/typescript-eslint/commit/dfcafae515e7f4d1ae69387eb163200e455dd0ce)