### PR TITLE
JS-362 Enable SonarJaRED to consume SonarJS ASTs without SonarArmor

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractAnalysis.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractAnalysis.java
@@ -102,7 +102,7 @@ abstract class AbstractAnalysis {
         LOG.debug("Analyzing file: {}", file.uri());
         progressReport.nextFile(file.toString());
         var fileContent = contextUtils.shouldSendFileContent(file) ? file.contents() : null;
-        var skipAst = !consumers.hasConsumers() || !contextUtils.isSonarArmorEnabled();
+        var skipAst = !consumers.hasConsumers() || !(contextUtils.isSonarArmorEnabled() || contextUtils.isSonarJaredEnabled());
         var request = getJsAnalysisRequest(file, fileContent, tsProgram, tsConfigs, skipAst);
 
         var response = isJavaScript(file)

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/ContextUtils.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/ContextUtils.java
@@ -30,6 +30,9 @@ class ContextUtils {
   /* Internal property to enable Armor (disabled by default) */
   private static final String ARMOR_INTERNAL_ENABLED = "sonar.armor.internal.enabled";
 
+  /* Internal property to enable JaRED (disabled by default) */
+  private static final String JARED_INTERNAL_ENABLED = "sonar.jared.internal.enabled";
+
   private final SensorContext context;
 
   ContextUtils(SensorContext context) {
@@ -65,5 +68,9 @@ class ContextUtils {
 
   boolean isSonarArmorEnabled() {
     return context.config().getBoolean(ARMOR_INTERNAL_ENABLED).orElse(false);
+  }
+
+  boolean isSonarJaredEnabled() {
+    return context.config().getBoolean(JARED_INTERNAL_ENABLED).orElse(false);
   }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
@@ -402,6 +402,24 @@ class JsTsSensorTest {
   }
 
   @Test
+  void should_not_send_the_skipAst_flag_when_jared_is_enabled() throws Exception {
+    var ctx = createSensorContext(baseDir);
+    ctx.setSettings(new MapSettings().setProperty("sonar.jared.internal.enabled", "true"));
+    var inputFile = createInputFile(ctx);
+    var tsProgram = new TsProgram("1", List.of(inputFile.absolutePath()), List.of());
+    var consumer = createConsumer();
+    var sensor = createSensorWithConsumer(consumer);
+    when(bridgeServerMock.createProgram(any())).thenReturn(tsProgram);
+    when(bridgeServerMock.analyzeTypeScript(any())).thenReturn(new AnalysisResponse());
+    sensor.execute(ctx);
+
+    createSensor().execute(context);
+    var captor = ArgumentCaptor.forClass(JsAnalysisRequest.class);
+    verify(bridgeServerMock).analyzeTypeScript(captor.capture());
+    assertThat(captor.getValue().skipAst()).isFalse();
+  }
+
+  @Test
   void should_send_the_skipAst_flag_when_there_are_consumers_but_armor_is_disabled() throws Exception {
     var ctx = createSensorContext(baseDir);
     ctx.setSettings(new MapSettings().setProperty("sonar.armor.internal.enabled", "false"));


### PR DESCRIPTION
I suggest we move forward with this change for now. There is no reason for JaRED to depend on Armor.
However, let's raise the topic of the relevance of these properties on the next weekly.