### PR TITLE
Optimize plugin download on SonarCloud

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/pom.xml
+++ b/sonar-plugin/sonar-javascript-plugin/pom.xml
@@ -124,12 +124,13 @@
         <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
         <artifactId>sonar-packaging-maven-plugin</artifactId>
         <configuration>
+          <jreMinVersion>${jdk.min.version}</jreMinVersion>
           <pluginName>JavaScript/TypeScript/CSS Code Quality and Security</pluginName>
           <pluginClass>org.sonar.plugins.javascript.JavaScriptPlugin</pluginClass>
+          <requiredForLanguages>js,ts,css,web,yaml</requiredForLanguages>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <sonarLintSupported>true</sonarLintSupported>
           <sonarQubeMinVersion>${sonarQubeMinVersion}</sonarQubeMinVersion>
-          <jreMinVersion>${jdk.min.version}</jreMinVersion>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Fixes #4223 

For information sonar-javascript-plugin doesn't honor the rule that the property defining the files of the language has the form `sonar.{language_key}.file.suffix`, that's why there is hardcoded mapping on SonarCloud side here 

https://github.com/SonarSource/sonarcloud-core/blob/ec30b0f6d37e33a31eb04da7bcec098826f4bb05/sonar-scanner-engine/src/main/java/org/sonar/scanner/repository/language/DefaultLanguagesRepository.java#L30 

We don't have a way to test it automatically. We can contact SonarCloud team (Cody) after the release to validate it manually.