### PR TITLE
JS-558 Add `contrib` folder name to default exclusions

### DIFF
--- a/packages/ruling/tests/tools/testProject.ts
+++ b/packages/ruling/tests/tools/testProject.ts
@@ -84,6 +84,7 @@ const DEFAULT_EXCLUSIONS = [
   '**/dist/**',
   '**/vendor/**',
   '**/external/**',
+  '**/contrib/**',
 ].map(pattern => new Minimatch(pattern, { nocase: true, dot: true }));
 
 export function setupBeforeAll(projectFile: string) {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -120,6 +120,7 @@ public class JavaScriptPlugin implements Plugin {
     "**/dist/**",
     "**/vendor/**",
     "**/external/**",
+    "**/contrib/**",
     "**/*.d.ts",
   };
 

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/filter/JavaScriptExclusionsFileFilterTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/filter/JavaScriptExclusionsFileFilterTest.java
@@ -64,6 +64,7 @@ class JavaScriptExclusionsFileFilterTest {
     assertThat(filter.accept(inputFile("build/some_lib.js"))).isTrue();
     assertThat(filter.accept(inputFile("dist/some_lib.js"))).isFalse();
     assertThat(filter.accept(inputFile("external/some_lib.js"))).isFalse();
+    assertThat(filter.accept(inputFile("contrib/some_lib.js"))).isFalse();
     assertThat(logTester.logs(Level.DEBUG)).contains(
       "File test_node_modules/node_modules/some_lib.js was excluded by sonar.javascript.exclusions or sonar.typescript.exclusions"
     );


### PR DESCRIPTION
[JS-558](https://sonarsource.atlassian.net/browse/JS-558)



[JS-558]: https://sonarsource.atlassian.net/browse/JS-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ