### PR TITLE
Do not serialize the AST if the `skipAst` flag is set

### DIFF
--- a/packages/jsts/src/analysis/analyzer.ts
+++ b/packages/jsts/src/analysis/analyzer.ts
@@ -92,9 +92,11 @@ function analyzeFile(
       ...extendedMetrics,
     };
 
-    const ast = serializeAst(sourceCode, filePath, input.skipAst);
-    if (ast) {
-      result.ast = ast;
+    if (!input.skipAst) {
+      const ast = serializeAst(sourceCode, filePath);
+      if (ast) {
+        result.ast = ast;
+      }
     }
 
     return result;

--- a/packages/jsts/src/analysis/analyzer.ts
+++ b/packages/jsts/src/analysis/analyzer.ts
@@ -110,8 +110,8 @@ function analyzeFile(
   }
 }
 
-function serializeAst(sourceCode: SourceCode, filePath: string, skipAst = false) {
-  if (!isSupported(filePath) || skipAst) {
+function serializeAst(sourceCode: SourceCode, filePath: string) {
+  if (!isSupported(filePath)) {
     return null;
   }
 

--- a/packages/jsts/src/analysis/analyzer.ts
+++ b/packages/jsts/src/analysis/analyzer.ts
@@ -92,8 +92,8 @@ function analyzeFile(
       ...extendedMetrics,
     };
 
-    const ast = serializeAst(sourceCode, filePath);
-    if (!input.skipAst && ast) {
+    const ast = serializeAst(sourceCode, filePath, input.skipAst);
+    if (ast) {
       result.ast = ast;
     }
 
@@ -108,8 +108,8 @@ function analyzeFile(
   }
 }
 
-function serializeAst(sourceCode: SourceCode, filePath: string) {
-  if (!isSupported(filePath)) {
+function serializeAst(sourceCode: SourceCode, filePath: string, skipAst = false) {
+  if (!isSupported(filePath) || skipAst) {
     return null;
   }
 


### PR DESCRIPTION
With this change, we skip the AST serialization, not just the sending of the AST in the response.