### PR TITLE
JS-552 Stop sending telemtry under javascript.dependency.*

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/PluginTelemetry.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/PluginTelemetry.java
@@ -17,19 +17,16 @@
 package org.sonar.plugins.javascript.analysis;
 
 import java.util.HashMap;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.javascript.bridge.BridgeServer;
-import org.sonar.plugins.javascript.bridge.BridgeServer.Dependency;
 
 public class PluginTelemetry {
 
   private static final Logger LOG = LoggerFactory.getLogger(PluginTelemetry.class);
   private static final String KEY_PREFIX = "javascript.";
-  private static final String DEPENDENCY_PREFIX = KEY_PREFIX + "dependency.";
   private static final String RUNTIME_PREFIX = KEY_PREFIX + "runtime.";
 
   private final BridgeServer server;
@@ -51,14 +48,7 @@ public class PluginTelemetry {
       return;
     }
     var telemetry = server.getTelemetry();
-    var keyMapToSave = new HashMap<>(
-      telemetry
-        .dependencies()
-        .stream()
-        .collect(
-          Collectors.toMap(dependency -> DEPENDENCY_PREFIX + dependency.name(), Dependency::version)
-        )
-    );
+    var keyMapToSave = new HashMap<String, String>();
     keyMapToSave.put(
       RUNTIME_PREFIX + "node-executable-origin",
       telemetry.runtimeTelemetry().nodeExecutableOrigin()

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JavaScriptEslintBasedSensorTest.java
@@ -779,7 +779,7 @@ class JavaScriptEslintBasedSensorTest {
     createInputFile(context);
     sensor.execute(context);
     assertThat(logTester.logs(Level.DEBUG)).contains(
-      "Telemetry saved: {javascript.runtime.node-executable-origin=embedded, javascript.runtime.major-version=22, javascript.dependency.pkg1=1.1.0, javascript.runtime.version=22.9}"
+      "Telemetry saved: {javascript.runtime.node-executable-origin=embedded, javascript.runtime.major-version=22, javascript.runtime.version=22.9}"
     );
   }
 

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JavaScriptEslintBasedSensorTest.java
@@ -779,7 +779,7 @@ class JavaScriptEslintBasedSensorTest {
     createInputFile(context);
     sensor.execute(context);
     assertThat(logTester.logs(Level.DEBUG)).contains(
-      "Telemetry saved: {javascript.runtime.node-executable-origin=embedded, javascript.runtime.major-version=22, javascript.runtime.version=22.9}"
+      "Telemetry saved: {javascript.runtime.major-version=22, javascript.runtime.version=22.9, javascript.runtime.node-executable-origin=embedded}"
     );
   }
 

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/PluginTelemetryTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/PluginTelemetryTest.java
@@ -62,13 +62,6 @@ class PluginTelemetryTest {
   }
 
   @Test
-  void shouldReport() {
-    when(ctx.runtime().getApiVersion()).thenReturn(Version.create(10, 9));
-    pluginTelemetry.reportTelemetry();
-    verify(ctx).addTelemetryProperty("javascript.dependency.pkg1", "1.0.0");
-  }
-
-  @Test
   void shouldReportRuntimeTelemetry() {
     when(ctx.runtime().getApiVersion()).thenReturn(Version.create(10, 9));
     pluginTelemetry.reportTelemetry();


### PR DESCRIPTION
[JS-552](https://sonarsource.atlassian.net/browse/JS-552)

Based on email thread and discussion. We were being too noisy in our logging. Let us remove the dependency telemetry, until we need it again or come up with a more scalable solution.

[JS-552]: https://sonarsource.atlassian.net/browse/JS-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ