### PR TITLE
Fix dot folder exclusion from ruling analysis

### DIFF
--- a/packages/ruling/tests/tools/testProject.ts
+++ b/packages/ruling/tests/tools/testProject.ts
@@ -85,7 +85,7 @@ const DEFAULT_EXCLUSIONS = [
   '**/dist/**',
   '**/vendor/**',
   '**/external/**',
-].map(pattern => new Minimatch(pattern, { nocase: true }));
+].map(pattern => new Minimatch(pattern, { nocase: true, dot: true }));
 
 export function setupBeforeAll(projectFile: string, customRules?: CustomRule[]) {
   const { project, rules, expectedPath, actualPath } = extractParameters(projectFile);


### PR DESCRIPTION
Each time when the JsTsRuling test is ran, we get a new folder generated under .scannerwork. The reason is that there are files in that folder with an absolute path like: "/Users/michal.zgliczynski/codes/sonarjs-ruling-sources/jsts/projects/reddit-mobile/.scannerwork/.sonartmp/bridge-bundle/package/lib/server.js" and the minimatch pattern we have for exclusion is like this: https://github.com/SonarSource/SonarJS/blob/a9a8c41c266cd9493b6cc1a11739e4524de6dc6a/packages/ruling/tests/tools/testProject.ts#L81
Now, the reason this doesn't work is that minimatch doesn't match ** to .* (dot) folders. So when we have multiple (.scannerwork/.sonartmp) dot folders, they do not get excluded.

This fixes it.