### PR TITLE
Ignore fast ruling generated files on prettifying

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ lib
 packages/*/tests/**/fixtures
 packages/jsts/src/rules/*/*.fixture.*
 packages/jsts/src/rules/*/fixtures
+packages/ruling/tests/actual
 
 its/sources
 


### PR DESCRIPTION
While there is nothing worth prettifying, prettier is unnecessarily wasting time considering all generated files from fast ruling:

```
packages/ruling/tests/actual/jsts/ace/javascript-CommentRegexTest.json 3ms
packages/ruling/tests/actual/jsts/ace/javascript-S100.json 10ms
packages/ruling/tests/actual/jsts/ace/javascript-S103.json 3ms
packages/ruling/tests/actual/jsts/ace/javascript-S104.json 1ms
packages/ruling/tests/actual/jsts/ace/javascript-S105.json 1ms
packages/ruling/tests/actual/jsts/ace/javascript-S106.json 1ms
packages/ruling/tests/actual/jsts/ace/javascript-S1066.json 1ms
packages/ruling/tests/actual/jsts/ace/javascript-S1067.json 1ms
packages/ruling/tests/actual/jsts/ace/javascript-S107.json 1ms
packages/ruling/tests/actual/jsts/ace/javascript-S108.json 0ms
packages/ruling/tests/actual/jsts/ace/javascript-S109.json 2578ms
...
```
