### PR TITLE
JS-571 Add extending the RuleConfig.options with the default configurations

### DIFF
--- a/packages/jsts/src/linter/config/rule-config.ts
+++ b/packages/jsts/src/linter/config/rule-config.ts
@@ -20,6 +20,8 @@ import { FileType } from '../../../../shared/src/helpers/files.js';
 import { JsTsLanguage } from '../../../../shared/src/helpers/language.js';
 import type { JSONSchema4 } from 'json-schema';
 import { AnalysisMode } from '../../analysis/analysis.js';
+import { defaultOptions, type ESLintConfiguration } from '../../rules/helpers/configs.js';
+import merge from 'lodash.merge';
 
 /**
  * An input rule configuration for linting
@@ -46,22 +48,27 @@ export interface RuleConfig {
  * Extends an input rule configuration
  *
  * A rule configuration might be extended depending on the rule definition.
- * The purpose of the extension is to activate additional features during
- * linting, e.g., secondary locations.
+ * Primarily, this includes adding the default options stored in `schema.json` files in the rule directory
+ * Also, it allows the extension is to activate additional features during linting, e.g., secondary locations.
  *
  * _A rule extension only applies to rules whose implementation is available._
  *
  * @param schema the rule schema
  * @param inputRule the rule configuration
  * @param workDir the working directory used by rules using the 'sonar-context' flag
+ * @param defaultConfiguration possibly undefined ESLint default options configuration added to the
+ *  provided inputRule.configuration
  * @returns the extended rule configuration
  */
 export function extendRuleConfig(
   schema: JSONSchema4 | JSONSchema4[] | undefined,
   inputRule: RuleConfig,
   workDir?: string,
+  defaultConfiguration?: ESLintConfiguration,
 ) {
-  const options = [...inputRule.configurations];
+  const options = Object.values(
+    merge(defaultOptions(defaultConfiguration), [...inputRule.configurations]),
+  );
   if (hasSonarRuntimeOption(schema)) {
     options.push(SONAR_RUNTIME);
   }

--- a/packages/jsts/src/linter/linter.ts
+++ b/packages/jsts/src/linter/linter.ts
@@ -264,6 +264,7 @@ export class Linter {
    * that are used during linting.
    *
    * @param rules the rules from the active quality profile
+   * @param sonarlint indicates if we are in SonarLint context
    */
   private static createRulesRecord(
     rules: RuleConfig[],
@@ -272,9 +273,9 @@ export class Linter {
     return {
       ...rules.reduce((rules, rule) => {
         const ruleMeta = ruleMetas[rule.key as keyof typeof ruleMetas];
-        let eslintConfiguration;
-        if (ruleMeta && 'fields' in ruleMeta) {
-          eslintConfiguration = ruleMeta.fields as ESLintConfiguration;
+        let eslintConfiguration: ESLintConfiguration | undefined;
+        if ('fields' in ruleMeta) {
+          eslintConfiguration = ruleMeta.fields;
         }
         rules[`sonarjs/${rule.key}`] = [
           'error',

--- a/packages/jsts/src/linter/linter.ts
+++ b/packages/jsts/src/linter/linter.ts
@@ -30,6 +30,8 @@ import { AnalysisMode, FileStatus } from '../analysis/analysis.js';
 import globalsPkg from 'globals';
 import { APIError } from '../../../shared/src/errors/error.js';
 import { pathToFileURL } from 'node:url';
+import * as ruleMetas from '../rules/metas.js';
+import { ESLintConfiguration } from '../rules/helpers/configs.js';
 
 export function createLinterConfigKey(
   fileType: FileType,
@@ -269,6 +271,11 @@ export class Linter {
   ): ESLintLinter.RulesRecord {
     return {
       ...rules.reduce((rules, rule) => {
+        const ruleMeta = ruleMetas[rule.key as keyof typeof ruleMetas];
+        let eslintConfiguration;
+        if (ruleMeta && 'fields' in ruleMeta) {
+          eslintConfiguration = ruleMeta.fields as ESLintConfiguration;
+        }
         rules[`sonarjs/${rule.key}`] = [
           'error',
           /**
@@ -281,6 +288,7 @@ export class Linter {
             Linter.rules[rule.key].meta?.schema || undefined,
             rule,
             Linter.rulesWorkdir,
+            eslintConfiguration,
           ),
         ];
         return rules;

--- a/packages/jsts/src/rules/S103/config.ts
+++ b/packages/jsts/src/rules/S103/config.ts
@@ -25,7 +25,7 @@ export const fields = [
       type: 'integer',
       description: 'The maximum authorized line length.',
       default: 180,
-      sqName: 'maximumLineLength',
+      displayName: 'maximumLineLength',
     },
     {
       field: 'tabWidth',

--- a/packages/jsts/src/rules/S107/config.ts
+++ b/packages/jsts/src/rules/S107/config.ts
@@ -23,7 +23,7 @@ export const fields = [
     {
       field: 'max',
       type: 'integer',
-      sqName: 'maximumFunctionParameters',
+      displayName: 'maximumFunctionParameters',
       description: 'The maximum authorized number of parameters',
       default: 7,
     },

--- a/packages/jsts/src/rules/S1105/config.ts
+++ b/packages/jsts/src/rules/S1105/config.ts
@@ -23,7 +23,7 @@ export const fields = [
     default: '1tbs',
     type: 'string',
     description: 'enforced brace-style: 1tbs, stroustrup or allman.',
-    sqName: 'braceStyle',
+    displayName: 'braceStyle',
   },
   [
     {

--- a/packages/jsts/src/rules/S1105/config.ts
+++ b/packages/jsts/src/rules/S1105/config.ts
@@ -20,7 +20,7 @@ import { ESLintConfiguration } from '../helpers/configs.js';
 
 export const fields = [
   {
-    default: '1tbps',
+    default: '1tbs',
     type: 'string',
     description: 'enforced brace-style: 1tbs, stroustrup or allman.',
     sqName: 'braceStyle',

--- a/packages/jsts/src/rules/S138/config.ts
+++ b/packages/jsts/src/rules/S138/config.ts
@@ -25,7 +25,7 @@ export const fields = [
       type: 'integer',
       description: 'Maximum authorized lines in a function',
       default: 200,
-      sqName: 'max',
+      displayName: 'max',
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S139/config.ts
+++ b/packages/jsts/src/rules/S139/config.ts
@@ -25,7 +25,7 @@ export const fields = [
       type: 'string',
       description: 'Pattern (JavaScript syntax) for text of trailing comments that are allowed.',
       default: '^\\s*[^\\s]+$',
-      sqName: 'pattern',
+      displayName: 'pattern',
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S1441/config.ts
+++ b/packages/jsts/src/rules/S1441/config.ts
@@ -23,7 +23,7 @@ export const fields = [
     description: 'Set to true to require single quotes, false for double quotes.',
     type: 'string',
     default: 'single',
-    sqName: 'singleQuotes',
+    displayName: 'singleQuotes',
   },
   [
     {

--- a/packages/jsts/src/rules/S1451/config.ts
+++ b/packages/jsts/src/rules/S1451/config.ts
@@ -25,7 +25,7 @@ export const fields = [
       type: 'string',
       description: 'Expected copyright and license header',
       default: '',
-      sqFieldType: 'TEXT',
+      fieldType: 'TEXT',
     },
     {
       field: 'isRegularExpression',

--- a/packages/jsts/src/rules/S1479/config.ts
+++ b/packages/jsts/src/rules/S1479/config.ts
@@ -20,7 +20,7 @@ import { ESLintConfiguration } from '../helpers/configs.js';
 
 export const fields = [
   {
-    sqName: 'maximum',
+    displayName: 'maximum',
     type: 'number',
     description: 'Maximum number of "case".',
     default: 30,

--- a/packages/jsts/src/rules/S1541/config.ts
+++ b/packages/jsts/src/rules/S1541/config.ts
@@ -25,7 +25,7 @@ export const fields = [
       type: 'integer',
       description: 'The maximum authorized complexity.',
       default: 10,
-      sqName: 'Threshold',
+      displayName: 'Threshold',
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S2004/config.ts
+++ b/packages/jsts/src/rules/S2004/config.ts
@@ -25,7 +25,7 @@ export const fields = [
       type: 'integer',
       description: 'Maximum depth of allowed nested functions.',
       default: 4,
-      sqName: 'max',
+      displayName: 'max',
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S3524/config.ts
+++ b/packages/jsts/src/rules/S3524/config.ts
@@ -26,7 +26,7 @@ export const fields = [
       description:
         'True to require parentheses around parameters. False to forbid them for single parameter.',
       default: false,
-      sqName: 'parameter_parens',
+      displayName: 'parameter_parens',
     },
     {
       field: 'requireBodyBraces',
@@ -34,7 +34,7 @@ export const fields = [
       description:
         'True to require curly braces around function body. False to forbid them for single-return bodies.',
       default: false,
-      sqName: 'body_braces',
+      displayName: 'body_braces',
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S3776/config.ts
+++ b/packages/jsts/src/rules/S3776/config.ts
@@ -22,6 +22,6 @@ export const fields = [
   {
     default: 15,
     type: 'integer',
-    sqName: 'threshold',
+    displayName: 'threshold',
   },
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S6747/config.ts
+++ b/packages/jsts/src/rules/S6747/config.ts
@@ -28,7 +28,7 @@ export const fields = [
       },
       default: [],
       description: 'Comma-separated list of property and attribute names to ignore',
-      sqName: 'whitelist',
+      displayName: 'whitelist',
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/helpers/configs.ts
+++ b/packages/jsts/src/rules/helpers/configs.ts
@@ -16,7 +16,6 @@
  */
 
 type ESLintConfigurationProperty = {
-  field?: string;
   type: 'string' | 'number' | 'array' | 'boolean' | 'integer';
   default: string | boolean | number | string[] | number[];
   description?: string;
@@ -27,6 +26,22 @@ type ESLintConfigurationProperty = {
   };
 };
 
-type ESLintConfigurationElement = ESLintConfigurationProperty[] | ESLintConfigurationProperty;
+type ESLintNamedProperty = ESLintConfigurationProperty & {
+  field: string;
+};
+
+type ESLintConfigurationElement = ESLintNamedProperty[] | ESLintConfigurationProperty;
 
 export type ESLintConfiguration = ESLintConfigurationElement[];
+
+export function defaultOptions(configuration?: ESLintConfiguration) {
+  return configuration?.map(element => {
+    if (Array.isArray(element)) {
+      return Object.fromEntries(
+        element.map(namedProperty => [namedProperty.field, namedProperty.default]),
+      );
+    } else {
+      return element.default;
+    }
+  });
+}

--- a/packages/jsts/src/rules/helpers/configs.ts
+++ b/packages/jsts/src/rules/helpers/configs.ts
@@ -15,22 +15,35 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 
-type ESLintConfigurationProperty = {
+type ESLintConfigurationDefaultProperty = {
   type: 'string' | 'number' | 'array' | 'boolean' | 'integer';
   default: string | boolean | number | string[] | number[];
-  description?: string;
-  sqName?: string;
-  sqFieldType?: 'TEXT';
   items?: {
     type: string;
   };
 };
 
-type ESLintNamedProperty = ESLintConfigurationProperty & {
+/**
+ * Necessary for the property to show up in the SonarQube interface.
+ * @param description will explain to the user what the property configures
+ * @param displayName only necessary if the name of the property is different from the `field` name
+ * @param fieldType only necessary if you need to override the default fieldType in SQ
+ */
+type ESLintConfigurationSQProperty = ESLintConfigurationDefaultProperty & {
+  description: string;
+  displayName?: string;
+  fieldType?: 'TEXT';
+};
+
+type ESLintConfigurationProperty =
+  | ESLintConfigurationDefaultProperty
+  | ESLintConfigurationSQProperty;
+
+type ESLintConfigurationNamedProperty = ESLintConfigurationProperty & {
   field: string;
 };
 
-type ESLintConfigurationElement = ESLintNamedProperty[] | ESLintConfigurationProperty;
+type ESLintConfigurationElement = ESLintConfigurationNamedProperty[] | ESLintConfigurationProperty;
 
 export type ESLintConfiguration = ESLintConfigurationElement[];
 

--- a/packages/jsts/tests/linter/config/rule-config.test.ts
+++ b/packages/jsts/tests/linter/config/rule-config.test.ts
@@ -19,6 +19,7 @@ import { expect } from 'expect';
 import { SONAR_RUNTIME } from '../../../src/rules/index.js';
 import { extendRuleConfig, RuleConfig } from '../../../src/linter/config/rule-config.js';
 import { SONAR_CONTEXT } from '../../../src/linter/parameters/sonar-context.js';
+import { ESLintConfiguration } from '../../../src/rules/helpers/configs.js';
 
 describe('extendRuleConfig', () => {
   it('should include `sonar-runtime`', () => {
@@ -62,5 +63,54 @@ describe('extendRuleConfig', () => {
       '/tmp/dir',
     );
     expect(config).toEqual([42, SONAR_RUNTIME, { workDir: '/tmp/dir' }]);
+  });
+
+  it('should merge with a simple default configuration with sonar runtime present', () => {
+    const inputRule: RuleConfig = {
+      key: 'some-rule',
+      configurations: [42],
+      fileTypeTargets: ['MAIN'],
+      language: 'js',
+      analysisModes: ['DEFAULT'],
+    };
+    const defaultConfiguration: ESLintConfiguration = [
+      { default: 100, type: 'integer' },
+      [
+        {
+          field: 'format',
+          type: 'string',
+          default: 'allow',
+        },
+      ],
+    ];
+    const config = extendRuleConfig(
+      [{ enum: SONAR_RUNTIME, title: SONAR_CONTEXT }],
+      inputRule,
+      '/tmp/dir',
+      defaultConfiguration,
+    );
+    expect(config).toEqual([42, { format: 'allow' }, SONAR_RUNTIME, { workDir: '/tmp/dir' }]);
+  });
+
+  it('should use default configuration when empty configuration provided', () => {
+    const inputRule: RuleConfig = {
+      key: 'some-rule',
+      configurations: [],
+      fileTypeTargets: ['MAIN'],
+      language: 'js',
+      analysisModes: ['DEFAULT'],
+    };
+    const defaultConfiguration: ESLintConfiguration = [
+      { default: 100, type: 'integer' },
+      [
+        {
+          field: 'format',
+          type: 'string',
+          default: 'allow',
+        },
+      ],
+    ];
+    const config = extendRuleConfig(undefined, inputRule, '/tmp/dir', defaultConfiguration);
+    expect(config).toEqual([100, { format: 'allow' }]);
   });
 });

--- a/packages/jsts/tests/linter/index.test.ts
+++ b/packages/jsts/tests/linter/index.test.ts
@@ -136,7 +136,7 @@ describe('Linter', () => {
     });
     expect(Linter.rulesConfig.get(createLinterConfigKey('MAIN', 'js', 'DEFAULT'))).toEqual(
       expect.objectContaining({
-        'sonarjs/S100': ['error'],
+        'sonarjs/S100': ['error', { format: '^[_a-z][a-zA-Z0-9]*$' }],
       }),
     );
   });
@@ -154,7 +154,7 @@ describe('Linter', () => {
       ],
     });
     expect(Linter.rulesConfig.get(createLinterConfigKey('MAIN', 'js', 'DEFAULT'))).toEqual({
-      'sonarjs/S100': ['error'],
+      'sonarjs/S100': ['error', { format: '^[_a-z][a-zA-Z0-9]*$' }],
       'sonarjs/internal-cognitive-complexity': ['error', 'metric'],
       'sonarjs/internal-symbol-highlighting': ['error'],
     });
@@ -176,7 +176,7 @@ describe('Linter', () => {
       sonarlint: true,
     });
     expect(Linter.rulesConfig.get(createLinterConfigKey('MAIN', 'js', 'DEFAULT'))).toEqual({
-      'sonarjs/S100': ['error'],
+      'sonarjs/S100': ['error', { format: '^[_a-z][a-zA-Z0-9]*$' }],
     });
   });
 

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.5.16</version>
+        <version>1.5.17</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
[JS-571](https://sonarsource.atlassian.net/browse/JS-571)

Keeping this as a small PR, so that it's digestible. Here, we augment the method `extendRuleConfig` to accept the `ESLintConfiguration` object and update the options. To note, the `RuleConfig.configuration` takes priority and overrides what is in the default `ESLintConfiguration`.

[JS-571]: https://sonarsource.atlassian.net/browse/JS-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ