### PR TITLE
SONARARMOR-680 StandaloneParser supports filename usage.

### DIFF
--- a/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
+++ b/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
@@ -78,8 +78,12 @@ public class StandaloneParser implements AutoCloseable {
   }
 
   public ESTree.Program parse(String code) {
+    return parse(code, "file.js");
+  }
+
+  public ESTree.Program parse(String code, String filename) {
     BridgeServer.JsAnalysisRequest request = new BridgeServer.JsAnalysisRequest(
-      "file.js",
+      filename,
       "MAIN",
       code,
       true,

--- a/sonar-plugin/standalone/src/test/java/org/sonar/plugins/javascript/standalone/StandaloneParserTest.java
+++ b/sonar-plugin/standalone/src/test/java/org/sonar/plugins/javascript/standalone/StandaloneParserTest.java
@@ -40,7 +40,7 @@ class StandaloneParserTest {
   }
 
   @Test
-  void should_parse_multiple_time() {
+  void should_parse_multiple_time_multiple_language() {
     Program firstSample = parser.parse("var a = 42;");
     assertThat(firstSample.body()).hasSize(1);
     var firstElement = firstSample.body().get(0);
@@ -56,7 +56,7 @@ class StandaloneParserTest {
         );
       });
     });
-    Program secondSample = parser.parse("let x;");
+    Program secondSample = parser.parse("let x = <T>42;", "typescript-file.ts");
     assertThat(secondSample.body()).hasSize(1);
   }
 


### PR DESCRIPTION
[SONARARMOR-680](https://sonarsource.atlassian.net/browse/SONARARMOR-680)

In Sonar Jasmin, 
we have some `its` failing because typescript files are parsed as JS files.

During `its` We would like to have the option to send the actual filename to the wonderful `StandaloneParser` 🤩 


[SONARARMOR-680]: https://sonarsource.atlassian.net/browse/SONARARMOR-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ