### PR TITLE
JS-588 Improve error message for unresponsive bridge server

### DIFF
--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -388,7 +388,10 @@ public class BridgeServerImpl implements BridgeServer {
         return new BridgeServer.BridgeResponse(new String(response.body(), StandardCharsets.UTF_8));
       }
     } catch (IOException e) {
-      throw new IllegalStateException("The bridge server is unresponsive", e);
+      throw new IllegalStateException(
+        "The bridge server is unresponsive. It might be because you don't have enough memory, so please go see the troubleshooting section: https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/languages/javascript-typescript-css/#slow-or-unresponsive-analysis",
+        e
+      );
     }
   }
 

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -580,7 +580,9 @@ class BridgeServerImplTest {
 
     assertThatThrownBy(() -> bridgeServer.loadTsConfig("any.ts"))
       .isInstanceOf(IllegalStateException.class)
-      .hasMessage("The bridge server is unresponsive");
+      .hasMessage(
+        "The bridge server is unresponsive. It might be because you don't have enough memory, so please go see the troubleshooting section: https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/languages/javascript-typescript-css/#slow-or-unresponsive-analysis"
+      );
   }
 
   @Test


### PR DESCRIPTION
[JS-588](https://sonarsource.atlassian.net/browse/JS-588)


Updated the error message in `BridgeServerImpl` to provide additional context and a troubleshooting link when the bridge server is unresponsive. This helps users understand potential causes like memory issues and directs them to relevant documentation.

[JS-588]: https://sonarsource.atlassian.net/browse/JS-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ