### PR TITLE
Fix FP S3800 (`function-return-type`): Make the exception of returning at least one `this` instead of all `this`

### DIFF
--- a/its/ruling/src/test/expected/jsts/ace/javascript-S3800.json
+++ b/its/ruling/src/test/expected/jsts/ace/javascript-S3800.json
@@ -11,7 +11,6 @@
 9484
 ],
 "ace:lib/ace/mode/javascript/jshint.js": [
-7902,
 18292
 ],
 "ace:src/keyboard/hash_handler.js": [

--- a/its/ruling/src/test/expected/jsts/angular.js/javascript-S3800.json
+++ b/its/ruling/src/test/expected/jsts/angular.js/javascript-S3800.json
@@ -14,8 +14,5 @@
 1536,
 1542,
 1548
-],
-"angular.js:src/ngMock/angular-mocks.js": [
-432
 ]
 }

--- a/its/ruling/src/test/expected/jsts/jshint/javascript-S3800.json
+++ b/its/ruling/src/test/expected/jsts/jshint/javascript-S3800.json
@@ -1,5 +1,0 @@
-{
-"jshint:src/jshint.js": [
-3344
-]
-}

--- a/packages/jsts/src/rules/S3800/cb.fixture.js
+++ b/packages/jsts/src/rules/S3800/cb.fixture.js
@@ -1,0 +1,13 @@
+String.prototype.foo = function() {
+  if (this.length == 10)
+    return this.substring(5);
+  return this;
+}
+
+// necessary example to have at least 1 noncompliant case
+function foo() { // Noncompliant
+    if (condition) {
+      return 42;
+    }
+    return 'str';
+  }

--- a/packages/jsts/src/rules/S3800/cb.test.ts
+++ b/packages/jsts/src/rules/S3800/cb.test.ts
@@ -1,0 +1,28 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { check } from '../tools';
+import { rule } from './';
+import path from 'path';
+
+const sonarId = path.basename(__dirname);
+
+describe(`Rule`, () => {
+  check(sonarId, rule, __dirname);
+});

--- a/packages/jsts/src/rules/S3800/rule.ts
+++ b/packages/jsts/src/rules/S3800/rule.ts
@@ -67,7 +67,7 @@ export const rule: Rule.RuleModule = {
 
     function onFunctionExit(node: estree.Node) {
       const returnStatements = scopes.pop()!.getReturnStatements();
-      if (returnStatements.every(retStmt => retStmt.argument?.type === 'ThisExpression')) {
+      if (returnStatements.some(retStmt => retStmt.argument?.type === 'ThisExpression')) {
         return;
       }
       const signature = checker.getSignatureFromDeclaration(


### PR DESCRIPTION
Fixes #4251 
