### PR TITLE
fix(S6654.html): Missing text in method references

### DIFF
--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6654.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6654.html
@@ -5,17 +5,17 @@ accessing a property or a method of an object, if it is not found at the top lev
 further down the prototype chain. This feature allows for very powerful dynamic inheritance patterns but can also lead to confusion when compared to
 the classic inheritance.</p>
 <p>To simplify the access to the prototype of an object some browsers introduced the <code>__proto__</code> property, which was later deprecated and
-removed from the language. The current ECMAScript standard includes <code>Object.getPrototype</code> and <code>Object.setPrototype</code> static
+removed from the language. The current ECMAScript standard includes <code>Object.getPrototypeOf</code> and <code>Object.setPrototypeOf</code> static
 methods that should be used instead of the <code>__proto__</code> property.</p>
 <pre data-diff-id="1" data-diff-type="noncompliant">
-let prototype = foo.__proto__;  // Noncompliant: use Object.getPrototype
-foo.__proto__ = bar; // Noncompliant: use Object.setPrototype
+let prototype = foo.__proto__;  // Noncompliant: use Object.getPrototypeOf
+foo.__proto__ = bar; // Noncompliant: use Object.setPrototypeOf
 </pre>
-<p>To fix your code replace <code>__proto__</code> with calls to <code>Object.getPrototype</code> and <code>Object.setPrototype</code> static
+<p>To fix your code replace <code>__proto__</code> with calls to <code>Object.getPrototypeOf</code> and <code>Object.setPrototypeOf</code> static
 methods.</p>
 <pre data-diff-id="1" data-diff-type="compliant">
-let prototype = Object.getPrototype(foo);
-Object.setPrototype(foo, bar);
+let prototype = Object.getPrototypeOf(foo);
+Object.setPrototypeOf(foo, bar);
 </pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>


### PR DESCRIPTION
Inconsistency in naming references to the actual getter/setter methods of Object.

Fixes #4623
