### PR TITLE
JS-633 Improve S3735: if no types, don't raise

### DIFF
--- a/packages/jsts/src/rules/S3735/unit.test.ts
+++ b/packages/jsts/src/rules/S3735/unit.test.ts
@@ -52,28 +52,24 @@ describe('S3735', () => {
             void (() => 42) ()
             `,
         },
-      ],
-      invalid: [
-        {
-          code: `
-            foo(void 42);
-            `,
-          errors: [
-            {
-              message: `Remove this use of the \"void\" operator.`,
-              line: 2,
-              endLine: 2,
-              column: 17,
-              endColumn: 21,
-            },
-          ],
-        },
         {
           code: `
             const f = () => { return new Promise(() => {}); };
-            void f(); // FP: should be ignored since 'f()' is a promise but we are missing type information
-            `,
-          errors: 1,
+            void f(); // FN: should be ignored since 'f()' is a promise but we are missing type information`,
+        },
+      ],
+      invalid: [
+        {
+          code: `void 42;`,
+          errors: [
+            {
+              message: `Remove this use of the \"void\" operator.`,
+              line: 1,
+              endLine: 1,
+              column: 1,
+              endColumn: 5,
+            },
+          ],
         },
       ],
     });

--- a/packages/jsts/src/rules/S3735/unit.test.ts
+++ b/packages/jsts/src/rules/S3735/unit.test.ts
@@ -54,8 +54,8 @@ describe('S3735', () => {
         },
         {
           code: `
-            const f = () => { return new Promise(() => {}); };
-            void f(); // FN: should be ignored since 'f()' is a promise but we are missing type information`,
+            const f = () => {};
+            void f(); // FN: should raise since 'f()' is not a promise but we are missing type information`,
         },
       ],
       invalid: [


### PR DESCRIPTION
[JS-633](https://sonarsource.atlassian.net/browse/JS-633)

If we don't have typescript types, lets be permissive and if we have a function call that it can be a promise.

[JS-633]: https://sonarsource.atlassian.net/browse/JS-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ