### PR TITLE
Update S4649: Clarify how to use the rule property "ignoreFontFamilies"

### DIFF
--- a/sonar-plugin/css/src/main/java/org/sonar/css/rules/FontFamilyNoMissingGenericFamilyKeyword.java
+++ b/sonar-plugin/css/src/main/java/org/sonar/css/rules/FontFamilyNoMissingGenericFamilyKeyword.java
@@ -33,7 +33,7 @@ public class FontFamilyNoMissingGenericFamilyKeyword implements CssRule {
 
   @RuleProperty(
     key = "ignoreFontFamilies",
-    description = "Comma-separated list of font families exempt from this rule (regular expressions supported).",
+    description = "Comma-separated list of font families to ignore. Each value can be a string or a regular expression with the syntax /pattern/.",
     defaultValue = "" + DEFAULT_IGNORE_FONT_FAMILIES
   )
   String ignoreFontFamilies = DEFAULT_IGNORE_FONT_FAMILIES;


### PR DESCRIPTION
Before being off, I addressed the following [user feedback](https://community.sonarsource.com/t/how-to-configure-regex-for-css-s4649/116346), but I didn't get a chance to tackle it.
This change is simply about clarifying the usage of the rule property with regular expressions.