### PR TITLE
Fix FP S4123 (`no-invalid-await`): Ignore function calls for functions whose definition have JSdoc with a `returns` tag

### DIFF
--- a/its/ruling/src/test/expected/jsts/desktop/typescript-S4123.json
+++ b/its/ruling/src/test/expected/jsts/desktop/typescript-S4123.json
@@ -3,7 +3,6 @@
 80
 ],
 "desktop:app/src/lib/git/cherry-pick.ts": [
-153,
 414
 ],
 "desktop:app/src/ui/app.tsx": [

--- a/its/ruling/src/test/expected/jsts/desktop/typescript-S4123.json
+++ b/its/ruling/src/test/expected/jsts/desktop/typescript-S4123.json
@@ -3,6 +3,7 @@
 80
 ],
 "desktop:app/src/lib/git/cherry-pick.ts": [
+153,
 414
 ],
 "desktop:app/src/ui/app.tsx": [

--- a/packages/jsts/src/rules/S4123/rule.ts
+++ b/packages/jsts/src/rules/S4123/rule.ts
@@ -22,7 +22,7 @@
 import { Rule } from 'eslint';
 import * as estree from 'estree';
 import * as ts from 'typescript';
-import { isRequiredParserServices, getTypeFromTreeNode } from '../helpers';
+import { isRequiredParserServices, getTypeFromTreeNode, getSignatureFromCallee } from '../helpers';
 import { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
 
 export const rule: Rule.RuleModule = {
@@ -36,14 +36,12 @@ export const rule: Rule.RuleModule = {
     if (isRequiredParserServices(services)) {
       return {
         AwaitExpression: (node: estree.AwaitExpression) => {
-          if (isException(node, services)) {
-            return;
-          }
           const awaitedType = getTypeFromTreeNode(
             (node as estree.AwaitExpression).argument,
             services,
           );
           if (
+            !isException(node, services) &&
             !isThenable(awaitedType) &&
             !isAny(awaitedType) &&
             !isUnknown(awaitedType) &&

--- a/packages/jsts/src/rules/S4123/rule.ts
+++ b/packages/jsts/src/rules/S4123/rule.ts
@@ -73,13 +73,8 @@ function isException(node: estree.AwaitExpression, services: ParserServicesWithT
   const tc = services.program.getTypeChecker();
   const symbol = tc.getSymbolAtLocation(tsCallExpr);
   const declarations = symbol?.declarations;
-  if (!declarations) {
-    return false;
-  }
-  for (const declaration of declarations) {
-    if (hasJsDoc(declaration)) {
-      return true;
-    }
+  if (declarations?.some(d => hasJsDoc(d))) {
+    return true;
   }
   return false;
 

--- a/packages/jsts/src/rules/S4123/rule.ts
+++ b/packages/jsts/src/rules/S4123/rule.ts
@@ -68,15 +68,8 @@ function isException(node: estree.AwaitExpression, services: ParserServicesWithT
   if (node.argument.type !== 'CallExpression') {
     return false;
   }
-  const callExpression = node.argument;
-  const tsCallExpr = services.esTreeNodeToTSNodeMap.get(callExpression.callee as TSESTree.Node);
-  const tc = services.program.getTypeChecker();
-  const symbol = tc.getSymbolAtLocation(tsCallExpr);
-  const declarations = symbol?.declarations;
-  if (declarations?.some(d => hasJsDoc(d))) {
-    return true;
-  }
-  return false;
+  const signature = getSignatureFromCallee(node.argument, services);
+  return signature?.declaration && hasJsDoc(signature.declaration);
 
   function hasJsDoc(declaration: ts.Declaration & { jsDoc?: ts.JSDoc[] }) {
     return declaration.jsDoc && declaration.jsDoc.length > 0;

--- a/packages/jsts/src/rules/S4123/unit.test.ts
+++ b/packages/jsts/src/rules/S4123/unit.test.ts
@@ -296,6 +296,19 @@ function bar () {
 }`,
         errors: 1,
       },
+      {
+        code: `
+async function foo () {
+    await bar() // Noncompliant
+}
+/**
+ * JSdoc without return type
+ */
+function bar () {
+    return 5;
+}`,
+        errors: 1,
+      },
     ],
   },
 );

--- a/packages/jsts/src/rules/S4123/unit.test.ts
+++ b/packages/jsts/src/rules/S4123/unit.test.ts
@@ -154,6 +154,13 @@ ruleTester.run('await should only be used with promises.', rule, {
       function qux(): Foo {}
       const baz = await qux();`,
     },
+    {
+      code: `
+      async function foo() {
+        await bar();
+      }
+      `,
+    },
   ],
   invalid: [
     {

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4123.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4123.html
@@ -18,34 +18,9 @@ Promise API to provide a clean and intuitive way to write asynchronous code in J
 const x = Promise.resolve(42);
 await x;
 </pre>
-<p>When running on JavaScript code, the JSdoc is prioritized over the type inference, so make sure that they are correct, using a
-<code>Promise&lt;T&gt;</code> type when needed.</p>
-<pre data-diff-id="2" data-diff-type="noncompliant">
-/**
- * @return {number}
- */
-async function foo() {
-  return await Promise.resolve(42);
-}
-async function bar() {
-  await foo(); // Noncompliant
-}
-</pre>
-<p>Either remove the JSdoc or fix it to correct the issue.</p>
-<pre data-diff-id="2" data-diff-type="compliant">
-/**
- * @return {Promise&lt;number&gt;}
- */
-async function foo() {
-  return await Promise.resolve(42);
-}
-async function bar() {
-  await foo();
-}
-</pre>
 <p>When calling a function that returns a promise as the last expression, you might forget to return it, especially if you refactored your code from a
 single-expression arrow function.</p>
-<pre data-diff-id="3" data-diff-type="noncompliant">
+<pre data-diff-id="2" data-diff-type="noncompliant">
 function foo() {
   Promise.resolve(42);
 }
@@ -54,12 +29,27 @@ async function bar() {
 }
 </pre>
 <p>Make sure that you return the promise.</p>
-<pre data-diff-id="3" data-diff-type="compliant">
+<pre data-diff-id="2" data-diff-type="compliant">
 function foo() {
   return Promise.resolve(42);
 }
 async function bar() {
-  await foo();
+  await foo(); // Compliant
+}
+</pre>
+<h3>Exceptions</h3>
+<p>The rule does not raise issues if you are awaiting a function whose definition contains JSdoc with <code>@returns</code> or <code>@return</code>
+tags. This is due to JSdoc often mistakenly declaring a returning type without mentioning that it is resolved by a promise. For example:</p>
+<pre>
+async function foo () {
+  await bar(); // Compliant
+}
+
+/**
+ * @return {number}
+ */
+async function bar () {
+  return 42;
 }
 </pre>
 <h2>Resources</h2>


### PR DESCRIPTION
Fixes #4516 
