### PR TITLE
JS-67 Fix FP S4782 (`no-redundant-optional`): Ignore when "exactOptionalPropertyTypes" is enabled

### DIFF
--- a/packages/jsts/src/rules/S4782/fixtures/index.ts
+++ b/packages/jsts/src/rules/S4782/fixtures/index.ts
@@ -1,0 +1,1 @@
+// intentionally left empty

--- a/packages/jsts/src/rules/S4782/fixtures/tsconfig.json
+++ b/packages/jsts/src/rules/S4782/fixtures/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "exactOptionalPropertyTypes": true
+  }
+}

--- a/packages/jsts/src/rules/S4782/rule.ts
+++ b/packages/jsts/src/rules/S4782/rule.ts
@@ -33,6 +33,11 @@ export const rule: Rule.RuleModule = {
       return {};
     }
 
+    const compilerOptions = context.sourceCode.parserServices.program.getCompilerOptions();
+    if (compilerOptions.exactOptionalPropertyTypes) {
+      return {};
+    }
+
     function checkProperty(node: estree.Node) {
       const tsNode = node as TSESTree.Node as
         | TSESTree.PropertyDefinition

--- a/packages/jsts/src/rules/S4782/unit.test.ts
+++ b/packages/jsts/src/rules/S4782/unit.test.ts
@@ -19,6 +19,8 @@
  */
 import { TypeScriptRuleTester } from '../../../tests/tools';
 import { rule } from './';
+import { RuleTester } from 'eslint';
+import path from 'path';
 
 const ruleTester = new TypeScriptRuleTester();
 ruleTester.run(
@@ -222,3 +224,23 @@ ruleTester.run(
     ],
   },
 );
+
+const noopRuleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    project: `tsconfig.json`,
+    tsconfigRootDir: path.join(__dirname, 'fixtures'),
+  },
+});
+
+noopRuleTester.run('S4782 becomes noop when exactOptionalPropertyTypes is enabled', rule, {
+  valid: [
+    {
+      code: 'interface T { p?: string | undefined; }',
+      filename: path.join(__dirname, 'fixtures', 'index.ts'),
+    },
+  ],
+  invalid: [],
+});


### PR DESCRIPTION
Please have a look also at this [RSPEC change](https://github.com/SonarSource/rspec/pull/4275), where I mention the behavior of the rule if `exactOptionalPropertyTypes` is enabled.

Note that I leave the update of the HTML rule description for when we run the rule-api tool before the next release.