### PR TITLE
JS-238 Fix response.ast serialization with node 20.13

### DIFF
--- a/packages/bridge/src/worker.js
+++ b/packages/bridge/src/worker.js
@@ -226,7 +226,7 @@ if (parentPort) {
 
 function sendFormData(result, response) {
   const fd = new formData();
-  fd.append('ast', Buffer.from(result.ast));
+  fd.append('ast', Buffer.from(result.ast), { filename: 'ast' });
   delete result.ast;
   fd.append('json', JSON.stringify(result));
   // this adds the boundary string that will be used to separate the parts

--- a/packages/bridge/tests/router.test.ts
+++ b/packages/bridge/tests/router.test.ts
@@ -134,7 +134,7 @@ describe('router', () => {
         message: `Use a regular expression literal instead of the 'RegExp' constructor.`,
       }),
     );
-    expect(response.get('ast')).toBeInstanceOf(File);
+    expect(response.get('ast')).toBeInstanceOf(Blob);
     const ast = response.get('ast') as File;
     const buffer = Buffer.from(await ast.arrayBuffer());
     const protoMessage = deserializeProtobuf(buffer);

--- a/packages/bridge/tests/router.test.ts
+++ b/packages/bridge/tests/router.test.ts
@@ -134,6 +134,7 @@ describe('router', () => {
         message: `Use a regular expression literal instead of the 'RegExp' constructor.`,
       }),
     );
+    expect(response.get('ast')).toBeInstanceOf(File);
     const ast = response.get('ast') as File;
     const buffer = Buffer.from(await ast.arrayBuffer());
     const protoMessage = deserializeProtobuf(buffer);


### PR DESCRIPTION
I narrowed this down to a regression between 20.12.2 -> 20.13.0, but I was not able to find it in the changelog.
With this update, we are now receiving a "File" object consistently.