### PR TITLE
Check format with `prettier` before build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,7 +117,7 @@ build_task:
   build_and_deploy_script:
     - source cirrus-env BUILD
     - npm ci
-    - npm run check-format
+    - prettier --list-different .
     - npm run build
     - regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dmaven.install.skip=true -Dsonar.skip=true
   cleanup_before_cache_script: cleanup_maven_repository

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,6 +116,7 @@ build_task:
   <<: *NPMRC_SCRIPT_DEFINITION
   build_and_deploy_script:
     - source cirrus-env BUILD
+    - npm run bbf
     - npm run check-format
     - npm run build
     - regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dmaven.install.skip=true -Dsonar.skip=true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,7 +117,7 @@ build_task:
   build_and_deploy_script:
     - source cirrus-env BUILD
     - npm ci
-    - prettier --list-different .
+    - npx prettier --list-different .
     - npm run build
     - regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dmaven.install.skip=true -Dsonar.skip=true
   cleanup_before_cache_script: cleanup_maven_repository

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,7 +117,7 @@ build_task:
   build_and_deploy_script:
     - source cirrus-env BUILD
     - npm ci
-    - npx prettier --list-different .
+    - npm run check-format
     - npm run build
     - regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dmaven.install.skip=true -Dsonar.skip=true
   cleanup_before_cache_script: cleanup_maven_repository

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,6 +116,7 @@ build_task:
   <<: *NPMRC_SCRIPT_DEFINITION
   build_and_deploy_script:
     - source cirrus-env BUILD
+    - npm run check-format
     - npm run build
     - regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dmaven.install.skip=true -Dsonar.skip=true
   cleanup_before_cache_script: cleanup_maven_repository

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,7 +116,7 @@ build_task:
   <<: *NPMRC_SCRIPT_DEFINITION
   build_and_deploy_script:
     - source cirrus-env BUILD
-    - npm run bbf
+    - npm ci
     - npm run check-format
     - npm run build
     - regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dmaven.install.skip=true -Dsonar.skip=true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SonarJS code analyzer",
   "scripts": {
     "format": "prettier --write .",
+    "check-format": "prettier --list-different .",
     "build": "mvn clean && npm run _:plugin:pre-build && npm run plugin:build-no-bridge && npm run update-ruling-data",
     "build:fast": "npm run bridge:build:fast && npm run _:plugin:prepare-bridge && npm run _:plugin-fetch-node && npm run plugin:build:fast && npm run update-ruling-data",
     "bf": "npm run build:fast",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "SonarJS code analyzer",
   "scripts": {
     "format": "prettier --write .",
-    "check-format": "prettier --list-different .",
     "build": "mvn clean && npm run _:plugin:pre-build && npm run plugin:build-no-bridge && npm run update-ruling-data",
     "build:fast": "npm run bridge:build:fast && npm run _:plugin:prepare-bridge && npm run _:plugin-fetch-node && npm run plugin:build:fast && npm run update-ruling-data",
     "bf": "npm run build:fast",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SonarJS code analyzer",
   "scripts": {
     "format": "prettier --write .",
+    "check-format": "prettier --list-different .",
     "build": "mvn clean && npm run _:plugin:pre-build && npm run plugin:build-no-bridge && npm run update-ruling-data",
     "build:fast": "npm run bridge:build:fast && npm run _:plugin:prepare-bridge && npm run _:plugin-fetch-node && npm run plugin:build:fast && npm run update-ruling-data",
     "bf": "npm run build:fast",
@@ -13,7 +14,7 @@
     "bridge:compile": "tsc -b packages profiling",
     "bridge:test": "jest --maxWorkers=40% --coverage --testPathIgnorePatterns=/packages/ruling/tests/",
     "bridge:build": "npm run bridge:build:fast && npm run bridge:test",
-    "bridge:build:fast": "npm ci && npm run format && npm run _:bridge:clear && npm run bridge:compile",
+    "bridge:build:fast": "npm ci && npm run _:bridge:clear && npm run bridge:compile",
     "bbf": "npm run bridge:build:fast",
     "plugin:build-no-bridge": "mvn install",
     "plugin:build:fast": "npm run plugin:build-no-bridge -- -DskipTests",


### PR DESCRIPTION
Until now, we were formatting the source code during build task, so we were not able to detect unformatted code. This adds back the format check before building the plugin