### PR TITLE
Add additional logs when embedded Node.js is not available

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/AbstractBridgeSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/AbstractBridgeSensor.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.plugins.javascript.bridge;
 
+import static org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl.NODE_EXECUTABLE_PROPERTY;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -87,7 +89,9 @@ public abstract class AbstractBridgeSensor implements Sensor {
       throw new IllegalStateException(
         "Error while running Node.js. A supported version of Node.js is required for running the analysis of " +
         this.lang +
-        " files. Please make sure a supported version of Node.js is available in the PATH. Alternatively, you can exclude " +
+        " files. Please make sure a supported version of Node.js is available in the PATH or an executable path is provided via '" +
+        NODE_EXECUTABLE_PROPERTY +
+        "' property. Alternatively, you can exclude " +
         this.lang +
         " files from your analysis using the 'sonar.exclusions' configuration property. " +
         "See the docs for configuring the analysis environment: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/javascript-typescript-css/",

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
@@ -168,7 +168,9 @@ public class EmbeddedNode {
       platform
     );
     if (platform == UNSUPPORTED) {
-      LOG.debug("Your platform is unsupported for embedded Node.js. Falling back to host Node.js.");
+      LOG.debug(
+        "Your platform is not supported for embedded Node.js. Falling back to host Node.js."
+      );
       return;
     }
     try {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
@@ -168,6 +168,7 @@ public class EmbeddedNode {
       platform
     );
     if (platform == UNSUPPORTED) {
+      LOG.debug("Your platform is unsupported for embedded Node.js. Falling back to host Node.js.");
       return;
     }
     try {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommandBuilderImpl.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommandBuilderImpl.java
@@ -48,7 +48,7 @@ public class NodeCommandBuilderImpl implements NodeCommandBuilder {
   private static final String NODE_EXECUTABLE_DEFAULT_MACOS =
     "package/node_modules/run-node/run-node";
 
-  private static final String NODE_EXECUTABLE_PROPERTY = "sonar.nodejs.executable";
+  public static final String NODE_EXECUTABLE_PROPERTY = "sonar.nodejs.executable";
   private static final String NODE_FORCE_HOST_PROPERTY = "sonar.nodejs.forceHost";
 
   private static final Pattern NODEJS_VERSION_PATTERN = Pattern.compile(

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/CssRuleSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/CssRuleSensorTest.java
@@ -283,7 +283,7 @@ class CssRuleSensorTest {
     assertThatThrownBy(() -> sensor.execute(context))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage(
-        "Error while running Node.js. A supported version of Node.js is required for running the analysis of CSS files. Please make sure a supported version of Node.js is available in the PATH. Alternatively, you can exclude CSS files from your analysis using the 'sonar.exclusions' configuration property. See the docs for configuring the analysis environment: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/javascript-typescript-css/"
+        "Error while running Node.js. A supported version of Node.js is required for running the analysis of CSS files. Please make sure a supported version of Node.js is available in the PATH or an executable path is provided via 'sonar.nodejs.executable' property. Alternatively, you can exclude CSS files from your analysis using the 'sonar.exclusions' configuration property. See the docs for configuring the analysis environment: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/javascript-typescript-css/"
       );
     assertThat(logTester.logs(LoggerLevel.ERROR)).contains("Exception Message");
   }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/EmbeddedNodeTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/EmbeddedNodeTest.java
@@ -150,6 +150,19 @@ class EmbeddedNodeTest {
   }
 
   @Test
+  void should_log_if_platform_unsupported() throws Exception {
+    logTester.setLevel(Level.DEBUG);
+    var en = new EmbeddedNode(mock(ProcessWrapper.class), createUnsupportedEnvironment());
+    en.deploy();
+    assertThat(logTester.logs())
+      .anyMatch(l ->
+        l.startsWith(
+          "Your platform is not supported for embedded Node.js. Falling back to host Node.js."
+        )
+      );
+  }
+
+  @Test
   void should_fail_gracefully() throws Exception {
     ProcessWrapper processWrapper = mock(ProcessWrapper.class);
     when(processWrapper.waitFor(any(), anyLong(), any()))

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/bridge/JavaScriptEslintBasedSensorTest.java
@@ -108,7 +108,7 @@ class JavaScriptEslintBasedSensorTest {
   private SensorContextTester context;
 
   private String nodeExceptionMessage =
-    "Error while running Node.js. A supported version of Node.js is required for running the analysis of JS/TS files. Please make sure a supported version of Node.js is available in the PATH. Alternatively, you can exclude JS/TS files from your analysis using the 'sonar.exclusions' configuration property. See the docs for configuring the analysis environment: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/javascript-typescript-css/";
+    "Error while running Node.js. A supported version of Node.js is required for running the analysis of JS/TS files. Please make sure a supported version of Node.js is available in the PATH or an executable path is provided via 'sonar.nodejs.executable' property. Alternatively, you can exclude JS/TS files from your analysis using the 'sonar.exclusions' configuration property. See the docs for configuring the analysis environment: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/javascript-typescript-css/";
 
   @TempDir
   Path workDir;


### PR DESCRIPTION
Fixes #4563 

As described in the task, we add the following logs:
1) Debug information, that the user platform is not supported
2) When the version of Node.js is unsupported, mention the possibility of setting it via the sonar.nodejs.executable property

Testing:
1) Augmented unit tests to verify that the logs get triggered
2) Manual test
- Build SonarJS
- Download SonarQube and copy the produced .jar into SonarQube extensions folder
- Change local Node version to 16
- Run Scanner on small JS project and observe in logs:
- 15:12:24.947 DEBUG: Your platform is unsupported for embedded Node.js. Falling back to host Node.js.
- 15:12:28.081 ERROR: Error during SonarScanner execution
java.lang.IllegalStateException: Error while running Node.js. A supported version of Node.js is required for running the analysis of JS/TS files. Please make sure a supported version of Node.js is available in the PATH or an executable path is provided via 'sonar.nodejs.executable' property. Alternatively, you can exclude JS/TS files from your analysis using the 'sonar.exclusions' configuration property. See the docs for configuring the analysis environment: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/javascript-typescript-css/