### PR TITLE
JS-658 Fix CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "create-rule-indexes": "tsx tools/generate-rule-indexes.ts",
     "bridge:compile": "tsc -b packages && npm run _:bridge:copy-protofiles",
     "bridge:test": "tsx --tsconfig packages/tsconfig.test.json --test --test-concurrency=4 --test-reporter spec --test-reporter-destination stdout \"packages/*/src/rules/*[!node_modules]/**/*.test.ts\" \"packages/*[!ruling]/tests/**/*.test.ts\"",
-    "bridge:test:cov": "run npm run bridge:test",
+    "bridge:test:cov": "npm run bridge:test",
     "bridge:bundle": "node esbuild.mjs",
     "bridge:build": "npm run bridge:build:fast && npm run bridge:test",
     "bridge:build:cov": "npm run bridge:build:fast && npm run bridge:test:cov",


### PR DESCRIPTION
[JS-658](https://sonarsource.atlassian.net/browse/JS-658)

It was broken by hasty commit https://github.com/SonarSource/SonarJS/pull/5236

[JS-658]: https://sonarsource.atlassian.net/browse/JS-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ