### PR TITLE
Remove-instructions

### DIFF
--- a/packages/jsts/src/dbd/js-to-dbd/core/context-manager.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/context-manager.ts
@@ -5,6 +5,7 @@ import { TSESTree } from '@typescript-eslint/typescript-estree';
 import type { Reference } from './values/reference';
 import type { Location } from './location';
 import { type Block } from './block';
+import { Instruction } from './instruction';
 
 export interface Context {
   readonly blockManager: BlockManager;
@@ -12,6 +13,7 @@ export interface Context {
   readonly scopeManager: ScopeManager;
 
   createScopedBlock(location: Location): Block;
+  addInstructions(instructions: Array<Instruction>): void;
 
   processFunctionInfo(
     name: string,
@@ -35,6 +37,9 @@ export const createContext = (
     processFunctionInfo,
     createScopedBlock: location => {
       return blockManager.createBlock(scopeManager.scopes[0], location); // todo: ScopeManager::getCurrentScope
+    },
+    addInstructions: instructions => {
+      blockManager.getCurrentBlock().instructions.push(...instructions);
     },
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expression-handler.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expression-handler.ts
@@ -1,10 +1,8 @@
 import { TSESTree } from '@typescript-eslint/utils';
-import type { Instruction } from './instruction';
 import type { Context } from './context-manager';
 import type { Value } from './value';
 
 export type ExpressionHandlerResult = {
-  readonly instructions: Array<Instruction>;
   readonly value: Value;
 };
 

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/array-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/array-expression.ts
@@ -54,12 +54,7 @@ export const handleArrayExpression: ExpressionHandler<TSESTree.ArrayExpression> 
       console.error(`Unsupported array element at ${JSON.stringify(node.loc)}`);
       return;
     }
-    const { instructions: elementInstructions, value: elementValue } = handleExpression(
-      element,
-      context,
-      scopeReference,
-    );
-    instructions.push(...elementInstructions);
+    const { value: elementValue } = handleExpression(element, context, scopeReference);
     instructions.push(
       createCallInstruction(
         context.scopeManager.createValueIdentifier(),
@@ -70,8 +65,8 @@ export const handleArrayExpression: ExpressionHandler<TSESTree.ArrayExpression> 
       ),
     );
   });
+  context.blockManager.getCurrentBlock().instructions.push(...instructions);
   return {
-    instructions,
     value: arrayValue,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/arrow-function-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/arrow-function-expression.ts
@@ -22,7 +22,6 @@ import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
 import { createNewObjectFunctionDefinition } from '../function-definition';
 import { createFunctionReference } from '../values/function-reference';
 import { createCallInstruction } from '../instructions/call-instruction';
-import type { Instruction } from '../instruction';
 import { createReference } from '../values/reference';
 
 export const handleArrowFunctionExpression: ExpressionHandler<TSESTree.ArrowFunctionExpression> = (
@@ -33,7 +32,6 @@ export const handleArrowFunctionExpression: ExpressionHandler<TSESTree.ArrowFunc
   const { createValueIdentifier, processFunctionInfo, getCurrentScopeIdentifier } = scopeManager;
 
   const scopeReference = createReference(getCurrentScopeIdentifier());
-  const instructions: Array<Instruction> = [];
 
   let body: Array<TSESTree.Statement>;
 
@@ -66,20 +64,21 @@ export const handleArrowFunctionExpression: ExpressionHandler<TSESTree.ArrowFunc
 
   currentFunctionInfo.functionReferences.push(functionReference);
 
-  instructions.push(
-    createCallInstruction(
-      functionReference.identifier,
-      null,
-      createNewObjectFunctionDefinition(),
-      [],
-      node.loc,
-    ),
-  );
+  context.blockManager
+    .getCurrentBlock()
+    .instructions.push(
+      createCallInstruction(
+        functionReference.identifier,
+        null,
+        createNewObjectFunctionDefinition(),
+        [],
+        node.loc,
+      ),
+    );
 
   // todo: add other functions symbols, through a common method shared with FunctionDeclaration handler
 
   return {
-    instructions,
     value: functionReference,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/assignment-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/assignment-expression.ts
@@ -1,7 +1,6 @@
 import { TSESTree } from '@typescript-eslint/utils';
 import { compileAsAssignment, handleExpression } from './index';
 import type { ExpressionHandler } from '../expression-handler';
-import type { Instruction } from '../instruction';
 import { createNull } from '../values/reference';
 
 export const handleAssignmentExpression: ExpressionHandler<TSESTree.AssignmentExpression> = (
@@ -9,26 +8,16 @@ export const handleAssignmentExpression: ExpressionHandler<TSESTree.AssignmentEx
   context,
   scopeReference,
 ) => {
-  const instructions: Array<Instruction> = [];
-
   const { left, right } = node;
 
   // rhs
-  const { instructions: rightInstructions, value: rightValue } = handleExpression(
-    right,
-    context,
-    scopeReference,
-  );
-
-  instructions.push(...rightInstructions);
+  const { value: rightValue } = handleExpression(right, context, scopeReference);
 
   // lhs
   const leftInstructions = compileAsAssignment(left, rightValue, context, scopeReference);
-
-  instructions.push(...leftInstructions);
+  context.blockManager.getCurrentBlock().instructions.push(...leftInstructions);
 
   return {
-    instructions,
     value: createNull(),
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/binary-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/binary-expression.ts
@@ -1,4 +1,3 @@
-import type { Instruction } from '../instruction';
 import { createReference } from '../values/reference';
 import { createCallInstruction } from '../instructions/call-instruction';
 import { createBinaryOperationFunctionDefinition } from '../function-definition';
@@ -11,41 +10,29 @@ export const handleBinaryExpression: ExpressionHandler<TSESTree.BinaryExpression
   context,
   scopeReference,
 ) => {
-  const instructions: Array<Instruction> = [];
-
   const { left, right, operator } = node;
 
   // rhs
-  const { instructions: rightInstructions, value: rightValue } = handleExpression(
-    right,
-    context,
-    scopeReference,
-  );
+  const { value: rightValue } = handleExpression(right, context, scopeReference);
 
   // lhs
-  const { instructions: leftInstructions, value: leftValue } = handleExpression(
-    left,
-    context,
-    scopeReference,
-  );
-
-  instructions.push(...rightInstructions);
-  instructions.push(...leftInstructions);
+  const { value: leftValue } = handleExpression(left, context, scopeReference);
 
   const value = createReference(context.scopeManager.createValueIdentifier());
 
-  instructions.push(
-    createCallInstruction(
-      value.identifier,
-      null,
-      createBinaryOperationFunctionDefinition(operator),
-      [leftValue, rightValue],
-      node.loc,
-    ),
-  );
+  context.blockManager
+    .getCurrentBlock()
+    .instructions.push(
+      createCallInstruction(
+        value.identifier,
+        null,
+        createBinaryOperationFunctionDefinition(operator),
+        [leftValue, rightValue],
+        node.loc,
+      ),
+    );
 
   return {
-    instructions,
     value,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/conditional-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/conditional-expression.ts
@@ -14,33 +14,18 @@ export const handleConditionalExpression: ExpressionHandler<TSESTree.Conditional
   const { test, consequent, alternate } = node;
   const { blockManager, createScopedBlock } = context;
 
-  const { instructions: testInstructions, value: testValue } = handleExpression(
-    test,
-    context,
-    scopeReference,
-  );
+  const { value: testValue } = handleExpression(test, context, scopeReference);
   const currentBlock = blockManager.getCurrentBlock();
-  currentBlock.instructions.push(...testInstructions);
 
   const consequentBlock = createScopedBlock(consequent.loc);
   blockManager.pushBlock(consequentBlock);
-  const { instructions: consequentInstructions, value: consequentValue } = handleExpression(
-    consequent,
-    context,
-    scopeReference,
-  );
+  const { value: consequentValue } = handleExpression(consequent, context, scopeReference);
   const afterConsequentInstructionsBlock = blockManager.getCurrentBlock();
-  afterConsequentInstructionsBlock.instructions.push(...consequentInstructions);
 
   const alternateBlock = createScopedBlock(alternate.loc);
   blockManager.pushBlock(alternateBlock);
-  const { instructions: alternateInstructions, value: alternateValue } = handleExpression(
-    alternate,
-    context,
-    scopeReference,
-  );
+  const { value: alternateValue } = handleExpression(alternate, context, scopeReference);
   const afterAlternateInstructionsBlock = blockManager.getCurrentBlock();
-  afterAlternateInstructionsBlock.instructions.push(...alternateInstructions);
 
   currentBlock.instructions.push(
     createConditionalBranchingInstruction(testValue, consequentBlock, alternateBlock, test.loc),

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/identifier.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/identifier.ts
@@ -52,7 +52,6 @@ export const handleIdentifier: ExpressionHandler<TSESTree.Identifier> = (
       console.log(name, 'IS A PARAMETER');
 
       return {
-        instructions,
         value: parameter,
       };
     } else {
@@ -103,13 +102,11 @@ export const handleIdentifier: ExpressionHandler<TSESTree.Identifier> = (
   // we return the last assignment
   if (assignment) {
     return {
-      instructions,
       value: createReference(assignment.identifier),
     };
   }
 
   return {
-    instructions,
     value: createNull(),
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/index.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/index.ts
@@ -70,11 +70,7 @@ export const compileAsAssignment = (
       const { object, property } = node;
 
       if (property.type === AST_NODE_TYPES.Identifier) {
-        const { instructions: objectInstructions, value: objectValue } = handleExpression(
-          object,
-          context,
-          scopeReference,
-        );
+        const { value: objectValue } = handleExpression(object, context, scopeReference);
 
         /**
          * ECMAScript allows assigning a value to a property that was not previously declared:
@@ -89,7 +85,7 @@ export const compileAsAssignment = (
          */
         const propertyInstructions = compileAsDeclaration(property, value, context, objectValue);
 
-        return [...objectInstructions, ...propertyInstructions];
+        return [...propertyInstructions];
       } else {
         console.error(`Not supported yet...`);
 

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/literal.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/literal.ts
@@ -1,5 +1,4 @@
 import { TSESTree } from '@typescript-eslint/utils';
-import type { Instruction } from '../instruction';
 import type { Value } from '../value';
 import { createConstant } from '../values/constant';
 import type { ExpressionHandler } from '../expression-handler';
@@ -7,7 +6,6 @@ import { createNull } from '../values/reference';
 
 export const handleLiteral: ExpressionHandler<TSESTree.Literal> = (node, context) => {
   const { createValueIdentifier } = context.scopeManager;
-  const instructions: Array<Instruction> = [];
 
   let value: Value;
 
@@ -18,7 +16,6 @@ export const handleLiteral: ExpressionHandler<TSESTree.Literal> = (node, context
   }
 
   return {
-    instructions,
     value,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/logical-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/logical-expression.ts
@@ -15,25 +15,15 @@ export const handleLogicalExpression: ExpressionHandler<TSESTree.LogicalExpressi
   const { left, right, operator } = node;
   const { createScopedBlock, blockManager } = context;
 
-  const { instructions: leftInstructions, value: leftValue } = handleExpression(
-    left,
-    context,
-    scopeReference,
-  );
+  const { value: leftValue } = handleExpression(left, context, scopeReference);
   const startingBlock = blockManager.getCurrentBlock();
-  startingBlock.instructions.push(...leftInstructions);
 
   const finallyBlock = createScopedBlock(node.loc);
 
   const consequentBlock = createScopedBlock(node.right.loc);
   blockManager.pushBlock(consequentBlock);
-  const { instructions: rightInstructions, value: rightValue } = handleExpression(
-    right,
-    context,
-    scopeReference,
-  );
+  const { value: rightValue } = handleExpression(right, context, scopeReference);
   const blockAfterRightExpression = blockManager.getCurrentBlock();
-  blockAfterRightExpression.instructions.push(...rightInstructions);
 
   const handleLogicalOperators = (operator: '||' | '&&') => {
     const falsyBlock = createScopedBlock(node.loc);

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/member-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/member-expression.ts
@@ -1,4 +1,3 @@
-import type { Instruction } from '../instruction';
 import { TSESTree } from '@typescript-eslint/utils';
 import { handleExpression } from './index';
 import type { ExpressionHandler } from '../expression-handler';
@@ -8,27 +7,12 @@ export const handleMemberExpression: ExpressionHandler<TSESTree.MemberExpression
   context,
   scopeReference,
 ) => {
-  const instructions: Array<Instruction> = [];
-
   const { object, property } = node;
-  const { instructions: objectInstructions, value: objectValue } = handleExpression(
-    object,
-    context,
-    scopeReference,
-  );
+  const { value: objectValue } = handleExpression(object, context, scopeReference);
 
-  instructions.push(...objectInstructions);
-
-  const { instructions: propertyInstructions, value: propertyValue } = handleExpression(
-    property,
-    context,
-    objectValue,
-  );
-
-  instructions.push(...propertyInstructions);
+  const { value: propertyValue } = handleExpression(property, context, objectValue);
 
   return {
-    instructions,
     value: propertyValue,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/unary-expression.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/unary-expression.ts
@@ -1,6 +1,5 @@
 import type { ExpressionHandler } from '../expression-handler';
 import { TSESTree } from '@typescript-eslint/utils';
-import type { Instruction } from '../instruction';
 import { handleExpression } from './index';
 import { createReference } from '../values/reference';
 import { createCallInstruction } from '../instructions/call-instruction';
@@ -11,18 +10,12 @@ export const handleUnaryExpression: ExpressionHandler<TSESTree.UnaryExpression> 
   context,
   scopeReference,
 ) => {
-  const instructions: Array<Instruction> = [];
   const { argument } = node;
 
-  const { instructions: argumentInstructions, value: argumentValue } = handleExpression(
-    argument,
-    context,
-    scopeReference,
-  );
-  instructions.push(...argumentInstructions);
+  const { value: argumentValue } = handleExpression(argument, context, scopeReference);
 
   const value = createReference(context.scopeManager.createValueIdentifier());
-  instructions.push(
+  context.addInstructions([
     createCallInstruction(
       value.identifier,
       null,
@@ -30,10 +23,9 @@ export const handleUnaryExpression: ExpressionHandler<TSESTree.UnaryExpression> 
       [argumentValue],
       node.loc,
     ),
-  );
+  ]);
 
   return {
-    instructions,
     value,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/expressions/variable-declarator.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/expressions/variable-declarator.ts
@@ -1,6 +1,5 @@
 import type { ExpressionHandler } from '../expression-handler';
 import { TSESTree } from '@typescript-eslint/utils';
-import type { Instruction } from '../instruction';
 import type { Value } from '../value';
 import { compileAsDeclaration, handleExpression } from './index';
 import { createNull } from '../values/reference';
@@ -10,18 +9,10 @@ export const handleVariableDeclarator: ExpressionHandler<TSESTree.VariableDeclar
   context,
   scopeReference,
 ) => {
-  const instructions: Array<Instruction> = [];
-
   let initValue: Value;
 
   if (node.init) {
-    const { instructions: initInstructions, value } = handleExpression(
-      node.init,
-      context,
-      scopeReference,
-    );
-
-    instructions.push(...initInstructions);
+    const { value } = handleExpression(node.init, context, scopeReference);
 
     initValue = value;
   } else {
@@ -30,10 +21,9 @@ export const handleVariableDeclarator: ExpressionHandler<TSESTree.VariableDeclar
 
   const idInstructions = compileAsDeclaration(node.id, initValue, context, scopeReference);
 
-  instructions.push(...idInstructions);
+  context.addInstructions(idInstructions);
 
   return {
-    instructions,
     value: initValue,
   };
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/statements/block-statement.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/statements/block-statement.ts
@@ -7,7 +7,7 @@ import { handleStatement } from './index';
 import { isTerminated } from '../utils';
 
 export const handleBlockStatement: StatementHandler<TSESTree.BlockStatement> = (node, context) => {
-  const { blockManager, scopeManager, createScopedBlock } = context;
+  const { blockManager, scopeManager, createScopedBlock, addInstructions } = context;
   const { getCurrentBlock, pushBlock } = blockManager;
   const { createScope, unshiftScope, shiftScope } = scopeManager;
 
@@ -18,7 +18,7 @@ export const handleBlockStatement: StatementHandler<TSESTree.BlockStatement> = (
   const bbn = createScopedBlock(node.loc);
 
   // branch current block to bbn
-  getCurrentBlock().instructions.push(createBranchingInstruction(bbn, node.loc));
+  addInstructions([createBranchingInstruction(bbn, node.loc)]);
 
   // promote bbn as current block
   pushBlock(bbn);
@@ -32,7 +32,7 @@ export const handleBlockStatement: StatementHandler<TSESTree.BlockStatement> = (
     node.loc,
   );
 
-  getCurrentBlock().instructions.push(instruction);
+  addInstructions([instruction]);
 
   node.body.forEach(statement => {
     return handleStatement(statement, context);

--- a/packages/jsts/src/dbd/js-to-dbd/core/statements/expression-statement.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/statements/expression-statement.ts
@@ -7,13 +7,11 @@ export const handleExpressionStatement: StatementHandler<TSESTree.ExpressionStat
   node,
   context,
 ) => {
-  const { blockManager, scopeManager } = context;
-  const { getCurrentBlock } = blockManager;
+  const { scopeManager } = context;
 
-  const { instructions } = handleExpression(
+  handleExpression(
     node.expression,
     context,
     createReference(scopeManager.getCurrentScopeIdentifier()),
   );
-  getCurrentBlock().instructions.push(...instructions);
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/statements/function-declaration.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/statements/function-declaration.ts
@@ -15,14 +15,13 @@ export const handleFunctionDeclaration: StatementHandler<TSESTree.FunctionDeclar
 ) => {
   const { id } = node;
   const {
-    blockManager,
+    addInstructions,
     scopeManager,
     functionInfo: currentFunctionInfo,
     processFunctionInfo,
   } = context;
   const { createValueIdentifier, getCurrentScopeIdentifier, addVariable, addAssignment } =
     scopeManager;
-  const { getCurrentBlock } = blockManager;
   const { name } = id;
 
   const scopeReference = createReference(getCurrentScopeIdentifier());
@@ -53,7 +52,7 @@ export const handleFunctionDeclaration: StatementHandler<TSESTree.FunctionDeclar
   currentFunctionInfo.functionReferences.push(functionReference);
 
   // create the function object
-  getCurrentBlock().instructions.push(
+  addInstructions([
     createCallInstruction(
       functionReference.identifier,
       null,
@@ -61,9 +60,6 @@ export const handleFunctionDeclaration: StatementHandler<TSESTree.FunctionDeclar
       [],
       node.loc,
     ),
-  );
-
-  getCurrentBlock().instructions.push(
     createCallInstruction(
       createValueIdentifier(),
       null,
@@ -71,7 +67,7 @@ export const handleFunctionDeclaration: StatementHandler<TSESTree.FunctionDeclar
       [scopeReference, functionReference],
       node.loc,
     ),
-  );
+  ]);
 
   const assignment = createAssignment(functionReference.identifier, variable);
 

--- a/packages/jsts/src/dbd/js-to-dbd/core/statements/if-statement.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/statements/if-statement.ts
@@ -53,14 +53,13 @@ export const handleIfStatement: StatementHandler<TSESTree.IfStatement> = (node, 
     return block;
   };
 
-  const { instructions: testInstructions, value: testValue } = handleExpression(
+  const { value: testValue } = handleExpression(
     test,
     context,
     createReference(scopeManager.getCurrentScopeIdentifier()),
   );
 
   const currentBlock = getCurrentBlock();
-  currentBlock.instructions.push(...testInstructions);
 
   // process the consequent block
   const consequentBlock = processNode(consequent);

--- a/packages/jsts/src/dbd/js-to-dbd/core/statements/return-statement.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/statements/return-statement.ts
@@ -8,18 +8,16 @@ export const handleReturnStatement: StatementHandler<TSESTree.ReturnStatement> =
   node,
   context,
 ) => {
-  const { blockManager, scopeManager } = context;
-  const { getCurrentBlock } = blockManager;
+  const { scopeManager, addInstructions } = context;
 
   if (node.argument === null) {
-    getCurrentBlock().instructions.push(createReturnInstruction(createNull(), node.loc));
+    addInstructions([createReturnInstruction(createNull(), node.loc)]);
   } else {
-    const value = handleExpression(
+    const { value } = handleExpression(
       node.argument,
       context,
       createReference(scopeManager.getCurrentScopeIdentifier()),
     );
-    getCurrentBlock().instructions.push(...value.instructions);
-    getCurrentBlock().instructions.push(createReturnInstruction(value.value, node.loc));
+    addInstructions([createReturnInstruction(value, node.loc)]);
   }
 };

--- a/packages/jsts/src/dbd/js-to-dbd/core/statements/variable-declaration.ts
+++ b/packages/jsts/src/dbd/js-to-dbd/core/statements/variable-declaration.ts
@@ -1,6 +1,5 @@
 import { TSESTree } from '@typescript-eslint/typescript-estree';
 import type { StatementHandler } from '../statement-handler';
-import type { Instruction } from '../instruction';
 import { handleExpression } from '../expressions';
 import { createReference } from '../values/reference';
 
@@ -8,19 +7,13 @@ export const handleVariableDeclaration: StatementHandler<TSESTree.VariableDeclar
   node,
   context,
 ) => {
-  const { blockManager, scopeManager } = context;
-  const { getCurrentBlock } = blockManager;
-  const instructions: Array<Instruction> = [];
+  const { scopeManager } = context;
 
   for (const declaration of node.declarations) {
-    const { instructions: declarationInstruction } = handleExpression(
+    handleExpression(
       declaration,
       context,
       createReference(scopeManager.getCurrentScopeIdentifier()),
     );
-
-    instructions.push(...declarationInstruction);
   }
-
-  getCurrentBlock().instructions.push(...instructions);
 };


### PR DESCRIPTION
As part of the ExpressionHandler we used to return the Instructions that later needed to be added to the current block. Let us push this responsibility on the ExpressionHandler themselves.