### PR TITLE
JS-209 Catch IllegalStateException when saving highlights and cpd tokens

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
@@ -200,7 +200,7 @@ public class AnalysisProcessor {
           highlight.location().toTextRange(file),
           TypeOfText.valueOf(highlight.textType())
         );
-      } catch (IllegalArgumentException e) {
+      } catch (IllegalArgumentException | IllegalStateException e) {
         LOG.warn("Failed to save highlight in {} at {}", file.uri(), highlight.location());
         LOG.warn("Exception cause", e);
         // continue processing other highlights
@@ -222,7 +222,7 @@ public class AnalysisProcessor {
             declaration.endLine(),
             declaration.endCol()
           );
-      } catch (IllegalArgumentException e) {
+      } catch (IllegalArgumentException | IllegalStateException e) {
         LOG.warn("Failed to create symbol declaration in {} at {}", file.uri(), declaration);
         continue;
       }
@@ -234,7 +234,7 @@ public class AnalysisProcessor {
             reference.endLine(),
             reference.endCol()
           );
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
           LOG.warn("Failed to create symbol reference in {} at {}", file.uri(), reference);
         }
       }
@@ -291,7 +291,7 @@ public class AnalysisProcessor {
         newCpdTokens.addToken(cpdToken.location().toTextRange(file), cpdToken.image());
       }
       newCpdTokens.save();
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | IllegalStateException e) {
       LOG.warn("Failed to save CPD token in {}. File will not be analyzed for duplications.", file.uri());
       LOG.warn("Exception cause", e);
     }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
@@ -200,13 +200,18 @@ public class AnalysisProcessor {
           highlight.location().toTextRange(file),
           TypeOfText.valueOf(highlight.textType())
         );
-      } catch (IllegalArgumentException | IllegalStateException e) {
-        LOG.warn("Failed to save highlight in {} at {}", file.uri(), highlight.location());
+      } catch (RuntimeException e) {
+        LOG.warn("Failed to create highlight in {} at {}", file.uri(), highlight.location());
         LOG.warn("Exception cause", e);
         // continue processing other highlights
       }
     }
-    highlighting.save();
+    try {
+      highlighting.save();
+    } catch (RuntimeException e) {
+      LOG.warn("Failed to save highlights in {}.", file.uri());
+      LOG.warn("Exception cause", e);
+    }
   }
 
   private void saveHighlightedSymbols(List<HighlightedSymbol> highlightedSymbols) {
@@ -222,7 +227,7 @@ public class AnalysisProcessor {
             declaration.endLine(),
             declaration.endCol()
           );
-      } catch (IllegalArgumentException | IllegalStateException e) {
+      } catch (RuntimeException e) {
         LOG.warn("Failed to create symbol declaration in {} at {}", file.uri(), declaration);
         continue;
       }
@@ -234,7 +239,7 @@ public class AnalysisProcessor {
             reference.endLine(),
             reference.endCol()
           );
-        } catch (IllegalArgumentException | IllegalStateException e) {
+        } catch (RuntimeException e) {
           LOG.warn("Failed to create symbol reference in {} at {}", file.uri(), reference);
         }
       }
@@ -291,7 +296,7 @@ public class AnalysisProcessor {
         newCpdTokens.addToken(cpdToken.location().toTextRange(file), cpdToken.image());
       }
       newCpdTokens.save();
-    } catch (IllegalArgumentException | IllegalStateException e) {
+    } catch (RuntimeException e) {
       LOG.warn("Failed to save CPD token in {}. File will not be analyzed for duplications.", file.uri());
       LOG.warn("Exception cause", e);
     }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisProcessorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisProcessorTest.java
@@ -45,7 +45,7 @@ class AnalysisProcessorTest {
     var response = new AnalysisResponse(null, List.of(), List.of(highlight), List.of(), new Metrics(), List.of(), List.of(), null);
     processor.processResponse(context, mock(JsTsChecks.class), file, response);
     assertThat(logTester.logs())
-      .contains("Failed to save highlight in " + file.uri() + " at 1:2-1:1");
+      .contains("Failed to create highlight in " + file.uri() + " at 1:2-1:1");
   }
 
   @Test


### PR DESCRIPTION
Seems illegal state is used for overlapping, and illegal argument for invalid offsets. 

We need to catch both

Fixes https://sonarsource.atlassian.net/browse/JS-209