### PR TITLE
JS-417 Add releasability check

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -1,8 +1,8 @@
 name: Releasability status
 'on':
-  check_suite:
-    types:
-      - completed
+  push:
+    branches:
+      - js-417
 jobs:
   update_releasability_status:
     runs-on: ubuntu-latest
@@ -11,13 +11,6 @@ jobs:
       id-token: write
       statuses: write
       contents: read
-    if: >-
-      (contains(fromJSON('["main", "master", "js-417"]'),
-      github.event.check_suite.head_branch) ||
-      startsWith(github.event.check_suite.head_branch, 'dogfood-') ||
-      startsWith(github.event.check_suite.head_branch, 'branch-')) &&
-      github.event.check_suite.conclusion == 'success' &&
-      github.event.check_suite.app.slug == 'cirrus-ci'
     steps:
       -   uses: >-
             SonarSource/gh-action_releasability/releasability-status@v2

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -1,0 +1,27 @@
+name: Releasability status
+'on':
+  check_suite:
+    types:
+      - completed
+jobs:
+  update_releasability_status:
+    runs-on: ubuntu-latest
+    name: Releasability status
+    permissions:
+      id-token: write
+      statuses: write
+      contents: read
+    if: >-
+      (contains(fromJSON('["main", "master", "js-417"]'),
+      github.event.check_suite.head_branch) ||
+      startsWith(github.event.check_suite.head_branch, 'dogfood-') ||
+      startsWith(github.event.check_suite.head_branch, 'branch-')) &&
+      github.event.check_suite.conclusion == 'success' &&
+      github.event.check_suite.app.slug == 'cirrus-ci'
+    steps:
+      -   uses: >-
+            SonarSource/gh-action_releasability/releasability-status@v2
+          with:
+            optional_checks: "Jira"
+          env:
+            GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -1,8 +1,8 @@
 name: Releasability status
 'on':
-  push:
-    branches:
-      - js-417
+  check_suite:
+    types:
+      - completed
 jobs:
   update_releasability_status:
     runs-on: ubuntu-latest
@@ -11,6 +11,13 @@ jobs:
       id-token: write
       statuses: write
       contents: read
+    if: >-
+      (contains(fromJSON('["main", "master"]'),
+      github.event.check_suite.head_branch) ||
+      startsWith(github.event.check_suite.head_branch, 'dogfood-') ||
+      startsWith(github.event.check_suite.head_branch, 'branch-')) &&
+      github.event.check_suite.conclusion == 'success' &&
+      github.event.check_suite.app.slug == 'cirrus-ci'
     steps:
       -   uses: >-
             SonarSource/gh-action_releasability/releasability-status@v2


### PR DESCRIPTION
[JS-417](https://sonarsource.atlassian.net/browse/JS-417)



[JS-417]: https://sonarsource.atlassian.net/browse/JS-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



We will only see that this works after it lands in master. It needs the promote to run and will only happen on master. This PR is same as on SONARPHP - https://github.com/SonarSource/sonar-php/pull/1259