### PR TITLE
JS-493 Add 'get-telemetry' endpoint on bridge-server

### DIFF
--- a/packages/bridge/src/handle-request.ts
+++ b/packages/bridge/src/handle-request.ts
@@ -28,7 +28,14 @@ import {
 } from '../../jsts/src/program/program.js';
 import { initializeLinter } from '../../jsts/src/linter/linters.js';
 import { clearTypeScriptESLintParserCaches } from '../../jsts/src/parsers/eslint.js';
-import { BridgeRequest, readFileLazily, RequestResult, serializeError } from './request.js';
+import {
+  BridgeRequest,
+  readFileLazily,
+  RequestResult,
+  serializeError,
+  Telemetry,
+} from './request.js';
+import { getAllDependencies } from '../../jsts/src/rules/index.js';
 
 export async function handleRequest(request: BridgeRequest): Promise<RequestResult> {
   try {
@@ -107,8 +114,18 @@ export async function handleRequest(request: BridgeRequest): Promise<RequestResu
         const output = await analyzeProject(request.data);
         return { type: 'success', result: output };
       }
+      case 'on-get-telemetry': {
+        const output = getTelemetry();
+        return { type: 'success', result: output };
+      }
     }
   } catch (err) {
     return { type: 'failure', error: serializeError(err) };
   }
+}
+
+function getTelemetry(): Telemetry {
+  return {
+    dependencies: getAllDependencies(),
+  };
 }

--- a/packages/bridge/src/handle-request.ts
+++ b/packages/bridge/src/handle-request.ts
@@ -16,7 +16,7 @@
  */
 import { analyzeCSS } from '../../css/src/analysis/analyzer.js';
 import { analyzeHTML } from '../../html/src/index.js';
-import { analyzeJSTS } from '../../jsts/src/analysis/analyzer.js';
+import { analyzeJSTS, getTelemetry } from '../../jsts/src/analysis/analyzer.js';
 import { analyzeProject } from '../../jsts/src/analysis/projectAnalysis/projectAnalyzer.js';
 import { analyzeYAML } from '../../yaml/src/index.js';
 import { logHeapStatistics } from './memory.js';
@@ -28,14 +28,7 @@ import {
 } from '../../jsts/src/program/program.js';
 import { initializeLinter } from '../../jsts/src/linter/linters.js';
 import { clearTypeScriptESLintParserCaches } from '../../jsts/src/parsers/eslint.js';
-import {
-  BridgeRequest,
-  readFileLazily,
-  RequestResult,
-  serializeError,
-  Telemetry,
-} from './request.js';
-import { getAllDependencies } from '../../jsts/src/rules/index.js';
+import { BridgeRequest, readFileLazily, RequestResult, serializeError } from './request.js';
 
 export async function handleRequest(request: BridgeRequest): Promise<RequestResult> {
   try {
@@ -122,10 +115,4 @@ export async function handleRequest(request: BridgeRequest): Promise<RequestResu
   } catch (err) {
     return { type: 'failure', error: serializeError(err) };
   }
-}
-
-function getTelemetry(): Telemetry {
-  return {
-    dependencies: getAllDependencies(),
-  };
 }

--- a/packages/bridge/src/request.ts
+++ b/packages/bridge/src/request.ts
@@ -23,16 +23,21 @@ import { TsConfigJson } from 'type-fest';
 import { RuleConfig } from '../../jsts/src/linter/config/rule-config.js';
 import { readFile } from '../../shared/src/helpers/files.js';
 import { APIError, ErrorCode } from '../../shared/src/errors/error.js';
+import { NamedDependency } from '../../jsts/src/rules/index.js';
 
 export type RequestResult =
   | {
       type: 'success';
-      result: string | AnalysisOutput;
+      result: string | AnalysisOutput | Telemetry;
     }
   | {
       type: 'failure';
       error: ReturnType<typeof serializeError>;
     };
+
+export type Telemetry = {
+  dependencies: NamedDependency[];
+};
 
 export type RequestType = BridgeRequest['type'];
 
@@ -61,7 +66,8 @@ export type BridgeRequest =
   | DeleteProgramRequest
   | InitLinterRequest
   | NewTsConfigRequest
-  | TsConfigFilesRequest;
+  | TsConfigFilesRequest
+  | GetTelemetryRequest;
 
 type CssRequest = {
   type: 'on-analyze-css';
@@ -114,6 +120,9 @@ type NewTsConfigRequest = {
 type TsConfigFilesRequest = {
   type: 'on-tsconfig-files';
   data: { tsConfig: string };
+};
+type GetTelemetryRequest = {
+  type: 'on-get-telemetry';
 };
 
 /**

--- a/packages/bridge/src/router.ts
+++ b/packages/bridge/src/router.ts
@@ -36,6 +36,7 @@ export default function (worker?: Worker): express.Router {
   router.post('/init-linter', delegate('on-init-linter'));
   router.post('/new-tsconfig', delegate('on-new-tsconfig'));
   router.post('/tsconfig-files', delegate('on-tsconfig-files'));
+  router.post('/get-telemetry', delegate('on-get-telemetry'));
 
   /** Endpoints running on the main thread */
   router.get('/status', (_, response) => response.send('OK!'));

--- a/packages/bridge/src/router.ts
+++ b/packages/bridge/src/router.ts
@@ -36,7 +36,7 @@ export default function (worker?: Worker): express.Router {
   router.post('/init-linter', delegate('on-init-linter'));
   router.post('/new-tsconfig', delegate('on-new-tsconfig'));
   router.post('/tsconfig-files', delegate('on-tsconfig-files'));
-  router.post('/get-telemetry', delegate('on-get-telemetry'));
+  router.get('/get-telemetry', delegate('on-get-telemetry'));
 
   /** Endpoints running on the main thread */
   router.get('/status', (_, response) => response.send('OK!'));

--- a/packages/bridge/tests/router.test.ts
+++ b/packages/bridge/tests/router.test.ts
@@ -328,7 +328,7 @@ describe('router', () => {
   });
 
   it('should return empty get-telemetry on fresh server', async () => {
-    const response = (await request(server, '/get-telemetry', 'POST')) as string;
+    const response = (await request(server, '/get-telemetry', 'GET')) as string;
     const json = JSON.parse(response);
     expect(json).toEqual({ dependencies: [] });
   });

--- a/packages/bridge/tests/router.test.ts
+++ b/packages/bridge/tests/router.test.ts
@@ -326,6 +326,12 @@ describe('router', () => {
     expect(json.filename).toBeTruthy();
     expect(fs.existsSync(json.filename)).toBe(true);
   });
+
+  it('should return empty get-telemetry on fresh server', async () => {
+    const response = (await request(server, '/get-telemetry', 'POST')) as string;
+    const json = JSON.parse(response);
+    expect(json).toEqual({ dependencies: [] });
+  });
 });
 
 function requestInitLinter(server: http.Server, rules: RuleConfig[]) {

--- a/packages/jsts/src/analysis/analyzer.ts
+++ b/packages/jsts/src/analysis/analyzer.ts
@@ -29,7 +29,8 @@ import { getContext } from '../../../shared/src/helpers/context.js';
 import { computeMetrics, findNoSonarLines } from '../linter/visitors/metrics/index.js';
 import { getSyntaxHighlighting } from '../linter/visitors/syntax-highlighting.js';
 import { getCpdTokens } from '../linter/visitors/cpd.js';
-import { clearDependenciesCache } from '../rules/helpers/package-json.js';
+import { clearDependenciesCache, getAllDependencies } from '../rules/index.js';
+import { Telemetry } from '../../../bridge/src/request.js';
 
 /**
  * Analyzes a JavaScript / TypeScript analysis input
@@ -159,4 +160,10 @@ function computeExtendedMetrics(
       metrics: findNoSonarLines(sourceCode),
     };
   }
+}
+
+export function getTelemetry(): Telemetry {
+  return {
+    dependencies: getAllDependencies(),
+  };
 }

--- a/packages/jsts/src/rules/helpers/package-json.ts
+++ b/packages/jsts/src/rules/helpers/package-json.ts
@@ -20,7 +20,6 @@ import { toUnixPath, stripBOM } from './files.js';
 import { Minimatch } from 'minimatch';
 import { type Filesystem, createFindUp } from './find-up.js';
 import fs from 'fs';
-import { Telemetry } from '../../../../bridge/src/request.js';
 
 export const PACKAGE_JSON = 'package.json';
 

--- a/packages/jsts/src/rules/helpers/package-json.ts
+++ b/packages/jsts/src/rules/helpers/package-json.ts
@@ -20,6 +20,7 @@ import { toUnixPath, stripBOM } from './files.js';
 import { Minimatch } from 'minimatch';
 import { type Filesystem, createFindUp } from './find-up.js';
 import fs from 'fs';
+import { Telemetry } from '../../../../bridge/src/request.js';
 
 export const PACKAGE_JSON = 'package.json';
 

--- a/packages/jsts/src/rules/helpers/package-json.ts
+++ b/packages/jsts/src/rules/helpers/package-json.ts
@@ -47,6 +47,11 @@ type Dependency = MinimatchDependency | NamedDependency;
  */
 const cache: Map<string, Set<Dependency>> = new Map();
 
+/**
+ * Returns the dependencies of the root package.json file collected in the cache.
+ * As the cache is populated lazily, it could be null in case no rule execution has touched it.
+ * This removes duplicate dependencies and keeps the last occurrence.
+ */
 export function getAllDependencies(): NamedDependency[] {
   const dependencies = [...cache.values()]
     .flatMap(dependencies => [...dependencies])

--- a/packages/jsts/tests/analysis/analyzer.test.ts
+++ b/packages/jsts/tests/analysis/analyzer.test.ts
@@ -21,17 +21,14 @@ import { describe, beforeEach, it } from 'node:test';
 import { expect } from 'expect';
 import { getManifests, toUnixPath } from '../../src/rules/helpers/index.js';
 import { setContext } from '../../../shared/src/helpers/context.js';
-import { analyzeJSTS } from '../../src/analysis/analyzer.js';
+import { analyzeJSTS, getTelemetry } from '../../src/analysis/analyzer.js';
 import { APIError } from '../../../shared/src/errors/error.js';
 import { RuleConfig } from '../../src/linter/config/rule-config.js';
 import { initializeLinter } from '../../src/linter/linters.js';
 import { JsTsAnalysisOutput } from '../../src/analysis/analysis.js';
 import { createAndSaveProgram } from '../../src/program/program.js';
 import { deserializeProtobuf } from '../../src/parsers/ast.js';
-import {
-  getAllDependencies,
-  getDependencies,
-} from '../../../../lib/jsts/src/rules/helpers/package-json.js';
+import { getDependencies } from '../../../../lib/jsts/src/rules/helpers/package-json.js';
 
 const currentPath = toUnixPath(import.meta.dirname);
 
@@ -929,7 +926,8 @@ describe('analyzeJSTS', () => {
       { rules: { 'custom-rule-file': 'error' } },
       { filename: filePath, allowInlineConfig: false },
     );
-    const dependencies = getAllDependencies();
+    const telemetry = getTelemetry();
+    const dependencies = telemetry.dependencies;
     expect(dependencies).toStrictEqual([
       {
         name: 'test-module',

--- a/packages/jsts/tests/analysis/analyzer.test.ts
+++ b/packages/jsts/tests/analysis/analyzer.test.ts
@@ -925,8 +925,7 @@ describe('analyzeJSTS', () => {
       { rules: { 'custom-rule-file': 'error' } },
       { filename: filePath, allowInlineConfig: false },
     );
-    const telemetry = getTelemetry();
-    const dependencies = telemetry.dependencies;
+    const { dependencies } = getTelemetry();
     expect(dependencies).toStrictEqual([
       {
         name: 'test-module',

--- a/packages/jsts/tests/analysis/analyzer.test.ts
+++ b/packages/jsts/tests/analysis/analyzer.test.ts
@@ -19,7 +19,7 @@ import { jsTsInput, parseJavaScriptSourceFile } from '../tools/index.js';
 import { Linter, Rule } from 'eslint';
 import { describe, beforeEach, it } from 'node:test';
 import { expect } from 'expect';
-import { getManifests, toUnixPath } from '../../src/rules/helpers/index.js';
+import { getDependencies, getManifests, toUnixPath } from '../../src/rules/helpers/index.js';
 import { setContext } from '../../../shared/src/helpers/context.js';
 import { analyzeJSTS, getTelemetry } from '../../src/analysis/analyzer.js';
 import { APIError } from '../../../shared/src/errors/error.js';
@@ -28,7 +28,6 @@ import { initializeLinter } from '../../src/linter/linters.js';
 import { JsTsAnalysisOutput } from '../../src/analysis/analysis.js';
 import { createAndSaveProgram } from '../../src/program/program.js';
 import { deserializeProtobuf } from '../../src/parsers/ast.js';
-import { getDependencies } from '../../../../lib/jsts/src/rules/helpers/package-json.js';
 
 const currentPath = toUnixPath(import.meta.dirname);
 

--- a/packages/jsts/tests/analysis/fixtures/dependencies/index.js
+++ b/packages/jsts/tests/analysis/fixtures/dependencies/index.js
@@ -1,0 +1,1 @@
+console.log("Hello World!");

--- a/packages/jsts/tests/analysis/fixtures/dependencies/package.json
+++ b/packages/jsts/tests/analysis/fixtures/dependencies/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-module",
+  "version": "1.0.0",
+  "author": "Your Name <email@example.com>",
+  "dependencies": {
+    "pkg1": "1.0.0"
+  },
+  "devDependencies": {
+    "pkg2": "2.0.0"
+  }
+}

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
@@ -68,6 +68,8 @@ public interface BridgeServer extends Startable {
 
   TsConfigFile createTsConfigFile(String content) throws IOException;
 
+  TelemetryResponse getTelemetry();
+
   record JsAnalysisRequest(
     String filePath,
     String fileType,
@@ -275,4 +277,8 @@ public interface BridgeServer extends Startable {
   }
 
   record TsProgramRequest(String tsConfig) {}
+
+  record TelemetryResponse(List<Dependency> dependencies) {}
+
+  record Dependency(String name, String version) {}
 }

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -533,6 +533,16 @@ public class BridgeServerImpl implements BridgeServer {
     return GSON.fromJson(response.json(), TsConfigFile.class);
   }
 
+  @Override
+  public TelemetryResponse getTelemetry() {
+    try {
+      var result = http.get(url("get-telemetry"));
+      return GSON.fromJson(result, TelemetryResponse.class);
+    } catch (IOException e) {
+      return new TelemetryResponse(List.of());
+    }
+  }
+
   private static <T> List<T> emptyListIfNull(@Nullable List<T> list) {
     return list == null ? emptyList() : list;
   }

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -62,7 +62,9 @@ import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.TempFolder;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.javascript.bridge.BridgeServer.CssAnalysisRequest;
+import org.sonar.plugins.javascript.bridge.BridgeServer.Dependency;
 import org.sonar.plugins.javascript.bridge.BridgeServer.JsAnalysisRequest;
+import org.sonar.plugins.javascript.bridge.BridgeServer.TelemetryResponse;
 import org.sonar.plugins.javascript.bridge.BridgeServer.TsProgram;
 import org.sonar.plugins.javascript.bridge.BridgeServer.TsProgramRequest;
 import org.sonar.plugins.javascript.bridge.protobuf.Node;
@@ -749,6 +751,16 @@ class BridgeServerImplTest {
 
     assertThat(logTester.logs(DEBUG)).contains(
       "Security Frontend version is available: [some_bundle_version]"
+    );
+  }
+
+  @Test
+  void should_return_telemetry() throws Exception {
+    bridgeServer = createBridgeServer(START_SERVER_SCRIPT);
+    bridgeServer.startServer(serverConfig, emptyList());
+    var telemetry = bridgeServer.getTelemetry();
+    assertThat(telemetry).isEqualTo(
+      new TelemetryResponse(List.of(new Dependency("pkg1", "1.0.0")))
     );
   }
 

--- a/sonar-plugin/bridge/src/test/resources/mock-bridge/startServer.js
+++ b/sonar-plugin/bridge/src/test/resources/mock-bridge/startServer.js
@@ -47,6 +47,8 @@ const requestHandler = (request, response) => {
               loc: {}}]}]}],
         highlights: [{location: {startLine: 0, startColumn: 0, endLine: 0, endColumn: 0}}],
         metrics: {}, highlightedSymbols: [{}], cpdTokens: [{}] }`);
+    } else if (request.url === '/get-telemetry') {
+      response.end('{"dependencies": [{"name": "pkg1", "version": "1.0.0"}]}');
     } else {
       // /analyze-with-program
       // /analyze-js

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -36,7 +36,6 @@ import org.sonar.plugins.javascript.analysis.CssRuleSensor;
 import org.sonar.plugins.javascript.analysis.HtmlSensor;
 import org.sonar.plugins.javascript.analysis.JsTsChecks;
 import org.sonar.plugins.javascript.analysis.JsTsSensor;
-import org.sonar.plugins.javascript.analysis.PluginTelemetry;
 import org.sonar.plugins.javascript.analysis.TsConfigProvider;
 import org.sonar.plugins.javascript.analysis.YamlSensor;
 import org.sonar.plugins.javascript.bridge.AnalysisWarningsWrapper;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -36,6 +36,7 @@ import org.sonar.plugins.javascript.analysis.CssRuleSensor;
 import org.sonar.plugins.javascript.analysis.HtmlSensor;
 import org.sonar.plugins.javascript.analysis.JsTsChecks;
 import org.sonar.plugins.javascript.analysis.JsTsSensor;
+import org.sonar.plugins.javascript.analysis.PluginTelemetry;
 import org.sonar.plugins.javascript.analysis.TsConfigProvider;
 import org.sonar.plugins.javascript.analysis.YamlSensor;
 import org.sonar.plugins.javascript.bridge.AnalysisWarningsWrapper;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithProgram.java
@@ -111,6 +111,8 @@ public class AnalysisWithProgram extends AbstractAnalysis {
             )
           );
       }
+      var telemetry = bridgeServer.getTelemetry();
+      new PluginTelemetry(context).reportTelemetry(telemetry);
     } finally {
       if (success) {
         progressReport.stop();

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/PluginTelemetry.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/PluginTelemetry.java
@@ -1,0 +1,59 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.javascript.analysis;
+
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.utils.Version;
+import org.sonar.plugins.javascript.bridge.BridgeServer.Dependency;
+import org.sonar.plugins.javascript.bridge.BridgeServer.TelemetryResponse;
+
+public class PluginTelemetry {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PluginTelemetry.class);
+  private static final String KEY_PREFIX = "javascript.";
+  private static final String DEPENDENCY_PREFIX = KEY_PREFIX + "dependency.";
+
+  private final SensorContext ctx;
+
+  public PluginTelemetry(SensorContext ctx) {
+    this.ctx = ctx;
+  }
+
+  void reportTelemetry(@Nullable TelemetryResponse telemetry) {
+    var isTelemetrySupported = ctx
+      .runtime()
+      .getApiVersion()
+      .isGreaterThanOrEqual(Version.create(10, 9));
+    if (telemetry == null || !isTelemetrySupported) {
+      // addTelemetryProperty is added in 10.9:
+      // https://github.com/SonarSource/sonar-plugin-api/releases/tag/10.9.0.2362
+      return;
+    }
+    var keyMapToSave = telemetry
+      .dependencies()
+      .stream()
+      .collect(
+        Collectors.toMap(dependency -> DEPENDENCY_PREFIX + dependency.name(), Dependency::version)
+      );
+    keyMapToSave.forEach(ctx::addTelemetryProperty);
+    LOG.debug("Telemetry saved: {}", keyMapToSave);
+  }
+}

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JavaScriptEslintBasedSensorTest.java
@@ -57,6 +57,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
 import org.sonar.api.batch.rule.internal.NewActiveRule;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.cache.WriteCache;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
@@ -79,7 +80,9 @@ import org.sonar.plugins.javascript.analysis.cache.CacheTestUtils;
 import org.sonar.plugins.javascript.bridge.AnalysisWarningsWrapper;
 import org.sonar.plugins.javascript.bridge.BridgeServer;
 import org.sonar.plugins.javascript.bridge.BridgeServer.AnalysisResponse;
+import org.sonar.plugins.javascript.bridge.BridgeServer.Dependency;
 import org.sonar.plugins.javascript.bridge.BridgeServer.JsAnalysisRequest;
+import org.sonar.plugins.javascript.bridge.BridgeServer.TelemetryResponse;
 import org.sonar.plugins.javascript.bridge.BridgeServer.TsProgram;
 import org.sonar.plugins.javascript.bridge.EslintRule;
 import org.sonar.plugins.javascript.bridge.PluginInfo;
@@ -750,6 +753,28 @@ class JavaScriptEslintBasedSensorTest {
     InputFile file = createInputFile(context);
     sensor.execute(context);
     assertThat(logTester.logs(Level.DEBUG)).contains("Analyzing file: " + file.uri());
+  }
+
+  @Test
+  void should_add_telemetry_for_scanner_analysis() throws Exception {
+    when(bridgeServerMock.analyzeJavaScript(any())).thenReturn(new AnalysisResponse());
+    when(bridgeServerMock.getTelemetry()).thenReturn(
+      new TelemetryResponse(List.of(new Dependency("pkg1", "1.1.0")))
+    );
+    var sensor = createSensor();
+    context.setRuntime(
+      SonarRuntimeImpl.forSonarQube(
+        Version.create(10, 9),
+        SonarQubeSide.SCANNER,
+        SonarEdition.COMMUNITY
+      )
+    );
+    context.setNextCache(mock(WriteCache.class));
+    createInputFile(context);
+    sensor.execute(context);
+    assertThat(logTester.logs(Level.DEBUG)).contains(
+      "Telemetry saved: {javascript.dependency.pkg1=1.1.0}"
+    );
   }
 
   private static JsTsChecks checks(String... ruleKeys) {

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/PluginTelemetryTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/PluginTelemetryTest.java
@@ -1,0 +1,63 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.javascript.analysis;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.SonarRuntime;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.utils.Version;
+import org.sonar.plugins.javascript.bridge.BridgeServer.Dependency;
+import org.sonar.plugins.javascript.bridge.BridgeServer.TelemetryResponse;
+
+class PluginTelemetryTest {
+
+  private SensorContext ctx;
+  private PluginTelemetry pluginTelemetry;
+  private TelemetryResponse telemetryResponse;
+
+  @BeforeEach
+  void setUp() {
+    ctx = mock(SensorContext.class);
+    SonarRuntime sonarRuntime = mock(SonarRuntime.class);
+    when(ctx.runtime()).thenReturn(sonarRuntime);
+    pluginTelemetry = new PluginTelemetry(ctx);
+    telemetryResponse = new TelemetryResponse(List.of(new Dependency("pkg1", "1.0.0")));
+  }
+
+  @Test
+  void shouldNotReportIfApiVersionIsLessThan109() {
+    when(ctx.runtime().getApiVersion()).thenReturn(Version.create(10, 8));
+    pluginTelemetry.reportTelemetry(telemetryResponse);
+    verify(ctx, never()).addTelemetryProperty(anyString(), anyString());
+  }
+
+  @Test
+  void shouldReportIfApiVersionIsGreaterThanOrEqualTo109() {
+    when(ctx.runtime().getApiVersion()).thenReturn(Version.create(10, 9));
+    pluginTelemetry.reportTelemetry(telemetryResponse);
+    verify(ctx).addTelemetryProperty("javascript.dependency.pkg1", "1.0.0");
+  }
+}


### PR DESCRIPTION
[JS-493](https://sonarsource.atlassian.net/browse/JS-493)

Added a new endpoint 'get-telemetry'. This is assumed to be called after an analysis has occurred and the dependency cache is filled.

Tested in 2 ways:
1) with postman and verified that after a) initialize-linter and b) analyze-file, a request to 'get-telemetry' returned results
2) Added a simple unit-test, with a custom rule implementation, that verified that a simple package.json was picked up.

[JS-493]: https://sonarsource.atlassian.net/browse/JS-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ