### PR TITLE
Register babel presets and plugin from their actual modules

### DIFF
--- a/packages/jsts/src/parsers/options.ts
+++ b/packages/jsts/src/parsers/options.ts
@@ -18,6 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { Linter } from 'eslint';
+const babelReactPreset = require('@babel/preset-react').default;
+const babelFlowPreset = require('@babel/preset-flow').default;
+const babelEnvPreset = require('@babel/preset-env').default;
+const babelDecoratorProposalPlugin = require('@babel/plugin-proposal-decorators').default;
 
 /**
  * Builds ESLint parser options
@@ -69,16 +73,11 @@ export function buildParserOptions(initialOptions: Linter.ParserOptions, usingBa
  * @param options the parser options to extend
  * @returns the extend parser options
  */
-function babelParserOptions(options: Linter.ParserOptions) {
-  const pluginPath = `${__dirname}/../../../../node_modules`;
-  const babelOptions = {
+function babelParserOptions(options: Linter.ParserOptions): Linter.ParserOptions {
+  const babelOptions: Linter.ParserOptions = {
     targets: 'defaults',
-    presets: [
-      `${pluginPath}/@babel/preset-react`,
-      `${pluginPath}/@babel/preset-flow`,
-      `${pluginPath}/@babel/preset-env`,
-    ],
-    plugins: [[`${pluginPath}/@babel/plugin-proposal-decorators`, { version: '2022-03' }]],
+    presets: [babelReactPreset, babelFlowPreset, babelEnvPreset],
+    plugins: [[babelDecoratorProposalPlugin, { version: '2022-03' }]],
     babelrc: false,
     configFile: false,
     parserOpts: {


### PR DESCRIPTION
Testing the pattern that consists at importing the actual Babel modules instead of referencing their packages by their name, as supported by Babel:

https://babeljs.io/docs/options#plugin-and-preset-options
https://babeljs.io/docs/options#entrytarget

It allows dependency resolvers to organically emit the Babel plugins and parsers to the bundler, instead of having to register them explicitely.

Practically, when using esbuild and the package manifest plugin, it allows us to replace the following esbuild configuration:

```js
{
      entryPoints: [
        {
          in: './worker.js',
          out: 'worker'
        },
        {
          in: './main.ts',
          out: 'index'
        }
      ],
      bundle: true,
      outdir: 'target',
      format: "cjs",
      minify: true,
      platform: "node",
      packages: "external",
      plugins: [
        createPackageManifestPlugin({
          dependencies: {
            '@babel/core': '7.24.3',
            '@babel/preset-flow': '7.24.1',
            '@babel/preset-env': '7.24.3',
            '@babel/plugin-proposal-decorators': '7.24.1'
          },
          bundledDependencies: [
            '@babel/core',
            '@babel/preset-flow',
            '@babel/preset-env',
            '@babel/plugin-proposal-decorators'
          ]
        }, '../../../package.json', {
          shouldBundleDependencies: true
        })
      ]
    })
  ]);
}
```

...with this shorter and more maintainable one:

```js
{
      entryPoints: [
        {
          in: './worker.js',
          out: 'worker'
        },
        {
          in: './main.ts',
          out: 'index'
        }
      ],
      bundle: true,
      outdir: 'target',
      format: "cjs",
      minify: true,
      platform: "node",
      packages: "external",
      plugins: [
        createPackageManifestPlugin({}, '../../../package.json', {
          shouldBundleDependencies: true
        })
      ]
    })
  ]);
}
```