### PR TITLE
JS-458 Fix missing constructor for nullable argument

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithWatchProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithWatchProgram.java
@@ -36,6 +36,14 @@ public class AnalysisWithWatchProgram extends AbstractAnalysis {
   public AnalysisWithWatchProgram(
     BridgeServer bridgeServer,
     AnalysisProcessor analysisProcessor,
+    AnalysisWarningsWrapper analysisWarnings
+  ) {
+    this(bridgeServer, analysisProcessor, analysisWarnings, null);
+  }
+
+  public AnalysisWithWatchProgram(
+    BridgeServer bridgeServer,
+    AnalysisProcessor analysisProcessor,
     AnalysisWarningsWrapper analysisWarnings,
     @Nullable TsConfigCache tsConfigCache
   ) {


### PR DESCRIPTION
[JS-458](https://sonarsource.atlassian.net/browse/JS-458)

This fails with SonarQube cloud, because it uses PicoContainer and doesn't support @Nullable for constructor dependency injection


[JS-458]: https://sonarsource.atlassian.net/browse/JS-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ