### PR TITLE
Resolve false postive in S5693 for multer storage engine init

### DIFF
--- a/packages/jsts/src/rules/S5693/rule.ts
+++ b/packages/jsts/src/rules/S5693/rule.ts
@@ -130,6 +130,10 @@ function checkFormidable(context: Rule.RuleContext, callExpression: estree.CallE
 }
 
 function checkMulter(context: Rule.RuleContext, callExpression: estree.CallExpression) {
+  if (callExpression.callee.type === 'MemberExpression') {
+    return;
+  }
+
   if (callExpression.arguments.length === 0) {
     report(context, callExpression.callee);
     return;

--- a/packages/jsts/src/rules/S5693/unit.test.ts
+++ b/packages/jsts/src/rules/S5693/unit.test.ts
@@ -36,6 +36,14 @@ ruleTester.run('Allowing requests with excessive content length is security-sens
       code: `
       const multer = require('multer');
       const upload = multer(options);
+      const storage = multer.diskStorage({
+        destination: function (req, file, cb) {
+          cb(null, '/tmp/my-uploads')
+        },
+        filename: function (req, file, cb) {
+          cb(null, file.fieldname)
+        }
+      });
         `,
       options,
     },


### PR DESCRIPTION
The express multer middleware module has several member exports in addition to the main export. This change fixes the logic in S5693 so that it doesn't check for the content length limit parameter being passed to those members, since it's not applicable.

Googled a bit and have seen several folks in the community stumped by this false positive, e.g. https://stackoverflow.com/questions/76305839/sonar-security-warning-for-multer-express-js
