### PR TITLE
JS-100 Allow the server to restart after failed status

### DIFF
--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -88,7 +88,7 @@ public class BridgeServerImpl implements BridgeServer {
   private final ScheduledExecutorService heartbeatService;
   private ScheduledFuture<?> heartbeatFuture;
   private final Http http;
-  private long latestOKIsAliveTimestamp;
+  private Long latestOKIsAliveTimestamp;
 
   // Used by pico container for dependency injection
   public BridgeServerImpl(
@@ -471,7 +471,10 @@ public class BridgeServerImpl implements BridgeServer {
   }
 
   private boolean shouldRestartFailedServer() {
-    return System.currentTimeMillis() - latestOKIsAliveTimestamp > TIME_AFTER_FAILURE_TO_RESTART_MS;
+    return (
+      latestOKIsAliveTimestamp != null &&
+      System.currentTimeMillis() - latestOKIsAliveTimestamp > TIME_AFTER_FAILURE_TO_RESTART_MS
+    );
   }
 
   @Override


### PR DESCRIPTION
[JS-100](https://sonarsource.atlassian.net/browse/JS-100)

Tested by hand with killing the node processes and waiting a minute to see that the server actually gets respawned. See logs:
```
 [2024-12-04T16:52:13.064] [sonarlint-analysis-engine] DEBUG sonarlint - Skipping the start of the bridge server as it failed to start during the first analysis or it's not answering anymore
..
 [2024-12-04T16:52:23.924] [sonarlint-analysis-engine] DEBUG sonarlint - Skipping the start of the bridge server as it failed to start during the first analysis or it's not answering anymore
..
 [2024-12-04T16:52:30.923] [sonarlint-analysis-engine] DEBUG sonarlint - Skipping the start of the bridge server as it failed to start during the first analysis or it's not answering anymore
..
 [2024-12-04T16:52:36.868] [sonarlint-analysis-engine] DEBUG sonarlint - Skipping the start of the bridge server as it failed to start during the first analysis or it's not answering anymore
..
 [2024-12-04T16:52:43.438] [sonarlint-analysis-engine] WARN sonarlint - No workDir in SonarLint
 [2024-12-04T16:52:43.439] [sonarlint-analysis-engine] DEBUG sonarlint - Setting deploy location to /Users/michal.zgliczynski/codes/SonarJS
 [2024-12-04T16:52:43.439] [sonarlint-analysis-engine] INFO sonarlint - 'sonar.nodejs.executable' is set. Skipping embedded Node.js runtime deployment.
 [2024-12-04T16:52:43.439] [sonarlint-analysis-engine] DEBUG sonarlint - Starting server
 [2024-12-04T16:52:43.439] [sonarlint-analysis-engine] DEBUG sonarlint - Creating Node.js process to start the bridge server on port 65465 
 [2024-12-04T16:52:43.439] [sonarlint-analysis-engine] INFO sonarlint - Running in SonarLint context, metrics will not be computed.
 [2024-12-04T16:52:43.439] [sonarlint-analysis-engine] INFO sonarlint - Using Node.js executable /Users/michal.zgliczynski/.nvm/versions/node/v22.9.0/bin/node from property sonar.nodejs.executable.
 [2024-12-04T16:52:43.439] [sonarlint-analysis-engine] DEBUG sonarlint - Checking Node.js version
 [2024-12-04T16:52:43.439] [sonarlint-analysis-engine] DEBUG sonarlint - Launching command /Users/michal.zgliczynski/.nvm/versions/node/v22.9.0/bin/node -v
 [2024-12-04T16:52:43.462] [sonarlint-analysis-engine] DEBUG sonarlint - Using Node.js v22.9.0.
 [2024-12-04T16:52:43.462] [sonarlint-analysis-engine] DEBUG sonarlint - Launching command /Users/michal.zgliczynski/.nvm/versions/node/v22.9.0/bin/node /Users/michal.zgliczynski/codes/SonarJS/package/bin/server.cjs 65465 127.0.0.1 /Users/michal.zgliczynski/codes/SonarJS true true false 
 [2024-12-04T16:52:44.125] [nodejs-stream-consumer] INFO sonarlint - Memory configuration: OS (36864 MB), Node.js (4144 MB).
 [2024-12-04T16:52:44.125] [nodejs-stream-consumer] DEBUG sonarlint - Starting the bridge server
 [2024-12-04T16:52:44.13] [nodejs-stream-consumer] DEBUG sonarlint - The bridge server is listening on port 65465
 [2024-12-04T16:52:44.134] [nodejs-stream-consumer] DEBUG sonarlint - The worker thread is running
 [2024-12-04T16:52:44.244] [sonarlint-analysis-engine] DEBUG sonarlint - Bridge server started on port 65465 in 805 ms
 
```


[JS-100]: https://sonarsource.atlassian.net/browse/JS-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ