### PR TITLE
JS-41 Augment vitest assertions to include expectTypeOf and assertType

### DIFF
--- a/packages/jsts/src/rules/S2699/vitest.fixture.js
+++ b/packages/jsts/src/rules/S2699/vitest.fixture.js
@@ -1,6 +1,6 @@
 // sum.test.js
 const vitest = require('vitest');
-const { describe, expect, it } = require('vitest');
+const { describe, expect, it, expectTypeOf, assertType } = require('vitest');
 
 describe('vitest test cases', () => {
   it('no assertion', () => { // Noncompliant {{Add at least one assertion to this test case.}}
@@ -17,6 +17,18 @@ describe('vitest test cases', () => {
 
   it('transitive assertion', () => { // Compliant
     check();
+  });
+
+  it('expectTypeOf works properly', () => {
+    vitest.expectTypeOf(it).toBeFunction()
+  });
+
+  it('destructured expectTypeOf works properly', () => {
+    expectTypeOf(it).toBeFunction()
+  });
+
+  it('assertType works properly', () => {
+    assertType(mount({ name: 42 }));
   });
 
   function check() {

--- a/packages/jsts/src/rules/helpers/vitest.ts
+++ b/packages/jsts/src/rules/helpers/vitest.ts
@@ -28,12 +28,9 @@ export namespace Vitest {
   }
 
   export function isAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
-    return isExpectUsage(context, node);
-  }
-
-  function isExpectUsage(context: Rule.RuleContext, node: estree.Node) {
-    // expect(), vitest.expect()
-    return extractFQNforCallExpression(context, node) === 'vitest.expect';
+    const validExpectations = ['vitest.expect', 'vitest.expectTypeOf', 'vitest.assertType'];
+    const fullyQualifiedName = extractFQNforCallExpression(context, node);
+    return !!fullyQualifiedName && validExpectations.includes(fullyQualifiedName);
   }
 
   function extractFQNforCallExpression(context: Rule.RuleContext, node: estree.Node) {

--- a/packages/jsts/src/rules/helpers/vitest.ts
+++ b/packages/jsts/src/rules/helpers/vitest.ts
@@ -28,9 +28,9 @@ export namespace Vitest {
   }
 
   export function isAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
-    const validExpectations = ['vitest.expect', 'vitest.expectTypeOf', 'vitest.assertType'];
+    const validAssertionCalls = ['vitest.expect', 'vitest.expectTypeOf', 'vitest.assertType'];
     const fullyQualifiedName = extractFQNforCallExpression(context, node);
-    return !!fullyQualifiedName && validExpectations.includes(fullyQualifiedName);
+    return !!fullyQualifiedName && validAssertionCalls.includes(fullyQualifiedName);
   }
 
   function extractFQNforCallExpression(context: Rule.RuleContext, node: estree.Node) {


### PR DESCRIPTION
[JS-41](https://sonarsource.atlassian.net/browse/JS-41)

To decrease the number of false positives, let us understand more of vitest syntax.


[JS-41]: https://sonarsource.atlassian.net/browse/JS-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ