### PR TITLE
JS-668 Update rule metadata for CSS

### DIFF
--- a/css-sonarpedia/sonarpedia.json
+++ b/css-sonarpedia/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "CSS"
   ],
-  "latest-update": "2025-02-17T08:41:01.715828Z",
+  "latest-update": "2025-04-02T12:43:21.010187Z",
   "options": {
     "no-language-in-filenames": true
   }

--- a/sonar-plugin/css/src/main/resources/org/sonar/l10n/css/rules/css/S4647.json
+++ b/sonar-plugin/css/src/main/resources/org/sonar/l10n/css/rules/css/S4647.json
@@ -3,7 +3,7 @@
   "type": "BUG",
   "code": {
     "impacts": {
-      "RELIABILITY": "HIGH"
+      "RELIABILITY": "BLOCKER"
     },
     "attribute": "LOGICAL"
   },


### PR DESCRIPTION
[JS-668](https://sonarsource.atlassian.net/browse/JS-668)

By curiosity, I ran it for CSS and found a difference.

Do we already have a ticket to make the rule-api maven plugin work for CSS?

I created this one in case it's not: https://sonarsource.atlassian.net/browse/JS-670

[JS-668]: https://sonarsource.atlassian.net/browse/JS-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ