### PR TITLE
JS-435 Clear dependencies cache when a package.json is modified.

### DIFF
--- a/packages/jsts/src/analysis/analysis.ts
+++ b/packages/jsts/src/analysis/analysis.ts
@@ -49,6 +49,7 @@ export interface JsTsAnalysisInput extends AnalysisInput {
   tsConfigs?: string[];
   programId?: string;
   skipAst?: boolean;
+  shouldClearDependenciesCache?: boolean;
 }
 
 export interface ParsingError {

--- a/packages/jsts/src/analysis/analyzer.ts
+++ b/packages/jsts/src/analysis/analyzer.ts
@@ -29,6 +29,7 @@ import { getContext } from '../../../shared/src/helpers/context.js';
 import { computeMetrics, findNoSonarLines } from '../linter/visitors/metrics/index.js';
 import { getSyntaxHighlighting } from '../linter/visitors/syntax-highlighting.js';
 import { getCpdTokens } from '../linter/visitors/cpd.js';
+import { clearDependenciesCache } from '../rules/helpers/package-json.js';
 
 /**
  * Analyzes a JavaScript / TypeScript analysis input
@@ -70,7 +71,8 @@ function analyzeFile(
   sourceCode: SourceCode,
 ): JsTsAnalysisOutput {
   try {
-    const { filePath, fileType, language } = input;
+    const { filePath, fileType, language, shouldClearDependenciesCache } = input;
+    shouldClearDependenciesCache && clearDependenciesCache();
     const { issues, highlightedSymbols, cognitiveComplexity, ucfgPaths } = linter.lint(
       sourceCode,
       filePath,

--- a/packages/jsts/src/rules/helpers/package-json.ts
+++ b/packages/jsts/src/rules/helpers/package-json.ts
@@ -62,6 +62,14 @@ export function getDependencies(filename: string, cwd: string) {
   return result;
 }
 
+/**
+ * In the case of SonarIDE, when a package.json file changes, the cache can become obsolete.
+ */
+export function clearDependenciesCache() {
+  console.debug('Clearing dependencies cache');
+  cache.clear();
+}
+
 export function getDependenciesFromPackageJson(content: PackageJson) {
   const result = new Set<string | Minimatch>();
   if (content.name) {

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
@@ -63,7 +63,7 @@ public interface BridgeServer extends Startable {
   TsConfigFile createTsConfigFile(String content) throws IOException;
 
   record JsAnalysisRequest(String filePath, String fileType, String language, @Nullable String fileContent, boolean ignoreHeaderComments,
-                           @Nullable List<String> tsConfigs, @Nullable String programId, String linterId, boolean skipAst) {
+                           @Nullable List<String> tsConfigs, @Nullable String programId, String linterId, boolean skipAst, boolean shouldClearDependenciesCache) {
 
   }
 

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -239,6 +239,7 @@ class BridgeServerImplTest {
       singletonList(tsConfig.absolutePath()),
       null,
       DEFAULT_LINTER_ID,
+      false,
       false
     );
     assertThat(bridgeServer.analyzeTypeScript(request).issues()).hasSize(1);
@@ -268,6 +269,7 @@ class BridgeServerImplTest {
       null,
       null,
       DEFAULT_LINTER_ID,
+      false,
       false
     );
   }
@@ -295,6 +297,7 @@ class BridgeServerImplTest {
       null,
       programCreated.programId(),
       DEFAULT_LINTER_ID,
+      false,
       false
     );
     assertThat(bridgeServer.analyzeTypeScript(request).issues()).hasSize(1);
@@ -516,6 +519,7 @@ class BridgeServerImplTest {
       null,
       null,
       DEFAULT_LINTER_ID,
+      false,
       false
     );
     assertThatThrownBy(() -> bridgeServer.analyzeJavaScript(request))
@@ -767,7 +771,8 @@ class BridgeServerImplTest {
       null,
       null,
       DEFAULT_LINTER_ID,
-      true
+      true,
+      false
     );
     var response = bridgeServer.analyzeJavaScript(request);
     assertThat(response.ast()).isNull();

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractAnalysis.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractAnalysis.java
@@ -87,7 +87,7 @@ abstract class AbstractAnalysis {
 
   abstract void analyzeFiles(List<InputFile> inputFiles, List<String> tsConfigs) throws IOException;
 
-  protected void analyzeFile(InputFile file, @Nullable List<String> tsConfigs, @Nullable TsProgram tsProgram) throws IOException {
+  protected void analyzeFile(InputFile file, @Nullable List<String> tsConfigs, @Nullable TsProgram tsProgram, boolean dirtyPackageJSONCache) throws IOException {
     if (context.isCancelled()) {
       throw new CancellationException(
         "Analysis interrupted because the SensorContext is in cancelled state"
@@ -100,7 +100,7 @@ abstract class AbstractAnalysis {
         progressReport.nextFile(file.toString());
         var fileContent = contextUtils.shouldSendFileContent(file) ? file.contents() : null;
         var skipAst = !consumers.hasConsumers() || !(contextUtils.isSonarArmorEnabled() || contextUtils.isSonarJasminEnabled() || contextUtils.isSonarJaredEnabled());
-        var request = getJsAnalysisRequest(file, fileContent, tsProgram, tsConfigs, skipAst);
+        var request = getJsAnalysisRequest(file, fileContent, tsProgram, tsConfigs, skipAst, dirtyPackageJSONCache);
 
         var response = isJavaScript(file)
           ? bridgeServer.analyzeJavaScript(request)
@@ -143,7 +143,8 @@ abstract class AbstractAnalysis {
     @Nullable String fileContent,
     @Nullable TsProgram tsProgram,
     @Nullable List<String> tsConfigs,
-    boolean skipAst
+    boolean skipAst,
+    boolean shouldClearDependenciesCache
   ) {
     return new BridgeServer.JsAnalysisRequest(
       file.absolutePath(),
@@ -154,7 +155,8 @@ abstract class AbstractAnalysis {
       tsConfigs,
       tsProgram != null ? tsProgram.programId() : null,
       analysisMode.getLinterIdFor(file),
-      skipAst
+      skipAst,
+      shouldClearDependenciesCache
     );
   }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithProgram.java
@@ -99,7 +99,7 @@ public class AnalysisWithProgram extends AbstractAnalysis {
         );
         for (var f : skippedFiles) {
           LOG.debug("File not part of any tsconfig.json: {}", f);
-          analyzeFile(f, null, null);
+          analyzeFile(f, null, null, false);
         }
       }
       success = true;
@@ -131,7 +131,7 @@ public class AnalysisWithProgram extends AbstractAnalysis {
         continue;
       }
       if (analyzedFiles.add(inputFile)) {
-        analyzeFile(inputFile, null, program);
+        analyzeFile(inputFile, null, program, false);
         counter++;
       } else {
         LOG.debug(

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithWatchProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithWatchProgram.java
@@ -51,7 +51,7 @@ public class AnalysisWithWatchProgram extends AbstractAnalysis {
       progressReport.start(inputFiles.size(), inputFiles.iterator().next().toString());
       for (InputFile inputFile : inputFiles) {
         var tsConfigFile = tsConfigCache.getTsConfigForInputFile(inputFile);
-        analyzeFile(inputFile, tsConfigFile == null ? List.of() : List.of(tsConfigFile.getFilename()), null);
+        analyzeFile(inputFile, tsConfigFile == null ? List.of() : List.of(tsConfigFile.getFilename()), null, this.tsConfigCache != null && this.tsConfigCache.getAndResetShouldClearDependenciesCache());
       }
       success = true;
       if (analysisProcessor.parsingErrorFilesCount() > 0) {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithWatchProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithWatchProgram.java
@@ -51,7 +51,7 @@ public class AnalysisWithWatchProgram extends AbstractAnalysis {
       progressReport.start(inputFiles.size(), inputFiles.iterator().next().toString());
       for (InputFile inputFile : inputFiles) {
         var tsConfigFile = tsConfigCache.getTsConfigForInputFile(inputFile);
-        analyzeFile(inputFile, tsConfigFile == null ? List.of() : List.of(tsConfigFile.getFilename()), null, this.tsConfigCache != null && this.tsConfigCache.getAndResetShouldClearDependenciesCache());
+        analyzeFile(inputFile, tsConfigFile == null ? List.of() : List.of(tsConfigFile.getFilename()), null, this.tsConfigCache.getAndResetShouldClearDependenciesCache());
       }
       success = true;
       if (analysisProcessor.parsingErrorFilesCount() > 0) {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/HtmlSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/HtmlSensor.java
@@ -129,6 +129,7 @@ public class HtmlSensor extends AbstractBridgeSensor {
         null,
         null,
         analysisMode.getLinterIdFor(file),
+        false,
         false
       );
       var response = bridgeServer.analyzeHtml(jsAnalysisRequest);

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/YamlSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/YamlSensor.java
@@ -162,6 +162,7 @@ public class YamlSensor extends AbstractBridgeSensor {
           null,
           null,
           analysisMode.getLinterIdFor(file),
+          false,
           false
         );
         var response = bridgeServer.analyzeYaml(jsAnalysisRequest);

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/sonarlint/TsConfigCache.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/sonarlint/TsConfigCache.java
@@ -26,6 +26,7 @@ public interface TsConfigCache {
   void initializeWith(List<String> tsConfigs, TsConfigOrigin origin);
   List<String> listCachedTsConfigs(TsConfigOrigin origin);
   void setOrigin(TsConfigOrigin origin);
+  boolean getAndResetShouldClearDependenciesCache();
 
   void setProjectSize(int projectSize);
   int getProjectSize();

--- a/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
+++ b/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
@@ -79,7 +79,9 @@ public class StandaloneParser implements AutoCloseable {
       null,
       null,
       AnalysisMode.DEFAULT_LINTER_ID,
-      false);
+      false,
+      false
+    );
     try {
       BridgeServer.AnalysisResponse result = bridge.analyzeJavaScript(request);
       Node ast = result.ast();


### PR DESCRIPTION
[JS-435](https://sonarsource.atlassian.net/browse/JS-435)

As it might happen when the package.json is changed, we should dirty the cache.

I've tested, building the jar, copying it into the plugins and verifying that the 2 logs I've added are being triggered. I will add tests once the integration tests for SonarIDE are available.

I've verified, that opening a file from node_modules directory, does not trigger this event:
```
Trigger: EDITOR_OPEN
[EDITOR_OPEN] 1 file(s) submitted
File 'package.json' excluded: file is excluded or ignored in project structure
```


[JS-435]: https://sonarsource.atlassian.net/browse/JS-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ