### PR TITLE
JS-602 Show what are the issues with ruling

### DIFF
--- a/packages/ruling/tests/projects/Ghost.ruling.test.ts
+++ b/packages/ruling/tests/projects/Ghost.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/Joust.ruling.test.ts
+++ b/packages/ruling/tests/projects/Joust.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/TypeScript.ruling.test.ts
+++ b/packages/ruling/tests/projects/TypeScript.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/ace.ruling.test.ts
+++ b/packages/ruling/tests/projects/ace.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/ag-grid.ruling.test.ts
+++ b/packages/ruling/tests/projects/ag-grid.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/amplify.ruling.test.ts
+++ b/packages/ruling/tests/projects/amplify.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/angular.js.ruling.test.ts
+++ b/packages/ruling/tests/projects/angular.js.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/ant-design.ruling.test.ts
+++ b/packages/ruling/tests/projects/ant-design.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/backbone.ruling.test.ts
+++ b/packages/ruling/tests/projects/backbone.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/console.ruling.test.ts
+++ b/packages/ruling/tests/projects/console.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/courselit.ruling.test.ts
+++ b/packages/ruling/tests/projects/courselit.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/desktop.ruling.test.ts
+++ b/packages/ruling/tests/projects/desktop.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/ecmascript6-today.ruling.test.ts
+++ b/packages/ruling/tests/projects/ecmascript6-today.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/eigen.ruling.test.ts
+++ b/packages/ruling/tests/projects/eigen.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/es5-shim.ruling.test.ts
+++ b/packages/ruling/tests/projects/es5-shim.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/expressionist.js.ruling.test.ts
+++ b/packages/ruling/tests/projects/expressionist.js.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/file-for-rules.ruling.test.ts
+++ b/packages/ruling/tests/projects/file-for-rules.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/fireact.ruling.test.ts
+++ b/packages/ruling/tests/projects/fireact.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/fireface.ruling.test.ts
+++ b/packages/ruling/tests/projects/fireface.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/http.ruling.test.ts
+++ b/packages/ruling/tests/projects/http.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/ionic2-auth.ruling.test.ts
+++ b/packages/ruling/tests/projects/ionic2-auth.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/it-tools.ruling.test.ts
+++ b/packages/ruling/tests/projects/it-tools.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/jStorage.ruling.test.ts
+++ b/packages/ruling/tests/projects/jStorage.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/jira-clone.ruling.test.ts
+++ b/packages/ruling/tests/projects/jira-clone.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/jquery.ruling.test.ts
+++ b/packages/ruling/tests/projects/jquery.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/jshint.ruling.test.ts
+++ b/packages/ruling/tests/projects/jshint.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/knockout.ruling.test.ts
+++ b/packages/ruling/tests/projects/knockout.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/moose.ruling.test.ts
+++ b/packages/ruling/tests/projects/moose.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/mootools-core.ruling.test.ts
+++ b/packages/ruling/tests/projects/mootools-core.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/ocanvas.ruling.test.ts
+++ b/packages/ruling/tests/projects/ocanvas.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/p5.js.ruling.test.ts
+++ b/packages/ruling/tests/projects/p5.js.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/paper.js.ruling.test.ts
+++ b/packages/ruling/tests/projects/paper.js.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/postgraphql.ruling.test.ts
+++ b/packages/ruling/tests/projects/postgraphql.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/prettier-vscode.ruling.test.ts
+++ b/packages/ruling/tests/projects/prettier-vscode.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/prototype.ruling.test.ts
+++ b/packages/ruling/tests/projects/prototype.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/qunit.ruling.test.ts
+++ b/packages/ruling/tests/projects/qunit.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/react-cloud-music.ruling.test.ts
+++ b/packages/ruling/tests/projects/react-cloud-music.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/reddit-mobile.ruling.test.ts
+++ b/packages/ruling/tests/projects/reddit-mobile.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/redux.ruling.test.ts
+++ b/packages/ruling/tests/projects/redux.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/router.ruling.test.ts
+++ b/packages/ruling/tests/projects/router.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/rxjs.ruling.test.ts
+++ b/packages/ruling/tests/projects/rxjs.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/searchkit.ruling.test.ts
+++ b/packages/ruling/tests/projects/searchkit.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/sizzle.ruling.test.ts
+++ b/packages/ruling/tests/projects/sizzle.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/snoode.ruling.test.ts
+++ b/packages/ruling/tests/projects/snoode.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/sonar-web.ruling.test.ts
+++ b/packages/ruling/tests/projects/sonar-web.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/templating.ruling.test.ts
+++ b/packages/ruling/tests/projects/templating.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/underscore.ruling.test.ts
+++ b/packages/ruling/tests/projects/underscore.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/vuetify.ruling.test.ts
+++ b/packages/ruling/tests/projects/vuetify.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/watchtower.js.ruling.test.ts
+++ b/packages/ruling/tests/projects/watchtower.js.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/projects/yaml.ruling.test.ts
+++ b/packages/ruling/tests/projects/yaml.ruling.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { projectName, testProject } from '../tools/testProject.js';
+import { projectName, testProject, ok } from '../tools/testProject.js';
 import { describe, it } from 'node:test';
-import { ok } from 'assert';
 
 describe('Ruling', () => {
   const name = projectName(import.meta.filename);

--- a/packages/ruling/tests/tools/testProject.ts
+++ b/packages/ruling/tests/tools/testProject.ts
@@ -32,8 +32,9 @@ import { analyzeProject } from '../../../jsts/src/analysis/projectAnalysis/proje
 import { toUnixPath } from '../../../shared/src/helpers/files.js';
 import { AnalysisInput, AnalysisOutput } from '../../../shared/src/types/analysis.js';
 import { createParsingIssue, parseParsingError } from '../../../bridge/src/errors/index.js';
-import { compare } from 'dir-compare';
+import { compare, Result } from 'dir-compare';
 import { RuleConfig } from '../../../jsts/src/linter/config/rule-config.js';
+import { expect } from 'expect';
 
 const sourcesPath = join(
   toUnixPath(import.meta.dirname),
@@ -129,7 +130,17 @@ export async function testProject(projectName: string) {
 
   await writeResults(projectPath, name, results, actualPath);
 
-  return (await compare(expectedPath, actualPath, { compareContent: true })).same;
+  return await compare(expectedPath, actualPath, { compareContent: true });
+}
+
+export function ok(diff: Result) {
+  expect(
+    JSON.stringify(
+      diff.diffSet.filter(value => value.state !== 'equal'),
+      null,
+      2,
+    ),
+  ).toEqual('[]');
 }
 
 /**


### PR DESCRIPTION
[JS-602](https://sonarsource.atlassian.net/browse/JS-602)

Let me know what you think?
I think this will make for much more readable ruling results. Not just that it filed, but the file comparison.

If I get the green light, I'll update the rest of the tests.

Here is an example where there is no 'actual' results:

```
expect(received).toEqual(expected) // deep equality

- Expected  -    1
+ Received  + 1706

- []
+ [
+   {
+     "path1": "/Users/zglicz/sonar/codes/SonarJS/its/ruling/src/test/expected/jsts/file-for-rules",
+     "relativePath": "/",
+     "name1": "javascript-S103.json",
+     "state": "left",
+     "permissionDeniedState": "access-ok",
+     "type1": "file",
+     "type2": "missing",
+     "level": 0,
+     "size1": 37,
+     "date1": "2024-05-12T16:52:00.594Z"
+   },
+   {
+     "path1": "/Users/zglicz/sonar/codes/SonarJS/its/ruling/src/test/expected/jsts/file-for-rules",
+     "relativePath": "/",
+     "name1": "javascript-S105.json",
+     "state": "left",
+     "permissionDeniedState": "access-ok",
+     "type1": "file",
+     "type2": "missing",
+     "level": 0,
+     "size1": 37,
+     "date1": "2024-05-12T16:52:00.594Z"
+   },
...
```


[JS-602]: https://sonarsource.atlassian.net/browse/JS-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ