### PR TITLE
JS-296 Fix rule S128 to support eslint v9

### DIFF
--- a/its/eslint9-plugin-sonarjs/file.js
+++ b/its/eslint9-plugin-sonarjs/file.js
@@ -28,6 +28,18 @@ function S2376() {
   }
 }
 
+function doSomething() {
+  doSmth();
+}
+switch (x) {
+  case 0:
+    doSomething();
+  case 1:
+    doSomething();
+  default:
+    doSomethingElse();
+}
+
 /*
 
 function S125() {

--- a/its/eslint9-plugin-sonarjs/index.test.js
+++ b/its/eslint9-plugin-sonarjs/index.test.js
@@ -2,15 +2,18 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const spawn = require('cross-spawn');
 
+function verifyErrors(output) {
+  console.log(output);
+  const errorLines = output.split('\n').filter(line => line.includes('error'));
+  assert(errorLines.length >= 8);
+}
+
 test('should work with CommonJS config', async t => {
   const result = spawn.sync('npx', ['eslint', '-c', 'eslint.config.cjs', 'file.js'], {
     cwd: __dirname,
     encoding: 'utf-8',
   });
-  const output = result.stdout;
-  console.log(output);
-  const errorLines = output.split('\n').filter(line => line.includes('error'));
-  assert(errorLines.length > 4);
+  verifyErrors(result.stdout);
 });
 
 test('should work with ECMAScript modules config', async t => {
@@ -18,10 +21,7 @@ test('should work with ECMAScript modules config', async t => {
     cwd: __dirname,
     encoding: 'utf-8',
   });
-  const output = result.stdout;
-  console.log(output);
-  const errorLines = output.split('\n').filter(line => line.includes('error'));
-  assert(errorLines.length > 4);
+  verifyErrors(result.stdout);
 });
 
 test('should work with TSESLint config', async t => {
@@ -29,8 +29,5 @@ test('should work with TSESLint config', async t => {
     cwd: __dirname,
     encoding: 'utf-8',
   });
-  const output = result.stdout;
-  console.log(output);
-  const errorLines = output.split('\n').filter(line => line.includes('error'));
-  assert(errorLines.length > 4);
+  verifyErrors(result.stdout);
 });

--- a/its/eslint9-plugin-sonarjs/package.json
+++ b/its/eslint9-plugin-sonarjs/package.json
@@ -6,11 +6,9 @@
     "test": "node index.test.js"
   },
   "devDependencies": {
-    "@types/eslint": "^8.56.12",
     "cross-spawn": "7.0.3",
-    "eslint": "8.57.0",
-    "eslint-plugin-import": "2.29.1",
+    "eslint": "^9.10.0",
     "typescript": "5.5.4",
-    "typescript-eslint": "7.16.1"
+    "typescript-eslint": "^8.5.0"
   }
 }

--- a/packages/jsts/src/rules/package-lock.json
+++ b/packages/jsts/src/rules/package-lock.json
@@ -30,7 +30,7 @@
         "minimatch": "^9.0.3",
         "scslre": "0.3.0",
         "semver": "7.6.0",
-        "typescript": "5.4.3",
+        "typescript": "*",
         "vue-eslint-parser": "9.4.3"
       },
       "devDependencies": {


### PR DESCRIPTION
Reported in community - https://sonarsource.atlassian.net/jira/software/c/projects/JS/issues/JS-296?jql=project%20%3D%20%22JS%22%20AND%20text%20~%20%22SQ%2010.7%22%20ORDER%20BY%20created%20DESC

Following the migration guidelines outlined here - https://eslint.org/docs/latest/use/migrate-to-9.0.0#removed-codepath-currentsegments

Test:
- fix rule S128
- npm run --prefix packages/jsts/src/rules/ build 
- cd to its/eslint9-plugin-sonarjs
- npm run build 
- npm run test

Perform the same check with its/eslint8-plugin-sonarjs