### PR TITLE
Add `.git` folder name to default exclusions

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -112,6 +112,7 @@ public class JavaScriptPlugin implements Plugin {
   public static final String JS_EXCLUSIONS_KEY = "sonar.javascript.exclusions";
   public static final String TS_EXCLUSIONS_KEY = "sonar.typescript.exclusions";
   public static final String[] EXCLUSIONS_DEFAULT_VALUE = new String[] {
+    ".git/**",
     "**/node_modules/**",
     "**/bower_components/**",
     "**/dist/**",


### PR DESCRIPTION
Reported in community:
https://community.sonarsource.com/t/unmappable-characters-since-sonarqube-upgrade/132291/3

