### PR TITLE
JS-691 Improve SonarQube for IDE support

### DIFF
--- a/its/plugin/sonarlint-tests/src/test/java/com/sonar/javascript/it/plugin/sonarlint/tests/SonarLintTest.java
+++ b/its/plugin/sonarlint-tests/src/test/java/com/sonar/javascript/it/plugin/sonarlint/tests/SonarLintTest.java
@@ -69,14 +69,14 @@ class SonarLintTest {
   Path sonarLintHome;
 
   @BeforeEach
-  public void prepare() throws Exception {
+  void prepare() throws Exception {
     logs = new ArrayList<>();
     StandaloneGlobalConfiguration sonarLintConfig = getSonarLintConfig();
     sonarlintEngine = new StandaloneSonarLintEngineImpl(sonarLintConfig);
   }
 
   @AfterEach
-  public void stop() {
+  void stop() {
     sonarlintEngine.stop();
   }
 
@@ -107,7 +107,9 @@ class SonarLintTest {
         logs
           .stream()
           .anyMatch(s ->
-            s.matches("Using Node\\.js executable .* from property sonar\\.nodejs\\.executable\\.")
+            s.matches(
+              "Using Node\\.js executable '.*' from property 'sonar\\.nodejs\\.executable'\\."
+            )
           )
       ).isTrue();
     }
@@ -291,8 +293,7 @@ class SonarLintTest {
     return getSonarLintConfig(nodeJsHelper.getNodeJsPath(), nodeJsHelper.getNodeJsVersion());
   }
 
-  private StandaloneGlobalConfiguration getSonarLintConfig(Path nodePath, Version nodeVersion)
-    throws IOException {
+  private StandaloneGlobalConfiguration getSonarLintConfig(Path nodePath, Version nodeVersion) {
     ClientLogOutput logOutput = (formattedMessage, level) -> {
       logs.add(formattedMessage);
       System.out.println(formattedMessage);

--- a/packages/shared/src/types/analysis.ts
+++ b/packages/shared/src/types/analysis.ts
@@ -49,11 +49,6 @@ export interface AnalysisInput {
  */
 export interface AnalysisOutput {}
 
-/**
- * In SonarQube context, an analysis input includes both path and content of a file
- * to analyze. However, in SonarLint, we might only get the file path. As a result,
- * we read the file if the content is missing in the input.
- */
 export async function fillFileContent<T extends AnalysisInput>(
   input: T,
 ): Promise<Omit<T, 'fileContent'> & { fileContent: string }> {

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -18,6 +18,7 @@ package org.sonar.plugins.javascript.bridge;
 
 import static java.util.Collections.emptyList;
 import static org.sonar.plugins.javascript.bridge.NetUtils.findOpenPort;
+import static org.sonar.plugins.javascript.nodejs.NodeCommand.toWslPathIfNeeded;
 import static org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl.NODE_EXECUTABLE_PROPERTY;
 import static org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl.NODE_FORCE_HOST_PROPERTY;
 import static org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl.SKIP_NODE_PROVISIONING_PROPERTY;
@@ -440,15 +441,19 @@ public class BridgeServerImpl implements BridgeServer {
   }
 
   TsConfigResponse tsConfigFiles(String tsconfigAbsolutePath) {
+    var tsconfigPathAdapted = toWslPathIfNeeded(
+      nodeCommand.shouldExecuteWithWsl(),
+      tsconfigAbsolutePath
+    );
     String result = null;
     try {
-      TsConfigRequest tsConfigRequest = new TsConfigRequest(tsconfigAbsolutePath);
+      TsConfigRequest tsConfigRequest = new TsConfigRequest(tsconfigPathAdapted);
       result = request(GSON.toJson(tsConfigRequest), "tsconfig-files").json();
       return GSON.fromJson(result, TsConfigResponse.class);
     } catch (JsonSyntaxException e) {
       LOG.error(
         "Failed to parse response when requesting files for tsconfig: {}: \n-----\n{}\n-----\n{}",
-        tsconfigAbsolutePath,
+        tsconfigPathAdapted,
         result,
         e.getMessage()
       );

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
@@ -197,7 +197,7 @@ public class EmbeddedNode {
         extractWithLocking(is, versionIs, targetRuntime, targetDirectory);
       }
       // we try to run 'node -v' to test that node is working
-      var detected = NodeVersion.getVersion(processWrapper, binary().toString());
+      var detected = NodeVersion.getVersion(processWrapper, binary().toString(), false);
       LOG.debug("Deployed node version {}", detected);
       isAvailable = true;
     } catch (Exception e) {

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommand.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommand.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.javascript.nodejs;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -162,24 +163,15 @@ public class NodeCommand {
       return path;
     }
 
-    if (path.isEmpty()) {
-      return "";
-    }
-
-    var normalizedPath = path.replace('\\', '/');
-
-    if (
-      normalizedPath.length() > 2 &&
-      Character.isLetter(normalizedPath.charAt(0)) &&
-      normalizedPath.charAt(1) == ':'
-    ) {
-      var driveLetter = String.valueOf(normalizedPath.charAt(0)).toLowerCase();
+    if (path.length() > 2 && Character.isLetter(path.charAt(0)) && path.charAt(1) == ':') {
+      var normalizedPath = path.replace('\\', '/');
+      var driveLetter = String.valueOf(normalizedPath.charAt(0)).toLowerCase(Locale.ROOT);
 
       var remainingPath = normalizedPath.substring(2);
 
       return "/mnt/" + driveLetter + remainingPath;
     } else {
-      return normalizedPath;
+      return path;
     }
   }
 }

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommandBuilderImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommandBuilderImpl.java
@@ -269,7 +269,7 @@ public class NodeCommandBuilderImpl implements NodeCommandBuilder {
     throw new NodeCommandException("Provided Node.js executable file does not exist in WSL.");
   }
 
-  private String handleStandardNode(String nodeExecutable) throws NodeCommandException {
+  private static String handleStandardNode(String nodeExecutable) throws NodeCommandException {
     File file = new File(nodeExecutable);
     if (file.exists()) {
       LOG.info(

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeVersion.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeVersion.java
@@ -32,8 +32,11 @@ public class NodeVersion {
     // utility class
   }
 
-  public static String getVersion(ProcessWrapper processWrapper, String nodeExecutable)
-    throws NodeCommandException {
+  public static String getVersion(
+    ProcessWrapper processWrapper,
+    String nodeExecutable,
+    boolean shouldExecuteWithWsl
+  ) throws NodeCommandException {
     var output = new StringBuilder();
     var nodeCommand = new NodeCommand(
       processWrapper,
@@ -49,7 +52,8 @@ public class NodeVersion {
         "RUN_NODE_ERROR_MSG",
         "Couldn't find the Node.js binary. Ensure you have Node.js installed."
       ),
-      "host"
+      "host",
+      shouldExecuteWithWsl
     );
     nodeCommand.start();
     int exitValue = nodeCommand.waitFor();

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractAnalysis.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractAnalysis.java
@@ -142,7 +142,7 @@ public abstract class AbstractAnalysis {
     boolean shouldClearDependenciesCache
   ) {
     return new BridgeServer.JsAnalysisRequest(
-      file.absolutePath(),
+      file.relativePath(),
       file.type().toString(),
       fileContent,
       context.ignoreHeaderComments(),

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
@@ -89,7 +89,7 @@ public class AnalysisProcessor {
     this.checks = checks;
     this.file = file;
     if (response.parsingError() != null) {
-      uniqueParsingErrors.add(file.absolutePath());
+      uniqueParsingErrors.add(file.relativePath());
       processParsingError(context, response.parsingError());
       return new ArrayList<>();
     }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/CssRuleSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/CssRuleSensor.java
@@ -135,15 +135,15 @@ public class CssRuleSensor extends AbstractBridgeSensor {
     List<Issue> issues;
 
     try {
-      URI uri = inputFile.uri();
-      if (!"file".equalsIgnoreCase(uri.getScheme())) {
-        LOG.debug("Skipping {} as it has not 'file' scheme", uri);
+      String relativeFilePath = inputFile.relativePath();
+      if (!inputFile.isFile()) {
+        LOG.debug("Skipping {} as it is not a file", relativeFilePath);
         return new ArrayList<>();
       }
-      LOG.debug("Analyzing file: {}", uri);
+      LOG.debug("Analyzing file: {}", relativeFilePath);
       String fileContent = context.shouldSendFileContent(inputFile) ? inputFile.contents() : null;
       CssAnalysisRequest request = new CssAnalysisRequest(
-        new File(uri).getAbsolutePath(),
+        new File(relativeFilePath).getAbsolutePath(),
         fileContent,
         rules
       );

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/HtmlSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/HtmlSensor.java
@@ -124,7 +124,7 @@ public class HtmlSensor extends AbstractBridgeSensor {
       LOG.debug("Analyzing file: {}", file.uri());
       var fileContent = context.shouldSendFileContent(file) ? file.contents() : null;
       var jsAnalysisRequest = new JsAnalysisRequest(
-        file.absolutePath(),
+        file.relativePath(),
         file.type().toString(),
         fileContent,
         context.ignoreHeaderComments(),

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/YamlSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/YamlSensor.java
@@ -156,7 +156,7 @@ public class YamlSensor extends AbstractBridgeSensor {
         LOG.debug("Analyzing file: {}", file.uri());
         var fileContent = context.shouldSendFileContent(file) ? file.contents() : null;
         var jsAnalysisRequest = new JsAnalysisRequest(
-          file.absolutePath(),
+          file.relativePath(),
           file.type().toString(),
           fileContent,
           context.ignoreHeaderComments(),

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/ExternalIssueRepository.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/ExternalIssueRepository.java
@@ -114,18 +114,21 @@ public class ExternalIssueRepository {
     // at that point, we have the list of issues that were persisted
     // we can now persist the ESLint issues that match none of the persisted issues
     for (var externalIssue : externalIssues) {
-      var issueKey = String.format(
-        "%s-%s-%d-%d-%d-%d",
-        externalIssue.name(),
-        externalIssue.file().absolutePath().replaceAll(Pattern.quote(File.separator), "/"),
-        externalIssue.location().start().line(),
-        externalIssue.location().start().lineOffset(),
-        externalIssue.location().end().line(),
-        externalIssue.location().end().lineOffset()
-      );
+      var absolutePath = externalIssue.file().absolutePath();
+      if (absolutePath != null) {
+        var issueKey = String.format(
+          "%s-%s-%d-%d-%d-%d",
+          externalIssue.name(),
+          absolutePath.replaceAll(Pattern.quote(File.separator), "/"),
+          externalIssue.location().start().line(),
+          externalIssue.location().start().lineOffset(),
+          externalIssue.location().end().line(),
+          externalIssue.location().end().lineOffset()
+        );
 
-      if (!normalizedIssues.contains(issueKey)) {
-        deduplicatedIssues.add(externalIssue);
+        if (!normalizedIssues.contains(issueKey)) {
+          deduplicatedIssues.add(externalIssue);
+        }
       }
     }
     return deduplicatedIssues;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/sonarlint/TsConfigCacheImpl.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/sonarlint/TsConfigCacheImpl.java
@@ -68,7 +68,7 @@ public class TsConfigCacheImpl implements TsConfigCache, ModuleFileListener {
     boolean initialized = false;
 
     TsConfigFile getTsConfigForInputFile(InputFile inputFile) {
-      var inputFilePath = inputFile.absolutePath();
+      var inputFilePath = inputFile.relativePath();
       if (!initialized) {
         LOG.error("TsConfigCacheImpl is not initialized for file {}", inputFilePath);
         return null;
@@ -150,9 +150,11 @@ public class TsConfigCacheImpl implements TsConfigCache, ModuleFileListener {
     private Deque<String> improvedPendingTsConfigOrder(InputFile inputFile) {
       var newPendingTsConfigFiles = new ArrayDeque<String>();
       var notMatchingPendingTsConfigFiles = new ArrayList<String>();
+      var absolutePath = inputFile.absolutePath();
       pendingTsConfigFiles.forEach(ts -> {
         if (
-          inputFile.absolutePath().startsWith(Path.of(ts).getParent().toAbsolutePath().toString())
+          absolutePath != null &&
+          absolutePath.startsWith(Path.of(ts).getParent().toAbsolutePath().toString())
         ) {
           newPendingTsConfigFiles.add(ts);
         } else {
@@ -210,7 +212,7 @@ public class TsConfigCacheImpl implements TsConfigCache, ModuleFileListener {
   @Override
   public void process(ModuleFileEvent moduleFileEvent) {
     var file = moduleFileEvent.getTarget();
-    var filename = file.absolutePath();
+    var filename = file.filename();
     LOG.debug("Processing file event {} with event {}", filename, moduleFileEvent.getType());
     // Look for any event on files named *tsconfig*.json
     // Filenames other than tsconfig.json can be discovered through references

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JavaScriptEslintBasedSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JavaScriptEslintBasedSensorTest.java
@@ -393,7 +393,7 @@ class JavaScriptEslintBasedSensorTest {
     var inputFile = createInputFile(context);
     var tsConfigFile = new TsConfigFile(
       "/path/to/file",
-      List.of(inputFile.absolutePath()),
+      List.of(inputFile.getProjectRelativePath()),
       emptyList()
     );
     when(bridgeServerMock.analyzeJsTs(any())).thenReturn(responseMetrics);
@@ -651,7 +651,7 @@ class JavaScriptEslintBasedSensorTest {
 
     var tsConfigFile = new TsConfigFile(
       "/path/to/file",
-      List.of(inputFile.absolutePath()),
+      List.of(inputFile.getProjectRelativePath()),
       emptyList()
     );
     when(bridgeServerMock.createTsConfigFile(any())).thenReturn(tsConfigFile);

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/TsConfigCacheTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/TsConfigCacheTest.java
@@ -96,17 +96,17 @@ class TsConfigCacheTest {
     List<TsConfigFile> tsConfigFiles = Arrays.asList(
       new TsConfigFile(
         absolutePath(baseDir, "dir1/tsconfig.json"),
-        singletonList(inputFiles.get(0).absolutePath()),
+        singletonList(inputFiles.get(0).relativePath()),
         emptyList()
       ),
       new TsConfigFile(
         absolutePath(baseDir, "dir2/tsconfig.json"),
-        singletonList(inputFiles.get(1).absolutePath()),
+        singletonList(inputFiles.get(1).relativePath()),
         emptyList()
       ),
       new TsConfigFile(
         absolutePath(baseDir, "dir3/tsconfig.json"),
-        singletonList(inputFiles.get(2).absolutePath()),
+        singletonList(inputFiles.get(2).relativePath()),
         emptyList()
       )
     );
@@ -116,7 +116,7 @@ class TsConfigCacheTest {
       Files.createDirectory(tsConfigPath.getParent());
       Files.createFile(tsConfigPath);
     }
-    var ctx = new JsTsContext<SensorContextTester>(SensorContextTester.create(baseDir));
+    var ctx = new JsTsContext<>(SensorContextTester.create(baseDir));
     TsConfigProvider.initializeTsConfigCache(ctx, this::tsConfigFileCreator, tsConfigCache);
 
     when(bridgeServerMock.loadTsConfig(any())).thenAnswer(invocationOnMock -> {
@@ -186,7 +186,7 @@ class TsConfigCacheTest {
     );
     var tsConfigFile2 = new TsConfigFile(
       tsconfig2.toAbsolutePath().toString(),
-      singletonList(file1.absolutePath()),
+      singletonList(file1.getProjectRelativePath()),
       emptyList()
     );
     Files.createFile(tsconfig1);
@@ -236,10 +236,10 @@ class TsConfigCacheTest {
     Files.createFile(tsconfig1);
     var tsConfigFile = new TsConfigFile(
       tsconfig1.toAbsolutePath().toString(),
-      singletonList(file1.absolutePath()),
+      singletonList(file1.getProjectRelativePath()),
       emptyList()
     );
-    var ctx = new JsTsContext<SensorContextTester>(SensorContextTester.create(baseDir));
+    var ctx = new JsTsContext<>(SensorContextTester.create(baseDir));
     ctx
       .getSensorContext()
       .setSettings(new MapSettings().setProperty(TSCONFIG_PATHS, "tsconfig.*.json,tsconfig.json"));
@@ -304,12 +304,12 @@ class TsConfigCacheTest {
     Path tsconfig1 = baseDir.resolve("tsconfig.json");
     var tsConfigFile = new TsConfigFile(
       tsconfig1.toAbsolutePath().toString(),
-      singletonList(file1.absolutePath()),
+      singletonList(file1.getProjectRelativePath()),
       emptyList()
     );
     Files.createFile(tsconfig1);
 
-    var ctx = new JsTsContext<SensorContextTester>(SensorContextTester.create(baseDir));
+    var ctx = new JsTsContext<>(SensorContextTester.create(baseDir));
     TsConfigProvider.initializeTsConfigCache(ctx, this::tsConfigFileCreator, tsConfigCache);
     when(bridgeServerMock.loadTsConfig(any())).thenReturn(tsConfigFile);
     return Pair.of(file1, tsConfigFile);


### PR DESCRIPTION
[JS-691](https://sonarsource.atlassian.net/browse/JS-691)

This PR aims at improving support with SonarQube for IDE, this includes:
- Running `Node.js` from a WSL environment, while the analyzer runs outside
- Allow the analysis of projects from WSL, while the analyzer runs outside (typically when the IDE is opened on Windows, and then the project is opened from WSL). The main issue is the usage of the deprecated `absolutepath()` which should be avoided as much as possible. In such a configuration, the absolute path cannot be resolved.
- Allow the analysis of non `file://` scheme, this is typically useful in the context of SonarQube for IDE where file might have specific scheme (`tmp://` or else)

> /**
>  * In SonarQube context, an analysis input includes both path and content of a file
>  * to analyze. However, in SonarLint, we might only get the file path. As a result,
>  * we read the file if the content is missing in the input.
>  */

This quote is untrue, SonarQube for IDE will always send the file content. This is part of the contract of the plugin API.

___

The changes from this PR have been tested on various environments in SQ:IDE:
- Linux
- Windows with and without WSL

I did not notice anything wrong.

[JS-691]: https://sonarsource.atlassian.net/browse/JS-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ