### PR TITLE
Simple inference of InstanceMethod

### DIFF
--- a/packages/jsts/src/dbd/frontend/expressions/call-expression.ts
+++ b/packages/jsts/src/dbd/frontend/expressions/call-expression.ts
@@ -29,6 +29,7 @@ export function handleCallExpression(
 ) {
   let calleeValueId;
   let simpleName;
+  let calleObjectSimpleName;
   switch (callExpression.callee.type) {
     case TSESTree.AST_NODE_TYPES.MemberExpression:
       calleeValueId = handleMemberExpression(scopeTranslator, callExpression.callee);
@@ -36,6 +37,9 @@ export function handleCallExpression(
         throw new Error(
           `Unhandled method call ${JSON.stringify(getLocation(callExpression.callee.property))}`,
         );
+      }
+      if (callExpression.callee.object.type === TSESTree.AST_NODE_TYPES.Identifier) {
+        calleObjectSimpleName = callExpression.callee.object.name;
       }
       simpleName = callExpression.callee.property.name;
       break;
@@ -56,11 +60,16 @@ export function handleCallExpression(
     }
     args.push(handleExpression(scopeTranslator, arg));
   });
+  const isInstanceMethodCall =
+    calleObjectSimpleName !== undefined && scopeTranslator.variableMap.has(calleObjectSimpleName);
   scopeTranslator.addCallExpression(
     getLocation(callExpression),
     resultValueId,
     scopeTranslator.getFunctionId(simpleName),
     args,
+    undefined,
+    undefined,
+    isInstanceMethodCall,
   );
   return resultValueId;
 }

--- a/packages/jsts/src/dbd/frontend/scope-translator.ts
+++ b/packages/jsts/src/dbd/frontend/scope-translator.ts
@@ -129,6 +129,7 @@ export class ScopeTranslator {
     args: number[] = [],
     variableName?: string,
     staticType?: TypeInfo,
+    isInstanceMethodCall?: boolean,
   ) {
     const callInstruction = new CallInstruction({
       location,
@@ -137,6 +138,7 @@ export class ScopeTranslator {
       functionId,
       arguments: args,
       staticType,
+      isInstanceMethodCall,
     });
     if (!isBuiltinFunction(functionId.simpleName)) {
       this.methodCalls.add(this.getFunctionSignature(functionId.simpleName));


### PR DESCRIPTION
If we have a CallExpression in the form <obj>.<meth>() and obj is an identifier and we can find it in the variableMap, let us mark this as an instanceMethod