### PR TITLE
JS-545 Configure renovate to use repox private npm registry

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,13 +40,20 @@
       "enabled": false
     },
     {
-      "packageRules": [
-        {
-          "matchUpdateTypes": ["minor", "patch"],
-          "matchCurrentVersion": "!/^0/",
-          "automerge": false
-        }
-      ]
+      "matchDatasources": ["npm"],
+      "registryUrls": ["https://repox.jfrog.io/artifactory/api/npm/npm"]
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": false
+    }
+  ],
+  "hostRules": [
+    {
+      "hostType": "npm",
+      "endpoint": "https://repox.jfrog.io/artifactory/api/npm/npm",
+      "token": "{{ secrets.REPOX_TOKEN }}"
     }
   ]
 }


### PR DESCRIPTION
[JS-545](https://sonarsource.atlassian.net/browse/JS-545)

As we noticed, renovate uses the public npm registry. Let us update this to first look in repox as the registry!
@jayadeep-km-sonarsource @hedinasr (I found your names as you've either previously touched this config or added a new source - https://sonarsource.atlassian.net/browse/BUILD-5885 ) - 2 questions:
1) how can I test this?
2) should this be added in the parent configs of renovate? I see that for maven we already have this in a common setup - https://github.com/SonarSource/renovate-config/blob/master/default.json#L22 
Could this come preconfigured for npm to use repox? As example see this pull request and the package-lock.json file - 
https://github.com/SonarSource/SonarJS/pull/5233/files
We change all of the urls from repox to the public repository.

[JS-545]: https://sonarsource.atlassian.net/browse/JS-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ