### PR TITLE
Update the package.json bugs URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "license": "LGPL-3.0-only",
   "bugs": {
-    "url": "https://github.com/SonarSource/SonarJS/issues"
+    "url": "https://community.sonarsource.com/"
   },
   "homepage": "https://github.com/SonarSource/SonarJS#readme",
   "engines": {


### PR DESCRIPTION
Should we update it to community or [JIRA](https://sonarsource.atlassian.net/browse/JS/)? The "[open issue](https://github.com/SonarSource/SonarJS/issues/new/choose)" link on GitHub points to both.