### PR TITLE
JS-327 Support TSExportAssignment nodes

### DIFF
--- a/packages/jsts/src/parsers/ast.ts
+++ b/packages/jsts/src/parsers/ast.ts
@@ -274,6 +274,9 @@ function getProtobufShapeForNode(node: TSESTree.Node) {
     case 'EmptyStatement':
       shape = visitEmptyStatement(node);
       break;
+    case 'TSExportAssignment':
+      shape = visitExportAssignment(node);
+      break;
     case 'ExpressionStatement':
       // Special case: can be 'Directive' or 'ExpressionStatement'.
       shape = visitExpressionStatement(node);
@@ -336,7 +339,6 @@ function getProtobufShapeForNode(node: TSESTree.Node) {
     case 'TSEmptyBodyFunctionExpression':
     case 'TSEnumDeclaration':
     case 'TSEnumMember':
-    case 'TSExportAssignment':
     case 'TSExportKeyword':
     case 'TSExternalModuleReference':
     case 'TSFunctionType':
@@ -561,6 +563,12 @@ function visitObjectPattern(node: TSESTree.ObjectPattern) {
 function visitPrivateIdentifier(node: TSESTree.PrivateIdentifier) {
   return {
     name: node.name,
+  };
+}
+
+function visitExportAssignment(node: TSESTree.TSExportAssignment) {
+  return {
+    expression: visitNode(node.expression),
   };
 }
 

--- a/packages/jsts/src/parsers/estree.proto
+++ b/packages/jsts/src/parsers/estree.proto
@@ -87,6 +87,7 @@ enum NodeType {
   LiteralType = 68;
   TemplateElementType = 69;
   FunctionExpressionType = 70;
+  ExportAssignment = 71;
   UnknownNodeType = 1000;
 }
 message Node {
@@ -164,6 +165,7 @@ message Node {
     Literal literal = 71;
     TemplateElement templateElement = 72;
     FunctionExpression functionExpression = 73;
+    ExportAssignment exportAssignment = 74;
     UnknownNode unknownNode = 1000;
   }
 }
@@ -468,6 +470,9 @@ message FunctionExpression {
   repeated Node params = 3;
   optional bool generator = 4;
   optional bool async = 5;
+}
+message ExportAssignment {
+  Node expression = 1;
 }
 
 message UnknownNode {

--- a/packages/jsts/src/parsers/estree.proto
+++ b/packages/jsts/src/parsers/estree.proto
@@ -87,7 +87,7 @@ enum NodeType {
   LiteralType = 68;
   TemplateElementType = 69;
   FunctionExpressionType = 70;
-  ExportAssignment = 71;
+  ExportAssignmentType = 71;
   UnknownNodeType = 1000;
 }
 message Node {

--- a/packages/jsts/tests/parsers/ast.test.ts
+++ b/packages/jsts/tests/parsers/ast.test.ts
@@ -149,6 +149,16 @@ describe('ast', () => {
     expect(functionParameter.type).toEqual(NODE_TYPE_ENUM.values['IdentifierType']);
     expect(functionParameter.identifier.name).toEqual('foo');
   });
+
+  test('should support TSExportAssignment nodes', async () => {
+    const code = `export = foo();`;
+    const ast = await parseSourceCode(code, parsers.typescript);
+    const serializedAST = visitNode(ast as TSESTree.Program);
+
+    const expression = serializedAST.program.body[0].tSExportAssignment.expression;
+    expect(expression.type).toEqual(NODE_TYPE_ENUM.values['CallExpressionType']);
+    expect(expression.callExpression.callee.identifier.name).toEqual('foo');
+  });
 });
 
 /**

--- a/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/estree/ESTree.java
+++ b/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/estree/ESTree.java
@@ -109,6 +109,7 @@ public class ESTree {
   public record DoWhileStatement(Location loc, Statement body, Expression test) implements Statement {}
   public record EmptyStatement(Location loc) implements Statement {}
   public record ExportAllDeclaration(Location loc, Optional<IdentifierOrLiteral> exported, Literal source) implements ModuleDeclaration {}
+  public record ExportAssignment(Location loc, Expression expression) implements Statement {}
   // In "d.ts" file, the declaration field has type: MaybeNamedFunctionDeclaration | MaybeNamedClassDeclaration | Expression.
   // The "MaybeNamed" are there to show that the id is optional in this specific case.
   // We decided to not create this extra class, and instead use the existing FunctionDeclaration and ClassDeclaration classes.

--- a/sonar-plugin/api/src/test/java/org/sonar/plugins/javascript/api/estree/ESTreeTest.java
+++ b/sonar-plugin/api/src/test/java/org/sonar/plugins/javascript/api/estree/ESTreeTest.java
@@ -11,14 +11,14 @@ class ESTreeTest {
   void test() {
 
     Class<?>[] classes = ESTree.class.getDeclaredClasses();
-    assertThat(classes).hasSize(107);
+    assertThat(classes).hasSize(108);
 
     //filter all classes that are interface
     var ifaceCount = Arrays.stream(classes).filter(Class::isInterface).count();
     assertThat(ifaceCount).isEqualTo(25);
 
     var recordCount = Arrays.stream(classes).filter(Class::isRecord).count();
-    assertThat(recordCount).isEqualTo(77);
+    assertThat(recordCount).isEqualTo(78);
   }
 
   @Test
@@ -39,7 +39,7 @@ class ESTreeTest {
   void test_statement_subclasses() {
     Class<?> sealedClass = ESTree.Statement.class;
     Class<?>[] permittedSubclasses = sealedClass.getPermittedSubclasses();
-    assertThat(permittedSubclasses).hasSize(21);
+    assertThat(permittedSubclasses).hasSize(22);
   }
 
   @Test

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/ESTreeFactory.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/ESTreeFactory.java
@@ -43,6 +43,7 @@ import org.sonar.plugins.javascript.bridge.protobuf.ConditionalExpression;
 import org.sonar.plugins.javascript.bridge.protobuf.ContinueStatement;
 import org.sonar.plugins.javascript.bridge.protobuf.DoWhileStatement;
 import org.sonar.plugins.javascript.bridge.protobuf.ExportAllDeclaration;
+import org.sonar.plugins.javascript.bridge.protobuf.ExportAssignment;
 import org.sonar.plugins.javascript.bridge.protobuf.ExportDefaultDeclaration;
 import org.sonar.plugins.javascript.bridge.protobuf.ExportNamedDeclaration;
 import org.sonar.plugins.javascript.bridge.protobuf.ExportSpecifier;
@@ -180,6 +181,7 @@ public class ESTreeFactory {
       case LiteralType -> fromLiteralType(node);
       case TemplateElementType -> fromTemplateElementType(node);
       case FunctionExpressionType -> fromFunctionExpressionType(node);
+      case ExportAssignmentType -> fromExportAssignment(node);
       case UnknownNodeType -> fromUnknownNodeType(node);
       case UNRECOGNIZED ->
         throw new IllegalArgumentException("Unknown node type: " + node.getType() + " at " + node.getLoc());
@@ -214,6 +216,12 @@ public class ESTreeFactory {
         Optional.of(from(exportAllDeclaration.getExported(), ESTree.IdentifierOrLiteral.class)) :
         Optional.empty(),
       from(exportAllDeclaration.getSource(), ESTree.Literal.class));
+  }
+
+  private static ESTree.ExportAssignment fromExportAssignment(Node node) {
+    ExportAssignment exportAssignment = node.getExportAssignment();
+    return new ESTree.ExportAssignment(fromLocation(node.getLoc()),
+      from(exportAssignment.getExpression(), ESTree.Expression.class));
   }
 
   private static ESTree.Identifier fromIdentifierType(Node node) {

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/ESTreeFactoryTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/ESTreeFactoryTest.java
@@ -719,6 +719,23 @@ class ESTreeFactoryTest {
   }
 
   @Test
+  void should_create_export_assignment() {
+    CallExpression callExpression = CallExpression.newBuilder()
+      .setCallee(Node.newBuilder().build())
+      .build();
+    Node protobufNode = Node.newBuilder()
+      .setType(NodeType.ExportAssignmentType)
+      .setCallExpression(callExpression)
+      .build();
+
+    ESTree.Node estreeExpressionStatement = ESTreeFactory.from(protobufNode, ESTree.Node.class);
+    assertThat(estreeExpressionStatement).isInstanceOfSatisfying(ESTree.ExportAssignment.class, exportAssignment -> {
+      assertThat(exportAssignment.expression()).isInstanceOf(CallExpression.class);
+      assertThat(exportAssignment.expression()).isNotNull();
+    });
+  }
+
+  @Test
   void throw_exception_from_unrecognized_type() {
     Node protobufNode = Node.newBuilder()
       .setTypeValue(-1)

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/ESTreeFactoryTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/ESTreeFactoryTest.java
@@ -42,6 +42,7 @@ import org.sonar.plugins.javascript.bridge.protobuf.ChainExpression;
 import org.sonar.plugins.javascript.bridge.protobuf.ClassDeclaration;
 import org.sonar.plugins.javascript.bridge.protobuf.EmptyStatement;
 import org.sonar.plugins.javascript.bridge.protobuf.ExportAllDeclaration;
+import org.sonar.plugins.javascript.bridge.protobuf.ExportAssignment;
 import org.sonar.plugins.javascript.bridge.protobuf.ExportDefaultDeclaration;
 import org.sonar.plugins.javascript.bridge.protobuf.ExportSpecifier;
 import org.sonar.plugins.javascript.bridge.protobuf.ExpressionStatement;
@@ -721,17 +722,24 @@ class ESTreeFactoryTest {
   @Test
   void should_create_export_assignment() {
     CallExpression callExpression = CallExpression.newBuilder()
-      .setCallee(Node.newBuilder().build())
+      .setCallee(Node.newBuilder().setType(NodeType.SuperType).build())
+      .build();
+    Node node = Node.newBuilder()
+      .setType(NodeType.CallExpressionType)
+      .setCallExpression(callExpression)
+      .build();
+    //
+    ExportAssignment exportAssignment = ExportAssignment.newBuilder()
+      .setExpression(node)
       .build();
     Node protobufNode = Node.newBuilder()
       .setType(NodeType.ExportAssignmentType)
-      .setCallExpression(callExpression)
+      .setExportAssignment(exportAssignment)
       .build();
 
     ESTree.Node estreeExpressionStatement = ESTreeFactory.from(protobufNode, ESTree.Node.class);
-    assertThat(estreeExpressionStatement).isInstanceOfSatisfying(ESTree.ExportAssignment.class, exportAssignment -> {
-      assertThat(exportAssignment.expression()).isInstanceOf(CallExpression.class);
-      assertThat(exportAssignment.expression()).isNotNull();
+    assertThat(estreeExpressionStatement).isInstanceOfSatisfying(ESTree.ExportAssignment.class, export -> {
+      assertThat(export.expression()).isInstanceOf(ESTree.CallExpression.class);
     });
   }
 


### PR DESCRIPTION
For the AST, you can use this in [ASTexplorer](https://astexplorer.net/):
```js
export = TAINT_SOURCE();
```

which yields:
```json
{
  "type": "Program",
  "body": [
    {
      "type": "TSExportAssignment",
      "expression": {
        "type": "CallExpression",
        "callee": {
          "type": "Identifier",
          "name": "TAINT_SOURCE",
          "range": [
            9,
            21
          ]
        },
        "arguments": [],
        "optional": false,
        "range": [
          9,
          23
        ]
      },
      "range": [
        0,
        24
      ]
    }
  ],
  "sourceType": "module",
  "range": [
    0,
    24
  ]
}
```