### PR TITLE
!chore: use react and vue dependencies as optional

### DIFF
--- a/packages/jsts/src/linter/config/linter-config.ts
+++ b/packages/jsts/src/linter/config/linter-config.ts
@@ -53,9 +53,12 @@ export function createLinterConfig(
     globals,
     parserOptions,
     rules: {},
-    /* using "max" version to prevent `eslint-plugin-react` from printing a warning */
-    settings: { react: { version: '999.999.999' } },
   };
+  try {
+    require.resolve('eslint-plugin-react');
+    /* using "max" version to prevent `eslint-plugin-react` from printing a warning */
+    config.settings = { react: { version: '999.999.999' } };
+  } catch {}
   enableRules(config, inputRules, linterRules);
   enableInternalCustomRules(config);
   return config;

--- a/packages/jsts/src/linter/quickfixes/rules.ts
+++ b/packages/jsts/src/linter/quickfixes/rules.ts
@@ -76,9 +76,18 @@ export const quickFixRules = new Set([
   'S1264',
 
   // eslint-plugin-react
-  'S6754',
-  'S6479',
-  'S6747',
+  ...(() => {
+    try {
+      require.resolve('eslint-plugin-react');
+      return [
+        'S6754',
+        'S6479',
+        'S6747',
+      ];
+    } catch {
+      return [];
+    }
+  })(),
 
   // @typescript-eslint plugin
   'S6568',

--- a/packages/jsts/src/parsers/options.ts
+++ b/packages/jsts/src/parsers/options.ts
@@ -71,13 +71,19 @@ export function buildParserOptions(initialOptions: Linter.ParserOptions, usingBa
  */
 function babelParserOptions(options: Linter.ParserOptions) {
   const pluginPath = `${__dirname}/../../../../node_modules`;
+  const presets = [
+    `${pluginPath}/@babel/preset-flow`,
+    `${pluginPath}/@babel/preset-env`,
+  ];
+
+  try {
+    require.resolve('@babel/preset-react');
+    presets.push(`${pluginPath}/@babel/preset-react`);
+  } catch {}
+
   const babelOptions = {
     targets: 'defaults',
-    presets: [
-      `${pluginPath}/@babel/preset-react`,
-      `${pluginPath}/@babel/preset-flow`,
-      `${pluginPath}/@babel/preset-env`,
-    ],
+    presets,
     plugins: [[`${pluginPath}/@babel/plugin-proposal-decorators`, { version: '2022-03' }]],
     babelrc: false,
     configFile: false,

--- a/packages/jsts/src/rules/S125/rule.ts
+++ b/packages/jsts/src/rules/S125/rule.ts
@@ -146,6 +146,13 @@ function containsCode(value: string) {
     return false;
   }
 
+  const presets = [`@babel/preset-flow`, `@babel/preset-env`];
+
+  try {
+    require.resolve('@babel/preset-react');
+    presets.push(`@babel/preset-react`);
+  } catch {}
+
   try {
     const result = babel.parse(value, {
       filename: 'some/filePath',
@@ -164,7 +171,7 @@ function containsCode(value: string) {
       requireConfigFile: false,
       babelOptions: {
         targets: 'defaults',
-        presets: [`@babel/preset-react`, `@babel/preset-flow`, `@babel/preset-env`],
+        presets,
         plugins: [[`@babel/plugin-proposal-decorators`, { version: '2022-03' }]],
         babelrc: false,
         configFile: false,

--- a/packages/jsts/src/rules/external.ts
+++ b/packages/jsts/src/rules/external.ts
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { eslintRules } from './core';
-import { rules as reactPluginRules } from 'eslint-plugin-react';
 import { tsEslintRules } from './typescript-eslint';
 import { rules as a11yPluginRules } from 'eslint-plugin-jsx-a11y';
 import { rules as importPluginRules } from 'eslint-plugin-import';
@@ -72,9 +71,34 @@ export const rules = {
   S4325: tsEslintRules['no-unnecessary-type-assertion'],
   S4326: eslintRules['no-return-await'],
   S6325: eslintRules['prefer-regex-literals'],
-  S6435: reactPluginRules['require-render-return'],
-  S6438: reactPluginRules['jsx-no-comment-textnodes'],
-  S6480: reactPluginRules['jsx-no-bind'],
+  ...await (async () => {
+    try {
+      require.resolve('eslint-plugin-react');
+      const { rules: reactPluginRules } = await import('eslint-plugin-react');
+      return {
+        S6435: reactPluginRules['require-render-return'],
+        S6438: reactPluginRules['jsx-no-comment-textnodes'],
+        S6480: reactPluginRules['jsx-no-bind'],
+        S6746: reactPluginRules['no-direct-mutation-state'],
+        S6748: reactPluginRules['no-children-prop'],
+        S6750: reactPluginRules['no-render-return-value'],
+        S6756: reactPluginRules['no-access-state-in-setstate'],
+        S6757: reactPluginRules['no-this-in-sfc'],
+        S6761: reactPluginRules['no-danger-with-children'],
+        S6763: reactPluginRules['no-redundant-should-component-update'],
+        S6766: reactPluginRules['no-unescaped-entities'],
+        S6767: reactPluginRules['no-unused-prop-types'],
+        S6770: reactPluginRules['jsx-pascal-case'],
+        S6772: reactPluginRules['jsx-child-element-spacing'],
+        S6774: reactPluginRules['prop-types'],
+        S6775: reactPluginRules['default-props-match-prop-types'],
+        S6789: reactPluginRules['no-is-mounted'],
+        S6790: reactPluginRules['no-string-refs'],
+      };
+    } catch {
+      return {};
+    }
+  })(),
   S6509: eslintRules['no-extra-boolean-cast'],
   S6522: eslintRules['no-import-assign'],
   S6523: eslintRules['no-unsafe-optional-chaining'],
@@ -96,21 +120,6 @@ export const rules = {
   S6654: eslintRules['no-proto'],
   S6657: eslintRules['no-octal-escape'],
   S6671: tsEslintRules['prefer-promise-reject-errors'],
-  S6746: reactPluginRules['no-direct-mutation-state'],
-  S6748: reactPluginRules['no-children-prop'],
-  S6750: reactPluginRules['no-render-return-value'],
-  S6756: reactPluginRules['no-access-state-in-setstate'],
-  S6757: reactPluginRules['no-this-in-sfc'],
-  S6761: reactPluginRules['no-danger-with-children'],
-  S6763: reactPluginRules['no-redundant-should-component-update'],
-  S6766: reactPluginRules['no-unescaped-entities'],
-  S6767: reactPluginRules['no-unused-prop-types'],
-  S6770: reactPluginRules['jsx-pascal-case'],
-  S6772: reactPluginRules['jsx-child-element-spacing'],
-  S6774: reactPluginRules['prop-types'],
-  S6775: reactPluginRules['default-props-match-prop-types'],
-  S6789: reactPluginRules['no-is-mounted'],
-  S6790: reactPluginRules['no-string-refs'],
   S6793: a11yPluginRules['aria-proptypes'],
   S6807: a11yPluginRules['role-has-required-aria-props'],
   S6811: a11yPluginRules['role-supports-aria-props'],

--- a/packages/jsts/src/rules/package.json
+++ b/packages/jsts/src/rules/package.json
@@ -32,7 +32,25 @@
     "lib"
   ],
   "peerDependencies": {
-    "eslint": "^8.0.0 || ^9.0.0"
+    "@babel/preset-react": "7.0.0",
+    "eslint": "^8.0.0 || ^9.0.0",
+    "eslint-plugin-react": "^7.0.0",
+    "eslint-plugin-react-hooks": "4.0.0",
+    "vue-eslint-parser": "9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@babel/preset-react": {
+      "optional": true
+    },
+    "eslint-plugin-react": {
+      "optional": true
+    },
+    "eslint-plugin-react-hooks": {
+      "optional": true
+    },
+    "vue-eslint-parser": {
+      "optional": true
+    }
   },
   "homepage": "https://github.com/SonarSource/SonarJS#readme",
   "dependencies": {
@@ -41,7 +59,6 @@
     "@babel/plugin-proposal-decorators": "7.24.7",
     "@babel/preset-env": "7.25.4",
     "@babel/preset-flow": "7.24.7",
-    "@babel/preset-react": "7.24.7",
     "@eslint-community/regexpp": "4.11.1",
     "@typescript-eslint/eslint-plugin": "7.16.1",
     "@typescript-eslint/utils": "^7.16.1",
@@ -49,18 +66,16 @@
     "bytes": "3.1.2",
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
-    "eslint-plugin-react": "^7.36.1",
-    "eslint-plugin-react-hooks": "4.6.2",
     "eslint-scope": "8.0.2",
     "functional-red-black-tree": "1.0.1",
     "jsx-ast-utils": "^3.3.5",
     "minimatch": "^9.0.3",
     "scslre": "0.3.0",
     "semver": "7.6.3",
-    "typescript": "*",
-    "vue-eslint-parser": "9.4.3"
+    "typescript": "*"
   },
   "devDependencies": {
+    "@babel/preset-react": "7.24.7",
     "@types/bytes": "3.1.4",
     "@types/eslint": "8.56.10",
     "@types/eslint-scope": "3.7.7",
@@ -68,7 +83,10 @@
     "@types/node": "20.11.30",
     "@types/semver": "7.5.8",
     "eslint-doc-generator": "1.7.1",
+    "eslint-plugin-react": "^7.36.1",
+    "eslint-plugin-react-hooks": "4.6.2",
     "json-schema-to-ts": "3.1.1",
-    "type-fest": "4.26.1"
+    "type-fest": "4.26.1",
+    "vue-eslint-parser": "9.4.3"
   }
 }


### PR DESCRIPTION
Change to option peer dependencies:
- @babel/preset-react
- eslint-plugin-react
- eslint-plugin-react-hooks
- vue-eslint-parser

### Note
Please run `npm i --lockfile-version 3` to update `packages\jsts\src\rules\package-lock.json`