### PR TITLE
Add typeinfo to the lower levels

### DIFF
--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/array-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/array-expression.ts
@@ -20,7 +20,6 @@
 
 import { ContextManager } from '../context-manager';
 import { TSESTree } from '@typescript-eslint/utils';
-import { createReference } from '../values/reference';
 import { Instruction } from '../instruction';
 import { createCallInstruction } from '../instructions/call-instruction';
 import {
@@ -28,13 +27,23 @@ import {
   createNewObjectFunctionDefinition,
 } from '../function-definition';
 import { handleExpression } from './index';
+import { createTypeName } from '../values/type-name';
+import { createTypeInfo } from '../type-info';
 
 export function handleArrayExpression(context: ContextManager, node: TSESTree.ArrayExpression) {
   const arrayIdentifier = context.scope.createValueIdentifier();
-  const arrayValue = createReference(arrayIdentifier);
+  const typeInfo = createTypeInfo('ARRAY', 'object', false);
+  const arrayValue = createTypeName(arrayIdentifier, 'list', typeInfo);
 
   const instructions: Instruction[] = [
-    createCallInstruction(arrayIdentifier, null, createNewObjectFunctionDefinition(), [], node.loc),
+    createCallInstruction(
+      arrayIdentifier,
+      null,
+      createNewObjectFunctionDefinition(),
+      [],
+      node.loc,
+      typeInfo,
+    ),
   ];
   node.elements.forEach(element => {
     if (!element || element.type === TSESTree.AST_NODE_TYPES.SpreadElement) {

--- a/packages/jsts/src/dbd/js-to-dbd/core/instructions/call-instruction.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/instructions/call-instruction.ts
@@ -7,7 +7,6 @@ import type { Location } from '../location';
 export type CallInstruction = BaseValueInstruction<'call'> & {
   readonly functionDefinition: FunctionDefinition;
   readonly isInstanceMethodCall: boolean;
-  readonly staticType: TypeInfo;
 };
 
 export const createCallInstruction = (
@@ -16,15 +15,15 @@ export const createCallInstruction = (
   functionDefinition: FunctionDefinition,
   operands: Array<Value>,
   location: Location,
+  staticType: TypeInfo = {
+    kind: 0,
+    qualifiedName: 'foo',
+    hasIncompleteSemantics: false,
+  },
 ): CallInstruction => {
   return {
-    ...createValueInstruction('call', valueIndex, variableName, operands, location),
+    ...createValueInstruction('call', valueIndex, variableName, operands, location, staticType),
     functionDefinition,
     isInstanceMethodCall: false,
-    staticType: {
-      kind: 0,
-      qualifiedName: 'foo',
-      hasIncompleteSemantics: false,
-    },
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/instructions/phi-instruction.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/instructions/phi-instruction.ts
@@ -2,6 +2,7 @@ import { type BaseValueInstruction, createValueInstruction } from './value-instr
 import type { Location } from '../location';
 import type { Value } from '../value';
 import type { Block } from '../block';
+import { TypeInfo } from '../type-info';
 
 export type PhiInstruction = BaseValueInstruction<'phi'> & {
   valuesByBlock: Map<Block, Value>;
@@ -12,9 +13,17 @@ export const createPhiInstruction = (
   variableName: string | null,
   valuesByBlock: Map<Block, Value>,
   location: Location,
+  staticType: TypeInfo | undefined = undefined,
 ): PhiInstruction => {
   return {
-    ...createValueInstruction('phi', targetValue.identifier, variableName, [], location),
+    ...createValueInstruction(
+      'phi',
+      targetValue.identifier,
+      variableName,
+      [],
+      location,
+      staticType,
+    ),
     valuesByBlock,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/instructions/value-instruction.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/instructions/value-instruction.ts
@@ -3,6 +3,7 @@ import type { Location } from '../location';
 import { type BaseInstruction, createInstruction } from '../instruction';
 import type { CallInstruction } from './call-instruction';
 import type { PhiInstruction } from './phi-instruction';
+import { TypeInfo } from '../type-info';
 
 export type ValueInstructionType = 'call' | 'phi';
 
@@ -12,6 +13,7 @@ export type BaseValueInstruction<Type extends ValueInstructionType> = BaseInstru
 > & {
   readonly valueIndex: number;
   readonly variableName: string | null;
+  readonly staticType: TypeInfo | undefined;
 };
 
 export type ValueInstruction = CallInstruction | PhiInstruction;
@@ -22,10 +24,12 @@ export const createValueInstruction = <Type extends ValueInstructionType>(
   variableName: string | null,
   operands: Array<Value>,
   location: Location,
+  staticType: TypeInfo | undefined,
 ): BaseValueInstruction<Type> => {
   return {
     ...createInstruction(instructionType, operands, location),
     valueIndex,
     variableName,
+    staticType,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/statements/variable-declaration.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/statements/variable-declaration.ts
@@ -13,8 +13,12 @@ export function handleVariableDeclaration(
   node: TSESTree.VariableDeclaration,
 ) {
   for (const declarator of node.declarations) {
-    if (!declarator || declarator.type !== TSESTree.AST_NODE_TYPES.VariableDeclarator) {
-      throw new Error('Unhandled declaration');
+    if (declarator.type !== TSESTree.AST_NODE_TYPES.VariableDeclarator) {
+      console.error(`Unhandled declaration at ${declarator.type}`);
+      return {
+        instructions: [],
+        value: createNull(),
+      };
     }
     if (declarator.id.type !== TSESTree.AST_NODE_TYPES.Identifier) {
       console.error(`Unhandled declaration id type ${declarator.id.type}`);
@@ -28,7 +32,6 @@ export function handleVariableDeclaration(
     const currentBlock = context.block.getCurrentBlock();
 
     let value: Value;
-
     if (declarator.init) {
       const result = handleExpression(context, declarator.init);
 
@@ -57,6 +60,7 @@ export function handleVariableDeclaration(
       createSetFieldFunctionDefinition(variableName),
       [createReference(currentScope.identifier), value],
       node.loc,
+      value.typeInfo,
     );
 
     currentBlock.instructions.push(instruction);

--- a/packages/jsts/src/dbd/js-to-dbd/core/type-info.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/type-info.ts
@@ -1,5 +1,19 @@
+export type TypeInfo_Kind = 'primitive' | 'PRIMITIVE' | 'ARRAY' | 0;
+
 export type TypeInfo = {
-  kind: 'primitive' | 'PRIMITIVE' | 0;
+  kind: TypeInfo_Kind;
   qualifiedName: string;
   hasIncompleteSemantics: boolean;
+};
+
+export const createTypeInfo = (
+  kind: TypeInfo_Kind,
+  qualifiedName: string,
+  hasIncompleteSemantics: boolean,
+): TypeInfo => {
+  return {
+    kind,
+    qualifiedName,
+    hasIncompleteSemantics,
+  };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/value.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/value.ts
@@ -4,6 +4,7 @@ import type { Instruction } from './instruction';
 import type { Parameter } from './values/parameter';
 import type { TypeName } from './values/type-name';
 import type { Reference } from './values/reference';
+import { TypeInfo } from './type-info';
 
 export type Value = Constant | Null | Parameter | Reference | TypeName;
 
@@ -11,15 +12,18 @@ export type BaseValue<Type extends string | null> = {
   readonly identifier: number;
   readonly type: Type | null;
   readonly users: Array<Instruction>;
+  readonly typeInfo: TypeInfo | undefined;
 };
 
 export const createValue = <Type extends string>(
   identifier: number,
   type: Type | null = null,
+  typeInfo: TypeInfo | undefined = undefined,
 ): BaseValue<Type> => {
   return {
     identifier,
     type,
+    typeInfo,
     users: [],
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/values/constant.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/values/constant.ts
@@ -1,19 +1,13 @@
-import type { TypeInfo } from '../type-info';
+import { createTypeInfo } from '../type-info';
 import { type BaseValue, createValue } from '../value';
 
 export type Constant = BaseValue<'constant'> & {
   readonly value: bigint | boolean | null | number | RegExp | string | undefined;
-  readonly typeInfo: TypeInfo;
 };
 
 export const createConstant = (identifier: number, value: Constant['value']): Constant => {
   return {
-    ...createValue(identifier, 'constant'),
-    typeInfo: {
-      kind: 'PRIMITIVE',
-      qualifiedName: typeof value,
-      hasIncompleteSemantics: true,
-    },
+    ...createValue(identifier, 'constant', createTypeInfo('PRIMITIVE', typeof value, true)),
     value,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/values/parameter.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/values/parameter.ts
@@ -1,11 +1,10 @@
-import type { TypeInfo } from '../type-info';
+import { createTypeInfo } from '../type-info';
 import { type BaseValue, createValue } from '../value';
 import type { Location } from '../location';
 
 export type Parameter = BaseValue<'parameter'> & {
   readonly location: Location;
   readonly name: string;
-  readonly typeInfo: TypeInfo;
 };
 export const createParameter = (
   identifier: number,
@@ -13,13 +12,8 @@ export const createParameter = (
   location: Location,
 ): Parameter => {
   return {
-    ...createValue(identifier, 'parameter'),
+    ...createValue(identifier, 'parameter', createTypeInfo('PRIMITIVE', 'foo', true)),
     name,
     location,
-    typeInfo: {
-      kind: 'PRIMITIVE',
-      qualifiedName: 'foo',
-      hasIncompleteSemantics: true,
-    },
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/values/reference.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/values/reference.ts
@@ -6,6 +6,7 @@ export const createReference = (identifier: number): Reference => {
   return {
     identifier,
     type: 'reference',
+    typeInfo: undefined,
     users: [],
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/values/type-name.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/values/type-name.ts
@@ -1,7 +1,13 @@
 import type { TypeInfo } from '../type-info';
-import { type BaseValue } from '../value';
+import { type BaseValue, createValue } from '../value';
 
 export type TypeName = BaseValue<'type_name'> & {
   readonly name: string;
-  readonly typeInfo: TypeInfo;
+};
+
+export const createTypeName = (identifier: number, name: string, typeInfo: TypeInfo): TypeName => {
+  return {
+    ...createValue(identifier, 'type_name', typeInfo),
+    name,
+  };
 };

--- a/snippet.ts
+++ b/snippet.ts
@@ -1,5 +1,0 @@
-const x = 1;
-{
-  console.log(x); // ReferenceError
-  const x = 2;
-}

--- a/snippet.ts
+++ b/snippet.ts
@@ -1,0 +1,5 @@
+const x = 1;
+{
+  console.log(x); // ReferenceError
+  const x = 2;
+}


### PR DESCRIPTION
I would like to have better types when creating objects. Let us put the TypeInfo to the root of the Value