### PR TITLE
JS-621 Remove maxItems: 2 in eslint rule schemas

### DIFF
--- a/packages/jsts/src/linter/custom-rules/symbol-highlighting.ts
+++ b/packages/jsts/src/linter/custom-rules/symbol-highlighting.ts
@@ -16,13 +16,12 @@
  */
 import { CustomRule } from './custom-rule.js';
 import { rule as symbolHighlightingRule } from '../visitors/symbol-highlighting.js';
-import type { Rule } from 'eslint';
 
 /**
  * The internal _symbol highlighting_ custom rule
  */
 export const rule: CustomRule = {
   ruleId: 'internal-symbol-highlighting',
-  ruleModule: symbolHighlightingRule as unknown as Rule.RuleModule,
+  ruleModule: symbolHighlightingRule,
   ruleConfig: [],
 };

--- a/packages/jsts/src/rules/S1067/meta.ts
+++ b/packages/jsts/src/rules/S1067/meta.ts
@@ -24,7 +24,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
 export const schema = {
   type: 'array',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 1,
   items: [
     {
       type: 'object',

--- a/packages/jsts/src/rules/S1192/meta.ts
+++ b/packages/jsts/src/rules/S1192/meta.ts
@@ -24,7 +24,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
 export const schema = {
   type: 'array',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 1,
   items: [
     {
       type: 'object',

--- a/packages/jsts/src/rules/S134/meta.ts
+++ b/packages/jsts/src/rules/S134/meta.ts
@@ -24,7 +24,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
 export const schema = {
   type: 'array',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 1,
   items: [
     {
       type: 'object',

--- a/packages/jsts/src/rules/S1541/meta.ts
+++ b/packages/jsts/src/rules/S1541/meta.ts
@@ -24,7 +24,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
 export const schema = {
   type: 'array',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 1,
   items: [
     {
       type: 'object',

--- a/packages/jsts/src/rules/S2004/meta.ts
+++ b/packages/jsts/src/rules/S2004/meta.ts
@@ -24,7 +24,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
 export const schema = {
   type: 'array',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 1,
   items: [
     {
       type: 'object',

--- a/packages/jsts/src/rules/S2999/meta.ts
+++ b/packages/jsts/src/rules/S2999/meta.ts
@@ -24,7 +24,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
 export const schema = {
   type: 'array',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 1,
   items: [
     {
       type: 'object',

--- a/packages/jsts/src/rules/S4144/meta.ts
+++ b/packages/jsts/src/rules/S4144/meta.ts
@@ -23,6 +23,6 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
 export const schema = {
   type: 'array',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 1,
   items: [{ type: 'integer', minimum: 3 }],
 } as const satisfies JSONSchema4;

--- a/packages/jsts/src/rules/S5843/meta.ts
+++ b/packages/jsts/src/rules/S5843/meta.ts
@@ -24,7 +24,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
 export const schema = {
   type: 'array',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 1,
   items: [
     {
       type: 'object',


### PR DESCRIPTION
[JS-621](https://sonarsource.atlassian.net/browse/JS-621)

We had places where we provided the schema, in them, we marked that the maxItems can be 2, the second option being the 'sonar-runtime' option. We no longer need this. Let us cleanup.

[JS-621]: https://sonarsource.atlassian.net/browse/JS-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ