### PR TITLE
Add reserved domain patterns to EXCEPTION_TOP_HOSTS list

### DIFF
--- a/packages/jsts/src/rules/S5332/rule.lib.ts
+++ b/packages/jsts/src/rules/S5332/rule.lib.ts
@@ -48,7 +48,7 @@ const EXCEPTION_FULL_HOSTS = [
   'graphml.graphdrawing.org',
   'json-schema.org',
 ];
-const EXCEPTION_TOP_HOSTS = [/(.*\.)?example\.com$/, /(.*\.)?example\.org$/, /(.*\.)?test\.com$/];
+const EXCEPTION_TOP_HOSTS = [/\.example$/, /(.*\.)?example\.com$/, /(.*\.)?example\.org$/, /\.test$/, /(.*\.)?test\.com$/];
 
 export const rule: Rule.RuleModule = {
   meta: {

--- a/packages/jsts/src/rules/S5332/unit.test.ts
+++ b/packages/jsts/src/rules/S5332/unit.test.ts
@@ -120,10 +120,14 @@ ruleTester.run('Using clear-text protocols is security-sensitive', rule, {
     },
     {
       code: `
+      url = "http://example.example";
+      url = "http://subdomain.example.example";
       url = "http://example.com";
       url = "http://someSubdomain.example.com";
       url = "http://example.org";
       url = "http://someSubdomain.example.org";
+      url = "http://example.test";
+      url = "http://subdomain.example.test";
       url = "http://test.com";
       url = "http://someSubdomain.test.com";
       `,


### PR DESCRIPTION
SonarSource Community Forum Topic: 
https://community.sonarsource.com/t/adding-reserved-domain-patterns-to-sonarqubes-security-exception-list/110822/1

This PR addresses the need to align our security exception list with the reserved domain names outlined in [RFC 2606](https://www.rfc-editor.org/rfc/rfc2606.html).
By incorporating these changes, we aim to reduce false positives in security checks and ensure that our practices are consistent with established internet standards.

Changes:
- Updated the EXCEPTION_TOP_HOSTS array to include the .test and .example top-level domains (TLDs) as exceptions.
- Added test cases to validate that URLs containing these TLDs are correctly handled as non-sensitive and do not trigger security warnings.