### PR TITLE
JS-666 Revert "GitHub workflows migration to self hosted runners"

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   dogfood_merge:
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     name: Update dogfood branch
     permissions:
       id-token: write # required for SonarSource/vault-action-wrapper

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -5,7 +5,7 @@ name: Releasability status
       - completed
 jobs:
   update_releasability_status:
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     name: Releasability status
     permissions:
       id-token: write

--- a/.github/workflows/release_eslint_plugin.yml
+++ b/.github/workflows/release_eslint_plugin.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     permissions:
       id-token: write # required for SonarSource/vault-action-wrapper
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event.inputs.release_version }}
       NPM_REPOSITORY: "sonarsource-npm-public"

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   publish-rules-helper-site:
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write # for vault
       contents: write # for publish


### PR DESCRIPTION
[JS-666](https://sonarsource.atlassian.net/browse/JS-666)

This reverts commit a2ed9be7e21c71a5d31ff3bd0a6d89983bd07304.

Self hosted runners should not be used on public repositories. Sonar-runner is only for [private and internal repositories](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/Using+Self-Hosted+GitHub+Runners+-+GitHub#1.-Repository-access-to-the-runner).

[JS-666]: https://sonarsource.atlassian.net/browse/JS-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ