### PR TITLE
[`eslint-plugin-sonarjs`] Remove `typescript-eslint/parser` 7.X prerequisite from `README.md`

### DIFF
--- a/packages/jsts/src/rules/README.md
+++ b/packages/jsts/src/rules/README.md
@@ -6,7 +6,6 @@ SonarJS rules for ESLint to help developers produce [Clean Code](https://www.son
 
 - Node.js (>=16.x).
 - ESLint 8.x (version 9.X not yet supported)
-- typescript-eslint/parser 7.X (version 8.X not yet supported)
 
 ## Usage
 


### PR DESCRIPTION
I tested `eslint-plugin-sonarjs@2.0.2` with `@typescript-eslint/parser@8.5.0` and it worked, so I assume this is outdated information.
