### PR TITLE
BUILD-6583: migrate from CirrusCI-8 cluster

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
 load("github.com/SonarSource/cirrus-modules@v3", "load_features")
 
 def main(ctx):
-    return load_features(ctx, aws=dict(cluster_name="CirrusCI-8"))
+    return load_features(ctx)

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBasedRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/EslintBasedRulesTest.java
@@ -257,7 +257,7 @@ class EslintBasedRulesTest {
     assertThat(buildResult.isSuccess()).isTrue();
     assertThat(buildResult.getLogs()).contains("Configured Node.js --max-old-space-size=500000.");
     var osMem = Pattern.compile(
-      ".*Memory configuration: OS \\(\\d+ MB\\), Node.js \\(\\d+ MB\\)\\..*",
+      ".*Memory configuration: OS \\(\\d+ MB\\),.*",
       Pattern.DOTALL
     );
     assertThat(buildResult.getLogs()).matches(osMem);


### PR DESCRIPTION
[BUILD-6583](https://sonarsource.atlassian.net/browse/BUILD-6583)

As the Development Infrastructure Squad has migrated all the workload out of the Docker In Docker implementation now we are getting rid of the CirrusCI-8 build Cluster (it will be decommissioned). As the Cirrus Modules v3 is pointing to the latest up-to-date Cluster, we are requesting all users to update!

This repository CirrusCI tasks has been specifically pinned to the CirrusCI-8 Cluster, removing the specification, defaults to the latest settings.


[BUILD-6583]: https://sonarsource.atlassian.net/browse/BUILD-6583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ