### PR TITLE
Change trigger type of perf task to `manual`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -300,7 +300,7 @@ perf_task:
   timeout_in: 240m
   depends_on:
     - build
-  only_if: $CIRRUS_CRON == "nightly"
+  trigger_type: manual
   eks_container:
     <<: *CONTAINER_DEFINITION
     image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest


### PR DESCRIPTION
Unfortunately current infra doesn't allow to have stable enough results for meaningful perf regression testing. To avoid having alarm on the wallboard I will "disable" the task by setting it to manual execution only.