### PR TITLE
Update all of the rule testers to only use the required parser

### DIFF
--- a/packages/jsts/src/rules/S100/unit.test.ts
+++ b/packages/jsts/src/rules/S100/unit.test.ts
@@ -15,10 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new NoTypeCheckingRuleTester();
 
 const DEFAULT_FORMAT = '^[_a-z][a-zA-Z0-9]*$';
 const ALLOW_UPPERCASE = '^[A-Z][a-zA-Z0-9]*$';

--- a/packages/jsts/src/rules/S101/unit.test.ts
+++ b/packages/jsts/src/rules/S101/unit.test.ts
@@ -15,10 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import {
-  DefaultParserRuleTester,
-  NoTypeCheckingRuleTester,
-} from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 const ruleTester = new NoTypeCheckingRuleTester();

--- a/packages/jsts/src/rules/S101/unit.test.ts
+++ b/packages/jsts/src/rules/S101/unit.test.ts
@@ -15,10 +15,13 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+} from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new NoTypeCheckingRuleTester();
 
 const DEFAULT_FORMAT = '^[A-Z][a-zA-Z0-9]*$';
 const CUSTOM_FORMAT = '^[_A-Z][a-zA-Z0-9]*$';

--- a/packages/jsts/src/rules/S104/unit.test.ts
+++ b/packages/jsts/src/rules/S104/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S104', () => {
   it('S104', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Too many lines in file', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S105/unit.test.ts
+++ b/packages/jsts/src/rules/S105/unit.test.ts
@@ -14,11 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 describe('S105', () => {
   it('S105', () => {

--- a/packages/jsts/src/rules/S1066/unit.test.ts
+++ b/packages/jsts/src/rules/S1066/unit.test.ts
@@ -15,10 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 describe('S1066', () => {
   it('S1066', () => {

--- a/packages/jsts/src/rules/S1067/unit.test.ts
+++ b/packages/jsts/src/rules/S1067/unit.test.ts
@@ -16,10 +16,10 @@
  */
 import { rule } from './index.js';
 import { EncodedMessage, IssueLocation } from '../helpers/index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 const options = [
   {

--- a/packages/jsts/src/rules/S1068/unit.test.ts
+++ b/packages/jsts/src/rules/S1068/unit.test.ts
@@ -14,11 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new NoTypeCheckingRuleTester();
 
 describe('S1068', () => {
   it('S1068', () => {

--- a/packages/jsts/src/rules/S107/unit.test.ts
+++ b/packages/jsts/src/rules/S107/unit.test.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 const MAX_PARAMS_3 = 3;
@@ -27,7 +27,7 @@ const createOptions = (max: number) => {
 
 describe('S107', () => {
   it('S107', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
     ruleTester.run(``, rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1116/unit.test.ts
+++ b/packages/jsts/src/rules/S1116/unit.test.ts
@@ -15,13 +15,13 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { Rule } from 'eslint';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { isProtectionSemicolon } from './decorator.js';
 import { describe, it } from 'node:test';
 import { expect } from 'expect';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 describe('S1116', () => {
   it('S1116', () => {

--- a/packages/jsts/src/rules/S1119/unit.test.ts
+++ b/packages/jsts/src/rules/S1119/unit.test.ts
@@ -15,10 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 describe('S1119', () => {
   it('S1119', () => {
     ruleTester.run('Labels should not be used', rule, {

--- a/packages/jsts/src/rules/S1121/unit.test.ts
+++ b/packages/jsts/src/rules/S1121/unit.test.ts
@@ -14,11 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 describe('S1121', () => {
   it('S1121', () => {

--- a/packages/jsts/src/rules/S1125/unit.test.ts
+++ b/packages/jsts/src/rules/S1125/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1125', () => {
   it('S1125', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('no-redundant-boolean', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1126/unit.test.ts
+++ b/packages/jsts/src/rules/S1126/unit.test.ts
@@ -15,10 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 describe('S1126', () => {
   it('S1126', () => {

--- a/packages/jsts/src/rules/S1134/unit.test.ts
+++ b/packages/jsts/src/rules/S1134/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1134', () => {
   it('S1134', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Track uses of FIXME tags', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1135/unit.test.ts
+++ b/packages/jsts/src/rules/S1135/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1135', () => {
   it('S1135', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Track uses of TODO tags', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S117/unit.test.ts
+++ b/packages/jsts/src/rules/S117/unit.test.ts
@@ -15,10 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new NoTypeCheckingRuleTester();
 
 const DEFAULT_FORMAT = '^[_$A-Za-z][$A-Za-z0-9]*$|^[_$A-Z][_$A-Z0-9]+$';
 const CUSTOM_FORMAT = '^[a-z][a-z0-9]+$';

--- a/packages/jsts/src/rules/S1172/unit.test.ts
+++ b/packages/jsts/src/rules/S1172/unit.test.ts
@@ -19,11 +19,11 @@ import { isParameterProperty, rule } from './rule.js';
 import { describe, it } from 'node:test';
 import { expect } from 'expect';
 
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 
 describe('S1172', () => {
   it('S1172', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('Unused function parameters should be removed', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1186/unit.test.ts
+++ b/packages/jsts/src/rules/S1186/unit.test.ts
@@ -18,11 +18,11 @@ import type { Rule } from 'eslint';
 import { rule } from './index.js';
 import { reportWithQuickFixIfApplicable } from './decorator.js';
 import { describe, it } from 'node:test';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 
 describe('S1186', () => {
   it('S1186', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(`Decorated rule should provide suggestion`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S1192/unit.test.ts
+++ b/packages/jsts/src/rules/S1192/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1192', () => {
   it('S1192', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('S1192', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1219/unit.test.ts
+++ b/packages/jsts/src/rules/S1219/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1219', () => {
   it('S1219', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(`"switch" statements should not contain non-case labels`, rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1226/unit.test.ts
+++ b/packages/jsts/src/rules/S1226/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1226', () => {
   it('S1226', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     const NON_COMPLIANT_REGEX = /\/\/\sNoncompliant\s{{(\w+)}}/;
     function invalidTest(code: string) {

--- a/packages/jsts/src/rules/S124/unit.test.ts
+++ b/packages/jsts/src/rules/S124/unit.test.ts
@@ -14,11 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 const optionsWithouthMessage = [{ regularExpression: '[a-z]' }];
 const optionsWithMessage = [{ regularExpression: '[a-z]', message: 'this is a message' }];

--- a/packages/jsts/src/rules/S125/unit.test.ts
+++ b/packages/jsts/src/rules/S125/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S125', () => {
   it('S125', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
     ruleTester.run('Sections of code should not be commented out', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S126/unit.test.ts
+++ b/packages/jsts/src/rules/S126/unit.test.ts
@@ -14,11 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 describe('S126', () => {
   it('S126', () => {
     ruleTester.run(`"if ... else if" constructs should end with "else" clauses`, rule, {

--- a/packages/jsts/src/rules/S1264/unit.test.ts
+++ b/packages/jsts/src/rules/S1264/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1264', () => {
   it('S1264', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     const message = 'replaceForWithWhileLoop';
 

--- a/packages/jsts/src/rules/S128/unit.test.ts
+++ b/packages/jsts/src/rules/S128/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S128', () => {
   it('S128', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('No fallthrough in switch statement', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1291/unit.test.ts
+++ b/packages/jsts/src/rules/S1291/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1291', () => {
   it('S1291', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('"NOSONAR" comments should not be used', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1301/unit.test.ts
+++ b/packages/jsts/src/rules/S1301/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1301', () => {
   it('S1301', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('"if" statements should be preferred over "switch" when simpler', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1313/unit.test.ts
+++ b/packages/jsts/src/rules/S1313/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1313', () => {
   it('S1313', () => {
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
 
     ruleTesterTs.run('Hardcoded ip addresses should be avoided', rule, {
       valid: [

--- a/packages/jsts/src/rules/S134/unit.test.ts
+++ b/packages/jsts/src/rules/S134/unit.test.ts
@@ -14,12 +14,12 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { EncodedMessage, IssueLocation } from '../helpers/index.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 const THRESHOLD = 3;
 

--- a/packages/jsts/src/rules/S1439/unit.test.ts
+++ b/packages/jsts/src/rules/S1439/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1439', () => {
   it('S1439', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Only "while", "do", "for" and "switch" statements should be labelled', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1451/unit.test.ts
+++ b/packages/jsts/src/rules/S1451/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1451', () => {
   it('S1451', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     const errors = [
       {

--- a/packages/jsts/src/rules/S1472/unit.test.ts
+++ b/packages/jsts/src/rules/S1472/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1472', () => {
   it('S1472', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
     ruleTester.run(`Function call arguments should not start on new lines`, rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1479/unit.test.ts
+++ b/packages/jsts/src/rules/S1479/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1479', () => {
   it('S1479', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('max-switch-cases', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1481/unit.test.ts
+++ b/packages/jsts/src/rules/S1481/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1481', () => {
   it('S1481', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Local variables should be used', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1488/unit.test.ts
+++ b/packages/jsts/src/rules/S1488/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1488', () => {
   it('S1488', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('prefer-immediate-return', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1515/unit.test.ts
+++ b/packages/jsts/src/rules/S1515/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1515', () => {
   it('S1515', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(`Functions should not be defined inside loops`, rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1523/unit.test.ts
+++ b/packages/jsts/src/rules/S1523/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1523', () => {
   it('S1523', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Dynamically executing code is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1526/unit.test.ts
+++ b/packages/jsts/src/rules/S1526/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1526', () => {
   it('S1526', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Variables declared with "var" should be declared before they are used`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S1528/unit.test.ts
+++ b/packages/jsts/src/rules/S1528/unit.test.ts
@@ -14,15 +14,15 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1528', () => {
   it('S1528', () => {
-    const eslintRuleTester = new RuleTester();
+    const eslintRuleTester = new DefaultParserRuleTester();
 
-    const typeScriptRuleTester = new RuleTester();
+    const typeScriptRuleTester = new DefaultParserRuleTester();
     const testCases = {
       valid: [
         {

--- a/packages/jsts/src/rules/S1530/unit.test.ts
+++ b/packages/jsts/src/rules/S1530/unit.test.ts
@@ -15,12 +15,15 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+} from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1530', () => {
   it('S1530', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(`Function declarations should not be made within blocks`, rule, {
       valid: [
         {
@@ -70,7 +73,7 @@ describe('S1530', () => {
       ],
     });
 
-    const ruleTesterTS = new RuleTester();
+    const ruleTesterTS = new NoTypeCheckingRuleTester();
 
     ruleTesterTS.run(`Function declarations should not be made within blocks`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S1533/unit.test.ts
+++ b/packages/jsts/src/rules/S1533/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1533', () => {
   it('S1533', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('Wrapper objects should not be used for primitive types', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1534/unit.test.ts
+++ b/packages/jsts/src/rules/S1534/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1534', () => {
   it('S1534', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(`Decorated rule should provide suggestion`, rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1535/unit.test.ts
+++ b/packages/jsts/src/rules/S1535/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1535', () => {
   it('S1535', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('"for...in" loops should filter properties before acting on them', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S1541/unit.test.ts
+++ b/packages/jsts/src/rules/S1541/unit.test.ts
@@ -14,14 +14,14 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { EncodedMessage, IssueLocation } from '../helpers/index.js';
 import { describe, it } from 'node:test';
 
 describe('S1541', () => {
   it('S1541', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     const options = [
       {
         threshold: 2,

--- a/packages/jsts/src/rules/S1607/unit.test.ts
+++ b/packages/jsts/src/rules/S1607/unit.test.ts
@@ -14,14 +14,14 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1607', () => {
   it('S1607', () => {
     process.chdir(import.meta.dirname); // change current working dir to avoid the package.json lookup to up in the tree
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Tests should not be skipped without providing a reason`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S1751/unit.test.ts
+++ b/packages/jsts/src/rules/S1751/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1751', () => {
   it('S1751', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('no-one-iteration-loop', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1763/unit.test.ts
+++ b/packages/jsts/src/rules/S1763/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1763', () => {
   it('S1763', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Decorated rule should provide suggestion`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S1764/unit.test.ts
+++ b/packages/jsts/src/rules/S1764/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1764', () => {
   it('S1764', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('no-identical-expressions', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1821/unit.test.ts
+++ b/packages/jsts/src/rules/S1821/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1821', () => {
   it('S1821', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     const messageId = 'removeNestedSwitch';
 

--- a/packages/jsts/src/rules/S1848/unit.test.ts
+++ b/packages/jsts/src/rules/S1848/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1848', () => {
   it('S1848', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(
       `Objects should not be created to be dropped immediately without being used`,

--- a/packages/jsts/src/rules/S1854/unit.test.ts
+++ b/packages/jsts/src/rules/S1854/unit.test.ts
@@ -14,11 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new NoTypeCheckingRuleTester();
 
 describe('S1854', () => {
   it('S1854', () => {

--- a/packages/jsts/src/rules/S1862/unit.test.ts
+++ b/packages/jsts/src/rules/S1862/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1862', () => {
   it('S1862', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('no-identical-conditions', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1871/unit.test.ts
+++ b/packages/jsts/src/rules/S1871/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1871', () => {
   it('S1871', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('no-duplicated-branches if', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1940/unit.test.ts
+++ b/packages/jsts/src/rules/S1940/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S1940', () => {
   it('S1940', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('no-inverted-boolean-check', rule, {
       valid: [

--- a/packages/jsts/src/rules/S1994/unit.test.ts
+++ b/packages/jsts/src/rules/S1994/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S1994', () => {
   it('S1994', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Loop counter', rule, {
       valid: [

--- a/packages/jsts/src/rules/S2004/unit.test.ts
+++ b/packages/jsts/src/rules/S2004/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2004', () => {
   it('S2004', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Functions should not be nested too deeply', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S2077/unit.test.ts
+++ b/packages/jsts/src/rules/S2077/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2077', () => {
   it('S2077', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Formatting SQL queries is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S2092/unit.test.ts
+++ b/packages/jsts/src/rules/S2092/unit.test.ts
@@ -14,14 +14,14 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2092', () => {
   it('S2092', () => {
-    const ruleTesterJs = new RuleTester();
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
 
     const cookieSessionTestCases = {
       valid: [

--- a/packages/jsts/src/rules/S2123/unit.test.ts
+++ b/packages/jsts/src/rules/S2123/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2123', () => {
   it('S2123', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Values should not be uselessly incremented', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S2137/unit.test.ts
+++ b/packages/jsts/src/rules/S2137/unit.test.ts
@@ -14,11 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new NoTypeCheckingRuleTester();
 
 describe('S2137', () => {
   it('S2137', () => {

--- a/packages/jsts/src/rules/S2138/unit.test.ts
+++ b/packages/jsts/src/rules/S2138/unit.test.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 const tests = {
@@ -58,8 +58,8 @@ const tests = {
   ],
 };
 
-const ruleTesterJs = new RuleTester();
-const ruleTesterTs = new RuleTester();
+const ruleTesterJs = new DefaultParserRuleTester();
+const ruleTesterTs = new DefaultParserRuleTester();
 
 describe('S2138', () => {
   it('S2138', () => {

--- a/packages/jsts/src/rules/S2208/unit.test.ts
+++ b/packages/jsts/src/rules/S2208/unit.test.ts
@@ -14,11 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
-const ruleTesterJS = new RuleTester();
+const ruleTesterJS = new DefaultParserRuleTester();
 
 describe('S2208', () => {
   it('S2208', () => {

--- a/packages/jsts/src/rules/S2245/unit.test.ts
+++ b/packages/jsts/src/rules/S2245/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2245', () => {
   it('S2245', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Using pseudorandom number generators (PRNGs) is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S2251/unit.test.ts
+++ b/packages/jsts/src/rules/S2251/unit.test.ts
@@ -14,14 +14,14 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2251', () => {
   it('S2251', () => {
-    const ruleTesterJs = new RuleTester();
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
 
     const testCases = {
       valid: [

--- a/packages/jsts/src/rules/S2255/unit.test.ts
+++ b/packages/jsts/src/rules/S2255/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2255', () => {
   it('S2255', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Writing cookies is security-sensitive', rule, {
       valid: [

--- a/packages/jsts/src/rules/S2301/unit.test.ts
+++ b/packages/jsts/src/rules/S2301/unit.test.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule as S2301 } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester, RuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2301', () => {
@@ -188,7 +188,7 @@ function tempt8(name: string, ofAge: boolean) {
       ],
     });
 
-    const javaScriptRuleTester = new RuleTester();
+    const javaScriptRuleTester = new DefaultParserRuleTester();
 
     javaScriptRuleTester.run('S2301:JavaScript', S2301, {
       invalid: [],

--- a/packages/jsts/src/rules/S2310/unit.test.ts
+++ b/packages/jsts/src/rules/S2310/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2310', () => {
   it('S2310', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Loop counter should not be updated inside loop', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S2376/unit.test.ts
+++ b/packages/jsts/src/rules/S2376/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2376', () => {
   it('S2376', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(`Property getters and setters should come in pairs`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S2392/unit.test.ts
+++ b/packages/jsts/src/rules/S2392/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2392', () => {
   it('S2392', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Variables should be used in the blocks where they are declared', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S2424/unit.test.ts
+++ b/packages/jsts/src/rules/S2424/unit.test.ts
@@ -15,7 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+} from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2424', () => {
@@ -68,7 +71,7 @@ describe('S2424', () => {
       ],
     };
 
-    const ruleTesterJs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
     ruleTesterJs.run('Built-in objects should not be overridden [js]', rule, tests);
 
     tests.valid.push({
@@ -79,7 +82,7 @@ describe('S2424', () => {
     }`,
     });
 
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterTs = new NoTypeCheckingRuleTester();
     ruleTesterTs.run('Built-in objects should not be overridden [ts]', rule, tests);
   });
 });

--- a/packages/jsts/src/rules/S2428/unit.test.ts
+++ b/packages/jsts/src/rules/S2428/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2428', () => {
   it('S2428', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('prefer-literal', rule, {
       valid: [

--- a/packages/jsts/src/rules/S2430/unit.test.ts
+++ b/packages/jsts/src/rules/S2430/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2430', () => {
   it('S2430', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`A constructor name should not start with a lowercase letter`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S2589/unit.test.ts
+++ b/packages/jsts/src/rules/S2589/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2589', () => {
   it('S2589', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     const falsySonarRuntimeData = JSON.stringify({
       message: 'This always evaluates to falsy. Consider refactoring this code.',

--- a/packages/jsts/src/rules/S2598/unit.test.ts
+++ b/packages/jsts/src/rules/S2598/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2598', () => {
   it('S2598', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     function encodedMessage(
       message: string,

--- a/packages/jsts/src/rules/S2612/unit.test.ts
+++ b/packages/jsts/src/rules/S2612/unit.test.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2612', () => {
@@ -296,10 +296,10 @@ describe('S2612', () => {
       ],
     };
 
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Using publicly writable directories is security-sensitive', rule, tests);
 
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
     ruleTesterTs.run('Using publicly writable directories is security-sensitive [TS]', rule, tests);
   });
 });

--- a/packages/jsts/src/rules/S2681/unit.test.ts
+++ b/packages/jsts/src/rules/S2681/unit.test.ts
@@ -14,14 +14,17 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+} from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2681', () => {
   it('S2681', () => {
-    const ruleTester = new RuleTester();
-    const ruleTesterTs = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
+    const ruleTesterTs = new NoTypeCheckingRuleTester();
 
     ruleTester.run('Multiline blocks should be enclosed in curly braces', rule, {
       valid: [

--- a/packages/jsts/src/rules/S2703/unit.test.ts
+++ b/packages/jsts/src/rules/S2703/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2703', () => {
   it('S2703', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('No implicit global', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S2737/unit.test.ts
+++ b/packages/jsts/src/rules/S2737/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2737', () => {
   it('S2737', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('no-useless-catch', rule, {
       valid: [

--- a/packages/jsts/src/rules/S2755/unit.test.ts
+++ b/packages/jsts/src/rules/S2755/unit.test.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2755', () => {
@@ -96,8 +96,8 @@ describe('S2755', () => {
       ],
     };
 
-    const ruleTesterJs = new RuleTester();
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
 
     ruleTesterJs.run('XML parsers should not be vulnerable to XXE attacks [js]', rule, tests);
     ruleTesterTs.run('XML parsers should not be vulnerable to XXE attacks [ts]', rule, tests);

--- a/packages/jsts/src/rules/S2757/unit.test.ts
+++ b/packages/jsts/src/rules/S2757/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2757', () => {
   it('S2757', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run("Non-existent operators '=+', '=-' and '=!' should not be used", rule, {
       valid: [

--- a/packages/jsts/src/rules/S2814/unit.test.ts
+++ b/packages/jsts/src/rules/S2814/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S2814', () => {
   it('S2814', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(`Variables and functions should not be redeclared`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S2990/unit.test.ts
+++ b/packages/jsts/src/rules/S2990/unit.test.ts
@@ -15,13 +15,16 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+} from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S2990', () => {
   it('S2990', () => {
-    const ruleTesterJS = new RuleTester();
-    const ruleTesterTS = new RuleTester();
+    const ruleTesterJS = new DefaultParserRuleTester();
+    const ruleTesterTS = new NoTypeCheckingRuleTester();
 
     const testCases = {
       valid: [

--- a/packages/jsts/src/rules/S3001/unit.test.ts
+++ b/packages/jsts/src/rules/S3001/unit.test.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester, RuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3001', () => {
@@ -102,7 +102,7 @@ describe('S3001', () => {
       ],
     };
 
-    const ruleTesterJs = new RuleTester();
+    const ruleTesterJs = new NoTypeCheckingRuleTester();
     const ruleTesterTs = new RuleTester();
 
     ruleTesterJs.run('"delete" should be used only with object properties [js]', rule, tests);

--- a/packages/jsts/src/rules/S3330/unit.test.ts
+++ b/packages/jsts/src/rules/S3330/unit.test.ts
@@ -14,15 +14,15 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3330', () => {
   it('S3330', () => {
-    const ruleTesterJs = new RuleTester();
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
 
     const cookieSessionTestCases = {
       valid: [

--- a/packages/jsts/src/rules/S3358/unit.test.ts
+++ b/packages/jsts/src/rules/S3358/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3358', () => {
   it('S3358', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Ternary operators should not be nested', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S3498/unit.test.ts
+++ b/packages/jsts/src/rules/S3498/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3498', () => {
   it('S3498', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Object literal shorthand syntax should be used`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S3499/unit.test.ts
+++ b/packages/jsts/src/rules/S3499/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3499', () => {
   it('S3499', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(
       'Shorthand object properties should be grouped at the beginning or end of an object declaration',
       rule,

--- a/packages/jsts/src/rules/S3500/unit.test.ts
+++ b/packages/jsts/src/rules/S3500/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3500', () => {
   it('S3500', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Attempts should not be made to update "const" variables', rule, {
       valid: [],
       invalid: [

--- a/packages/jsts/src/rules/S3512/unit.test.ts
+++ b/packages/jsts/src/rules/S3512/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3512', () => {
   it('S3512', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Template strings should be used instead of concatenation`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S3513/unit.test.ts
+++ b/packages/jsts/src/rules/S3513/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3513', () => {
   it('S3513', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(`"arguments" should not be accessed directly`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S3514/unit.test.ts
+++ b/packages/jsts/src/rules/S3514/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3514', () => {
   it('S3514', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Destructuring syntax should be used for assignments', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S3516/unit.test.ts
+++ b/packages/jsts/src/rules/S3516/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3516', () => {
   it('S3516', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(`Function returns should not be invariant`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S3531/unit.test.ts
+++ b/packages/jsts/src/rules/S3531/unit.test.ts
@@ -14,14 +14,14 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3531', () => {
   it('S3531', () => {
-    const ruleTester = new RuleTester();
-    const ruleTesterTs = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
 
     const testCases = {
       valid: [

--- a/packages/jsts/src/rules/S3616/unit.test.ts
+++ b/packages/jsts/src/rules/S3616/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3616', () => {
   it('S3616', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Comma and logical OR operators should not be used in switch cases', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S3626/unit.test.ts
+++ b/packages/jsts/src/rules/S3626/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3626', () => {
   it('S3626', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Jump statements should not be redundant', rule, {
       invalid: [

--- a/packages/jsts/src/rules/S3686/unit.test.ts
+++ b/packages/jsts/src/rules/S3686/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3686', () => {
   it('S3686', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Functions should not be called both with and without "new"', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S3696/unit.test.ts
+++ b/packages/jsts/src/rules/S3696/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3696', () => {
   it('S3696', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Decorated rule should provide suggestion`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S3699/unit.test.ts
+++ b/packages/jsts/src/rules/S3699/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3699', () => {
   it('S3699', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     const FUNCTION_NO_RETURN = 'function noReturn() { }\n ';
 

--- a/packages/jsts/src/rules/S3723/unit.test.ts
+++ b/packages/jsts/src/rules/S3723/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3723', () => {
   it('S3723', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Trailing commas should be used', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S3776/unit.test.ts
+++ b/packages/jsts/src/rules/S3776/unit.test.ts
@@ -16,12 +16,12 @@
  */
 import { rule } from './index.js';
 import type { IssueLocation } from '../helpers/index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3776', () => {
   it('S3776', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('cognitive-complexity', rule, {
       valid: [

--- a/packages/jsts/src/rules/S3800/unit.test.ts
+++ b/packages/jsts/src/rules/S3800/unit.test.ts
@@ -575,7 +575,7 @@ const sanitize = () => {
       ],
     });
 
-    const ruleTestJSWithTypes = new RuleTester();
+    const ruleTestJSWithTypes = new DefaultParserRuleTester();
     ruleTestJSWithTypes.run(
       `'Functions should always return the same type [js with type inference]'`,
       rule,

--- a/packages/jsts/src/rules/S3801/unit.test.ts
+++ b/packages/jsts/src/rules/S3801/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3801', () => {
   it('S3801', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(`Functions should use "return" consistently`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S3827/unit.test.ts
+++ b/packages/jsts/src/rules/S3827/unit.test.ts
@@ -14,13 +14,16 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+} from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3827', () => {
   it('S3827', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Variables should be defined before being used', rule, {
       valid: [
         {
@@ -138,7 +141,7 @@ describe('S3827', () => {
       ],
     });
 
-    const ruleTesterScript = new RuleTester();
+    const ruleTesterScript = new NoTypeCheckingRuleTester();
     ruleTesterScript.run('No issues within with statements', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S3854/unit.test.ts
+++ b/packages/jsts/src/rules/S3854/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3854', () => {
   it('S3854', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('"super()" should be invoked appropriately', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S3923/unit.test.ts
+++ b/packages/jsts/src/rules/S3923/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3923', () => {
   it('S3923', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('S3923 if', rule, {
       valid: [

--- a/packages/jsts/src/rules/S3972/unit.test.ts
+++ b/packages/jsts/src/rules/S3972/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S3972', () => {
   it('S3972', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Conditionals should start on new lines', rule, {
       valid: [

--- a/packages/jsts/src/rules/S3973/unit.test.ts
+++ b/packages/jsts/src/rules/S3973/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3973', () => {
   it('S3973', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`A conditionally executed single line should be denoted by indentation`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S3984/unit.test.ts
+++ b/packages/jsts/src/rules/S3984/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S3984', () => {
   it('S3984', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Exception should not be created without being thrown', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4023/unit.test.ts
+++ b/packages/jsts/src/rules/S4023/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4023', () => {
   it('S4023', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
     ruleTester.run(`Decorated rule should provide suggestion`, rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4030/unit.test.ts
+++ b/packages/jsts/src/rules/S4030/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4030', () => {
   it('S4030', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     function invalidTest(code: string) {
       const line = code.split('\n').findIndex(str => str.includes('// Noncompliant')) + 1;

--- a/packages/jsts/src/rules/S4123/unit.test.ts
+++ b/packages/jsts/src/rules/S4123/unit.test.ts
@@ -15,7 +15,11 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+  RuleTester,
+} from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4123', () => {
@@ -215,7 +219,7 @@ describe('S4123', () => {
       ],
     });
 
-    const ruleTesterWithNoFullTypeInfo = new RuleTester();
+    const ruleTesterWithNoFullTypeInfo = new NoTypeCheckingRuleTester();
 
     ruleTesterWithNoFullTypeInfo.run('await should only be used with promises.', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4123/unit.test.ts
+++ b/packages/jsts/src/rules/S4123/unit.test.ts
@@ -15,11 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import {
-  DefaultParserRuleTester,
-  NoTypeCheckingRuleTester,
-  RuleTester,
-} from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester, RuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4123', () => {

--- a/packages/jsts/src/rules/S4138/unit.test.ts
+++ b/packages/jsts/src/rules/S4138/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4138', () => {
   it('S4138', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Decorated rule should provide suggestion`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S4143/unit.test.ts
+++ b/packages/jsts/src/rules/S4143/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4143', () => {
   it('S4143', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('no-element-overwrite', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4144/unit.test.ts
+++ b/packages/jsts/src/rules/S4144/unit.test.ts
@@ -16,12 +16,12 @@
  */
 import { rule } from './rule.js';
 import { expandMessage, IssueLocation } from '../helpers/index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4144', () => {
   it('S4144', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('no-identical-functions', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4158/unit.test.ts
+++ b/packages/jsts/src/rules/S4158/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4158', () => {
   it('S4158', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('Empty collections should not be accessed or iterated', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4165/unit.test.ts
+++ b/packages/jsts/src/rules/S4165/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4165', () => {
   it('S4165', () => {
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterTs = new NoTypeCheckingRuleTester();
 
     ruleTesterTs.run('', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4275/unit.test.ts
+++ b/packages/jsts/src/rules/S4275/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4275', () => {
   it('S4275', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     function missingReturn(...codes: string[]) {
       return codes.map(code => ({

--- a/packages/jsts/src/rules/S4323/unit.test.ts
+++ b/packages/jsts/src/rules/S4323/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4323', () => {
   it('S4323', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('Type aliases should be used', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4423/unit.test.ts
+++ b/packages/jsts/src/rules/S4423/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4423', () => {
   it('S4423', () => {
-    const ruleTesterJs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
 
     const minMaxVersion = {
       valid: [

--- a/packages/jsts/src/rules/S4426/unit.test.ts
+++ b/packages/jsts/src/rules/S4426/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4426', () => {
   it('S4426', () => {
-    const ruleTesterJS = new RuleTester();
+    const ruleTesterJS = new DefaultParserRuleTester();
 
     ruleTesterJS.run('Cryptographic keys should be robust', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4502/unit.test.ts
+++ b/packages/jsts/src/rules/S4502/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4502', () => {
   it('S4502', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Disabling CSRF protections is security-sensitive', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4507/unit.test.ts
+++ b/packages/jsts/src/rules/S4507/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4507', () => {
   it('S4507', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     const message =
       'Make sure this debug feature is deactivated before delivering the code in production.';

--- a/packages/jsts/src/rules/S4524/unit.test.ts
+++ b/packages/jsts/src/rules/S4524/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4524', () => {
   it('S4524', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('"default" clauses should be last', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4621/unit.test.ts
+++ b/packages/jsts/src/rules/S4621/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4621', () => {
   it('S4621', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(
       'Union and intersection types should not be defined with duplicated elements',

--- a/packages/jsts/src/rules/S4622/unit.test.ts
+++ b/packages/jsts/src/rules/S4622/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4622', () => {
   it('S4622', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     const DEFAULT_THRESHOLD = 3;
     const CUSTOM_THRESHOLD = 4;

--- a/packages/jsts/src/rules/S4624/unit.test.ts
+++ b/packages/jsts/src/rules/S4624/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './rule.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4624', () => {
   it('S4624', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Template literals should not be nested', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4634/unit.test.ts
+++ b/packages/jsts/src/rules/S4634/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4634', () => {
   it('S4634', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('Shorthand promises should be used', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4721/unit.test.ts
+++ b/packages/jsts/src/rules/S4721/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4721', () => {
   it('S4721', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Executing OS commands is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4784/unit.test.ts
+++ b/packages/jsts/src/rules/S4784/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4784', () => {
   it('S4784', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     const message = 'Make sure that using a regular expression is safe here.';
 

--- a/packages/jsts/src/rules/S4787/unit.test.ts
+++ b/packages/jsts/src/rules/S4787/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4787', () => {
   it('S4787', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Encrypting data is security-sensitive: client side', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4798/unit.test.ts
+++ b/packages/jsts/src/rules/S4798/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S4798', () => {
   it('S4798', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('Optional boolean parameters should have default value', rule, {
       valid: [

--- a/packages/jsts/src/rules/S4817/unit.test.ts
+++ b/packages/jsts/src/rules/S4817/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4817', () => {
   it('S4817', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Executing XPath expressions is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4818/unit.test.ts
+++ b/packages/jsts/src/rules/S4818/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4818', () => {
   it('S4818', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Handling files is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4823/unit.test.ts
+++ b/packages/jsts/src/rules/S4823/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4823', () => {
   it('S4823', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Using command line arguments is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4829/unit.test.ts
+++ b/packages/jsts/src/rules/S4829/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4829', () => {
   it('S4829', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Reading the Standard Input is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S4830/unit.test.ts
+++ b/packages/jsts/src/rules/S4830/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S4830', () => {
   it('S4830', () => {
-    const ruleTesterJs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
 
     const testCasesHttps = {
       valid: [

--- a/packages/jsts/src/rules/S5042/unit.test.ts
+++ b/packages/jsts/src/rules/S5042/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5042', () => {
   it('S5042', () => {
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
 
     /*
  +-+-+-+

--- a/packages/jsts/src/rules/S5332/unit.test.ts
+++ b/packages/jsts/src/rules/S5332/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5332', () => {
   it('S5332', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Using clear-text protocols is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5443/unit.test.ts
+++ b/packages/jsts/src/rules/S5443/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5443', () => {
   it('S5443', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Using publicly writable directories is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5527/unit.test.ts
+++ b/packages/jsts/src/rules/S5527/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5527', () => {
   it('S5527', () => {
-    const ruleTesterJs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
 
     const testCasesHttps = {
       valid: [

--- a/packages/jsts/src/rules/S5547/unit.test.ts
+++ b/packages/jsts/src/rules/S5547/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5547', () => {
   it('S5547', () => {
-    const ruleTesterJs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
 
     ruleTesterJs.run('[JS] Cipher algorithms should be robust', rule, {
       valid: [

--- a/packages/jsts/src/rules/S5604/unit.test.ts
+++ b/packages/jsts/src/rules/S5604/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5604', () => {
   it('S5604', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     const defaultOptions = [{ permissions: ['geolocation'] }];
 

--- a/packages/jsts/src/rules/S5659/unit.test.ts
+++ b/packages/jsts/src/rules/S5659/unit.test.ts
@@ -15,13 +15,13 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5659', () => {
   it('S5659', () => {
-    const ruleTesterJs = new RuleTester();
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterJs = new DefaultParserRuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
 
     const testCases = {
       valid: [

--- a/packages/jsts/src/rules/S5689/unit.test.ts
+++ b/packages/jsts/src/rules/S5689/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5689', () => {
   it('S5689', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(
       'Recovering fingerprints from web application technologies should not be possible',
       rule,

--- a/packages/jsts/src/rules/S5691/unit.test.ts
+++ b/packages/jsts/src/rules/S5691/unit.test.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
@@ -22,7 +22,7 @@ describe('S5691', () => {
   it('S5691', () => {
     const message = 'Make sure serving hidden files is safe here.';
 
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Statically serving hidden files is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5693/unit.test.ts
+++ b/packages/jsts/src/rules/S5693/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5693', () => {
   it('S5693', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     const options = [{ fileUploadSizeLimit: 8_000_000, standardSizeLimit: 2_000_000 }];
 
     ruleTester.run('Allowing requests with excessive content length is security-sensitive', rule, {

--- a/packages/jsts/src/rules/S5728/unit.test.ts
+++ b/packages/jsts/src/rules/S5728/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5728', () => {
   it('S5728', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(
       'Disabling content security policy fetch directives is security-sensitive',
       rule,

--- a/packages/jsts/src/rules/S5730/unit.test.ts
+++ b/packages/jsts/src/rules/S5730/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5730', () => {
   it('S5730', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Allowing mixed-content is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5732/unit.test.ts
+++ b/packages/jsts/src/rules/S5732/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5732', () => {
   it('S5732', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(
       'Disabling content security policy frame-ancestors directive is security-sensitive',
       rule,

--- a/packages/jsts/src/rules/S5734/unit.test.ts
+++ b/packages/jsts/src/rules/S5734/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5734', () => {
   it('S5734', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Allowing browsers to sniff MIME types is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5736/unit.test.ts
+++ b/packages/jsts/src/rules/S5736/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5736', () => {
   it('S5736', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Disabling strict HTTP no-referrer policy is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5739/unit.test.ts
+++ b/packages/jsts/src/rules/S5739/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5739', () => {
   it('S5739', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Disabling Strict-Transport-Security policy is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5742/unit.test.ts
+++ b/packages/jsts/src/rules/S5742/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5742', () => {
   it('S5742', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Disabling Certificate Transparency monitoring is security-sensitive', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5743/unit.test.ts
+++ b/packages/jsts/src/rules/S5743/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5743', () => {
   it('S5743', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Allowing browsers to perform DNS prefetching is security-sensitive', rule, {
       valid: [

--- a/packages/jsts/src/rules/S5757/unit.test.ts
+++ b/packages/jsts/src/rules/S5757/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5757', () => {
   it('S5757', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Allowing confidential information to be logged is security-sensitive', rule, {
       valid: [

--- a/packages/jsts/src/rules/S5759/unit.test.ts
+++ b/packages/jsts/src/rules/S5759/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S5759', () => {
   it('S5759', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('ip forwarding should be avoided', rule, {
       valid: [

--- a/packages/jsts/src/rules/S5842/unit.test.ts
+++ b/packages/jsts/src/rules/S5842/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5842', () => {
   it('S5842', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Regular expression repetitions matching the empty string', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5843/unit.test.ts
+++ b/packages/jsts/src/rules/S5843/unit.test.ts
@@ -14,7 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+  RuleTester,
+} from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
@@ -24,7 +28,7 @@ describe('S5843', () => {
       return [{ threshold }];
     };
 
-    const ruleTesterThreshold0 = new RuleTester();
+    const ruleTesterThreshold0 = new DefaultParserRuleTester();
     ruleTesterThreshold0.run(
       'Regular expressions should not be too complicated with threshold 0',
       rule,
@@ -451,7 +455,7 @@ if (isString(regex)) {
       },
     );
 
-    const ruleTesterThreshold1 = new RuleTester();
+    const ruleTesterThreshold1 = new DefaultParserRuleTester();
     ruleTesterThreshold1.run(
       'Regular expressions should not be too complicated with threshold 1',
       rule,
@@ -556,7 +560,7 @@ if (isString(regex)) {
       },
     );
 
-    const ruleTesterDefaultThreshold = new RuleTester();
+    const ruleTesterDefaultThreshold = new NoTypeCheckingRuleTester();
     ruleTesterDefaultThreshold.run(
       'Regular expressions should not be too complicated with default threshold',
       rule,

--- a/packages/jsts/src/rules/S5850/unit.test.ts
+++ b/packages/jsts/src/rules/S5850/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5850', () => {
   it('S5850', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Anchor precedence', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5852/unit.test.ts
+++ b/packages/jsts/src/rules/S5852/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5852', () => {
   it('S5852', () => {
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterTs = new NoTypeCheckingRuleTester();
     ruleTesterTs.run('redos', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5863/unit.test.ts
+++ b/packages/jsts/src/rules/S5863/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5863', () => {
   it('S5863', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     // Main test cases are in the file comment-based fixture file.
     // Here we are testing that no issues are reported when no 'chai' import.

--- a/packages/jsts/src/rules/S5867/unit.test.ts
+++ b/packages/jsts/src/rules/S5867/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5867', () => {
   it('S5867', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(`Regular expressions using Unicode constructs with the 'u' flag`, rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5869/unit.test.ts
+++ b/packages/jsts/src/rules/S5869/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5869', () => {
   it('S5869', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Duplicated characters in character classes', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S5876/unit.test.ts
+++ b/packages/jsts/src/rules/S5876/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S5876', () => {
   it('S5876', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(
       'Create a new session during user authentication to prevent session fixation attacks.',
       rule,

--- a/packages/jsts/src/rules/S6019/unit.test.ts
+++ b/packages/jsts/src/rules/S6019/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6019', () => {
   it('S6019', () => {
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
     ruleTesterTs.run('Reluctant quantifiers followed by an optional', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6035/unit.test.ts
+++ b/packages/jsts/src/rules/S6035/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6035', () => {
   it('S6035', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Single-character alternation', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6092/unit.test.ts
+++ b/packages/jsts/src/rules/S6092/unit.test.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
@@ -23,7 +23,7 @@ import { describe, it } from 'node:test';
 
 describe('S6092', () => {
   it('S6092', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Assertions should not be given twice the same argument', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6268/unit.test.ts
+++ b/packages/jsts/src/rules/S6268/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6268', () => {
   it('S6268', () => {
-    const ruleTesterTs = new RuleTester();
+    const ruleTesterTs = new DefaultParserRuleTester();
     ruleTesterTs.run('', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6299/unit.test.ts
+++ b/packages/jsts/src/rules/S6299/unit.test.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { RuleTester, DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 import parser from 'vue-eslint-parser';
@@ -25,7 +25,7 @@ describe('S6299', () => {
     const ruleTesterForVue = new RuleTester({
       parser,
     });
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     const message = `Make sure bypassing Vue built-in sanitization is safe here.`;
     const testName = 'Disabling Vue.js built-in escaping is security-sensitive';

--- a/packages/jsts/src/rules/S6323/unit.test.ts
+++ b/packages/jsts/src/rules/S6323/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6323', () => {
   it('S6323', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Alternation with empty alternatives', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6324/unit.test.ts
+++ b/packages/jsts/src/rules/S6324/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6324', () => {
   it('S6324', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('No control characters in regular expressions', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6326/unit.test.ts
+++ b/packages/jsts/src/rules/S6326/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6326', () => {
   it('S6326', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Regex with multiple spaces', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6331/unit.test.ts
+++ b/packages/jsts/src/rules/S6331/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6331', () => {
   it('S6331', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Empty groups', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6351/unit.test.ts
+++ b/packages/jsts/src/rules/S6351/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S6351', () => {
   it('S6351', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Regular expressions with the global flag should be used with caution', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6353/unit.test.ts
+++ b/packages/jsts/src/rules/S6353/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6353', () => {
   it('S6353', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(
       `Regular expression quantifiers and character classes should be used concisely`,

--- a/packages/jsts/src/rules/S6418/unit.test.ts
+++ b/packages/jsts/src/rules/S6418/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './rule.js';
 import { describe, it } from 'node:test';
 
 describe('S6418', () => {
   it('S6418', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Rule S6418 - no-hardcoded-secrets', rule, {
       valid: [],

--- a/packages/jsts/src/rules/S6479/unit.test.ts
+++ b/packages/jsts/src/rules/S6479/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './rule.js';
 import { describe, it } from 'node:test';
 
 describe('S6479', () => {
   it('S6479', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Rule S6479 - no-array-index-key', rule, {
       valid: [

--- a/packages/jsts/src/rules/S6598/unit.test.ts
+++ b/packages/jsts/src/rules/S6598/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S6598', () => {
   it('S6598', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(`Decorated rule should reword the issue message`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S6660/unit.test.ts
+++ b/packages/jsts/src/rules/S6660/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6660', () => {
   it('S6660', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run("'If' statement should not be the only statement in 'else' block", rule, {
       valid: [

--- a/packages/jsts/src/rules/S6666/unit.test.ts
+++ b/packages/jsts/src/rules/S6666/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6666', () => {
   it('S6666', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Spread syntax should be used instead of apply()`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S6676/unit.test.ts
+++ b/packages/jsts/src/rules/S6676/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6676', () => {
   it('S6676', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(`Calls to .call() and .apply() methods should not be redundant`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S6679/unit.test.ts
+++ b/packages/jsts/src/rules/S6679/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6679', () => {
   it('S6679', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run('Number.isNaN() should be used to check for NaN value', rule, {
       valid: [{ code: `x > x` }, { code: `x < x` }, { code: `x >= x` }, { code: `x <= x` }],

--- a/packages/jsts/src/rules/S6749/unit.test.ts
+++ b/packages/jsts/src/rules/S6749/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S6749', () => {
   it('S6749', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('Redundant React fragments should be removed', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S6754/unit.test.ts
+++ b/packages/jsts/src/rules/S6754/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6754', () => {
   it('S6754', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run(
       'The return value of "useState" should be destructured and named symmetrically',
       rule,

--- a/packages/jsts/src/rules/S6788/unit.test.ts
+++ b/packages/jsts/src/rules/S6788/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S6788', () => {
   it('S6788', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run(`Decorated rule should reword the issue message`, rule, {
       valid: [

--- a/packages/jsts/src/rules/S6791/unit.test.ts
+++ b/packages/jsts/src/rules/S6791/unit.test.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S6791', () => {
   it('S6791', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
 
     ruleTester.run(
       'The decorator should refine both message and location, and provide a quickfix',

--- a/packages/jsts/src/rules/S6958/unit.test.ts
+++ b/packages/jsts/src/rules/S6958/unit.test.ts
@@ -15,10 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 
 describe('S6958', () => {
   it('S6958', () => {

--- a/packages/jsts/src/rules/S6959/unit.test.ts
+++ b/packages/jsts/src/rules/S6959/unit.test.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { rule } from './index.js';
 import { describe, it } from 'node:test';
 
 describe('S6959', () => {
   it('S6959', () => {
-    const ruleTester = new RuleTester();
+    const ruleTester = new DefaultParserRuleTester();
     ruleTester.run('"Array.reduce()" calls should include an initial value', rule, {
       valid: [
         {

--- a/packages/jsts/src/rules/S905/unit.test.ts
+++ b/packages/jsts/src/rules/S905/unit.test.ts
@@ -15,10 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { RuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tests/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
-const ruleTester = new RuleTester();
+const ruleTester = new NoTypeCheckingRuleTester();
 
 describe('S905', () => {
   it('S905', () => {

--- a/packages/jsts/tests/rules/helpers/aws/cdk.test.ts
+++ b/packages/jsts/tests/rules/helpers/aws/cdk.test.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { AwsCdkTemplate } from '../../../../src/rules/index.js';
-import { RuleTester } from '../../../tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../tools/testers/rule-tester.js';
 import { describe } from 'node:test';
 
 const rule = AwsCdkTemplate({
@@ -24,7 +24,7 @@ const rule = AwsCdkTemplate({
   },
 });
 describe('aws test', () => {
-  const ruleTester = new RuleTester();
+  const ruleTester = new NoTypeCheckingRuleTester();
   ruleTester.run('AWS CDK Rule Template', rule, {
     valid: [
       {

--- a/packages/jsts/tests/rules/helpers/aws/s3.test.ts
+++ b/packages/jsts/tests/rules/helpers/aws/s3.test.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { RuleTester } from '../../../tools/testers/rule-tester.js';
+import { DefaultParserRuleTester } from '../../../tools/testers/rule-tester.js';
 import { S3BucketTemplate } from '../../../../src/rules/index.js';
 
 const rule = S3BucketTemplate((node, context) => {
@@ -26,7 +26,7 @@ const rule = S3BucketTemplate((node, context) => {
   }
 });
 
-const ruleTester = new RuleTester();
+const ruleTester = new DefaultParserRuleTester();
 ruleTester.run('S3 Bucket Template', rule, {
   valid: [
     {


### PR DESCRIPTION
As part of optimizing the CI, the bottleneck are the JS unit-tests. For some background. We have 3 different rule testers:
1) DefaultParserRuleTester - this is the default parser eslint ships with, it has no typescript syntax or type information
2) NoTypeCheckingRuleTest - this includes the parser from @typescript-elint, so it has typescript syntax, but no type information
3) RuleTester - the full shebang. It has typescript syntax along with type information.

Looking at the behavior of those in tests, 1 and 2 are quite quick, and 3) is much slower. On a single test in terminal the difference is: 0.8s vs 1.4s, hence 0.6s per test. With this excercise, I've dropped everything to use the DefaultParserRuleTester and checked which tests break, then verify in each of them do they need option 2) or 3).

The results, based on running 2 times each on my machine `npm run bridge:test`:
1) Before: ~200s 
2) After  : ~160s

This is another 20% gain. I hope that these will stack and we will get to around 45% improvements. I also think that with the lower load on the CPU, as the tests are lighter, we might be able to increase the concurrency to improve even more.