### PR TITLE
Reduce log severity to warning for unfound ESLint reports

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/EslintReportSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/EslintReportSensor.java
@@ -78,7 +78,7 @@ public class EslintReportSensor extends AbstractExternalIssuesSensor {
         }
       }
     } catch (IOException | JsonSyntaxException e) {
-      LOG.error(FILE_EXCEPTION_MESSAGE, e);
+      LOG.warn(FILE_EXCEPTION_MESSAGE, e);
     }
   }
 

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/EslintReportSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/EslintReportSensorTest.java
@@ -116,7 +116,7 @@ class EslintReportSensorTest {
     Collection<ExternalIssue> externalIssues = context.allExternalIssues();
     assertThat(externalIssues).hasSize(0);
 
-    assertThat(logTester.logs(LoggerLevel.ERROR))
+    assertThat(logTester.logs(LoggerLevel.WARN))
       .contains("No issues information will be saved as the report file can't be read.");
   }
 
@@ -128,7 +128,7 @@ class EslintReportSensorTest {
     Collection<ExternalIssue> externalIssues = context.allExternalIssues();
     assertThat(externalIssues).hasSize(0);
 
-    assertThat(logTester.logs(LoggerLevel.ERROR))
+    assertThat(logTester.logs(LoggerLevel.WARN))
       .contains("No issues information will be saved as the report file can't be read.");
   }
 


### PR DESCRIPTION
Fixes #1986 

The user's recommendation to log at the info-level might hide real problems that could be overlooked. Therefore, I advocate for logging at the warn-level to ensure it won't go unnoticed. This approach mirrors our handling of unfound LCOV reports.
