### PR TITLE
chore(eslint-plugin-sonarjs): add missing @typescript-eslint/parser dependency

### DIFF
--- a/packages/jsts/src/rules/package.json
+++ b/packages/jsts/src/rules/package.json
@@ -44,6 +44,7 @@
     "@babel/preset-react": "7.24.7",
     "@eslint-community/regexpp": "4.11.1",
     "@typescript-eslint/eslint-plugin": "7.16.1",
+    "@typescript-eslint/parser": "^7.18.0",
     "@typescript-eslint/utils": "^7.16.1",
     "builtin-modules": "3.3.0",
     "bytes": "3.1.2",


### PR DESCRIPTION
For `eslint-plugin-sonarjs`, fix issue missing transitive peer dependency `@typescript-eslint/parser` for `@typescript-eslint/eslint-plugin`.

After `eslint-plugin-sonarjs` is installed, with `yarn explain peer-requirements`:

```console
p72bb8 → ✓ eslint-plugin-sonarjs@npm:2.0.2 [0f3ca] provides @babel/core@npm:7.24.3 to @babel/eslint-parser@npm:7.24.1 [49e17] and 92 other dependencies
p6eeed → ✓ eslint-plugin-sonarjs@npm:2.0.2 [0f3ca] doesn't provide @types/babel__core to @babel/eslint-parser@npm:7.24.1 [49e17] and 92 other dependencies
p5afe6 → ✓ eslint-plugin-sonarjs@npm:2.0.2 [0f3ca] doesn't provide @types/typescript to @typescript-eslint/eslint-plugin@npm:7.16.1 [49e17] and 5 other dependencies
peb354 → ✓ eslint-plugin-sonarjs@npm:2.0.2 [0f3ca] doesn't provide @types/typescript-eslint__parser to @typescript-eslint/eslint-plugin@npm:7.16.1 [49e17] and 2 other dependencies
p6c73a → ✘ eslint-plugin-sonarjs@npm:2.0.2 [0f3ca] provides @typescript-eslint/parser@npm:8.6.0 [0f3ca] to @typescript-eslint/eslint-plugin@npm:7.16.1 [49e17] and 2 other dependencies
pb1c15 → ✓ eslint-plugin-sonarjs@npm:2.0.2 [0f3ca] provides typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07 to @typescript-eslint/eslint-plugin@npm:7.16.1 [49e17] and 5 other dependencies
```

There is an article written by author of yarn package manager: [Implicit Transitive Peer Dependencies](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0)

### Note
Please run `npm i --lockfile-version 3` to update `packages\jsts\src\rules\package-lock.json`