### PR TITLE
JS-591 Retry with different config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,7 +52,7 @@
   "hostRules": [
     {
       "hostType": "npm",
-      "endpoint": "https://repox.jfrog.io/artifactory/api/npm/npm",
+      "matchHost": "https://repox.jfrog.io/artifactory/api/npm/npm/",
       "token": "{{ secrets.REPOX_TOKEN }}"
     }
   ]


### PR DESCRIPTION
[JS-591](https://sonarsource.atlassian.net/browse/JS-591)

Reading through the renovate docs, there is no mention of 'endpoint' property, just the `matchHost` - https://docs.renovatebot.com/getting-started/private-packages/#add-hostrule-to-bots-config

I think I was using AI helpers and they gave me the `endpoint`...

[JS-591]: https://sonarsource.atlassian.net/browse/JS-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ