### PR TITLE
Replace deprecated "CallExpression#typeParameters" with "typeArguments"

### DIFF
--- a/packages/jsts/src/rules/S1472/rule.ts
+++ b/packages/jsts/src/rules/S1472/rule.ts
@@ -77,7 +77,7 @@ export const rule: Rule.RuleModule = {
 
 function getCallee(call: estree.CallExpression) {
   const node = call as TSESTree.CallExpression;
-  return (node.typeParameters ?? node.callee) as estree.Node;
+  return (node.typeArguments ?? node.callee) as estree.Node;
 }
 
 function isClosingParen(token: AST.Token) {


### PR DESCRIPTION
Running fast ruling emits a huge amount of the following deprecation warning:

```
(node:24845) DeprecationWarning: The 'typeParameters' property is deprecated on CallExpression nodes.
Use 'typeArguments' instead. See https://typescript-eslint.io/linting/troubleshooting#the-key-property-is-deprecated-on-type-nodes-use-key-instead-warnings.
```

We can safely replace "CallExpression#typeParameters" with "CallExpression# typeArguments".

