### PR TITLE
Update Apache commons-io to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
+        <version>2.17.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
Avoid SCA noise from CVE-2024-47554 - we are not vulnerable