### PR TITLE
JS-587 Remove type from SQ property

### DIFF
--- a/packages/jsts/src/rules/S100/config.ts
+++ b/packages/jsts/src/rules/S100/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'format',
-      type: 'string',
       description: 'Regular expression used to check the function names against.',
       default: '^[_a-z][a-zA-Z0-9]*$',
     },

--- a/packages/jsts/src/rules/S101/config.ts
+++ b/packages/jsts/src/rules/S101/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'format',
-      type: 'string',
       description: 'Regular expression used to check the class names against.',
       default: '^[A-Z][a-zA-Z0-9]*$',
     },

--- a/packages/jsts/src/rules/S103/config.ts
+++ b/packages/jsts/src/rules/S103/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'code',
-      type: 'integer',
       description: 'The maximum authorized line length.',
       default: 180,
       displayName: 'maximumLineLength',

--- a/packages/jsts/src/rules/S104/config.ts
+++ b/packages/jsts/src/rules/S104/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'maximum',
-      type: 'integer',
       description: 'Maximum authorized lines in a file',
       default: 1000,
     },

--- a/packages/jsts/src/rules/S1067/config.ts
+++ b/packages/jsts/src/rules/S1067/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'max',
-      type: 'integer',
       description: 'Maximum number of allowed conditional operators in an expression',
       default: 3,
     },

--- a/packages/jsts/src/rules/S107/config.ts
+++ b/packages/jsts/src/rules/S107/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'max',
-      type: 'integer',
       displayName: 'maximumFunctionParameters',
       description: 'The maximum authorized number of parameters',
       default: 7,

--- a/packages/jsts/src/rules/S1105/config.ts
+++ b/packages/jsts/src/rules/S1105/config.ts
@@ -21,7 +21,6 @@ import { ESLintConfiguration } from '../helpers/configs.js';
 export const fields = [
   {
     default: '1tbs',
-    type: 'string',
     description: 'enforced brace-style: 1tbs, stroustrup or allman.',
     displayName: 'braceStyle',
   },

--- a/packages/jsts/src/rules/S117/config.ts
+++ b/packages/jsts/src/rules/S117/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'format',
-      type: 'string',
       default: '^[_$A-Za-z][$A-Za-z0-9]*$|^[_$A-Z][_$A-Z0-9]+$',
       description: 'Regular expression used to check the names against.',
     },

--- a/packages/jsts/src/rules/S1192/config.ts
+++ b/packages/jsts/src/rules/S1192/config.ts
@@ -22,13 +22,11 @@ export const fields = [
   [
     {
       field: 'threshold',
-      type: 'integer',
       description: 'Number of times a literal must be duplicated to trigger an issue.',
       default: 3,
     },
     {
       field: 'ignoreStrings',
-      type: 'string',
       description: 'Comma-separated list of strings that must be ignored.',
       default: 'application/json',
     },

--- a/packages/jsts/src/rules/S124/config.ts
+++ b/packages/jsts/src/rules/S124/config.ts
@@ -22,19 +22,16 @@ export const fields = [
   [
     {
       field: 'regularExpression',
-      type: 'string',
       description: 'The regular expression (JavaScript syntax)',
       default: '',
     },
     {
       field: 'message',
-      type: 'string',
       description: 'The issue message',
       default: 'The regular expression matches this comment.',
     },
     {
       field: 'flags',
-      type: 'string',
       description: 'Regular expression modifier flags',
       default: '',
     },

--- a/packages/jsts/src/rules/S134/config.ts
+++ b/packages/jsts/src/rules/S134/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'maximumNestingLevel',
-      type: 'integer',
       description: `Maximum allowed \\"if/for/while/switch/try\\" statements nesting depth`,
       default: 3,
     },

--- a/packages/jsts/src/rules/S138/config.ts
+++ b/packages/jsts/src/rules/S138/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'maximum',
-      type: 'integer',
       description: 'Maximum authorized lines in a function',
       default: 200,
       displayName: 'max',

--- a/packages/jsts/src/rules/S139/config.ts
+++ b/packages/jsts/src/rules/S139/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'ignorePattern',
-      type: 'string',
       description: 'Pattern (JavaScript syntax) for text of trailing comments that are allowed.',
       default: `^\\s*[^\\s]+$`,
       customDefault: `^\\\\s*[^\\\\s]+$`,

--- a/packages/jsts/src/rules/S1441/config.ts
+++ b/packages/jsts/src/rules/S1441/config.ts
@@ -21,7 +21,6 @@ import { ESLintConfiguration } from '../helpers/configs.js';
 export const fields = [
   {
     description: 'Set to true to require single quotes, false for double quotes.',
-    type: 'boolean',
     default: 'single',
     customDefault: true,
     displayName: 'singleQuotes',

--- a/packages/jsts/src/rules/S1451/config.ts
+++ b/packages/jsts/src/rules/S1451/config.ts
@@ -22,14 +22,12 @@ export const fields = [
   [
     {
       field: 'headerFormat',
-      type: 'string',
       description: 'Expected copyright and license header',
       default: '',
       fieldType: 'TEXT',
     },
     {
       field: 'isRegularExpression',
-      type: 'boolean',
       description: 'Whether the headerFormat is a regular expression',
       default: false,
     },

--- a/packages/jsts/src/rules/S1479/config.ts
+++ b/packages/jsts/src/rules/S1479/config.ts
@@ -21,7 +21,6 @@ import { ESLintConfiguration } from '../helpers/configs.js';
 export const fields = [
   {
     displayName: 'maximum',
-    type: 'integer',
     description: 'Maximum number of \\"case\\".',
     default: 30,
   },

--- a/packages/jsts/src/rules/S2004/config.ts
+++ b/packages/jsts/src/rules/S2004/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'threshold',
-      type: 'integer',
       description: 'Maximum depth of allowed nested functions.',
       default: 4,
       displayName: 'max',

--- a/packages/jsts/src/rules/S2068/config.ts
+++ b/packages/jsts/src/rules/S2068/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'passwordWords',
-      type: 'array',
       items: {
         type: 'string',
       },

--- a/packages/jsts/src/rules/S2376/config.ts
+++ b/packages/jsts/src/rules/S2376/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'getWithoutSet',
-      type: 'boolean',
       description: 'Reports on getters without setters.',
       default: false,
     },

--- a/packages/jsts/src/rules/S2999/config.ts
+++ b/packages/jsts/src/rules/S2999/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'considerJSDoc',
-      type: 'boolean',
       description: 'Consider only functions with @constructor tag as constructor functions',
       default: false,
     },

--- a/packages/jsts/src/rules/S3524/config.ts
+++ b/packages/jsts/src/rules/S3524/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'requireParameterParentheses',
-      type: 'boolean',
       description:
         'True to require parentheses around parameters. False to forbid them for single parameter.',
       default: false,
@@ -30,7 +29,6 @@ export const fields = [
     },
     {
       field: 'requireBodyBraces',
-      type: 'boolean',
       description:
         'True to require curly braces around function body. False to forbid them for single-return bodies.',
       default: false,

--- a/packages/jsts/src/rules/S3776/config.ts
+++ b/packages/jsts/src/rules/S3776/config.ts
@@ -21,7 +21,6 @@ import { ESLintConfiguration } from '../helpers/configs.js';
 export const fields = [
   {
     default: 15,
-    type: 'integer',
     displayName: 'threshold',
     description: 'The maximum authorized complexity.',
   },

--- a/packages/jsts/src/rules/S4275/config.ts
+++ b/packages/jsts/src/rules/S4275/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'allowImplicit',
-      type: 'boolean',
       description: 'Allow implicitly returning undefined with a return statement.',
       default: false,
     },

--- a/packages/jsts/src/rules/S4328/config.ts
+++ b/packages/jsts/src/rules/S4328/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'whitelist',
-      type: 'array',
       items: {
         type: 'string',
       },

--- a/packages/jsts/src/rules/S4622/config.ts
+++ b/packages/jsts/src/rules/S4622/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'threshold',
-      type: 'integer',
       description: 'Maximum elements authorized in a union type definition.',
       default: 3,
     },

--- a/packages/jsts/src/rules/S5604/config.ts
+++ b/packages/jsts/src/rules/S5604/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'permissions',
-      type: 'array',
       items: {
         type: 'string',
       },

--- a/packages/jsts/src/rules/S5693/config.ts
+++ b/packages/jsts/src/rules/S5693/config.ts
@@ -22,13 +22,11 @@ export const fields = [
   [
     {
       field: 'fileUploadSizeLimit',
-      type: 'integer',
       description: 'The maximum size of HTTP requests handling file uploads (in bytes)',
       default: 8000000,
     },
     {
       field: 'standardSizeLimit',
-      type: 'integer',
       description: 'The maximum size of regular HTTP requests (in bytes)',
       default: 2000000,
     },

--- a/packages/jsts/src/rules/S5843/config.ts
+++ b/packages/jsts/src/rules/S5843/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'threshold',
-      type: 'integer',
       description: 'The maximum authorized complexity.',
       default: 20,
     },

--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -29,6 +29,7 @@ export const fields = [
       field: 'randomnessSensibility',
       description: 'Minimum shannon entropy threshold of the secret',
       default: 5.0,
+      customDefault: '5.0',
       customForConfiguration: `Double.parseDouble(randomnessSensibility)`,
     },
   ],

--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -22,13 +22,11 @@ export const fields = [
   [
     {
       field: 'secretWords',
-      type: 'string',
       description: 'Comma separated list of words identifying potential secrets',
       default: 'api[_.-]?key,auth,credential,secret,token',
     },
     {
       field: 'randomnessSensibility',
-      type: 'string',
       description: 'Minimum shannon entropy threshold of the secret',
       default: 5.0,
       customForConfiguration: `Double.parseDouble(randomnessSensibility)`,

--- a/packages/jsts/src/rules/S6747/config.ts
+++ b/packages/jsts/src/rules/S6747/config.ts
@@ -22,7 +22,6 @@ export const fields = [
   [
     {
       field: 'ignore',
-      type: 'array',
       items: {
         type: 'string',
       },

--- a/packages/jsts/src/rules/helpers/configs.ts
+++ b/packages/jsts/src/rules/helpers/configs.ts
@@ -25,7 +25,7 @@ type ESLintConfigurationDefaultProperty = {
  * Necessary for the property to show up in the SonarQube interface.
  * @param description will explain to the user what the property configures
  * @param displayName only necessary if the name of the property is different from the `field` name
- * @param type what is the type of the option
+ * @param customDefault only necessary if different default in SQ different than in JS/TS
  * @param items only necessary if type is 'array'
  * @param fieldType only necessary if you need to override the default fieldType in SQ
  * @param customForConfiguration replacement content how to pass this variable to the Configuration object

--- a/packages/jsts/src/rules/helpers/configs.ts
+++ b/packages/jsts/src/rules/helpers/configs.ts
@@ -15,7 +15,6 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 
-export type ValueType = 'string' | 'array' | 'boolean' | 'integer';
 export type Default = string | boolean | number | string[] | number[] | Object;
 
 type ESLintConfigurationDefaultProperty = {
@@ -35,7 +34,6 @@ export type ESLintConfigurationSQProperty = ESLintConfigurationDefaultProperty &
   description: string;
   displayName?: string;
   customDefault?: Default;
-  type: ValueType;
   items?: {
     type: 'string' | 'integer';
   };

--- a/tools/helpers.ts
+++ b/tools/helpers.ts
@@ -222,27 +222,28 @@ function generateBody(config: ESLintConfiguration, imports: Set<string>) {
     }
 
     const getJavaType = () => {
-      switch (property.type) {
-        case 'integer':
+      const defaultValue = property.customDefault ?? property.default;
+      switch (typeof defaultValue) {
+        case 'number':
           return 'int';
         case 'string':
           return 'String';
         case 'boolean':
           return 'boolean';
-        case 'array':
+        default:
           return 'String';
       }
     };
 
     const getDefaultValueString = () => {
       const defaultValue = property.customDefault ?? property.default;
-      switch (property.type) {
-        case 'integer':
+      switch (typeof defaultValue) {
+        case 'number':
         case 'boolean':
           return `"" + ${defaultValue}`;
         case 'string':
           return `"${defaultValue}"`;
-        case 'array': {
+        case 'object': {
           assert(Array.isArray(defaultValue));
           return `"${defaultValue.join(',')}"`;
         }
@@ -251,13 +252,13 @@ function generateBody(config: ESLintConfiguration, imports: Set<string>) {
 
     const getDefaultValue = () => {
       const defaultValue = property.customDefault ?? property.default;
-      switch (property.type) {
-        case 'integer':
+      switch (typeof defaultValue) {
+        case 'number':
         case 'boolean':
           return `${defaultValue.toString()}`;
         case 'string':
           return `"${defaultValue}"`;
-        case 'array':
+        case 'object':
           assert(Array.isArray(defaultValue));
           return `"${defaultValue.join(',')}"`;
       }
@@ -284,7 +285,7 @@ function generateBody(config: ESLintConfiguration, imports: Set<string>) {
             return undefined;
           }
           let value: string;
-          if (namedProperty.type === 'array') {
+          if (typeof namedProperty.default === 'object') {
             const castTo = namedProperty.items.type === 'string' ? 'String' : 'Integer';
             imports.add('import java.util.Arrays;');
             value = `Arrays.stream(${fieldName}.split(",")).map(String::trim).toArray(${castTo}[]::new)`;

--- a/tools/helpers.ts
+++ b/tools/helpers.ts
@@ -221,8 +221,12 @@ function generateBody(config: ESLintConfiguration, imports: Set<string>) {
       return;
     }
 
+    const getSQDefault = () => {
+      return property.customDefault ?? property.default;
+    };
+
     const getJavaType = () => {
-      const defaultValue = property.customDefault ?? property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
           return 'int';
@@ -236,7 +240,7 @@ function generateBody(config: ESLintConfiguration, imports: Set<string>) {
     };
 
     const getDefaultValueString = () => {
-      const defaultValue = property.customDefault ?? property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':
@@ -251,7 +255,7 @@ function generateBody(config: ESLintConfiguration, imports: Set<string>) {
     };
 
     const getDefaultValue = () => {
-      const defaultValue = property.customDefault ?? property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':


### PR DESCRIPTION
[JS-587](https://sonarsource.atlassian.net/browse/JS-587)

This can be derived from the `property.customDefault ?? property.default`, so lets remove it

[JS-587]: https://sonarsource.atlassian.net/browse/JS-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ