### PR TITLE
BUILD-7754: Use monthly cache for orchestrator

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,19 +50,6 @@ orchestrator_cache_preparation_definition_monthly: &ORCHESTRATOR_CACHE_MONTHLY
     fingerprint_script: echo ${THIS_MONTH}
     reupload_on_changes: 'true'
 
-orchestrator_cache_preparation_definition: &ORCHESTRATOR_CACHE
-  set_orchestrator_home_script: |
-    export TODAY=$(date '+%Y-%m-%d')
-    echo "TODAY=${TODAY}" >> $CIRRUS_ENV
-    echo "ORCHESTRATOR_HOME=${CIRRUS_WORKING_DIR}/orchestrator/${TODAY}" >> $CIRRUS_ENV
-  mkdir_orchestrator_home_script: |
-    echo "Create dir ${ORCHESTRATOR_HOME} if needed"
-    mkdir -p ${ORCHESTRATOR_HOME}
-  orchestrator_cache:
-    folder: ${ORCHESTRATOR_HOME}
-    fingerprint_script: echo ${TODAY}
-    reupload_on_changes: 'true'
-
 nodejs_runtimes_cache_definition: &RUNTIME_CACHE
   runtime_cache:
     folder: tools/fetch-node/downloads/
@@ -111,22 +98,6 @@ win_ssd_and_clone:
 
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
-
-plugin_qa_body: &PLUGIN_QA_BODY
-  depends_on:
-    - build
-  <<: *ONLY_SONARSOURCE_QA
-  eks_container:
-    <<: *CONTAINER_DEFINITION
-  env:
-    CIRRUS_CLONE_DEPTH: 10
-    SONARSOURCE_QA: true
-  <<: *MAVEN_CACHE
-  <<: *ORCHESTRATOR_CACHE
-  qa_script:
-    - source cirrus-env QA
-    - source set_maven_build_version $BUILD_NUMBER
-    - mvn -f its/plugin/pom.xml -Dsonar.runtimeVersion=${SQ_VERSION} ${MVN_TEST} -B -e -V verify surefire-report:report
 
 plugin_qa_body_monthly: &PLUGIN_QA_BODY_MONTHLY
   depends_on:
@@ -262,7 +233,7 @@ plugin_qa_no_node_alpine_task:
     MVN_TEST: '-Dtest=!EslintCustomRulesTest,!SonarJsIntegrationTest --projects !org.sonarsource.javascript:eslint-custom-rules-plugin'
 
 plugin_qa_sq_dev_task:
-  <<: *PLUGIN_QA_BODY
+  <<: *PLUGIN_QA_BODY_MONTHLY
   eks_container:
     image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,6 +37,19 @@ maven_cache_definition: &MAVEN_CACHE
         find . -name pom.xml -exec cat {} \+
       fi
 
+orchestrator_cache_preparation_definition_monthly: &ORCHESTRATOR_CACHE_MONTHLY
+  set_orchestrator_home_script: |
+    export THIS_MONTH=$(date '+%Y-%m')
+    echo "THIS_MONTH=${THIS_MONTH}" >> $CIRRUS_ENV
+    echo "ORCHESTRATOR_HOME=${CIRRUS_WORKING_DIR}/orchestrator/${THIS_MONTH}" >> $CIRRUS_ENV
+  mkdir_orchestrator_home_script: |
+    echo "Create dir ${ORCHESTRATOR_HOME} if needed"
+    mkdir -p ${ORCHESTRATOR_HOME}
+  orchestrator_cache:
+    folder: ${ORCHESTRATOR_HOME}
+    fingerprint_script: echo ${THIS_MONTH}
+    reupload_on_changes: 'true'
+
 orchestrator_cache_preparation_definition: &ORCHESTRATOR_CACHE
   set_orchestrator_home_script: |
     export TODAY=$(date '+%Y-%m-%d')
@@ -110,6 +123,22 @@ plugin_qa_body: &PLUGIN_QA_BODY
     SONARSOURCE_QA: true
   <<: *MAVEN_CACHE
   <<: *ORCHESTRATOR_CACHE
+  qa_script:
+    - source cirrus-env QA
+    - source set_maven_build_version $BUILD_NUMBER
+    - mvn -f its/plugin/pom.xml -Dsonar.runtimeVersion=${SQ_VERSION} ${MVN_TEST} -B -e -V verify surefire-report:report
+
+plugin_qa_body_monthly: &PLUGIN_QA_BODY_MONTHLY
+  depends_on:
+    - build
+  <<: *ONLY_SONARSOURCE_QA
+  eks_container:
+    <<: *CONTAINER_DEFINITION
+  env:
+    CIRRUS_CLONE_DEPTH: 10
+    SONARSOURCE_QA: true
+  <<: *MAVEN_CACHE
+  <<: *ORCHESTRATOR_CACHE_MONTHLY
   qa_script:
     - source cirrus-env QA
     - source set_maven_build_version $BUILD_NUMBER
@@ -207,7 +236,7 @@ ws_scan_task:
       path: 'whitesource/**/*'
 
 plugin_qa_with_node_task:
-  <<: *PLUGIN_QA_BODY
+  <<: *PLUGIN_QA_BODY_MONTHLY
   eks_container:
     dockerfile: .cirrus/nodejs.Dockerfile
   env:
@@ -215,7 +244,7 @@ plugin_qa_with_node_task:
     MVN_TEST: ''
 
 plugin_qa_no_node_task:
-  <<: *PLUGIN_QA_BODY
+  <<: *PLUGIN_QA_BODY_MONTHLY
   eks_container:
     image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest
   env:
@@ -224,7 +253,7 @@ plugin_qa_no_node_task:
     MVN_TEST: '-Dtest=!EslintCustomRulesTest,!SonarJsIntegrationTest --projects !org.sonarsource.javascript:eslint-custom-rules-plugin'
 
 plugin_qa_no_node_alpine_task:
-  <<: *PLUGIN_QA_BODY
+  <<: *PLUGIN_QA_BODY_MONTHLY
   eks_container:
     dockerfile: .cirrus/alpine.Dockerfile
   env:
@@ -255,7 +284,7 @@ plugin_qa_win_task:
       - TEST: 'CoverageTest,TypeScriptAnalysisTest,EslintBasedRulesTest,PRAnalysisTest,TypeCheckerConfigTest,VueAnalysisTest'
   <<: *WIN_SSD_AND_CLONE
   <<: *MAVEN_CACHE
-  <<: *ORCHESTRATOR_CACHE
+  <<: *ORCHESTRATOR_CACHE_MONTHLY
   qa_script:
     - source /c/buildTools-docker/bin/cirrus-env QA
     - source /c/buildTools-docker/bin/set_maven_build_version $BUILD_NUMBER
@@ -377,7 +406,7 @@ css_ruling_task:
     CIRRUS_CLONE_DEPTH: 10
     SONARSOURCE_QA: true
   <<: *MAVEN_CACHE
-  <<: *ORCHESTRATOR_CACHE
+  <<: *ORCHESTRATOR_CACHE_MONTHLY
   submodules_script:
     - git submodule update --init
   ruling_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,6 +50,19 @@ orchestrator_cache_preparation_definition_monthly: &ORCHESTRATOR_CACHE_MONTHLY
     fingerprint_script: echo ${THIS_MONTH}
     reupload_on_changes: 'true'
 
+orchestrator_cache_preparation_definition: &ORCHESTRATOR_CACHE
+  set_orchestrator_home_script: |
+    export TODAY=$(date '+%Y-%m-%d')
+    echo "TODAY=${TODAY}" >> $CIRRUS_ENV
+    echo "ORCHESTRATOR_HOME=${CIRRUS_WORKING_DIR}/orchestrator/${TODAY}" >> $CIRRUS_ENV
+  mkdir_orchestrator_home_script: |
+    echo "Create dir ${ORCHESTRATOR_HOME} if needed"
+    mkdir -p ${ORCHESTRATOR_HOME}
+  orchestrator_cache:
+    folder: ${ORCHESTRATOR_HOME}
+    fingerprint_script: echo ${TODAY}
+    reupload_on_changes: 'true'
+
 nodejs_runtimes_cache_definition: &RUNTIME_CACHE
   runtime_cache:
     folder: tools/fetch-node/downloads/
@@ -98,6 +111,22 @@ win_ssd_and_clone:
 
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
+
+plugin_qa_body: &PLUGIN_QA_BODY
+  depends_on:
+    - build
+  <<: *ONLY_SONARSOURCE_QA
+  eks_container:
+    <<: *CONTAINER_DEFINITION
+  env:
+    CIRRUS_CLONE_DEPTH: 10
+    SONARSOURCE_QA: true
+  <<: *MAVEN_CACHE
+  <<: *ORCHESTRATOR_CACHE
+  qa_script:
+    - source cirrus-env QA
+    - source set_maven_build_version $BUILD_NUMBER
+    - mvn -f its/plugin/pom.xml -Dsonar.runtimeVersion=${SQ_VERSION} ${MVN_TEST} -B -e -V verify surefire-report:report
 
 plugin_qa_body_monthly: &PLUGIN_QA_BODY_MONTHLY
   depends_on:
@@ -233,7 +262,7 @@ plugin_qa_no_node_alpine_task:
     MVN_TEST: '-Dtest=!EslintCustomRulesTest,!SonarJsIntegrationTest --projects !org.sonarsource.javascript:eslint-custom-rules-plugin'
 
 plugin_qa_sq_dev_task:
-  <<: *PLUGIN_QA_BODY_MONTHLY
+  <<: *PLUGIN_QA_BODY
   eks_container:
     image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest
   env:


### PR DESCRIPTION
[BUILD-7754](https://sonarsource.atlassian.net/browse/BUILD-7754)

Part of BUILD-7754: Use monthly cache for orchestrator
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

This PR changes the cache logic to invalidate only on a monthly basis for tasks which rely on latest releases. For the task which uses `dev` version, it will continue to use the existing logic to invalidate daily


[BUILD-7754]: https://sonarsource.atlassian.net/browse/BUILD-7754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ