### PR TITLE
JS-596 delete fake typings for typescript-eslint

### DIFF
--- a/typings/typescript-eslint/index.d.ts
+++ b/typings/typescript-eslint/index.d.ts
@@ -1,4 +1,0 @@
-declare module '@typescript-eslint/eslint-plugin' {
-  import type { Rule } from 'eslint';
-  export const rules: { [name: string]: Rule.RuleModule };
-}


### PR DESCRIPTION
[JS-596](https://sonarsource.atlassian.net/browse/JS-596)

As far as I see, these are@typescript-eslint/eslint-plugin is nicely typed. No need to fake it.

[JS-596]: https://sonarsource.atlassian.net/browse/JS-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ