### PR TITLE
COMMUNITY-129686 - Update program.ts

### DIFF
--- a/packages/jsts/src/program/program.ts
+++ b/packages/jsts/src/program/program.ts
@@ -100,7 +100,7 @@ export function createProgramOptions(
     {
       noEmit: true,
     },
-    tsConfig,
+    path.resolve(tsConfig),
     undefined,
     [
       {

--- a/packages/jsts/tests/program/program.test.ts
+++ b/packages/jsts/tests/program/program.test.ts
@@ -204,7 +204,7 @@ describe('program', () => {
 
   it('should report errors', () => {
     expect(() => createProgramOptions('tsconfig.json', '{ "files": [] }')).toThrow(
-      `The 'files' list in config file 'tsconfig.json' is empty.`,
+      `The 'files' list in config file '${path.resolve('tsconfig.json')}' is empty.`,
     );
   });
 


### PR DESCRIPTION
The sixth argument of `ts.parseJsonConfigFileContent` is wrongly set to the passed path. The method expect a _resolved path_. Passing a non-resolved path makes the program unable to resolve the included files.

Note that this is not the fix to COMMUNITY-129686. It is a fix required to debug the issue.