### PR TITLE
Resolve issue #4507

### DIFF
--- a/packages/jsts/src/rules/S2699/vitest.fixture.js
+++ b/packages/jsts/src/rules/S2699/vitest.fixture.js
@@ -27,3 +27,9 @@ describe('vitest test cases', () => {
     expect(1).toEqual(2);
   }
 });
+
+describe.concurrent('vitest concurrent test cases', () => {
+  it('recognizes global expect as an assertion', async ({ expect }) => {
+    expect(5).toEqual(5);
+  });
+});


### PR DESCRIPTION
Fixes #4507.

More accurately, #4507 is fixed by the fix provided to #4459, and this PR only adds a test to cover the specific case of using `describe.concurrrent`.


