### PR TITLE
JS-690 Update message on latest supported Typescript

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -57,7 +57,7 @@ import org.sonar.plugins.javascript.sonarlint.TsConfigCacheImpl;
 
 public class JavaScriptPlugin implements Plugin {
 
-  public static final String TYPESCRIPT_VERSION = "5.7.2";
+  public static final String TYPESCRIPT_VERSION = "5.8.3";
   private static final Logger LOG = LoggerFactory.getLogger(JavaScriptPlugin.class);
 
   // Subcategories


### PR DESCRIPTION
[JS-690](https://sonarsource.atlassian.net/browse/JS-690)

This will happen again every time renovate updates TS version. We should get rid of this TS hardcoded version in Java side

[JS-690]: https://sonarsource.atlassian.net/browse/JS-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ