### PR TITLE
SONARARMOR-735 Support parsing of ImportEqualsDeclaration nodes

### DIFF
--- a/packages/jsts/src/parsers/ast.ts
+++ b/packages/jsts/src/parsers/ast.ts
@@ -301,6 +301,15 @@ function getProtobufShapeForNode(node: TSESTree.Node) {
     case 'TSParameterProperty':
       // skipping node
       return visitNode(node.parameter);
+    case 'TSImportEqualsDeclaration':
+      shape = visitTSImportEqualsDeclaration(node);
+      break;
+    case 'TSQualifiedName':
+      shape = visitTSQualifiedName(node);
+      break;
+    case 'TSExternalModuleReference':
+      shape = visitTSExternalModuleReference(node);
+      break;
     case 'AccessorProperty':
     case 'Decorator':
     case 'ImportAttribute':
@@ -339,10 +348,8 @@ function getProtobufShapeForNode(node: TSESTree.Node) {
     case 'TSEnumDeclaration':
     case 'TSEnumMember':
     case 'TSExportKeyword':
-    case 'TSExternalModuleReference':
     case 'TSFunctionType':
     case 'TSInstantiationExpression':
-    case 'TSImportEqualsDeclaration':
     case 'TSImportType':
     case 'TSIndexedAccessType':
     case 'TSIndexSignature':
@@ -368,7 +375,6 @@ function getProtobufShapeForNode(node: TSESTree.Node) {
     case 'TSPropertySignature':
     case 'TSProtectedKeyword':
     case 'TSPublicKeyword':
-    case 'TSQualifiedName':
     case 'TSReadonlyKeyword':
     case 'TSRestType':
     case 'TSStaticKeyword':
@@ -950,6 +956,27 @@ function visitFunctionExpression(node: TSESTree.FunctionExpression) {
     params: node.params.map(visitNode),
     generator: node.generator,
     async: node.async,
+  };
+}
+
+function visitTSImportEqualsDeclaration(node: TSESTree.TSImportEqualsDeclaration) {
+  return {
+    id: visitNode(node.id),
+    moduleReference: visitNode(node.moduleReference),
+    importKind: node.importKind,
+  };
+}
+
+function visitTSQualifiedName(node: TSESTree.TSQualifiedName) {
+  return {
+    left: visitNode(node.left),
+    right: visitNode(node.right),
+  };
+}
+
+function visitTSExternalModuleReference(node: TSESTree.TSExternalModuleReference) {
+  return {
+    expression: visitNode(node.expression),
   };
 }
 

--- a/packages/jsts/src/parsers/estree.proto
+++ b/packages/jsts/src/parsers/estree.proto
@@ -88,6 +88,9 @@ enum NodeType {
   TemplateElementType = 69;
   FunctionExpressionType = 70;
   ExportAssignmentType = 71;
+  TSImportEqualsDeclarationType = 72;
+  TSQualifiedNameType = 73;
+  TSExternalModuleReferenceType = 74;
   UnknownNodeType = 1000;
 }
 message Node {
@@ -166,9 +169,13 @@ message Node {
     TemplateElement templateElement = 72;
     FunctionExpression functionExpression = 73;
     ExportAssignment exportAssignment = 74;
+    TSImportEqualsDeclaration tSImportEqualsDeclaration = 75;
+    TSQualifiedName tSQualifiedName = 76;
+    TSExternalModuleReference tSExternalModuleReference = 77;
     UnknownNode unknownNode = 1000;
   }
 }
+
 message Program {
   string sourceType = 1;
   repeated Node body = 2;
@@ -472,6 +479,18 @@ message FunctionExpression {
   optional bool async = 5;
 }
 message ExportAssignment {
+  Node expression = 1;
+}
+message TSImportEqualsDeclaration {
+  Node id = 1;
+  Node moduleReference = 2;
+  string importKind = 3;
+}
+message TSQualifiedName {
+  Node left = 1;
+  Node right = 2;
+}
+message TSExternalModuleReference {
   Node expression = 1;
 }
 

--- a/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/estree/ESTree.java
+++ b/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/estree/ESTree.java
@@ -37,22 +37,6 @@ public class ESTree {
     Location loc();
   }
 
-  public sealed interface IdentifierOrTSQualifiedNameOrTSExternalModuleReference extends Node {}
-
-  public record TSQualifiedName(Location loc, TSQualifiedName left, Identifier right)
-    implements IdentifierOrTSQualifiedNameOrTSExternalModuleReference {}
-
-  public record TSExternalModuleReference(Location loc, Literal expression)
-    implements IdentifierOrTSQualifiedNameOrTSExternalModuleReference {}
-
-  public record TSImportEqualsDeclaration(
-    Location loc,
-    Identifier id,
-    IdentifierOrTSQualifiedNameOrTSExternalModuleReference moduleReference,
-    String importKind
-  )
-    implements DirectiveOrModuleDeclarationOrStatement {}
-
   public record Position(int line, int column) {}
 
   public record Location(Position start, Position end) {}
@@ -657,4 +641,23 @@ public class ESTree {
         .orElse(null);
     }
   }
+
+  public sealed interface IdentifierOrTSQualifiedNameOrTSExternalModuleReference
+    extends IdentifierOrTSQualifiedName {}
+
+  public sealed interface IdentifierOrTSQualifiedName extends Node {}
+
+  public record TSQualifiedName(Location loc, IdentifierOrTSQualifiedName left, Identifier right)
+    implements IdentifierOrTSQualifiedNameOrTSExternalModuleReference {}
+
+  public record TSExternalModuleReference(Location loc, Literal expression)
+    implements IdentifierOrTSQualifiedNameOrTSExternalModuleReference {}
+
+  public record TSImportEqualsDeclaration(
+    Location loc,
+    Identifier id,
+    IdentifierOrTSQualifiedNameOrTSExternalModuleReference moduleReference,
+    String importKind
+  )
+    implements ModuleDeclaration {}
 }

--- a/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/estree/ESTree.java
+++ b/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/estree/ESTree.java
@@ -24,8 +24,8 @@ import java.util.Optional;
 
 /**
   This file is generated. Do not modify it manually. Look at tools/estree instead.
-  
-  This is !EXPERIMENTAL UNSUPPORTED INTERNAL API! It can be modified or removed without prior notice.   
+
+  This is !EXPERIMENTAL UNSUPPORTED INTERNAL API! It can be modified or removed without prior notice.
 */
 public class ESTree {
 
@@ -36,6 +36,22 @@ public class ESTree {
   public sealed interface Node {
     Location loc();
   }
+
+  public sealed interface IdentifierOrTSQualifiedNameOrTSExternalModuleReference extends Node {}
+
+  public record TSQualifiedName(Location loc, TSQualifiedName left, Identifier right)
+    implements IdentifierOrTSQualifiedNameOrTSExternalModuleReference {}
+
+  public record TSExternalModuleReference(Location loc, Literal expression)
+    implements IdentifierOrTSQualifiedNameOrTSExternalModuleReference {}
+
+  public record TSImportEqualsDeclaration(
+    Location loc,
+    Identifier id,
+    IdentifierOrTSQualifiedNameOrTSExternalModuleReference moduleReference,
+    String importKind
+  )
+    implements DirectiveOrModuleDeclarationOrStatement {}
 
   public record Position(int line, int column) {}
 
@@ -276,7 +292,11 @@ public class ESTree {
     implements Expression {}
 
   public record Identifier(Location loc, String name)
-    implements Expression, Pattern, IdentifierOrLiteral {}
+    implements
+      Expression,
+      Pattern,
+      IdentifierOrLiteral,
+      IdentifierOrTSQualifiedNameOrTSExternalModuleReference {}
 
   public record IfStatement(
     Location loc,

--- a/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/estree/ESTree.java
+++ b/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/estree/ESTree.java
@@ -22,11 +22,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-/**
-  This file is generated. Do not modify it manually. Look at tools/estree instead.
-
-  This is !EXPERIMENTAL UNSUPPORTED INTERNAL API! It can be modified or removed without prior notice.
-*/
 public class ESTree {
 
   private ESTree() {

--- a/sonar-plugin/api/src/test/java/org/sonar/plugins/javascript/api/estree/ESTreeTest.java
+++ b/sonar-plugin/api/src/test/java/org/sonar/plugins/javascript/api/estree/ESTreeTest.java
@@ -26,21 +26,21 @@ class ESTreeTest {
   @Test
   void test() {
     Class<?>[] classes = ESTree.class.getDeclaredClasses();
-    assertThat(classes).hasSize(108);
+    assertThat(classes).hasSize(113);
 
     //filter all classes that are interface
     var ifaceCount = Arrays.stream(classes).filter(Class::isInterface).count();
-    assertThat(ifaceCount).isEqualTo(25);
+    assertThat(ifaceCount).isEqualTo(27);
 
     var recordCount = Arrays.stream(classes).filter(Class::isRecord).count();
-    assertThat(recordCount).isEqualTo(78);
+    assertThat(recordCount).isEqualTo(81);
   }
 
   @Test
   void test_node_subclasses() {
     Class<?> sealedClass = ESTree.Node.class;
     Class<?>[] permittedSubclasses = sealedClass.getPermittedSubclasses();
-    assertThat(permittedSubclasses).hasSize(23);
+    assertThat(permittedSubclasses).hasSize(24);
   }
 
   @Test

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/ESTreeFactory.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/ESTreeFactory.java
@@ -180,6 +180,15 @@ public class ESTreeFactory {
         case TemplateElementType -> fromTemplateElementType(node);
         case FunctionExpressionType -> fromFunctionExpressionType(node);
         case ExportAssignmentType -> fromExportAssignment(node);
+        case TSImportEqualsDeclarationType -> throw new IllegalArgumentException(
+          "TSImportEqualsDeclaration is not supported"
+        );
+        case TSExternalModuleReferenceType -> throw new IllegalArgumentException(
+          "TSExternalModuleReference is not supported"
+        );
+        case TSQualifiedNameType -> throw new IllegalArgumentException(
+          "TSQualifiedName is not supported"
+        );
         case UnknownNodeType -> fromUnknownNodeType(node);
         case UNRECOGNIZED -> throw new IllegalArgumentException(
           "Unknown node type: " + node.getType() + " at " + node.getLoc()

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/ESTreeFactory.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/ESTreeFactory.java
@@ -79,6 +79,9 @@ import org.sonar.plugins.javascript.bridge.protobuf.SpreadElement;
 import org.sonar.plugins.javascript.bridge.protobuf.StaticBlock;
 import org.sonar.plugins.javascript.bridge.protobuf.SwitchCase;
 import org.sonar.plugins.javascript.bridge.protobuf.SwitchStatement;
+import org.sonar.plugins.javascript.bridge.protobuf.TSExternalModuleReference;
+import org.sonar.plugins.javascript.bridge.protobuf.TSImportEqualsDeclaration;
+import org.sonar.plugins.javascript.bridge.protobuf.TSQualifiedName;
 import org.sonar.plugins.javascript.bridge.protobuf.TaggedTemplateExpression;
 import org.sonar.plugins.javascript.bridge.protobuf.TemplateElement;
 import org.sonar.plugins.javascript.bridge.protobuf.TemplateLiteral;
@@ -180,15 +183,9 @@ public class ESTreeFactory {
         case TemplateElementType -> fromTemplateElementType(node);
         case FunctionExpressionType -> fromFunctionExpressionType(node);
         case ExportAssignmentType -> fromExportAssignment(node);
-        case TSImportEqualsDeclarationType -> throw new IllegalArgumentException(
-          "TSImportEqualsDeclaration is not supported"
-        );
-        case TSExternalModuleReferenceType -> throw new IllegalArgumentException(
-          "TSExternalModuleReference is not supported"
-        );
-        case TSQualifiedNameType -> throw new IllegalArgumentException(
-          "TSQualifiedName is not supported"
-        );
+        case TSImportEqualsDeclarationType -> fromTSImportEqualsDeclaration(node);
+        case TSExternalModuleReferenceType -> fromTSExternalModuleReferenceType(node);
+        case TSQualifiedNameType -> fromTSQualifiedName(node);
         case UnknownNodeType -> fromUnknownNodeType(node);
         case UNRECOGNIZED -> throw new IllegalArgumentException(
           "Unknown node type: " + node.getType() + " at " + node.getLoc()
@@ -953,6 +950,36 @@ public class ESTreeFactory {
       from(functionExpression.getParamsList(), ESTree.Pattern.class),
       functionExpression.getGenerator(),
       functionExpression.getAsync()
+    );
+  }
+
+  private static ESTree.TSExternalModuleReference fromTSExternalModuleReferenceType(Node node) {
+    TSExternalModuleReference tsExternalModuleReference = node.getTSExternalModuleReference();
+    return new ESTree.TSExternalModuleReference(
+      fromLocation(node.getLoc()),
+      from(tsExternalModuleReference.getExpression(), ESTree.Literal.class)
+    );
+  }
+
+  private static ESTree.TSQualifiedName fromTSQualifiedName(Node node) {
+    TSQualifiedName tsExternalModuleReference = node.getTSQualifiedName();
+    return new ESTree.TSQualifiedName(
+      fromLocation(node.getLoc()),
+      from(tsExternalModuleReference.getLeft(), ESTree.IdentifierOrTSQualifiedName.class),
+      from(tsExternalModuleReference.getRight(), ESTree.Identifier.class)
+    );
+  }
+
+  private static ESTree.TSImportEqualsDeclaration fromTSImportEqualsDeclaration(Node node) {
+    TSImportEqualsDeclaration tsImportEqualsDeclaration = node.getTSImportEqualsDeclaration();
+    return new ESTree.TSImportEqualsDeclaration(
+      fromLocation(node.getLoc()),
+      from(tsImportEqualsDeclaration.getId(), ESTree.Identifier.class),
+      from(
+        tsImportEqualsDeclaration.getModuleReference(),
+        ESTree.IdentifierOrTSQualifiedNameOrTSExternalModuleReference.class
+      ),
+      tsImportEqualsDeclaration.getImportKind()
     );
   }
 

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/ESTreeFactoryTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/ESTreeFactoryTest.java
@@ -54,6 +54,8 @@ import org.sonar.plugins.javascript.bridge.protobuf.Position;
 import org.sonar.plugins.javascript.bridge.protobuf.Program;
 import org.sonar.plugins.javascript.bridge.protobuf.SourceLocation;
 import org.sonar.plugins.javascript.bridge.protobuf.StaticBlock;
+import org.sonar.plugins.javascript.bridge.protobuf.TSExternalModuleReference;
+import org.sonar.plugins.javascript.bridge.protobuf.TSImportEqualsDeclaration;
 import org.sonar.plugins.javascript.bridge.protobuf.TSQualifiedName;
 import org.sonar.plugins.javascript.bridge.protobuf.UnaryExpression;
 import org.sonar.plugins.javascript.bridge.protobuf.UpdateExpression;
@@ -753,42 +755,85 @@ class ESTreeFactoryTest {
     );
   }
 
-  //  @Test
-  //  void should_create_ts_qualified_name() {
-  //    TSQualifiedName innerTsqn = TSQualifiedName.newBuilder()
-  //      .setLeft(Node.newBuilder().setType(NodeType.IdentifierType))
-  //      .setRight(Node.newBuilder().setType(NodeType.IdentifierType))
-  //      .build();
-  //
-  //    Node innerTsqnNode = Node.newBuilder().sett
-  //
-  //    TSQualifiedName tsQualifiedName = TSQualifiedName.newBuilder()
-  //      .setLeft(innerTSQN)
-  //      .setRight(Node.newBuilder().setType(NodeType.IdentifierType))
-  //      .build();
-  //
-  //    CallExpression callExpression = CallExpression.newBuilder()
-  //      .setCallee(Node.newBuilder().setType(NodeType.SuperType).build())
-  //      .build();
-  //    Node node = Node.newBuilder()
-  //      .setType(NodeType.CallExpressionType)
-  //      .setCallExpression(callExpression)
-  //      .build();
-  //    //
-  //    ExportAssignment exportAssignment = ExportAssignment.newBuilder().setExpression(node).build();
-  //    Node protobufNode = Node.newBuilder()
-  //      .setType(NodeType.ExportAssignmentType)
-  //      .setExportAssignment(exportAssignment)
-  //      .build();
-  //
-  //    ESTree.Node estreeExpressionStatement = ESTreeFactory.from(protobufNode, ESTree.Node.class);
-  //    assertThat(estreeExpressionStatement).isInstanceOfSatisfying(
-  //      ESTree.ExportAssignment.class,
-  //      export -> {
-  //        assertThat(export.expression()).isInstanceOf(ESTree.CallExpression.class);
-  //      }
-  //    );
-  //  }
+  @Test
+  void should_create_ts_qualified_name() {
+    TSQualifiedName innerTsqn = TSQualifiedName.newBuilder()
+      .setLeft(Node.newBuilder().setType(NodeType.IdentifierType))
+      .setRight(Node.newBuilder().setType(NodeType.IdentifierType))
+      .build();
+
+    Node innerTsqnNode = Node.newBuilder()
+      .setType(NodeType.TSQualifiedNameType)
+      .setTSQualifiedName(innerTsqn)
+      .build();
+
+    TSQualifiedName tsQualifiedName = TSQualifiedName.newBuilder()
+      .setLeft(innerTsqnNode)
+      .setRight(Node.newBuilder().setType(NodeType.IdentifierType))
+      .build();
+
+    Node protobufNode = Node.newBuilder()
+      .setType(NodeType.TSQualifiedNameType)
+      .setTSQualifiedName(tsQualifiedName)
+      .build();
+
+    ESTree.Node estreeTsQualifiedName = ESTreeFactory.from(protobufNode, ESTree.Node.class);
+    assertThat(estreeTsQualifiedName).isInstanceOfSatisfying(ESTree.TSQualifiedName.class, tsqn -> {
+      assertThat(tsqn.left()).isInstanceOfSatisfying(ESTree.TSQualifiedName.class, left -> {
+        assertThat(left.left()).isInstanceOf(ESTree.Identifier.class);
+        assertThat(left.right()).isInstanceOf(ESTree.Identifier.class);
+      });
+      assertThat(tsqn.right()).isInstanceOf(ESTree.Identifier.class);
+    });
+  }
+
+  @Test
+  void should_create_ts_external_module_reference() {
+    TSExternalModuleReference tsExternalModuleReference = TSExternalModuleReference.newBuilder()
+      .setExpression(Node.newBuilder().setType(NodeType.LiteralType))
+      .build();
+
+    Node protobufNode = Node.newBuilder()
+      .setType(NodeType.TSExternalModuleReferenceType)
+      .setTSExternalModuleReference(tsExternalModuleReference)
+      .build();
+
+    ESTree.Node estreeTsExternalModuleReference = ESTreeFactory.from(
+      protobufNode,
+      ESTree.Node.class
+    );
+    assertThat(estreeTsExternalModuleReference).isInstanceOfSatisfying(
+      ESTree.TSExternalModuleReference.class,
+      tsemr -> assertThat(tsemr.expression()).isInstanceOf(ESTree.Literal.class)
+    );
+  }
+
+  @Test
+  void should_create_ts_import_equals_declaration() {
+    TSImportEqualsDeclaration tsImportEqualsDeclaration = TSImportEqualsDeclaration.newBuilder()
+      .setId(Node.newBuilder().setType(NodeType.IdentifierType))
+      .setModuleReference(Node.newBuilder().setType(NodeType.IdentifierType))
+      .setImportKind("value")
+      .build();
+
+    Node protobufNode = Node.newBuilder()
+      .setType(NodeType.TSImportEqualsDeclarationType)
+      .setTSImportEqualsDeclaration(tsImportEqualsDeclaration)
+      .build();
+
+    ESTree.Node estreeTsImportEqualsDeclaration = ESTreeFactory.from(
+      protobufNode,
+      ESTree.Node.class
+    );
+    assertThat(estreeTsImportEqualsDeclaration).isInstanceOfSatisfying(
+      ESTree.TSImportEqualsDeclaration.class,
+      tsied -> {
+        assertThat(tsied.id()).isInstanceOf(ESTree.Identifier.class);
+        assertThat(tsied.moduleReference()).isInstanceOf(ESTree.Identifier.class);
+        assertThat(tsied.importKind()).isInstanceOf(String.class);
+      }
+    );
+  }
 
   @Test
   void throw_exception_from_unrecognized_type() {

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/ESTreeFactoryTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/ESTreeFactoryTest.java
@@ -54,6 +54,7 @@ import org.sonar.plugins.javascript.bridge.protobuf.Position;
 import org.sonar.plugins.javascript.bridge.protobuf.Program;
 import org.sonar.plugins.javascript.bridge.protobuf.SourceLocation;
 import org.sonar.plugins.javascript.bridge.protobuf.StaticBlock;
+import org.sonar.plugins.javascript.bridge.protobuf.TSQualifiedName;
 import org.sonar.plugins.javascript.bridge.protobuf.UnaryExpression;
 import org.sonar.plugins.javascript.bridge.protobuf.UpdateExpression;
 import org.sonar.plugins.javascript.bridge.protobuf.WithStatement;
@@ -751,6 +752,43 @@ class ESTreeFactoryTest {
       }
     );
   }
+
+  //  @Test
+  //  void should_create_ts_qualified_name() {
+  //    TSQualifiedName innerTsqn = TSQualifiedName.newBuilder()
+  //      .setLeft(Node.newBuilder().setType(NodeType.IdentifierType))
+  //      .setRight(Node.newBuilder().setType(NodeType.IdentifierType))
+  //      .build();
+  //
+  //    Node innerTsqnNode = Node.newBuilder().sett
+  //
+  //    TSQualifiedName tsQualifiedName = TSQualifiedName.newBuilder()
+  //      .setLeft(innerTSQN)
+  //      .setRight(Node.newBuilder().setType(NodeType.IdentifierType))
+  //      .build();
+  //
+  //    CallExpression callExpression = CallExpression.newBuilder()
+  //      .setCallee(Node.newBuilder().setType(NodeType.SuperType).build())
+  //      .build();
+  //    Node node = Node.newBuilder()
+  //      .setType(NodeType.CallExpressionType)
+  //      .setCallExpression(callExpression)
+  //      .build();
+  //    //
+  //    ExportAssignment exportAssignment = ExportAssignment.newBuilder().setExpression(node).build();
+  //    Node protobufNode = Node.newBuilder()
+  //      .setType(NodeType.ExportAssignmentType)
+  //      .setExportAssignment(exportAssignment)
+  //      .build();
+  //
+  //    ESTree.Node estreeExpressionStatement = ESTreeFactory.from(protobufNode, ESTree.Node.class);
+  //    assertThat(estreeExpressionStatement).isInstanceOfSatisfying(
+  //      ESTree.ExportAssignment.class,
+  //      export -> {
+  //        assertThat(export.expression()).isInstanceOf(ESTree.CallExpression.class);
+  //      }
+  //    );
+  //  }
 
   @Test
   void throw_exception_from_unrecognized_type() {


### PR DESCRIPTION
I have two issues about duplicated code, but according to the structure of the way the class is implemented, I would be inclined to mark them as 'won't fix'. Please let me know if I should fix them instead :) 