### PR TITLE
JS-502 Fix transitive dependency on nanoid@v3.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8637,9 +8637,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
[JS-502](https://sonarsource.atlassian.net/browse/JS-502)

Fixes CVE-2024-55565

to update the lock file:
`npm audit fix`


[JS-502]: https://sonarsource.atlassian.net/browse/JS-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ