### PR TITLE
Deprecate Node.js 16

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarning.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarning.java
@@ -44,7 +44,9 @@ public class NodeDeprecationWarning {
 
   static final Map<Integer, String> REMOVAL_DATE = Map.ofEntries(
     entry(14, "May 1st, 2023"),
-    entry(15, "May 1st, 2023")
+    entry(15, "May 1st, 2023"),
+    entry(16, "Nov 30th, 2023"),
+    entry(17, "Nov 30th, 2023")
   );
 
   private static final Logger LOG = Loggers.get(NodeDeprecationWarning.class);
@@ -55,8 +57,8 @@ public class NodeDeprecationWarning {
    * @see https://github.com/eslint/eslint/blob/d75d3c68ad8c98828aaa522b87ec267ab2dcb002/package.json#L169
    */
   static final Version MIN_SUPPORTED_NODE_VERSION = Version.create(14, 17, 0);
-  static final int MIN_RECOMMENDED_NODE_VERSION = 16;
-  static final List<Integer> RECOMMENDED_NODE_VERSIONS = Arrays.asList(16, 18, 20);
+  static final int MIN_RECOMMENDED_NODE_VERSION = 18;
+  static final List<Integer> RECOMMENDED_NODE_VERSIONS = Arrays.asList(18, 20);
   static final List<Integer> ALL_RECOMMENDED_NODE_VERSIONS = Arrays.asList(14, 16, 18, 20);
   private final AnalysisWarningsWrapper analysisWarnings;
 

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarningTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarningTest.java
@@ -55,14 +55,14 @@ class NodeDeprecationWarningTest {
     deprecationWarning.logNodeDeprecation(14);
     assertWarnings(
       "Using Node.js version 14 to execute analysis is deprecated and will stop being supported no earlier than May 1st, 2023. " +
-      "Please upgrade to a newer LTS version of Node.js [16, 18, 20]"
+      "Please upgrade to a newer LTS version of Node.js [18, 20]"
     );
   }
 
   @Test
   void test_recommended() {
-    deprecationWarning.logNodeDeprecation(16);
     deprecationWarning.logNodeDeprecation(18);
+    deprecationWarning.logNodeDeprecation(20);
     assertWarnings();
   }
 
@@ -70,8 +70,16 @@ class NodeDeprecationWarningTest {
   void test_15() {
     deprecationWarning.logNodeDeprecation(15);
     assertWarnings(
-      "Using Node.js version 15 to execute analysis is deprecated and will stop being supported no earlier than May 1st, 2023. Please upgrade to a newer LTS version of Node.js [16, 18, 20]",
-      "Node.js version 15 is not recommended, you might experience issues. Please use a recommended version of Node.js [16, 18, 20]"
+      "Using Node.js version 15 to execute analysis is deprecated and will stop being supported no earlier than May 1st, 2023. Please upgrade to a newer LTS version of Node.js [18, 20]",
+      "Node.js version 15 is not recommended, you might experience issues. Please use a recommended version of Node.js [18, 20]"
+    );
+  }
+
+  @Test
+  void test_16() {
+    deprecationWarning.logNodeDeprecation(16);
+    assertWarnings(
+      "Using Node.js version 16 to execute analysis is deprecated and will stop being supported no earlier than Nov 30th, 2023. Please upgrade to a newer LTS version of Node.js [18, 20]"
     );
   }
 
@@ -79,7 +87,8 @@ class NodeDeprecationWarningTest {
   void test_17() {
     deprecationWarning.logNodeDeprecation(17);
     assertWarnings(
-      "Node.js version 17 is not recommended, you might experience issues. Please use a recommended version of Node.js [16, 18, 20]"
+      "Using Node.js version 17 to execute analysis is deprecated and will stop being supported no earlier than Nov 30th, 2023. Please upgrade to a newer LTS version of Node.js [18, 20]",
+      "Node.js version 17 is not recommended, you might experience issues. Please use a recommended version of Node.js [18, 20]"
     );
   }
 


### PR DESCRIPTION
Fixes #4109

Node.js 16 was eol-ed 11th of September. https://nodejs.org/en/blog/announcements/nodejs16-eol 