### PR TITLE
JS-231 Deprecate the analyzer property sonar.nodejs.forceHost

### DIFF
--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommandBuilderImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommandBuilderImpl.java
@@ -265,7 +265,16 @@ public class NodeCommandBuilderImpl implements NodeCommandBuilder {
   }
 
   private static boolean isForceHost(Configuration configuration) {
-    return configuration.getBoolean(NODE_FORCE_HOST_PROPERTY).orElse(configuration.getBoolean(SKIP_NODE_PROVISIONING_PROPERTY).orElse(false));
+    var forceHost = configuration.getBoolean(NODE_FORCE_HOST_PROPERTY);
+    if (forceHost.isPresent()) {
+      LOG.warn(
+        "Property '{}' is deprecated and will be removed in a future version. Please use '{}' instead.",
+        NODE_FORCE_HOST_PROPERTY,
+        SKIP_NODE_PROVISIONING_PROPERTY
+      );
+      return forceHost.get();
+    }
+    return configuration.getBoolean(SKIP_NODE_PROVISIONING_PROPERTY).orElse(false);
   }
 
   private String locateNodeOnMac() throws IOException {

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/nodejs/NodeCommandTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/nodejs/NodeCommandTest.java
@@ -453,6 +453,25 @@ class NodeCommandTest {
       .contains("Forcing to use Node.js from the host.");
   }
 
+  @Test
+  void test_node_force_host_property_deprecation() throws Exception {
+    var forceHostProp = "sonar.nodejs.forceHost";
+    var settings = new MapSettings();
+    settings.setProperty(forceHostProp, true);
+
+    builder()
+      .configuration(settings.asConfig())
+      .script("script.js")
+      .pathResolver(getPathResolver())
+      .build();
+
+    assertThat(logTester.logs(Level.WARN))
+      .contains(
+        "Property 'sonar.nodejs.forceHost' is deprecated and will be removed in a future version. " +
+        "Please use 'sonar.scanner.skipNodeProvisioning' instead."
+      );
+  }
+
   private static String resourceScript(String script) throws URISyntaxException {
     return new File(NodeCommandTest.class.getResource("/" + script).toURI()).getAbsolutePath();
   }


### PR DESCRIPTION
This branch depends on #4820, which should be reviewed first.