### PR TITLE
Use more memory for the CI: 10cores/40GB and set the Jest maxWorkers to 8 (#cores-2)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,6 +28,8 @@ container_definition: &CONTAINER_DEFINITION
   region: eu-central-1
   namespace: default
   use_in_memory_disk: true
+  cpu: 10
+  memory: 40G
 
 maven_cache_definition: &MAVEN_CACHE
   maven_cache:
@@ -82,8 +84,6 @@ plugin_qa_body: &PLUGIN_QA_BODY
   <<: *ONLY_SONARSOURCE_QA
   eks_container:
     <<: *CONTAINER_DEFINITION
-    cpu: 15
-    memory: 30G
   env:
     CIRRUS_CLONE_DEPTH: 10
     SONARSOURCE_QA: true
@@ -100,8 +100,6 @@ build_task:
     dockerfile: .cirrus/nodejs.Dockerfile
     docker_arguments:
       CIRRUS_AWS_ACCOUNT: ${CIRRUS_AWS_ACCOUNT}
-    cpu: 10
-    memory: 40G
   env:
     #allow deployment of pull request artifacts to repox
     DEPLOY_PULL_REQUEST: true
@@ -128,8 +126,6 @@ analyze_task:
     dockerfile: .cirrus/nodejs.Dockerfile
     docker_arguments:
       CIRRUS_AWS_ACCOUNT: ${CIRRUS_AWS_ACCOUNT}
-    cpu: 15
-    memory: 30G
   depends_on:
     - build
   env:
@@ -259,8 +255,6 @@ js_ts_ruling_task:
     docker_arguments:
       CIRRUS_AWS_ACCOUNT: ${CIRRUS_AWS_ACCOUNT}
       NODE_VERSION: 20
-    cpu: 15
-    memory: 32G
   env:
     CIRRUS_CLONE_DEPTH: 1
     SONARSOURCE_QA: true
@@ -276,7 +270,7 @@ js_ts_ruling_task:
     - source set_maven_build_version $BUILD_NUMBER
     - npm run build:fast
     - npm run update-ruling-data
-    - npm run ruling -- --maxWorkers=60%
+    - npm run ruling -- --maxWorkers=8
   cleanup_before_cache_script: cleanup_maven_repository
 
 css_ruling_task:
@@ -286,8 +280,6 @@ css_ruling_task:
   eks_container:
     <<: *CONTAINER_DEFINITION
     image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest
-    cpu: 15
-    memory: 24G
   env:
     CIRRUS_CLONE_DEPTH: 10
     SONARSOURCE_QA: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -100,8 +100,8 @@ build_task:
     dockerfile: .cirrus/nodejs.Dockerfile
     docker_arguments:
       CIRRUS_AWS_ACCOUNT: ${CIRRUS_AWS_ACCOUNT}
-    cpu: 15
-    memory: 30G
+    cpu: 10
+    memory: 40G
   env:
     #allow deployment of pull request artifacts to repox
     DEPLOY_PULL_REQUEST: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ruling-sync": "rsync -avh packages/ruling/tests/actual/jsts/ its/ruling/src/test/expected/jsts/ --delete",
     "update-ruling-data": "mvn -f sonar-plugin/sonar-javascript-plugin/pom.xml compile && ts-node packages/ruling/tests/tools/parseRulesData.ts",
     "bridge:compile": "tsc -b packages profiling",
-    "bridge:test": "jest --maxWorkers=40% --coverage --testPathIgnorePatterns=/packages/ruling/tests/",
+    "bridge:test": "jest --maxWorkers=8 --coverage --testPathIgnorePatterns=/packages/ruling/tests/",
     "bridge:build": "npm run bridge:build:fast && npm run bridge:test",
     "bridge:build:fast": "npm ci && npm run _:bridge:clear && npm run bridge:compile",
     "bbf": "npm run bridge:build:fast",


### PR DESCRIPTION
When using the % in the Jest `maxWorkers` parameters, it computes the number of cores from an unknown number, **not the one we provide to the Cirrus node**!

So we decided for 4GB of RAM per core as that's the default RAM per node process and set the jest maxWorkers to: `#cores-2 = 8`