### PR TITLE
JS-634 Add default roles

### DIFF
--- a/packages/jsts/src/rules/S6845/config.ts
+++ b/packages/jsts/src/rules/S6845/config.ts
@@ -14,7 +14,15 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-export const implementation = 'external';
-export const eslintId = 'no-noninteractive-tabindex';
-export const externalPlugin = 'jsx-a11y';
-export * from './config.js';
+// https://sonarsource.github.io/rspec/#/rspec/S6847/javascript
+
+import { ESLintConfiguration } from '../helpers/configs.js';
+
+export const fields = [
+  [
+    {
+      field: 'roles',
+      default: ['tabpanel'],
+    },
+  ],
+] as const satisfies ESLintConfiguration;


### PR DESCRIPTION
[JS-634](https://sonarsource.atlassian.net/browse/JS-634)

Following the ticket and documentation from external plugin - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-tabindex.md#rule-options

[JS-634]: https://sonarsource.atlassian.net/browse/JS-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ