### PR TITLE
JS-459 Update husky command

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "plugin:build:fast": "mvn install -DskipTests && npm run update-ruling-data",
     "pbf": "npm run plugin:build:fast",
     "td": "npm --prefix typedoc/searchable-parameters-plugin run setup && npx typedoc --options typedoc/typedoc.js",
-    "prepare": "husky install",
+    "prepare": "husky",
     "precommit": "pretty-quick --staged",
     "count-rules": "node tools/count-rules.js",
     "_:bridge:copy-protofiles": "cpy --flat packages/jsts/src/parsers/estree.proto sonar-plugin/bridge/src/main/protobuf && cpy --flat packages/jsts/src/parsers/estree.proto lib/jsts/src/parsers",


### PR DESCRIPTION
[JS-459](https://sonarsource.atlassian.net/browse/JS-459)

The new command to be used should be: `husky init` or just `husky` - see stack overflow answer - https://stackoverflow.com/questions/77897612/problem-when-trying-to-add-prettiers-git-hook-husky-install-error-install-com . It was updated in v9 to include this message.

[JS-459]: https://sonarsource.atlassian.net/browse/JS-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ