### PR TITLE
JS-405 Simplify vue parser

### DIFF
--- a/packages/jsts/src/builders/build.ts
+++ b/packages/jsts/src/builders/build.ts
@@ -45,7 +45,7 @@ export function buildSourceCode(input: JsTsAnalysisInput, language: JsTsLanguage
       // enable logs for @typescript-eslint
       // debugLevel: true,
       filePath: input.filePath,
-      parser: vueFile ? parsers.typescript.parser : undefined,
+      parser: vueFile ? parsers.typescript : undefined,
     };
     const parser = vueFile ? parsers.vuejs : parsers.typescript;
     if (!vueFile) {


### PR DESCRIPTION
[JS-405](https://sonarsource.atlassian.net/browse/JS-405)

This avoids using a dynamic require internally. Instead, we pass the loaded object that has the "parse" function present.


[JS-405]: https://sonarsource.atlassian.net/browse/JS-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ