### PR TITLE
JS-604 Update license excludes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,13 +342,6 @@
           <version>3.5.0</version>
         </plugin>
         <plugin>
-          <groupId>com.mycila</groupId>
-          <artifactId>license-maven-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
           <version>1.7.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,8 @@
                 <exclude>**/*.fixture.*</exclude>
                 <!-- Resources -->
                 <exclude>**/src/test/resources/**/*</exclude>
+                <exclude>typedoc/**/*</exclude>
+                <exclude>coverage/**/*</exclude>
               </excludes>
             </licenseSet>
           </licenseSets>

--- a/tools/copy-test-resources.ts
+++ b/tools/copy-test-resources.ts
@@ -1,3 +1,19 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
 import path from 'path';
 import { cpSync, mkdirSync, statSync, accessSync } from 'node:fs';
 import { globSync } from 'glob';


### PR DESCRIPTION
[JS-604](https://sonarsource.atlassian.net/browse/JS-604)

As per the ticket, we shouldn't be looking into these folders.
Also, I had a hard time enabling this, but I noticed as a parting gift, as a wip, Eric added a skip to the license check. So, removing that.

To test just the license, ran:

`mvn license:check`

[JS-604]: https://sonarsource.atlassian.net/browse/JS-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ