### PR TITLE
Update eslint-plugin-sonarjs version

### DIFF
--- a/its/ruling/src/test/expected/jsts/ace/javascript-S4030.json
+++ b/its/ruling/src/test/expected/jsts/ace/javascript-S4030.json
@@ -1,7 +1,4 @@
 {
-"ace:lib/ace/mode/php/php.js": [
-1154
-],
 "ace:lib/ace/mode/yaml/yaml-lint.js": [
 3760
 ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "eslint-plugin-jsx-a11y": "6.8.0",
         "eslint-plugin-react": "7.34.1",
         "eslint-plugin-react-hooks": "4.6.0",
-        "eslint-plugin-sonarjs": "0.24.0",
+        "eslint-plugin-sonarjs": "0.25.0",
         "express": "4.19.2",
         "functional-red-black-tree": "1.0.1",
         "htmlparser2": "9.1.0",
@@ -5791,9 +5791,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "0.24.0",
-      "resolved": "https://repox.jfrog.io/repox/api/npm/npm/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.24.0.tgz",
-      "integrity": "sha1-tZTMubHWEj7dPD/jpFtDkuFJMtc=",
+      "version": "0.25.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.25.0.tgz",
+      "integrity": "sha512-DaZOtpUucEZbvowgKxVFwICV6r0h7jSCAx0IHICvCowP+etFussnhtaiCPSnYAuwVJ+P/6UFUhkv7QJklpXFyA==",
       "inBundle": true,
       "engines": {
         "node": ">=16"
@@ -16804,9 +16804,9 @@
       "requires": {}
     },
     "eslint-plugin-sonarjs": {
-      "version": "0.24.0",
-      "resolved": "https://repox.jfrog.io/repox/api/npm/npm/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.24.0.tgz",
-      "integrity": "sha1-tZTMubHWEj7dPD/jpFtDkuFJMtc=",
+      "version": "0.25.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.25.0.tgz",
+      "integrity": "sha512-DaZOtpUucEZbvowgKxVFwICV6r0h7jSCAx0IHICvCowP+etFussnhtaiCPSnYAuwVJ+P/6UFUhkv7QJklpXFyA==",
       "requires": {}
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-jsx-a11y": "6.8.0",
     "eslint-plugin-react": "7.34.1",
     "eslint-plugin-react-hooks": "4.6.0",
-    "eslint-plugin-sonarjs": "0.24.0",
+    "eslint-plugin-sonarjs": "0.25.0",
     "express": "4.19.2",
     "functional-red-black-tree": "1.0.1",
     "htmlparser2": "9.1.0",

--- a/packages/jsts/src/rules/S2004/rule.ts
+++ b/packages/jsts/src/rules/S2004/rule.ts
@@ -24,7 +24,7 @@ import { Rule } from 'eslint';
 import { TSESTree } from '@typescript-eslint/utils';
 import { getMainFunctionTokenLocation } from 'eslint-plugin-sonarjs/lib/utils/locations';
 import { SONAR_RUNTIME } from '../../linter/parameters';
-import { toEncodedMessage } from '../helpers';
+import { RuleContext, toEncodedMessage } from '../helpers';
 
 const DEFAULT_THRESHOLD = 4;
 
@@ -48,10 +48,12 @@ export const rule: Rule.RuleModule = {
         if (nestedStack.length === max + 1) {
           const secondaries = nestedStack.slice(0, -1);
           context.report({
-            loc: getMainFunctionTokenLocation(fn, fn.parent, context),
+            loc: getMainFunctionTokenLocation(fn, fn.parent, context as unknown as RuleContext),
             message: toEncodedMessage(
               `Refactor this code to not nest functions more than ${max} levels deep.`,
-              secondaries.map(n => ({ loc: getMainFunctionTokenLocation(n, n.parent, context) })),
+              secondaries.map(n => ({
+                loc: getMainFunctionTokenLocation(n, n.parent, context as unknown as RuleContext),
+              })),
               secondaries.map(_ => 'Nesting +1'),
             ),
           });


### PR DESCRIPTION
In preparation for release, let us update the eslint-plugin-sonarjs. 1 FP went away.