### PR TITLE
JS-593 Sync with rspec repo (for S6426)

### DIFF
--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1135.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1135.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "INFO"
     },
     "attribute": "COMPLETE"
   },

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2245.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2245.html
@@ -55,15 +55,10 @@ const buf = crypto.randomBytes(1);
   <li> OWASP - <a href="https://owasp.org/Top10/A02_2021-Cryptographic_Failures/">Top 10 2021 Category A2 - Cryptographic Failures</a> </li>
   <li> OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure">Top 10 2017 Category A3 - Sensitive Data
   Exposure</a> </li>
-  <li> OWASP - <a href="https://mas.owasp.org/checklists/MASVS-CRYPTO/">Mobile AppSec Verification Standard - Cryptography Requirements</a> </li>
-  <li> OWASP - <a href="https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography">Mobile Top 10 2016 Category M5 -
-  Insufficient Cryptography</a> </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/338">CWE-338 - Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)</a>
   </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/330">CWE-330 - Use of Insufficiently Random Values</a> </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/326">CWE-326 - Inadequate Encryption Strength</a> </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/1241">CWE-1241 - Use of Predictable Algorithm in Random Number Generator</a> </li>
-  <li> Derived from FindSecBugs rule <a href="https://h3xstream.github.io/find-sec-bugs/bugs.htm#PREDICTABLE_RANDOM">Predictable Pseudo Random Number
-  Generator</a> </li>
 </ul>
 

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2245.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2245.json
@@ -29,12 +29,6 @@
     "OWASP": [
       "A3"
     ],
-    "OWASP Mobile": [
-      "M5"
-    ],
-    "MASVS": [
-      "MSTG-CRYPTO-6"
-    ],
     "OWASP Top 10 2021": [
       "A2"
     ],

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2755.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S2755.json
@@ -3,7 +3,7 @@
   "type": "VULNERABILITY",
   "code": {
     "impacts": {
-      "SECURITY": "HIGH"
+      "SECURITY": "BLOCKER"
     },
     "attribute": "COMPLETE"
   },

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4423.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4423.json
@@ -30,12 +30,6 @@
       "A3",
       "A6"
     ],
-    "OWASP Mobile": [
-      "M3"
-    ],
-    "MASVS": [
-      "MSTG-NETWORK-2"
-    ],
     "OWASP Top 10 2021": [
       "A2",
       "A7"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4426.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4426.html
@@ -192,9 +192,6 @@ in mind that NIST-approved digital signature schemes, key agreement, and key tra
   Exposure</a> </li>
   <li> OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration">Top 10 2017 Category A6 - Security
   Misconfiguration</a> </li>
-  <li> OWASP - <a href="https://mas.owasp.org/checklists/MASVS-CRYPTO/">Mobile AppSec Verification Standard - Cryptography Requirements</a> </li>
-  <li> OWASP - <a href="https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography">Mobile Top 10 2016 Category M5 -
-  Insufficient Cryptography</a> </li>
   <li> <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf">NIST 800-131A</a> - Recommendation for Transitioning the
   Use of Cryptographic Algorithms and Key Lengths </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/326">CWE-326 - Inadequate Encryption Strength</a> </li>

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4426.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4426.json
@@ -28,12 +28,6 @@
       "A3",
       "A6"
     ],
-    "OWASP Mobile": [
-      "M5"
-    ],
-    "MASVS": [
-      "MSTG-CRYPTO-3"
-    ],
     "OWASP Top 10 2021": [
       "A2"
     ],

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4790.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4790.html
@@ -33,9 +33,6 @@ const hash = crypto.createHash('sha512'); // Compliant
   Exposure</a> </li>
   <li> OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration">Top 10 2017 Category A6 - Security
   Misconfiguration</a> </li>
-  <li> OWASP - <a href="https://mas.owasp.org/checklists/MASVS-CRYPTO/">Mobile AppSec Verification Standard - Cryptography Requirements</a> </li>
-  <li> OWASP - <a href="https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography">Mobile Top 10 2016 Category M5 -
-  Insufficient Cryptography</a> </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/1240">CWE-1240 - Use of a Risky Cryptographic Primitive</a> </li>
 </ul>
 

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4790.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4790.json
@@ -23,12 +23,6 @@
       "A3",
       "A6"
     ],
-    "OWASP Mobile": [
-      "M5"
-    ],
-    "MASVS": [
-      "MSTG-CRYPTO-4"
-    ],
     "OWASP Top 10 2021": [
       "A2"
     ],

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4830.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4830.html
@@ -139,10 +139,6 @@ roots. Rather than disabling certificate validation in your code, you can add th
   Exposure</a> </li>
   <li> OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration">Top 10 2017 Category A6 - Security
   Misconfiguration</a> </li>
-  <li> OWASP - <a href="https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication">Mobile Top 10 2016 Category M3 - Insecure
-  Communication</a> </li>
-  <li> OWASP - <a href="https://mas.owasp.org/checklists/MASVS-NETWORK/">Mobile AppSec Verification Standard - Network Communication Requirements</a>
-  </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/295">CWE-295 - Improper Certificate Validation</a> </li>
   <li> STIG Viewer - <a href="https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222550">Application Security and
   Development: V-222550</a> - The application must validate certificates by constructing a certification path to an accepted trust anchor. </li>

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4830.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S4830.json
@@ -29,12 +29,6 @@
       "A6",
       "A3"
     ],
-    "OWASP Mobile": [
-      "M3"
-    ],
-    "MASVS": [
-      "MSTG-NETWORK-3"
-    ],
     "OWASP Top 10 2021": [
       "A2",
       "A5",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5254.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5254.json
@@ -10,7 +10,7 @@
     "accessibility",
     "react"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-5254",
   "sqKey": "S5254",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5332.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5332.html
@@ -474,10 +474,6 @@ new CfnStream(this, 'cfnstream-explicit-encrypted', {
   <li> OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure">Top 10 2017 Category A3 - Sensitive Data
   Exposure</a> </li>
   <li> OWASP - <a href="https://owasp.org/Top10/A02_2021-Cryptographic_Failures/">Top 10 2021 Category A2 - Cryptographic Failures</a> </li>
-  <li> OWASP - <a href="https://mas.owasp.org/checklists/MASVS-NETWORK/">Mobile AppSec Verification Standard - Network Communication Requirements</a>
-  </li>
-  <li> OWASP - <a href="https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication">Mobile Top 10 2016 Category M3 - Insecure
-  Communication</a> </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/200">CWE-200 - Exposure of Sensitive Information to an Unauthorized Actor</a> </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/319">CWE-319 - Cleartext Transmission of Sensitive Information</a> </li>
   <li> STIG Viewer - <a href="https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222397">Application Security and

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5332.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5332.json
@@ -23,12 +23,6 @@
     "OWASP": [
       "A3"
     ],
-    "OWASP Mobile": [
-      "M3"
-    ],
-    "MASVS": [
-      "MSTG-NETWORK-1"
-    ],
     "OWASP Top 10 2021": [
       "A2"
     ],

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5527.html
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5527.html
@@ -107,10 +107,6 @@ consider replicating its service to a server whose certificate you can change yo
   Exposure</a> </li>
   <li> OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration">Top 10 2017 Category A6 - Security
   Misconfiguration</a> </li>
-  <li> OWASP - <a href="https://mas.owasp.org/checklists/MASVS-NETWORK/">Mobile AppSec Verification Standard - Network Communication Requirements</a>
-  </li>
-  <li> OWASP - <a href="https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication">Mobile Top 10 2016 Category M3 - Insecure
-  Communication</a> </li>
   <li> CWE - <a href="https://cwe.mitre.org/data/definitions/297">CWE-297 - Improper Validation of Certificate with Host Mismatch</a> </li>
   <li> STIG Viewer - <a href="https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222550">Application Security and
   Development: V-222550</a> - The application must validate certificates by constructing a certification path to an accepted trust anchor. </li>

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5527.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5527.json
@@ -29,12 +29,6 @@
       "A3",
       "A6"
     ],
-    "OWASP Mobile": [
-      "M3"
-    ],
-    "MASVS": [
-      "MSTG-NETWORK-3"
-    ],
     "OWASP Top 10 2021": [
       "A2",
       "A5",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5542.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5542.json
@@ -29,12 +29,6 @@
       "A6",
       "A3"
     ],
-    "OWASP Mobile": [
-      "M5"
-    ],
-    "MASVS": [
-      "MSTG-CRYPTO-3"
-    ],
     "OWASP Top 10 2021": [
       "A2"
     ],

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5547.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S5547.json
@@ -29,12 +29,6 @@
       "A3",
       "A6"
     ],
-    "OWASP Mobile": [
-      "M5"
-    ],
-    "MASVS": [
-      "MSTG-CRYPTO-3"
-    ],
     "OWASP Top 10 2021": [
       "A2"
     ],

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6426.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6426.json
@@ -16,7 +16,7 @@
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6426",
   "sqKey": "S6426",
-  "scope": "All",
+  "scope": "Tests",
   "quickfix": "covered",
   "compatibleLanguages": [
     "JAVASCRIPT",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6582.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6582.json
@@ -12,7 +12,7 @@
     "constantCost": "5min"
   },
   "tags": [],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6582",
   "sqKey": "S6582",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6747.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6747.json
@@ -16,7 +16,7 @@
   "quickfix": "covered",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "LOGICAL"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6772.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6772.json
@@ -16,7 +16,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "FORMATTED"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6774.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6774.json
@@ -16,7 +16,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6807.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6807.json
@@ -17,7 +17,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6811.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6811.json
@@ -17,7 +17,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6819.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6819.json
@@ -17,7 +17,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "CONVENTIONAL"
   },

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6822.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6822.json
@@ -17,7 +17,7 @@
   "quickfix": "targeted",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6823.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6823.json
@@ -10,7 +10,7 @@
     "react",
     "accessibility"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6823",
   "sqKey": "S6823",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6824.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6824.json
@@ -17,7 +17,7 @@
   "quickfix": "targeted",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6844.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6844.json
@@ -17,7 +17,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6845.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6845.json
@@ -10,7 +10,7 @@
     "accessibility",
     "react"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6845",
   "sqKey": "S6845",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6846.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6846.json
@@ -10,7 +10,7 @@
     "accessibility",
     "react"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6846",
   "sqKey": "S6846",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6847.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6847.json
@@ -10,7 +10,7 @@
     "accessibility",
     "react"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6847",
   "sqKey": "S6847",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6848.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6848.json
@@ -10,7 +10,7 @@
     "accessibility",
     "react"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6848",
   "sqKey": "S6848",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6851.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6851.json
@@ -10,14 +10,14 @@
     "accessibility",
     "react"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6851",
   "sqKey": "S6851",
   "scope": "All",
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6852.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6852.json
@@ -10,7 +10,7 @@
     "accessibility",
     "react"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6852",
   "sqKey": "S6852",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6853.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6853.json
@@ -10,7 +10,7 @@
     "accessibility",
     "react"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6853",
   "sqKey": "S6853",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6859.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6859.json
@@ -10,7 +10,7 @@
     "pitfall",
     "paths"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6859",
   "sqKey": "S6859",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6861.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6861.json
@@ -7,7 +7,7 @@
     "constantCost": "5min"
   },
   "tags": [],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6861",
   "sqKey": "S6861",
   "scope": "All",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7059.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7059.json
@@ -7,7 +7,7 @@
     "constantCost": "5min"
   },
   "tags": [],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-7059",
   "sqKey": "S7059",
   "scope": "All",

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "JS"
   ],
-  "latest-update": "2025-02-17T09:43:57.655670Z",
+  "latest-update": "2025-02-28T16:08:59.780708Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true


### PR DESCRIPTION
After the update to rspec (https://github.com/SonarSource/rspec/pull/4716), let us sync it. As this will drive for the checks, to which files the rules are applied to. It needs to be up to date.