### PR TITLE
Fix FP S2871 (`no-alphabetical-sort`): Rework the rule to emit a dedicated message for arrays of strings

### DIFF
--- a/packages/jsts/src/rules/S2871/rule.ts
+++ b/packages/jsts/src/rules/S2871/rule.ts
@@ -54,7 +54,7 @@ export const rule: Rule.RuleModule = {
       provideCompareFunction:
         'Provide a compare function to avoid sorting elements alphabetically.',
       provideCompareFunctionForArrayOfStrings:
-        'Provide a compare function that depends on String.localeCompare, to reliably sort elements alphabetically.',
+        'Provide a compare function that depends on "String.localeCompare", to reliably sort elements alphabetically.',
       suggestNumericOrder: 'Add a comparator function to sort in ascending order',
       suggestLanguageSensitiveOrder:
         'Add a comparator function to sort in ascending language-sensitive order',

--- a/packages/jsts/src/rules/S2871/rule.ts
+++ b/packages/jsts/src/rules/S2871/rule.ts
@@ -82,9 +82,9 @@ export const rule: Rule.RuleModule = {
             typeArgument = type;
           }
 
-          function isTypeAString(candidate: ts.Type): boolean {
+          const isTypeAString = (candidate: ts.Type): boolean => {
             return candidate.flags === 4;
-          }
+          };
 
           const types = isAUnionType(typeArgument) ? typeArgument.types : [typeArgument];
 

--- a/packages/jsts/src/rules/S2871/unit.test.ts
+++ b/packages/jsts/src/rules/S2871/unit.test.ts
@@ -607,7 +607,7 @@ ruleTester.run(
         errors: [
           {
             message:
-              'Provide a compare function that depends on String.localeCompare, to reliably sort elements alphabetically.',
+              'Provide a compare function that depends on "String.localeCompare", to reliably sort elements alphabetically.',
             suggestions: [
               {
                 desc: 'Add a comparator function to sort in ascending language-sensitive order',

--- a/packages/jsts/src/rules/S2871/unit.test.ts
+++ b/packages/jsts/src/rules/S2871/unit.test.ts
@@ -145,50 +145,6 @@ ruleTester.run(`A compare function should be provided when using "Array.prototyp
     {
       code: `Array.prototype.sort.apply([1, 2, 10])`,
     },
-    {
-      code: 'const array = ["foo", "bar"]; array.sort();',
-    },
-    // optional chain
-    {
-      code: `
-        function f(a: string[]) {
-          a?.sort();
-        }
-      `,
-    },
-    {
-      code: `
-        ['foo', 'bar', 'baz'].sort();
-      `,
-    },
-    {
-      code: `
-        function getString() {
-          return 'foo';
-        }
-        [getString(), getString()].sort();
-      `,
-    },
-    {
-      code: `
-        const foo = 'foo';
-        const bar = 'bar';
-        const baz = 'baz';
-        [foo, bar, baz].sort();
-      `,
-    },
-    {
-      code: `
-const names: Array<string> = [];
-names.sort();
-`,
-    },
-    {
-      code: `
-const names: Array<string | 'foo'> = [];
-names.sort();
-`,
-    },
   ],
   invalid: [
     {
@@ -332,17 +288,49 @@ names.sort();
       errors: [{ suggestions: [] }],
     },
     {
+      code: 'const array = ["foo", "bar"]; array.sort();',
+      errors: [
+        {
+          suggestions: [
+            {
+              desc: 'Add a comparator function to sort in ascending language-sensitive order',
+              output: 'const array = ["foo", "bar"]; array.sort((a, b) => a.localeCompare(b));',
+            },
+          ],
+        },
+      ],
+    },
+    // optional chain
+    {
       code: `
-const names: Array<number> = [];
-names.sort();
-`,
+        function f(a: string[]) {
+          a?.sort();
+        }
+      `,
       errors: 1,
     },
     {
       code: `
-const names: Array<string | number> = [];
-names.sort();
-`,
+        ['foo', 'bar', 'baz'].sort();
+      `,
+      errors: 1,
+    },
+    {
+      code: `
+        function getString() {
+          return 'foo';
+        }
+        [getString(), getString()].sort();
+      `,
+      errors: 1,
+    },
+    {
+      code: `
+        const foo = 'foo';
+        const bar = 'bar';
+        const baz = 'baz';
+        [foo, bar, baz].sort();
+      `,
       errors: 1,
     },
   ],
@@ -468,50 +456,6 @@ ruleTester.run(
       },
       {
         code: `const sorted = Array.prototype.toSorted.apply([1, 2, 10])`,
-      },
-      {
-        code: 'const array = ["foo", "bar"]; const sortedArray = array.toSorted();',
-      },
-      // optional chain
-      {
-        code: `
-        function f(a: string[]) {
-          return a?.toSorted();
-        }
-      `,
-      },
-      {
-        code: `
-        const sorted = ['foo', 'bar', 'baz'].toSorted();
-      `,
-      },
-      {
-        code: `
-        function getString() {
-          return 'foo';
-        }
-        const sorted = [getString(), getString()].toSorted();
-      `,
-      },
-      {
-        code: `
-        const foo = 'foo';
-        const bar = 'bar';
-        const baz = 'baz';
-        const sorted = [foo, bar, baz].toSorted();
-      `,
-      },
-      {
-        code: `
-const names: Array<string> = [];
-names.sort();
-`,
-      },
-      {
-        code: `
-const names: Array<string | 'foo'> = [];
-names.sort();
-`,
       },
     ],
     invalid: [
@@ -659,17 +603,52 @@ names.sort();
         errors: [{ suggestions: [] }],
       },
       {
+        code: 'const array = ["foo", "bar"]; const sortedArray = array.toSorted();',
+        errors: [
+          {
+            message:
+              'Provide a compare function that depends on String.localeCompare, to reliably sort elements alphabetically.',
+            suggestions: [
+              {
+                desc: 'Add a comparator function to sort in ascending language-sensitive order',
+                output:
+                  'const array = ["foo", "bar"]; const sortedArray = array.toSorted((a, b) => a.localeCompare(b));',
+              },
+            ],
+          },
+        ],
+      },
+      // optional chain
+      {
         code: `
-const names: Array<number> = [];
-names.sort();
-`,
+        function f(a: string[]) {
+          return a?.toSorted();
+        }
+      `,
         errors: 1,
       },
       {
         code: `
-const names: Array<string | number> = [];
-names.sort();
-`,
+        const sorted = ['foo', 'bar', 'baz'].toSorted();
+      `,
+        errors: 1,
+      },
+      {
+        code: `
+        function getString() {
+          return 'foo';
+        }
+        const sorted = [getString(), getString()].toSorted();
+      `,
+        errors: 1,
+      },
+      {
+        code: `
+        const foo = 'foo';
+        const bar = 'bar';
+        const baz = 'baz';
+        const sorted = [foo, bar, baz].toSorted();
+      `,
         errors: 1,
       },
     ],

--- a/packages/jsts/src/rules/S2871/unit.test.ts
+++ b/packages/jsts/src/rules/S2871/unit.test.ts
@@ -145,6 +145,50 @@ ruleTester.run(`A compare function should be provided when using "Array.prototyp
     {
       code: `Array.prototype.sort.apply([1, 2, 10])`,
     },
+    {
+      code: 'const array = ["foo", "bar"]; array.sort();',
+    },
+    // optional chain
+    {
+      code: `
+        function f(a: string[]) {
+          a?.sort();
+        }
+      `,
+    },
+    {
+      code: `
+        ['foo', 'bar', 'baz'].sort();
+      `,
+    },
+    {
+      code: `
+        function getString() {
+          return 'foo';
+        }
+        [getString(), getString()].sort();
+      `,
+    },
+    {
+      code: `
+        const foo = 'foo';
+        const bar = 'bar';
+        const baz = 'baz';
+        [foo, bar, baz].sort();
+      `,
+    },
+    {
+      code: `
+const names: Array<string> = [];
+names.sort();
+`,
+    },
+    {
+      code: `
+const names: Array<string | 'foo'> = [];
+names.sort();
+`,
+    },
   ],
   invalid: [
     {
@@ -288,49 +332,17 @@ ruleTester.run(`A compare function should be provided when using "Array.prototyp
       errors: [{ suggestions: [] }],
     },
     {
-      code: 'const array = ["foo", "bar"]; array.sort();',
-      errors: [
-        {
-          suggestions: [
-            {
-              desc: 'Add a comparator function to sort in ascending language-sensitive order',
-              output: 'const array = ["foo", "bar"]; array.sort((a, b) => a.localeCompare(b));',
-            },
-          ],
-        },
-      ],
-    },
-    // optional chain
-    {
       code: `
-        function f(a: string[]) {
-          a?.sort();
-        }
-      `,
+const names: Array<number> = [];
+names.sort();
+`,
       errors: 1,
     },
     {
       code: `
-        ['foo', 'bar', 'baz'].sort();
-      `,
-      errors: 1,
-    },
-    {
-      code: `
-        function getString() {
-          return 'foo';
-        }
-        [getString(), getString()].sort();
-      `,
-      errors: 1,
-    },
-    {
-      code: `
-        const foo = 'foo';
-        const bar = 'bar';
-        const baz = 'baz';
-        [foo, bar, baz].sort();
-      `,
+const names: Array<string | number> = [];
+names.sort();
+`,
       errors: 1,
     },
   ],
@@ -456,6 +468,50 @@ ruleTester.run(
       },
       {
         code: `const sorted = Array.prototype.toSorted.apply([1, 2, 10])`,
+      },
+      {
+        code: 'const array = ["foo", "bar"]; const sortedArray = array.toSorted();',
+      },
+      // optional chain
+      {
+        code: `
+        function f(a: string[]) {
+          return a?.toSorted();
+        }
+      `,
+      },
+      {
+        code: `
+        const sorted = ['foo', 'bar', 'baz'].toSorted();
+      `,
+      },
+      {
+        code: `
+        function getString() {
+          return 'foo';
+        }
+        const sorted = [getString(), getString()].toSorted();
+      `,
+      },
+      {
+        code: `
+        const foo = 'foo';
+        const bar = 'bar';
+        const baz = 'baz';
+        const sorted = [foo, bar, baz].toSorted();
+      `,
+      },
+      {
+        code: `
+const names: Array<string> = [];
+names.sort();
+`,
+      },
+      {
+        code: `
+const names: Array<string | 'foo'> = [];
+names.sort();
+`,
       },
     ],
     invalid: [
@@ -603,50 +659,17 @@ ruleTester.run(
         errors: [{ suggestions: [] }],
       },
       {
-        code: 'const array = ["foo", "bar"]; const sortedArray = array.toSorted();',
-        errors: [
-          {
-            suggestions: [
-              {
-                desc: 'Add a comparator function to sort in ascending language-sensitive order',
-                output:
-                  'const array = ["foo", "bar"]; const sortedArray = array.toSorted((a, b) => a.localeCompare(b));',
-              },
-            ],
-          },
-        ],
-      },
-      // optional chain
-      {
         code: `
-        function f(a: string[]) {
-          return a?.toSorted();
-        }
-      `,
+const names: Array<number> = [];
+names.sort();
+`,
         errors: 1,
       },
       {
         code: `
-        const sorted = ['foo', 'bar', 'baz'].toSorted();
-      `,
-        errors: 1,
-      },
-      {
-        code: `
-        function getString() {
-          return 'foo';
-        }
-        const sorted = [getString(), getString()].toSorted();
-      `,
-        errors: 1,
-      },
-      {
-        code: `
-        const foo = 'foo';
-        const bar = 'bar';
-        const baz = 'baz';
-        const sorted = [foo, bar, baz].toSorted();
-      `,
+const names: Array<string | number> = [];
+names.sort();
+`,
         errors: 1,
       },
     ],

--- a/packages/jsts/src/rules/helpers/type.ts
+++ b/packages/jsts/src/rules/helpers/type.ts
@@ -281,24 +281,3 @@ export function isTypeAlias(node: TSESTree.TypeNode, context: Rule.RuleContext) 
   const variable = getVariableFromScope(scope, node.typeName.name);
   return variable?.defs.some(def => def.node.type === 'TSTypeAliasDeclaration');
 }
-
-export function getTypeArguments(
-  type: ts.Type,
-  services: RequiredParserServices,
-): readonly ts.Type[] {
-  const checker = services.program.getTypeChecker();
-  return checker.getTypeArguments(type as ts.TypeReference);
-}
-
-type UnionType = ts.Type & {
-  types: ts.Type[];
-};
-
-/**
- * Type guard that guarantees that the passed candidate is a union and narrows its type to {@link UnionType}.
- *
- * @param candidate
- */
-export function isAUnionType(candidate: ts.Type): candidate is UnionType {
-  return candidate.flags === 1048576;
-}

--- a/packages/jsts/src/rules/helpers/type.ts
+++ b/packages/jsts/src/rules/helpers/type.ts
@@ -281,3 +281,24 @@ export function isTypeAlias(node: TSESTree.TypeNode, context: Rule.RuleContext) 
   const variable = getVariableFromScope(scope, node.typeName.name);
   return variable?.defs.some(def => def.node.type === 'TSTypeAliasDeclaration');
 }
+
+export function getTypeArguments(
+  type: ts.Type,
+  services: RequiredParserServices,
+): readonly ts.Type[] {
+  const checker = services.program.getTypeChecker();
+  return checker.getTypeArguments(type as ts.TypeReference);
+}
+
+type UnionType = ts.Type & {
+  types: ts.Type[];
+};
+
+/**
+ * Type guard that guarantees that the passed candidate is a union and narrows its type to {@link UnionType}.
+ *
+ * @param candidate
+ */
+export function isAUnionType(candidate: ts.Type): candidate is UnionType {
+  return candidate.flags === 1048576;
+}

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2871.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2871.html
@@ -31,6 +31,16 @@ const code3 = '\u0065\u0394'; // "eΔ"
 console.log([code1, code2, code3].sort()); // Noncompliant: ["éΔ", "eΔ", "éΔ"], "eΔ" position is inconsistent
 console.log([code1, code2, code3].sort((a, b) =&gt; a.localeCompare(b))); // ["eΔ", "éΔ", "éΔ"]
 </pre>
+<h3>Exceptions</h3>
+<p>The rule ignores arrays that only contain strings, or are declared as such.</p>
+<pre>
+const names = ['foo', 'bar'];
+names.sort(); // Compliant
+</pre>
+<pre>
+const names: string[] = [];
+names.sort(); // Compliant
+</pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2871.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2871.html
@@ -22,24 +22,15 @@ numbers.sort((a, b) =&gt; a - b);
 console.log(numbers); // Output: [1, 2, 5, 10, 30]
 </pre>
 <p>Even to sort strings, the default sort order may give unexpected results. Not only does it not support localization, it also doesn’t fully support
-Unicode, as it only considers UTF-16 code units. For example, in the code below, <code>"eΔ"</code> is surprisingly before and after
-<code>"éΔ"</code>.</p>
+Unicode, as it only considers UTF-16 code units. For example, in the code below, <code>"eΔ"</code> is surprisingly before and after <code>"éΔ"</code>.
+To guarantee that the sorting is reliable and remains as such in the long run, it is necessary to provide a compare function that is both locale and
+Unicode aware - typically <code>String.localeCompare</code>.</p>
 <pre>
 const code1 = '\u00e9\u0394'; // "éΔ"
 const code2 = '\u0065\u0301\u0394'; // "éΔ" using Unicode combining marks
 const code3 = '\u0065\u0394'; // "eΔ"
 console.log([code1, code2, code3].sort()); // Noncompliant: ["éΔ", "eΔ", "éΔ"], "eΔ" position is inconsistent
 console.log([code1, code2, code3].sort((a, b) =&gt; a.localeCompare(b))); // ["eΔ", "éΔ", "éΔ"]
-</pre>
-<h3>Exceptions</h3>
-<p>The rule ignores arrays that only contain strings, or are declared as such.</p>
-<pre>
-const names = ['foo', 'bar'];
-names.sort(); // Compliant
-</pre>
-<pre>
-const names: string[] = [];
-names.sort(); // Compliant
 </pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>


### PR DESCRIPTION
Fixes #4531 
