### PR TITLE
JS-701 Consider SonarJasmin active by default

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ConsumerPluginTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/ConsumerPluginTest.java
@@ -75,8 +75,6 @@ class ConsumerPluginTest {
       .setProjectName("Custom Rules")
       .setProjectVersion("1.0")
       .setDebugLogs(true)
-      // This flag is an intermediate solution to not run Jasmin for all projects during the development of the new analyzer.
-      .setProperty("sonar.jasmin.internal.enabled", "true")
       .setSourceDirs("src");
     orchestrator.getServer().provisionProject("custom-rules", "Custom Rules");
     orchestrator

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsContext.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsContext.java
@@ -55,8 +55,8 @@ public class JsTsContext<T extends SensorContext> {
   @Deprecated(forRemoval = true)
   private static final String ARMOR_INTERNAL_ENABLED = "sonar.armor.internal.enabled";
 
-  /* Internal property to enable Jasmin (disabled by default) */
-  private static final String JASMIN_INTERNAL_ENABLED = "sonar.jasmin.internal.enabled";
+  /* Internal property to disabled Jasmin (enabled by default) */
+  private static final String JASMIN_INTERNAL_DISABLED = "sonar.jasmin.internal.disabled";
 
   /* Internal property to enable JaRED (disabled by default) */
   private static final String JARED_INTERNAL_ENABLED = "sonar.jared.internal.enabled";
@@ -104,7 +104,7 @@ public class JsTsContext<T extends SensorContext> {
   }
 
   private boolean isSonarJasminEnabled() {
-    return context.config().getBoolean(JASMIN_INTERNAL_ENABLED).orElse(false);
+    return !context.config().getBoolean(JASMIN_INTERNAL_DISABLED).orElse(false);
   }
 
   private boolean isSonarJaredEnabled() {

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
@@ -513,7 +513,9 @@ class JsTsSensorTest {
   void should_send_the_skipAst_flag_when_there_are_consumers_but_armor_is_disabled()
     throws Exception {
     var ctx = createSensorContext(baseDir);
-    ctx.setSettings(new MapSettings().setProperty("sonar.armor.internal.enabled", "false"));
+    ctx.setSettings(new MapSettings()
+      .setProperty("sonar.armor.internal.enabled", "false")
+      .setProperty("sonar.jasmin.internal.disabled", "true"));
     var inputFile = createInputFile(ctx);
     var tsProgram = new TsProgram("1", List.of(inputFile.absolutePath()), List.of());
     var consumer = createConsumer();

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
@@ -473,7 +473,6 @@ class JsTsSensorTest {
   @Test
   void should_not_send_the_skipAst_flag_when_there_are_consumers() throws Exception {
     var ctx = createSensorContext(baseDir);
-    ctx.setSettings(new MapSettings().setProperty("sonar.jasmin.internal.enabled", "true"));
     var inputFile = createInputFile(ctx);
     var tsProgram = new TsProgram("1", List.of(inputFile.absolutePath()), List.of());
     var consumer = createConsumer();
@@ -533,7 +532,7 @@ class JsTsSensorTest {
   void should_send_the_skipAst_flag_when_there_are_consumers_but_jasmin_is_disabled()
     throws Exception {
     var ctx = createSensorContext(baseDir);
-    ctx.setSettings(new MapSettings().setProperty("sonar.jasmin.internal.enabled", "false"));
+    ctx.setSettings(new MapSettings().setProperty("sonar.jasmin.internal.disabled", "true"));
     var inputFile = createInputFile(ctx);
     var tsProgram = new TsProgram("1", List.of(inputFile.absolutePath()), List.of());
     var consumer = createConsumer();


### PR DESCRIPTION
[JS-701](https://sonarsource.atlassian.net/browse/JS-701)

For the moment we want to keep a possibility to fallback to SonarSecurity when setting `sonar.jasmin.internal.disabled` to `true`.

Please do not merge yet. Has to be coordinated with some other PRs 

[JS-701]: https://sonarsource.atlassian.net/browse/JS-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ