### PR TITLE
JS-70 More descriptive log when extracting node fails

### DIFF
--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
@@ -201,7 +201,15 @@ public class EmbeddedNode {
       LOG.debug("Deployed node version {}", detected);
       isAvailable = true;
     } catch (Exception e) {
-      LOG.warn("Embedded Node.js failed to deploy. Will fallback to host Node.js.", e);
+      LOG.warn("""
+        Embedded Node.js failed to deploy in {}.
+        You can change the location by setting the option `sonar.userHome` or the environment variable `SONAR_USER_HOME`.
+        Otherwise, it will default to {}.
+        Will fallback to host Node.js.""",
+        Environment.defaultSonarUserHome(),
+        deployLocation,
+        e
+      );
     }
   }
 

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/Environment.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/Environment.java
@@ -49,12 +49,16 @@ public class Environment {
       .of(
         configuration.get("sonar.userHome").orElse(null),
         System.getenv("SONAR_USER_HOME"),
-        System.getProperty("user.home") + File.separator + ".sonar"
+        defaultSonarUserHome()
       )
       .filter(Objects::nonNull)
       .findFirst()
       .map(Path::of)
       .get();
+  }
+
+  public static String defaultSonarUserHome() {
+    return System.getProperty("user.home") + File.separator + ".sonar";
   }
 
   public String getOsName() {

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/EmbeddedNodeTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/EmbeddedNodeTest.java
@@ -179,7 +179,7 @@ class EmbeddedNodeTest {
     en.deploy();
     assertThat(logTester.logs())
       .anyMatch(l ->
-        l.startsWith("Embedded Node.js failed to deploy. Will fallback to host Node.js")
+        l.startsWith("Embedded Node.js failed to deploy in ") && l.contains("You can change the location by setting the option `sonar.userHome` or the environment variable `SONAR_USER_HOME`.") && l.endsWith("Will fallback to host Node.js.")
       );
   }
 

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/EmbeddedNodeTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/EmbeddedNodeTest.java
@@ -179,7 +179,9 @@ class EmbeddedNodeTest {
     en.deploy();
     assertThat(logTester.logs())
       .anyMatch(l ->
-        l.startsWith("Embedded Node.js failed to deploy in ") && l.contains("You can change the location by setting the option `sonar.userHome` or the environment variable `SONAR_USER_HOME`.") && l.endsWith("Will fallback to host Node.js.")
+        l.startsWith("Embedded Node.js failed to deploy in ") &&
+          l.contains("You can change the location by setting the option `sonar.userHome` or the environment variable `SONAR_USER_HOME`.") &&
+          l.endsWith("Will fallback to host Node.js.")
       );
   }
 


### PR DESCRIPTION
Hopefully, this allows the user to optimally set the location of the node deployment in their project. This isn't documented in the docs, so maybe the logs will help.