### PR TITLE
Resolve issue #4459: Fix FP S2699 (`Tests should include assertions`): global `expect()` aren't detected

### DIFF
--- a/packages/jsts/src/rules/S2699/rule.ts
+++ b/packages/jsts/src/rules/S2699/rule.ts
@@ -90,7 +90,14 @@ class TestCaseAssertionVisitor {
       return;
     }
     if (isFunctionCall(node)) {
-      const functionDef = resolveFunction(this.context, node.callee);
+      const { callee } = node;
+
+      if (callee.name === 'expect') {
+        this.hasAssertions = true;
+        return;
+      }
+
+      const functionDef = resolveFunction(this.context, callee);
       if (functionDef) {
         this.visit(context, functionDef.body, visitedNodes);
       }

--- a/packages/jsts/src/rules/S2699/vitest.fixture.js
+++ b/packages/jsts/src/rules/S2699/vitest.fixture.js
@@ -19,6 +19,10 @@ describe('vitest test cases', () => {
     check();
   });
 
+  it('recognizes global expect as an assertion', () => {
+    expect(5).toEqual(5);
+  });
+
   function check() {
     expect(1).toEqual(2);
   }


### PR DESCRIPTION
Fixes #4459
