### PR TITLE
Remove cache for `.sonar` dir

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,11 +134,6 @@ analyze_task:
     ARTIFACTORY_DEPLOY_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer access_token]
   <<: *MAVEN_CACHE
   <<: *RUNTIME_CACHE
-  sonar_cache:
-    folder: ${HOME}/.sonar/cache
-    fingerprint_script:
-      - echo ${CIRRUS_OS}
-      - curl --silent ${SONAR_HOST_URL}/deploy/plugins/index.txt | sort
   build_and_analyze_script:
     - source cirrus-env QA
     - jfrog config add repox --url $ARTIFACTORY_URL --access-token $ARTIFACTORY_DEPLOY_ACCESS_TOKEN


### PR DESCRIPTION
Fixes #4402 

Before:
```
[INFO] User cache: /home/sonarsource/.sonar/cache
[INFO] Load/download plugins
[INFO] Load plugins index
[INFO] Load plugins index (done) | time=84ms
[INFO] Load/download plugins (done) | time=3826ms
```

After:
```
[INFO] Load/download plugins
[INFO] Load plugins index
[INFO] Load plugins index (done) | time=81ms
[INFO] Load/download plugins (done) | time=5605ms
```

Cache is not functioning anymore, as feature was already removed. Anyway, it's not worth to optimize 5 second download, because fetching the cache would take similar amount of time.