### PR TITLE
Authenticate by Repox on Windows as well

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -153,8 +153,11 @@ build_win_task:
   <<: *ONLY_SONARSOURCE_QA
   <<: *MAVEN_CACHE
   <<: *RUNTIME_CACHE
+  env:
+    ARTIFACTORY_DEPLOY_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer access_token]
   build_script:
     - source cirrus-env CI
+    - jf config add repox --url $ARTIFACTORY_URL --access-token $ARTIFACTORY_DEPLOY_ACCESS_TOKEN
     - npm config set registry "${ARTIFACTORY_URL}/api/npm/npm"
     - npm run build
   cleanup_before_cache_script: cleanup_maven_repository


### PR DESCRIPTION
Now that we have the [JFrog CLI available on the image used in Windows](https://github.com/SonarSource/re-ci-images/pull/386), we can perform authentication as well.

This is done as REs will disable unauthenticated downloads from the JFrog NPM repository some time.
It aligns what [is done for the Linux build](https://github.com/SonarSource/SonarJS/blob/502e047758d17b4333d1f2d57931973dcfbb0f56/.cirrus.yml#L114).

