### PR TITLE
Check for unknown tags in tr's

### DIFF
--- a/its/ruling/src/test/expected/jsts/ant-design/typescript-S5256.json
+++ b/its/ruling/src/test/expected/jsts/ant-design/typescript-S5256.json
@@ -1,5 +1,0 @@
-{
-"ant-design:site/theme/template/Resources/Articles/index.tsx": [
-91
-]
-}

--- a/its/ruling/src/test/expected/jsts/sonar-web/javascript-S5256.json
+++ b/its/ruling/src/test/expected/jsts/sonar-web/javascript-S5256.json
@@ -4,8 +4,5 @@
 ],
 "sonar-web:src/main/js/apps/project-permissions/project.js": [
 48
-],
-"sonar-web:src/main/js/apps/projects/search.js": [
-92
 ]
 }

--- a/packages/jsts/src/rules/S5260/cb.fixture.jsx
+++ b/packages/jsts/src/rules/S5260/cb.fixture.jsx
@@ -351,4 +351,19 @@
 
 <th></th>
 
+<table>
+  <tr>
+    <td colspan="2" headers="foo bar"></td>
+  </tr>
+  <tr>
+    {is_true ? <>
+      <th id="foo"></th>
+      <th id="bar"></th>
+    </> : <>
+      <th id="bar"></th>
+      <th id="foo"></th>
+    </>}
+  </tr>
+</table>
+
 </>


### PR DESCRIPTION
Talking with @vdiez - we figured out that the tr's aren't checking for custom other tags. Let us be very strict and only perform a check if under a `<tr>` we have `<td>` or `<th>`