### PR TITLE
JS-391 Babel presets as package names instead of paths

### DIFF
--- a/packages/jsts/src/parsers/options.ts
+++ b/packages/jsts/src/parsers/options.ts
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { Linter } from 'eslint';
-import { default as babelFlowPreset } from '@babel/preset-flow';
-import { default as babelReactPreset } from '@babel/preset-react';
-import { default as babelEnvPreset } from '@babel/preset-env';
-import babelDecoratorProposalPlugin from '@babel/plugin-proposal-decorators';
 
 /**
  * Builds ESLint parser options
@@ -76,8 +72,12 @@ export function buildParserOptions(initialOptions: Linter.ParserOptions, usingBa
 function babelParserOptions(options: Linter.ParserOptions) {
   const babelOptions = {
     targets: 'defaults',
-    presets: [babelReactPreset, babelFlowPreset, babelEnvPreset],
-    plugins: [[babelDecoratorProposalPlugin, { version: '2022-03' }]],
+    presets: [
+      ['@babel/preset-react', {}],
+      ['@babel/preset-flow', {}],
+      ['@babel/preset-env', {}],
+    ],
+    plugins: [['@babel/plugin-proposal-decorators', { version: '2022-03' }]],
     babelrc: false,
     configFile: false,
     parserOpts: {

--- a/packages/jsts/src/parsers/options.ts
+++ b/packages/jsts/src/parsers/options.ts
@@ -18,8 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { Linter } from 'eslint';
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { default as babelFlowPreset } from '@babel/preset-flow';
+import { default as babelReactPreset } from '@babel/preset-react';
+import { default as babelEnvPreset } from '@babel/preset-env';
+import babelDecoratorProposalPlugin from '@babel/plugin-proposal-decorators';
 
 /**
  * Builds ESLint parser options
@@ -72,15 +74,10 @@ export function buildParserOptions(initialOptions: Linter.ParserOptions, usingBa
  * @returns the extend parser options
  */
 function babelParserOptions(options: Linter.ParserOptions) {
-  const pluginPath = `${dirname(fileURLToPath(import.meta.url))}/../../../../node_modules`;
   const babelOptions = {
     targets: 'defaults',
-    presets: [
-      `${pluginPath}/@babel/preset-react`,
-      `${pluginPath}/@babel/preset-flow`,
-      `${pluginPath}/@babel/preset-env`,
-    ],
-    plugins: [[`${pluginPath}/@babel/plugin-proposal-decorators`, { version: '2022-03' }]],
+    presets: [babelReactPreset, babelFlowPreset, babelEnvPreset],
+    plugins: [[babelDecoratorProposalPlugin, { version: '2022-03' }]],
     babelrc: false,
     configFile: false,
     parserOpts: {

--- a/packages/jsts/tests/parsers/fixtures/parse/valid.js
+++ b/packages/jsts/tests/parsers/fixtures/parse/valid.js
@@ -1,1 +1,2 @@
 'howdy';
+const a = <bla></bla>;

--- a/packages/jsts/tests/parsers/parse.test.ts
+++ b/packages/jsts/tests/parsers/parse.test.ts
@@ -37,6 +37,20 @@ const parseFunctions = [
 ];
 
 describe('parseForESLint', () => {
+  it(`Babel should fail parsing input with JSX without the React preset`, async () => {
+    const filePath = path.join(import.meta.dirname, 'fixtures', 'parse', 'valid.js');
+    const fileContent = await readFile(filePath);
+    const fileType = 'MAIN';
+
+    const input = { filePath, fileType, fileContent } as JsTsAnalysisInput;
+    const options = buildParserOptions(input, true);
+    options.babelOptions.presets.shift();
+
+    expect(() => parseForESLint(fileContent, parseFunctions[0].parser.parse, options)).toThrow(
+      APIError.parsingError('Unexpected token (2:15)', { line: 2 }),
+    );
+  });
+
   parseFunctions.forEach(({ parser, usingBabel, errorMessage }) => {
     it(`should parse a valid input with ${parser.parser}`, async () => {
       const filePath = path.join(import.meta.dirname, 'fixtures', 'parse', 'valid.js');


### PR DESCRIPTION
[JS-391](https://sonarsource.atlassian.net/browse/JS-391)



[JS-391]: https://sonarsource.atlassian.net/browse/JS-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ