### PR TITLE
JS-390 Refactor HTTP layer in BridgeServerImpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,16 +188,7 @@
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents.client5</groupId>
-        <artifactId>httpclient5</artifactId>
-        <version>5.4</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5</artifactId>
-        <version>5.3</version>
-      </dependency>
+
 
       <!-- Test dependencies -->
       <dependency>

--- a/sonar-plugin/bridge/pom.xml
+++ b/sonar-plugin/bridge/pom.xml
@@ -43,14 +43,6 @@
       <groupId>org.tukaani</groupId>
       <artifactId>xz</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents.client5</groupId>
-      <artifactId>httpclient5</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents.core5</groupId>
-      <artifactId>httpcore5</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -153,31 +153,7 @@ public class BridgeServerImpl implements BridgeServer {
     this.heartbeatService = Executors.newSingleThreadScheduledExecutor();
     this.embeddedNode = embeddedNode;
     this.http = http;
-    silenceHttpClientLogs();
   }
-
-  private static void silenceHttpClientLogs() {
-    setLoggerLevelToInfo("org.apache.hc");
-  }
-
-  /**
-   * This method sets the log level of the logger with the given name to INFO.
-   * It assumes that SLF4J is used as the logging facade and Logback as the logging implementation.
-   * Since we don't want to directly depend on logback, we use reflection to set the log level.
-   * @param loggerName
-   */
-  private static void setLoggerLevelToInfo(String loggerName) {
-    try {
-      ClassLoader cl = BridgeServerImpl.class.getClassLoader();
-      Class<?> level = cl.loadClass("ch.qos.logback.classic.Level");
-      Logger logger = LoggerFactory.getLogger(loggerName);
-      Method setLevel = logger.getClass().getMethod("setLevel", level);
-      setLevel.invoke(logger, level.getField("INFO").get(null));
-    } catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
-      LOG.info("Failed to set logger level to INFO for " + loggerName, e);
-    }
-  }
-
 
   void heartbeat() {
     LOG.trace("Pinging the bridge server");

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -47,15 +47,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.SonarProduct;
@@ -421,35 +412,16 @@ public class BridgeServerImpl implements BridgeServer {
   }
 
   private BridgeResponse request(String json, String endpoint) throws IOException {
-    try (var httpclient = HttpClients.createDefault()) {
-
-      var config = RequestConfig.custom()
-        .setResponseTimeout(Timeout.ofSeconds(timeoutSeconds))
-        .build();
-
-      HttpPost httpPost = new HttpPost(url(endpoint));
-      httpPost.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
-      httpPost.setConfig(config);
-
-      return httpclient.execute(httpPost, response -> {
-        var contentTypeHeader = response.getHeader("Content-Type");
-        var responseBody = EntityUtils.toByteArray(response.getEntity());
-        if (isFormData(contentTypeHeader)) {
-          return FormDataUtils.parseFormData(contentTypeHeader.toString(), responseBody);
-        } else {
-          return new BridgeResponse(new String(responseBody, StandardCharsets.UTF_8));
-        }
-      });
-    } catch (IOException e) {
-      throw new IllegalStateException("The bridge server is unresponsive", e);
+    var response = Http.getInstance().post(json, url(endpoint), timeoutSeconds);
+    if (isFormData(response.contentType())) {
+      return FormDataUtils.parseFormData(response.contentType(), response.body());
+    } else {
+      return new BridgeServer.BridgeResponse(new String(response.body(), StandardCharsets.UTF_8));
     }
   }
 
-  private static boolean isFormData(@Nullable Header contentTypeHeader) {
-    if (contentTypeHeader == null) {
-      return false;
-    }
-    return contentTypeHeader.toString().contains("multipart/form-data");
+  private static boolean isFormData(@Nullable String contentTypeHeader) {
+    return contentTypeHeader != null && contentTypeHeader.contains("multipart/form-data");
   }
 
   private static AnalysisResponse response(BridgeResponse result, String filePath) {
@@ -470,9 +442,8 @@ public class BridgeServerImpl implements BridgeServer {
     if (nodeCommand == null && status != Status.STARTED) {
       return false;
     }
-    try (var client = HttpClients.custom().build()) {
-      var get = new HttpGet(url("status"));
-      var res = client.execute(get, response -> EntityUtils.toString(response.getEntity()));
+    try {
+      String res = Http.getInstance().get(url("status"));
       return "OK!".equals(res);
     } catch (IOException e) {
       return false;

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/Http.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/Http.java
@@ -26,21 +26,12 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import javax.annotation.Nullable;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-interface Http {
+public interface Http {
 
-  static Http getInstance() {
+  static Http getJdkHttpClient() {
     return new JdkHttp();
   }
 
@@ -48,7 +39,7 @@ interface Http {
 
   String get(URI uri) throws IOException;
 
-  record Response(String contentType, byte[] body) {}
+  record Response(@Nullable String contentType, byte[] body) {}
 
   class JdkHttp implements Http {
 
@@ -56,8 +47,7 @@ interface Http {
     private final HttpClient client;
 
     JdkHttp() {
-      this.client =
-        HttpClient.newBuilder().build();
+      this.client = HttpClient.newBuilder().build();
     }
 
     @Override
@@ -73,7 +63,7 @@ interface Http {
       try {
         var response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
         var contentType = response.headers().firstValue("Content-Type")
-          .orElseThrow(() -> new IllegalStateException("No Content-Type header"));
+          .orElse(null);
         return new Response(contentType, response.body());
       } catch (InterruptedException e) {
         throw handleInterruptedException(e, "Request " + uri + " was interrupted.");
@@ -102,39 +92,4 @@ interface Http {
 
   }
 
-  class ApacheHttp implements Http {
-
-    @Override
-    public Response post(String json, URI uri, long timeoutSeconds) throws IOException {
-      try (var httpclient = HttpClients.createDefault()) {
-
-        var config = RequestConfig.custom()
-          .setResponseTimeout(Timeout.ofSeconds(timeoutSeconds))
-          .build();
-
-        HttpPost httpPost = new HttpPost(uri);
-        httpPost.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
-        httpPost.setConfig(config);
-
-        return httpclient.execute(httpPost, response -> {
-          var contentTypeHeader = response.getHeader("Content-Type");
-          return new Response(contentTypeHeader.toString(), EntityUtils.toByteArray(response.getEntity()));
-        });
-      }
-    }
-
-    private static boolean isFormData(@Nullable Header contentTypeHeader) {
-      if (contentTypeHeader == null) {
-        return false;
-      }
-      return contentTypeHeader.toString().contains("multipart/form-data");
-    }
-
-    public String get(URI uri) throws IOException{
-      try (var client = HttpClients.custom().build()) {
-        var get = new HttpGet(uri);
-        return client.execute(get, response -> EntityUtils.toString(response.getEntity()));
-      }
-    }
-  }
 }

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/Http.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/Http.java
@@ -1,0 +1,140 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.javascript.bridge;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import javax.annotation.Nullable;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+interface Http {
+
+  static Http getInstance() {
+    return new JdkHttp();
+  }
+
+  Response post(String json, URI uri, long timeoutSeconds) throws IOException;
+
+  String get(URI uri) throws IOException;
+
+  record Response(String contentType, byte[] body) {}
+
+  class JdkHttp implements Http {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdkHttp.class);
+    private final HttpClient client;
+
+    JdkHttp() {
+      this.client =
+        HttpClient.newBuilder().build();
+    }
+
+    @Override
+    public Response post(String json, URI uri, long timeoutSeconds) throws IOException {
+      var request = HttpRequest
+        .newBuilder()
+        .uri(uri)
+        .timeout(Duration.ofSeconds(timeoutSeconds))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(json))
+        .build();
+
+      try {
+        var response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        var contentType = response.headers().firstValue("Content-Type")
+          .orElseThrow(() -> new IllegalStateException("No Content-Type header"));
+        return new Response(contentType, response.body());
+      } catch (InterruptedException e) {
+        throw handleInterruptedException(e, "Request " + uri + " was interrupted.");
+      }
+    }
+
+    @Override
+    public String get(URI uri) throws IOException{
+      var request = HttpRequest.newBuilder(uri).GET().build();
+      try {
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.body();
+      } catch (InterruptedException e) {
+        throw handleInterruptedException(e, "isAlive was interrupted");
+      }
+    }
+
+    private static IllegalStateException handleInterruptedException(
+      InterruptedException e,
+      String msg
+    ) {
+      LOG.error(msg, e);
+      Thread.currentThread().interrupt();
+      return new IllegalStateException(msg, e);
+    }
+
+  }
+
+  class ApacheHttp implements Http {
+
+    @Override
+    public Response post(String json, URI uri, long timeoutSeconds) throws IOException {
+      try (var httpclient = HttpClients.createDefault()) {
+
+        var config = RequestConfig.custom()
+          .setResponseTimeout(Timeout.ofSeconds(timeoutSeconds))
+          .build();
+
+        HttpPost httpPost = new HttpPost(uri);
+        httpPost.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+        httpPost.setConfig(config);
+
+        return httpclient.execute(httpPost, response -> {
+          var contentTypeHeader = response.getHeader("Content-Type");
+          return new Response(contentTypeHeader.toString(), EntityUtils.toByteArray(response.getEntity()));
+        });
+      }
+    }
+
+    private static boolean isFormData(@Nullable Header contentTypeHeader) {
+      if (contentTypeHeader == null) {
+        return false;
+      }
+      return contentTypeHeader.toString().contains("multipart/form-data");
+    }
+
+    public String get(URI uri) throws IOException{
+      try (var client = HttpClients.custom().build()) {
+        var get = new HttpGet(uri);
+        return client.execute(get, response -> EntityUtils.toString(response.getEntity()));
+      }
+    }
+  }
+}

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractAnalysis.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractAnalysis.java
@@ -115,7 +115,7 @@ abstract class AbstractAnalysis {
           file
         );
         acceptAstResponse(response, file);
-      } catch (IOException e) {
+      } catch (Exception e) {
         LOG.error("Failed to get response while analyzing " + file.uri(), e);
         throw e;
       }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
@@ -260,7 +260,7 @@ class JsTsSensorTest {
   @Test
   void should_explode_if_no_response() throws Exception {
     createVueInputFile();
-    when(bridgeServerMock.analyzeTypeScript(any())).thenThrow(new IOException("error"));
+    when(bridgeServerMock.analyzeTypeScript(any())).thenThrow(new IllegalStateException("error"));
 
     var tsProgram = new TsProgram("1", List.of(), List.of());
     when(bridgeServerMock.createProgram(any())).thenReturn(tsProgram);
@@ -778,7 +778,7 @@ class JsTsSensorTest {
   @Test
   void should_fail_fast() throws Exception {
     createTsConfigFile();
-    when(bridgeServerMock.analyzeTypeScript(any())).thenThrow(new IOException("error"));
+    when(bridgeServerMock.analyzeTypeScript(any())).thenThrow(new IllegalStateException("error"));
     JsTsSensor sensor = createSensor();
     createInputFile(context);
 

--- a/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
+++ b/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
@@ -140,7 +140,8 @@ public class StandaloneParser implements AutoCloseable {
 
         return httpclient.execute(httpPost, response -> {
           var contentTypeHeader = response.getHeader("Content-Type");
-          return new Response(contentTypeHeader.toString(), EntityUtils.toByteArray(response.getEntity()));
+          var contentType = contentTypeHeader != null ? contentTypeHeader.toString() : null;
+          return new Response(contentType, EntityUtils.toByteArray(response.getEntity()));
         });
       }
     }

--- a/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
+++ b/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
@@ -22,9 +22,19 @@ package org.sonar.plugins.javascript.standalone;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.Timeout;
 import org.sonar.api.SonarProduct;
+import org.sonar.plugins.javascript.bridge.Http;
 import org.sonar.plugins.javascript.api.estree.ESTree;
 import org.sonar.plugins.javascript.bridge.AnalysisMode;
 import org.sonar.plugins.javascript.bridge.AnalysisWarningsWrapper;
@@ -43,13 +53,22 @@ import org.sonar.plugins.javascript.nodejs.ProcessWrapperImpl;
 
 public class StandaloneParser implements AutoCloseable {
 
+  private static final int DEFAULT_TIMEOUT_SECONDS = 5 * 60;
+
   private final BridgeServerImpl bridge;
 
   public StandaloneParser() {
     ProcessWrapperImpl processWrapper = new ProcessWrapperImpl();
     EmptyConfiguration emptyConfiguration = new EmptyConfiguration();
-    bridge = new BridgeServerImpl(new NodeCommandBuilderImpl(processWrapper), new BundleImpl(), new RulesBundles(),
-      new NodeDeprecationWarning(new AnalysisWarningsWrapper()), new StandaloneTemporaryFolder(), new EmbeddedNode(processWrapper, new Environment(emptyConfiguration)));
+    bridge = new BridgeServerImpl(
+      new NodeCommandBuilderImpl(processWrapper),
+      DEFAULT_TIMEOUT_SECONDS,
+      new BundleImpl(),
+      new RulesBundles(),
+      new NodeDeprecationWarning(new AnalysisWarningsWrapper()),
+      new StandaloneTemporaryFolder(),
+      new EmbeddedNode(processWrapper, new Environment(emptyConfiguration)),
+      new ApacheHttp());
     try {
       bridge.startServerLazily(new BridgeServerConfig(emptyConfiguration, new File(".").getAbsolutePath(), SonarProduct.SONARLINT));
       bridge.initLinter(List.of(), List.of(), List.of(), AnalysisMode.DEFAULT, null, List.of());
@@ -102,6 +121,35 @@ public class StandaloneParser implements AutoCloseable {
     @Override
     public String[] getStringArray(String key) {
       return new String[0];
+    }
+  }
+
+  public static class ApacheHttp implements Http {
+
+    @Override
+    public Response post(String json, URI uri, long timeoutSeconds) throws IOException {
+      try (var httpclient = HttpClients.createDefault()) {
+
+        var config = RequestConfig.custom()
+          .setResponseTimeout(Timeout.ofSeconds(timeoutSeconds))
+          .build();
+
+        HttpPost httpPost = new HttpPost(uri);
+        httpPost.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+        httpPost.setConfig(config);
+
+        return httpclient.execute(httpPost, response -> {
+          var contentTypeHeader = response.getHeader("Content-Type");
+          return new Response(contentTypeHeader.toString(), EntityUtils.toByteArray(response.getEntity()));
+        });
+      }
+    }
+
+    public String get(URI uri) throws IOException{
+      try (var client = HttpClients.custom().build()) {
+        var get = new HttpGet(uri);
+        return client.execute(get, response -> EntityUtils.toString(response.getEntity()));
+      }
     }
   }
 }


### PR DESCRIPTION
[JS-390](https://sonarsource.atlassian.net/browse/JS-390)

I cleaned-up the signatures of Bridge which declared `throws IOException` although this could never happen because `IOException` is catched in `BridgeServerImpl#request`

See also change in https://github.com/SonarSource/sonar-armor/pull/394

[JS-390]: https://sonarsource.atlassian.net/browse/JS-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ