### PR TITLE
JS-406 S1607 for tests should extend TestFileCheck

### DIFF
--- a/sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/NoSkippedTestsCheck.java
+++ b/sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/NoSkippedTestsCheck.java
@@ -20,14 +20,14 @@
 package org.sonar.javascript.checks;
 
 import org.sonar.check.Rule;
-import org.sonar.plugins.javascript.api.Check;
 import org.sonar.plugins.javascript.api.JavaScriptRule;
+import org.sonar.plugins.javascript.api.TestFileCheck;
 import org.sonar.plugins.javascript.api.TypeScriptRule;
 
 @JavaScriptRule
 @TypeScriptRule
 @Rule(key = "S1607")
-public class NoSkippedTestsCheck extends Check {
+public class NoSkippedTestsCheck extends TestFileCheck {
 
 
 }


### PR DESCRIPTION
[JS-406](https://sonarsource.atlassian.net/browse/JS-406)

As part of the bundling effort and testing with JsTsRulingTest this rule was causing it to fail. Adding it as TestFileCheck causes it to be run on TEST files and not on MAIN files.

@yassin-kammoun-sonarsource @gabriel-vivas-sonarsource  - we should see this in the data, that this rule was being run on MAIN files and not giving any value for the test files.

[JS-406]: https://sonarsource.atlassian.net/browse/JS-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ