### PR TITLE
Fix failure handling of unexpected errors

### DIFF
--- a/packages/bridge/src/errors/middleware.ts
+++ b/packages/bridge/src/errors/middleware.ts
@@ -60,7 +60,7 @@ export function errorMiddleware(
       break;
     default:
       error(stack);
-      response.json({ error: message }).status(500);
+      response.status(500).json({ error: message });
       break;
   }
 }

--- a/packages/bridge/tests/errors/middleware.test.ts
+++ b/packages/bridge/tests/errors/middleware.test.ts
@@ -28,8 +28,8 @@ describe('errorMiddleware', () => {
   let mockResponse: Partial<express.Response>;
   beforeEach(() => {
     mockResponse = {
-      json: jest.fn(() => mockResponse as express.Response),
-      status: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn(() => mockResponse as express.Response),
     };
   });
 

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -398,7 +398,10 @@ public class BridgeServerImpl implements BridgeServer {
       var response = client.send(request, BodyHandlers.ofString());
       if (response.statusCode() != 200) {
         throw new IllegalStateException(
-          "The bridge server returned an unexpected status code: " + response.statusCode()
+          "The bridge server returned an unexpected status code: " +
+          response.statusCode() +
+          ". Response body: " +
+          response.body()
         );
       }
       return response.body();

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -669,7 +669,7 @@ class BridgeServerImplTest {
     bridgeServer.startServer(context, emptyList());
     assertThatThrownBy(() -> bridgeServer.request("{}", "error"))
       .isInstanceOf(IllegalStateException.class)
-      .hasMessage("The bridge server returned an unexpected status code: 500");
+      .hasMessage("The bridge server returned an unexpected status code: 500. Response body: body");
   }
 
   @Test

--- a/sonar-plugin/sonar-javascript-plugin/src/test/resources/mock-bridge/startServer.js
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/resources/mock-bridge/startServer.js
@@ -41,7 +41,7 @@ const requestHandler = (request, response) => {
       response.end('{"filename":"/path/to/tsconfig.json"}');
     } else if (request.url === "/error") {
       response.writeHead(500, { "Content-Type": "text/plain" });
-      response.end();
+      response.end("body");
     } else {
       // /analyze-with-program
       // /analyze-js


### PR DESCRIPTION
Middleware needs to set the status before body. Added logging of the response body on Java side
