### PR TITLE
JS-329 Upgrade TypeScript to 5.6.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -285,6 +285,8 @@ js_ts_ruling_task:
     - npm run build:fast
     - npm run update-ruling-data
     - npm run ruling -- --maxWorkers=8
+  on_failure:
+    debug_script: diff -rq its/ruling/src/test/expected/jsts packages/ruling/tests/actual/jsts
   cleanup_before_cache_script: cleanup_maven_repository
 
 eslint_plugin_test_task:

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintCustomRulesTest.java
@@ -127,7 +127,7 @@ class EslintCustomRulesTest {
       )
     )
       .isEmpty();
-    assertThat(buildResult.getLogsLines(l -> l.contains("TS API in custom rule: TS version 5.4.3")))
+    assertThat(buildResult.getLogsLines(l -> l.contains("TS API in custom rule: TS version 5.6.2")))
       .hasSize(2);
     List<Issue> issues = findIssues("eslint-custom-rules:sqKey", orchestrator);
     assertThat(issues).hasSize(2);

--- a/its/ruling/src/test/expected/jsts/TypeScript/typescript-S4325.json
+++ b/its/ruling/src/test/expected/jsts/TypeScript/typescript-S4325.json
@@ -316,19 +316,7 @@
 ],
 "TypeScript:src/harness/harness.ts": [
 36,
-743,
 1102
-],
-"TypeScript:src/harness/harnessLanguageService.ts": [
-151,
-190
-],
-"TypeScript:src/harness/virtualFileSystem.ts": [
-45,
-50,
-69,
-152,
-170
 ],
 "TypeScript:src/server/editorServices.ts": [
 1123

--- a/its/ruling/src/test/expected/jsts/ace/typescript-S1874.json
+++ b/its/ruling/src/test/expected/jsts/ace/typescript-S1874.json
@@ -1,0 +1,6 @@
+{
+"ace:demo/kitchen-sink/docs/typescript.ts": [
+35,
+46
+]
+}

--- a/its/ruling/src/test/expected/jsts/ant-design/typescript-S4325.json
+++ b/its/ruling/src/test/expected/jsts/ant-design/typescript-S4325.json
@@ -8,8 +8,7 @@
 144
 ],
 "ant-design:components/anchor/Anchor.tsx": [
-27,
-258
+27
 ],
 "ant-design:components/anchor/__tests__/Anchor.test.tsx": [
 61,
@@ -129,9 +128,6 @@
 "ant-design:components/mentions/index.tsx": [
 142
 ],
-"ant-design:components/message/index.tsx": [
-107
-],
 "ant-design:components/popconfirm/index.tsx": [
 152
 ],
@@ -167,8 +163,9 @@
 "ant-design:components/tag/index.tsx": [
 55
 ],
-"ant-design:components/timeline/Timeline.tsx": [
-48
+"ant-design:components/time-picker/index.tsx": [
+72,
+74
 ],
 "ant-design:components/transfer/__tests__/dropdown.test.tsx": [
 54,

--- a/its/ruling/src/test/expected/jsts/ant-design/typescript-S6606.json
+++ b/its/ruling/src/test/expected/jsts/ant-design/typescript-S6606.json
@@ -16,7 +16,6 @@
 217
 ],
 "ant-design:components/descriptions/index.tsx": [
-38,
 76
 ],
 "ant-design:components/form/FormItem.tsx": [

--- a/its/ruling/src/test/expected/jsts/courselit/typescript-S4325.json
+++ b/its/ruling/src/test/expected/jsts/courselit/typescript-S4325.json
@@ -2,14 +2,8 @@
 "courselit:apps/web/components/admin/media/media-preview.tsx": [
 98
 ],
-"courselit:apps/web/components/admin/settings.tsx": [
-310
-],
 "courselit:apps/web/pages/api/payment/initiate.ts": [
 55,
 65
-],
-"courselit:apps/web/payments/stripe-payment.ts": [
-72
 ]
 }

--- a/its/ruling/src/test/expected/jsts/eigen/typescript-S1874.json
+++ b/its/ruling/src/test/expected/jsts/eigen/typescript-S1874.json
@@ -1539,9 +1539,6 @@
 "eigen:src/app/tests/renderRelayTree.tsx": [
 105
 ],
-"eigen:src/app/tests/renderUntil.tsx": [
-38
-],
 "eigen:src/app/tests/renderWithLayout.tsx": [
 1,
 6

--- a/its/ruling/src/test/expected/jsts/eigen/typescript-S4325.json
+++ b/its/ruling/src/test/expected/jsts/eigen/typescript-S4325.json
@@ -61,21 +61,16 @@
 44
 ],
 "eigen:src/app/Components/Bidding/BidFlow.tests.tsx": [
-34,
 55
 ],
 "eigen:src/app/Components/Bidding/Helpers/FakeNavigator.tsx": [
 39
-],
-"eigen:src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx": [
-43
 ],
 "eigen:src/app/Components/Bidding/Screens/ConfirmBid/index.tsx": [
 601,
 613
 ],
 "eigen:src/app/Components/Bidding/Screens/Registration.tests.tsx": [
-28,
 151,
 161,
 763,
@@ -110,9 +105,6 @@
 ],
 "eigen:src/app/Components/PartnerEntityHeader.tsx": [
 25
-],
-"eigen:src/app/Components/ReadMore.tsx": [
-49
 ],
 "eigen:src/app/Components/ShareSheet/ShareSheet.tsx": [
 75
@@ -155,7 +147,6 @@
 49
 ],
 "eigen:src/app/Scenes/Artwork/Components/PartnerCard.tsx": [
-98,
 113
 ],
 "eigen:src/app/Scenes/AuctionBuyersPremium/AuctionBuyersPremium.tests.tsx": [
@@ -164,14 +155,8 @@
 "eigen:src/app/Scenes/BottomTabs/BottomTabsButton.tsx": [
 63
 ],
-"eigen:src/app/Scenes/City/Components/Event/index.tests.tsx": [
-10
-],
 "eigen:src/app/Scenes/City/Components/Event/index.tsx": [
 159
-],
-"eigen:src/app/Scenes/City/Components/TabFairItemRow/index.tests.tsx": [
-12
 ],
 "eigen:src/app/Scenes/City/Components/TabFairItemRow/index.tsx": [
 32
@@ -219,10 +204,6 @@
 ],
 "eigen:src/app/Scenes/Inbox/Components/ActiveBids/index.tsx": [
 42
-],
-"eigen:src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx": [
-74,
-75
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tests.tsx": [
 41
@@ -275,9 +256,6 @@
 50,
 51
 ],
-"eigen:src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx": [
-81
-],
 "eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx": [
 39
 ],
@@ -311,16 +289,7 @@
 "eigen:src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalizationModal.tsx": [
 230
 ],
-"eigen:src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetailsHeader.tsx": [
-20
-],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetailsPayment.tsx": [
-20
-],
-"eigen:src/app/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx": [
-24
-],
-"eigen:src/app/Scenes/OrderHistory/OrderHistoryRow.tsx": [
 20
 ],
 "eigen:src/app/Scenes/Sale/Components/BuyNowArtworksRail.tsx": [
@@ -437,9 +406,6 @@
 "eigen:src/app/navigation/NavStack.tsx": [
 33
 ],
-"eigen:src/app/navigation/routes.tsx": [
-31
-],
 "eigen:src/app/relay/middlewares/cacheMiddleware.ts": [
 22,
 27,
@@ -447,7 +413,6 @@
 ],
 "eigen:src/app/relay/middlewares/errorMiddleware.ts": [
 22,
-24,
 32
 ],
 "eigen:src/app/relay/middlewares/metaphysicsMiddleware.ts": [
@@ -458,6 +423,9 @@
 ],
 "eigen:src/app/utils/experiments/unleashClient.ts": [
 50
+],
+"eigen:src/app/utils/hideBackButtonOnScroll.tests.tsx": [
+15
 ],
 "eigen:src/app/utils/renderWithLoadProgress.tests.tsx": [
 9,
@@ -472,31 +440,10 @@
 85,
 88
 ],
-"eigen:src/app/utils/track/SegmentTrackingProvider.ts": [
-52,
-64,
-72,
-79,
-86,
-94
-],
 "eigen:src/app/utils/useImageSearch.ts": [
 100
 ],
-"eigen:src/palette/Theme.tsx": [
-278
-],
-"eigen:src/palette/atoms/Spacer/Spacer.stories.tsx": [
-23,
-43
-],
 "eigen:src/palette/elements/PhotoRow/PhotoRow.tests.tsx": [
 13
-],
-"eigen:src/palette/helpers/color.tests.tsx": [
-9
-],
-"eigen:src/palette/helpers/space.tests.tsx": [
-10
 ]
 }

--- a/its/ruling/src/test/expected/jsts/vuetify/typescript-S1874.json
+++ b/its/ruling/src/test/expected/jsts/vuetify/typescript-S1874.json
@@ -13,27 +13,8 @@
 45,
 46
 ],
-"vuetify:packages/vuetify/src/components/VDataIterator/VDataIterator.ts": [
-167,
-171
-],
-"vuetify:packages/vuetify/src/components/VDatePicker/VDatePicker.ts": [
-179
-],
-"vuetify:packages/vuetify/src/components/VDatePicker/util/createNativeLocaleFormatter.ts": [
-38
-],
-"vuetify:packages/vuetify/src/components/VDatePicker/util/isDateAllowed.ts": [
-8
-],
 "vuetify:packages/vuetify/src/components/VDatePicker/util/sanitizeDateString.ts": [
 7
-],
-"vuetify:packages/vuetify/src/components/VOtpInput/VOtpInput.ts": [
-245
-],
-"vuetify:packages/vuetify/src/components/VStepper/VStepperStep.ts": [
-139
 ],
 "vuetify:packages/vuetify/src/composables/theme.ts": [
 335

--- a/its/ruling/src/test/expected/jsts/vuetify/typescript-S4325.json
+++ b/its/ruling/src/test/expected/jsts/vuetify/typescript-S4325.json
@@ -2,6 +2,9 @@
 "vuetify:packages/vuetify/cypress/support/mount.ts": [
 32
 ],
+"vuetify:packages/vuetify/src/components/VCalendar/mixins/mouse.ts": [
+100
+],
 "vuetify:packages/vuetify/src/components/VData/VData.ts": [
 382
 ],
@@ -29,8 +32,17 @@
 55,
 57
 ],
+"vuetify:packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx": [
+95
+],
 "vuetify:packages/vuetify/src/components/VSelectionControl/__tests__/VSelectionControl.spec.tsx": [
 17
+],
+"vuetify:packages/vuetify/src/components/VStepper/VStepper.ts": [
+109,
+111,
+112,
+119
 ],
 "vuetify:packages/vuetify/src/components/VTextarea/VTextarea.tsx": [
 163,
@@ -50,14 +62,12 @@
 25,
 65
 ],
-"vuetify:packages/vuetify/src/composables/forwardRefs.ts": [
-66
-],
-"vuetify:packages/vuetify/src/composables/proxiedModel.ts": [
-47
+"vuetify:packages/vuetify/src/composables/router.tsx": [
+53
 ],
 "vuetify:packages/vuetify/src/composables/theme.ts": [
-237
+237,
+310
 ],
 "vuetify:packages/vuetify/src/composables/transition.ts": [
 27,
@@ -69,17 +79,8 @@
 38,
 42
 ],
-"vuetify:packages/vuetify/src/framework.ts": [
-131
-],
-"vuetify:packages/vuetify/src/util/defineComponent.tsx": [
-195
-],
 "vuetify:packages/vuetify/src/util/helpers.ts": [
 121,
 123
-],
-"vuetify:packages/vuetify/src/util/useRender.ts": [
-8
 ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "stylelint": "15.10.0",
         "tar": "6.2.1",
         "tmp": "0.2.3",
-        "typescript": "5.4.3",
+        "typescript": "5.6.2",
         "vue-eslint-parser": "9.4.2",
         "yaml": "2.4.1"
       },
@@ -124,7 +124,7 @@
         "ts-jest": "29.1.2",
         "ts-node": "10.9.2",
         "type-fest": "4.21.0",
-        "typedoc": "0.25.12"
+        "typedoc": "0.26.7"
       },
       "engines": {
         "node": "^18.17.0 || ^20.9.0 || >=21.1.0"
@@ -3218,6 +3218,57 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "inBundle": true
     },
+    "node_modules/@shikijs/core": {
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/core/-/core-1.17.0.tgz",
+      "integrity": "sha512-Mkk4Mp4bNnW1kytU8I7S5PK5teNSe0iKlfqxPss4sdwnlcU8a2N62Z3te2gVmZfU9t1HF6L3wyWuM43IvEeEsg==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/engine-javascript": "1.17.0",
+        "@shikijs/engine-oniguruma": "1.17.0",
+        "@shikijs/types": "1.17.0",
+        "@shikijs/vscode-textmate": "^9.2.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.2"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/engine-javascript/-/engine-javascript-1.17.0.tgz",
+      "integrity": "sha512-EiBVlxmzJZdC2ypzn8k+vxLngbBNgHLS4RilwrFOABGRc72kUZubbD/6Chrq2RcVtD3yq1GtiiIdFMGd9BTX3Q==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "1.17.0",
+        "oniguruma-to-js": "0.3.3",
+        "regex": "4.3.2"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/engine-oniguruma/-/engine-oniguruma-1.17.0.tgz",
+      "integrity": "sha512-nsXzJGLQ0fhKmA4Gwt1cF7vC8VuZ1HSDrTRuj48h/qDeX/TzmOlTDXQ3uPtyuhyg/2rbZRzNhN8UFU4fSnQfXg==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "1.17.0",
+        "@shikijs/vscode-textmate": "^9.2.2"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/types/-/types-1.17.0.tgz",
+      "integrity": "sha512-Tvu2pA69lbpXB+MmgIaROP1tio8y0uYvKb5Foh3q0TJBTAJuaoa5eDEtS/0LquyveacsiVrYF4uEZILju+7Ybg==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^9.2.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "9.2.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/vscode-textmate/-/vscode-textmate-9.2.2.tgz",
+      "integrity": "sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg==",
+      "dev": true
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3397,6 +3448,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -3462,6 +3522,15 @@
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/mime": {
@@ -3540,6 +3609,12 @@
       "version": "0.2.6",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/tmp/-/tmp-0.2.6.tgz",
       "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -3844,12 +3919,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -4539,6 +4608,16 @@
       "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
       "inBundle": true
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
@@ -4560,6 +4639,26 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chevrotain": {
@@ -4693,6 +4792,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/concat-map": {
@@ -5204,6 +5313,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -6925,6 +7047,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/hast-util-to-html/-/hast-util-to-html-9.0.2.tgz",
+      "integrity": "sha512-RP5wNpj5nm1Z8cloDv4Sl4RS8jH5HYa0v93YB6Wb4poEzgMo/dAAL0KcT4974dCjcNG5pkLqTImeFHHCwwfY3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -6968,6 +7126,16 @@
       "inBundle": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/htmlparser2": {
@@ -9140,12 +9308,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "dev": true
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -9260,6 +9422,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "inBundle": true
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -9393,16 +9564,21 @@
         "node": ">=8"
       }
     },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
-      "engines": {
-        "node": ">= 12"
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -9411,11 +9587,38 @@
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "inBundle": true
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "inBundle": true
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -9490,6 +9693,95 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9894,6 +10186,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/oniguruma-to-js": {
+      "version": "0.3.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/oniguruma-to-js/-/oniguruma-to-js-0.3.3.tgz",
+      "integrity": "sha512-m90/WEhgs8g4BxG37+Nu3YrMfJDs2YXtYtIllhsEPR+wP3+K4EZk6dDUvy2v2K4MNFDDOYKL4/yqYPXDqyozTQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/optionator": {
@@ -10482,6 +10783,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "inBundle": true
     },
+    "node_modules/property-information": {
+      "version": "6.5.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/property-information/-/property-information-6.5.0.tgz",
+      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.3.0",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/protobufjs/-/protobufjs-7.3.0.tgz",
@@ -10534,6 +10845,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "inBundle": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10739,6 +11059,12 @@
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
+    },
+    "node_modules/regex": {
+      "version": "4.3.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/regex/-/regex-4.3.2.tgz",
+      "integrity": "sha512-kK/AA3A9K6q2js89+VMymcboLOlF5lZRCYJv3gzszXFHBr6kO6qLGzbm+UIugBEV8SMMKCTR59txoY6ctRHYVw==",
+      "dev": true
     },
     "node_modules/regexp-ast-analysis": {
       "version": "0.7.1",
@@ -11137,15 +11463,15 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/shiki/-/shiki-1.17.0.tgz",
+      "integrity": "sha512-VZf8cPShRwfzPcaswv81+YP7qJEoFwRT+Ehy6bizim7M0zG9bk8Egug550C+xS9g7rKIOPhzAlp2uEyuCxbk/A==",
       "dev": true,
       "dependencies": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
+        "@shikijs/core": "1.17.0",
+        "@shikijs/types": "1.17.0",
+        "@shikijs/vscode-textmate": "^9.2.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/side-channel": {
@@ -11254,6 +11580,16 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/spdx-correct": {
@@ -11437,6 +11773,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -12031,6 +12381,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
@@ -12300,30 +12660,58 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.25.12",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typedoc/-/typedoc-0.25.12.tgz",
-      "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
+      "version": "0.26.7",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typedoc/-/typedoc-0.26.7.tgz",
+      "integrity": "sha512-gUeI/Wk99vjXXMi8kanwzyhmeFEGv1LTdTQsiyIsmSYsBebvFxhbcyAx7Zjo4cMbpLGxM4Uz3jVIjksu/I2v6Q==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.3.0",
-        "minimatch": "^9.0.3",
-        "shiki": "^0.14.7"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "shiki": "^1.16.2",
+        "yaml": "^2.5.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typedoc/node_modules/yaml": {
+      "version": "2.5.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+      "version": "5.6.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "inBundle": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -12332,6 +12720,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -12389,6 +12783,74 @@
       "inBundle": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -12488,17 +12950,33 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
-    "node_modules/vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "dev": true
+    "node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.2",
@@ -12798,6 +13276,16 @@
       "inBundle": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "packages/jsts/src/rules": {
@@ -14941,6 +15429,57 @@
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@shikijs/core": {
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/core/-/core-1.17.0.tgz",
+      "integrity": "sha512-Mkk4Mp4bNnW1kytU8I7S5PK5teNSe0iKlfqxPss4sdwnlcU8a2N62Z3te2gVmZfU9t1HF6L3wyWuM43IvEeEsg==",
+      "dev": true,
+      "requires": {
+        "@shikijs/engine-javascript": "1.17.0",
+        "@shikijs/engine-oniguruma": "1.17.0",
+        "@shikijs/types": "1.17.0",
+        "@shikijs/vscode-textmate": "^9.2.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.2"
+      }
+    },
+    "@shikijs/engine-javascript": {
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/engine-javascript/-/engine-javascript-1.17.0.tgz",
+      "integrity": "sha512-EiBVlxmzJZdC2ypzn8k+vxLngbBNgHLS4RilwrFOABGRc72kUZubbD/6Chrq2RcVtD3yq1GtiiIdFMGd9BTX3Q==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "1.17.0",
+        "oniguruma-to-js": "0.3.3",
+        "regex": "4.3.2"
+      }
+    },
+    "@shikijs/engine-oniguruma": {
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/engine-oniguruma/-/engine-oniguruma-1.17.0.tgz",
+      "integrity": "sha512-nsXzJGLQ0fhKmA4Gwt1cF7vC8VuZ1HSDrTRuj48h/qDeX/TzmOlTDXQ3uPtyuhyg/2rbZRzNhN8UFU4fSnQfXg==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "1.17.0",
+        "@shikijs/vscode-textmate": "^9.2.2"
+      }
+    },
+    "@shikijs/types": {
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/types/-/types-1.17.0.tgz",
+      "integrity": "sha512-Tvu2pA69lbpXB+MmgIaROP1tio8y0uYvKb5Foh3q0TJBTAJuaoa5eDEtS/0LquyveacsiVrYF4uEZILju+7Ybg==",
+      "dev": true,
+      "requires": {
+        "@shikijs/vscode-textmate": "^9.2.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "@shikijs/vscode-textmate": {
+      "version": "9.2.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@shikijs/vscode-textmate/-/vscode-textmate-9.2.2.tgz",
+      "integrity": "sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg==",
+      "dev": true
+    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -15120,6 +15659,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -15184,6 +15732,15 @@
       "dev": true,
       "requires": {
         "@types/lodash": "*"
+      }
+    },
+    "@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "*"
       }
     },
     "@types/mime": {
@@ -15259,6 +15816,12 @@
       "version": "0.2.6",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/tmp/-/tmp-0.2.6.tgz",
       "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true
     },
     "@types/yargs": {
@@ -15464,12 +16027,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -15991,6 +16548,12 @@
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
       "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ=="
     },
+    "ccount": {
+      "version": "2.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
@@ -16005,6 +16568,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
+    },
+    "character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "dev": true
     },
     "chevrotain": {
@@ -16112,6 +16687,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -16464,6 +17045,15 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "devlop": {
+      "version": "1.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.0"
+      }
     },
     "diff": {
       "version": "4.0.2",
@@ -17762,6 +18352,34 @@
         "function-bind": "^1.1.2"
       }
     },
+    "hast-util-to-html": {
+      "version": "9.0.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/hast-util-to-html/-/hast-util-to-html-9.0.2.tgz",
+      "integrity": "sha512-RP5wNpj5nm1Z8cloDv4Sl4RS8jH5HYa0v93YB6Wb4poEzgMo/dAAL0KcT4974dCjcNG5pkLqTImeFHHCwwfY3g==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      }
+    },
+    "hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^3.0.0"
+      }
+    },
     "hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -17795,6 +18413,12 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
       "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ=="
+    },
+    "html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true
     },
     "htmlparser2": {
       "version": "9.1.0",
@@ -19449,12 +20073,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
-    "jsonc-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "dev": true
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -19538,6 +20156,15 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "locate-path": {
       "version": "6.0.0",
@@ -19648,21 +20275,52 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
-    "marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true
+    "markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      }
     },
     "mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg=="
     },
+    "mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      }
+    },
     "mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+    },
+    "mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -19717,6 +20375,45 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+      "dev": true
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "dev": true
+    },
+    "micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "dev": true
     },
     "micromatch": {
       "version": "4.0.8",
@@ -20003,6 +20700,12 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
+    },
+    "oniguruma-to-js": {
+      "version": "0.3.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/oniguruma-to-js/-/oniguruma-to-js-0.3.3.tgz",
+      "integrity": "sha512-m90/WEhgs8g4BxG37+Nu3YrMfJDs2YXtYtIllhsEPR+wP3+K4EZk6dDUvy2v2K4MNFDDOYKL4/yqYPXDqyozTQ==",
+      "dev": true
     },
     "optionator": {
       "version": "0.9.3",
@@ -20433,6 +21136,12 @@
         }
       }
     },
+    "property-information": {
+      "version": "6.5.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/property-information/-/property-information-6.5.0.tgz",
+      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "dev": true
+    },
     "protobufjs": {
       "version": "7.3.0",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/protobufjs/-/protobufjs-7.3.0.tgz",
@@ -20475,6 +21184,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true
     },
     "pure-rand": {
       "version": "6.0.4",
@@ -20628,6 +21343,12 @@
       "requires": {
         "@babel/runtime": "^7.8.4"
       }
+    },
+    "regex": {
+      "version": "4.3.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/regex/-/regex-4.3.2.tgz",
+      "integrity": "sha512-kK/AA3A9K6q2js89+VMymcboLOlF5lZRCYJv3gzszXFHBr6kO6qLGzbm+UIugBEV8SMMKCTR59txoY6ctRHYVw==",
+      "dev": true
     },
     "regexp-ast-analysis": {
       "version": "0.7.1",
@@ -20917,15 +21638,15 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shiki": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/shiki/-/shiki-1.17.0.tgz",
+      "integrity": "sha512-VZf8cPShRwfzPcaswv81+YP7qJEoFwRT+Ehy6bizim7M0zG9bk8Egug550C+xS9g7rKIOPhzAlp2uEyuCxbk/A==",
       "dev": true,
       "requires": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
+        "@shikijs/core": "1.17.0",
+        "@shikijs/types": "1.17.0",
+        "@shikijs/vscode-textmate": "^9.2.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "side-channel": {
@@ -21009,6 +21730,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.2.0",
@@ -21158,6 +21885,16 @@
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      }
+    },
+    "stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "requires": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
       }
     },
     "strip-ansi": {
@@ -21595,6 +22332,12 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
@@ -21768,21 +22511,45 @@
       }
     },
     "typedoc": {
-      "version": "0.25.12",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typedoc/-/typedoc-0.25.12.tgz",
-      "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
+      "version": "0.26.7",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typedoc/-/typedoc-0.26.7.tgz",
+      "integrity": "sha512-gUeI/Wk99vjXXMi8kanwzyhmeFEGv1LTdTQsiyIsmSYsBebvFxhbcyAx7Zjo4cMbpLGxM4Uz3jVIjksu/I2v6Q==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.3.0",
-        "minimatch": "^9.0.3",
-        "shiki": "^0.14.7"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "shiki": "^1.16.2",
+        "yaml": "^2.5.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "yaml": {
+          "version": "2.5.1",
+          "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/yaml/-/yaml-2.5.1.tgz",
+          "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+          "dev": true
+        }
       }
     },
     "typescript": {
-      "version": "5.4.3",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg=="
+      "version": "5.6.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw=="
+    },
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -21823,6 +22590,54 @@
       "version": "2.1.0",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w=="
+    },
+    "unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      }
     },
     "universalify": {
       "version": "2.0.1",
@@ -21893,17 +22708,25 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
-    "vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
+    "vfile": {
+      "version": "6.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      }
     },
-    "vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "dev": true
+    "vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      }
     },
     "vue-eslint-parser": {
       "version": "9.4.2",
@@ -22134,6 +22957,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ts-jest": "29.1.2",
     "ts-node": "10.9.2",
     "type-fest": "4.21.0",
-    "typedoc": "0.25.12"
+    "typedoc": "0.26.7"
   },
   "dependencies": {
     "@babel/core": "7.24.3",
@@ -118,7 +118,7 @@
     "stylelint": "15.10.0",
     "tar": "6.2.1",
     "tmp": "0.2.3",
-    "typescript": "5.4.3",
+    "typescript": "5.6.2",
     "vue-eslint-parser": "9.4.2",
     "yaml": "2.4.1"
   },

--- a/packages/jsts/tests/program/program.test.ts
+++ b/packages/jsts/tests/program/program.test.ts
@@ -43,12 +43,10 @@ describe('program', () => {
     const { programId, files, projectReferences } = createAndSaveProgram(tsConfig);
 
     expect(programId).toBeDefined();
-    expect(files).toEqual(
-      expect.arrayContaining([
-        toUnixPath(path.join(fixtures, 'file.ts')),
-        toUnixPath(path.join(reference, 'file.ts')),
-      ]),
-    );
+    expect(files).toContain(toUnixPath(path.join(fixtures, 'file.ts')));
+    // behavior changed in TS 5.5, program will no longer include files from referenced projects
+    expect(files).not.toContain(toUnixPath(path.join(reference, 'file.ts')));
+
     expect(projectReferences).toEqual([path.join(reference, 'tsconfig.json')]);
   });
 
@@ -177,8 +175,11 @@ describe('program', () => {
     const program = getProgramById(programId);
 
     expect(program.getCompilerOptions().configFilePath).toEqual(toUnixPath(tsConfig));
-    expect(program.getRootFileNames()).toEqual(
-      files.map(toUnixPath).filter(file => file.startsWith(toUnixPath(fixtures))),
+    // behavior in TS 5.5 changed, program will no longer include files from referenced projects
+    expect(program.getSourceFiles().map(s => s.fileName)).toEqual(
+      expect.arrayContaining(
+        files.map(toUnixPath).filter(file => file.startsWith(toUnixPath(fixtures))),
+      ),
     );
   });
 


### PR DESCRIPTION
Behavior wrt. project references has changed. Previously, if a project overlapped with the referenced project, it would include the files of the referenced project regardless. Now, the files from the referenced project are not included. This is better for us since it avoids analyzing the files duplicitly.