### PR TITLE
Bridge should return error status on unexpected errors

### DIFF
--- a/packages/bridge/src/errors/middleware.ts
+++ b/packages/bridge/src/errors/middleware.ts
@@ -60,7 +60,7 @@ export function errorMiddleware(
       break;
     default:
       error(stack);
-      response.json({ error: message });
+      response.json({ error: message }).status(500);
       break;
   }
 }

--- a/packages/bridge/tests/errors/middleware.test.ts
+++ b/packages/bridge/tests/errors/middleware.test.ts
@@ -28,7 +28,8 @@ describe('errorMiddleware', () => {
   let mockResponse: Partial<express.Response>;
   beforeEach(() => {
     mockResponse = {
-      json: jest.fn(),
+      json: jest.fn(() => mockResponse as express.Response),
+      status: jest.fn(),
     };
   });
 
@@ -89,5 +90,6 @@ describe('errorMiddleware', () => {
     expect(mockResponse.json).toBeCalledWith({
       error: 'Something unexpected happened.',
     });
+    expect(mockResponse.status).toBeCalledWith(500);
   });
 });

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -385,7 +385,7 @@ public class BridgeServerImpl implements BridgeServer {
     return response(request(json, "analyze-html"), request.filePath);
   }
 
-  private String request(String json, String endpoint) throws IOException {
+  String request(String json, String endpoint) throws IOException {
     var request = HttpRequest
       .newBuilder()
       .uri(url(endpoint))
@@ -396,6 +396,11 @@ public class BridgeServerImpl implements BridgeServer {
 
     try {
       var response = client.send(request, BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        throw new IllegalStateException(
+          "The bridge server returned an unexpected status code: " + response.statusCode()
+        );
+      }
       return response.body();
     } catch (InterruptedException e) {
       throw handleInterruptedException(e, "Request " + endpoint + " was interrupted.");

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -663,6 +663,16 @@ class BridgeServerImplTest {
   }
 
   @Test
+  void should_stop_on_error_http_response() throws Exception {
+    bridgeServer = createBridgeServer(START_SERVER_SCRIPT);
+    bridgeServer.deploy();
+    bridgeServer.startServer(context, emptyList());
+    assertThatThrownBy(() -> bridgeServer.request("{}", "error"))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("The bridge server returned an unexpected status code: 500");
+  }
+
+  @Test
   void should_use_default_timeout() {
     bridgeServer =
       new BridgeServerImpl(

--- a/sonar-plugin/sonar-javascript-plugin/src/test/resources/mock-bridge/startServer.js
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/resources/mock-bridge/startServer.js
@@ -39,6 +39,9 @@ const requestHandler = (request, response) => {
       response.end("OK!");
     } else if (request.url === "/create-tsconfig-file") {
       response.end('{"filename":"/path/to/tsconfig.json"}');
+    } else if (request.url === "/error") {
+      response.writeHead(500, { "Content-Type": "text/plain" });
+      response.end();
     } else {
       // /analyze-with-program
       // /analyze-js


### PR DESCRIPTION
Bridge should return error status on unexpected errors and plugin should fail interrupting the analysis.
