### PR TITLE
JS-628 S2699: Improved handling cross-file method calls

### DIFF
--- a/packages/jsts/src/rules/S2699/loop.fixture.ts
+++ b/packages/jsts/src/rules/S2699/loop.fixture.ts
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const chai = require('chai');
 
 // this file tests an infinite loop issue that was introduced in 7e1b24d2019921c6c46440579274541c3f3ddde4
@@ -9,12 +10,20 @@ describe('test cases', () => {
   it('should reflect a single argument', () => { // Noncompliant {{Add at least one assertion to this test case.}}
     expectParameter(args[0], 'bar', 'Bar');
   });
+
+  it('should follow functions in file', () => {
+    functionWithAssertion();
+  });
 });
 
 function expectParameter(
   param: CtorParameter, name: string, type?: string|{name: string, moduleName: string},
   decorator?: string, decoratorFrom?: string): void {
     argExpressionToString(param.typeValueReference.expression);
+}
+
+function functionWithAssertion() {
+  assert(true);
 }
 
 function argExpressionToString(name: ts.Node|null): string {

--- a/packages/jsts/src/rules/S2699/repeat-blocks.fixture.js
+++ b/packages/jsts/src/rules/S2699/repeat-blocks.fixture.js
@@ -1,0 +1,20 @@
+const vitest = require('vitest');
+const assert = require('assert');
+
+describe("should work", () => {
+  it("should traverse", () => {
+    withAssertion();
+  });
+
+  it("should traverse as well", () => {
+    withAssertion();
+  });
+
+  it("should fail", () => { // Noncompliant {{Add at least one assertion to this test case.}}
+
+  });
+});
+
+function withAssertion() {
+  assert(true);
+}

--- a/packages/jsts/src/rules/S2699/rule.ts
+++ b/packages/jsts/src/rules/S2699/rule.ts
@@ -122,7 +122,7 @@ class TestCaseAssertionVisitor {
       nodeHasAssertions ||= this.visitTSNode(services, child, visitedTSNodes);
     });
     visitedTSNodes.set(node, nodeHasAssertions);
-    this.hasAssertions = this.hasAssertions || nodeHasAssertions;
+    this.hasAssertions ||= nodeHasAssertions;
     return nodeHasAssertions;
   }
 
@@ -171,7 +171,7 @@ class TestCaseAssertionVisitor {
       nodeHasAssertions ||= this.visit(context, child, visitedNodes, visitedTSNodes);
     }
     visitedNodes.set(node, nodeHasAssertions);
-    this.hasAssertions = this.hasAssertions || nodeHasAssertions;
+    this.hasAssertions ||= nodeHasAssertions;
     return nodeHasAssertions;
   }
 

--- a/packages/jsts/src/rules/S2699/rule.ts
+++ b/packages/jsts/src/rules/S2699/rule.ts
@@ -22,7 +22,9 @@ import {
   childrenOf,
   generateMeta,
   getFullyQualifiedName,
+  getSignatureFromCallee,
   isFunctionCall,
+  isRequiredParserServices,
   Mocha,
   resolveFunction,
   Sinon,
@@ -30,6 +32,8 @@ import {
 } from '../helpers/index.js';
 import { Supertest } from '../helpers/supertest.js';
 import * as meta from './generated-meta.js';
+import { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
+import ts from 'typescript';
 
 /**
  * We assume that the user is using a single assertion library per file,
@@ -39,13 +43,14 @@ import * as meta from './generated-meta.js';
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta),
   create(context: Rule.RuleContext) {
-    const visitedNodes: Set<estree.Node> = new Set();
+    const visitedNodes: Map<estree.Node, boolean> = new Map();
+    const visitedTSNodes: Map<ts.Node, boolean> = new Map();
     const potentialIssues: Rule.ReportDescriptor[] = [];
     return {
       'CallExpression:exit': (node: estree.Node) => {
         const testCase = Mocha.extractTestCase(node);
         if (testCase !== null) {
-          checkAssertions(testCase, context, potentialIssues, visitedNodes);
+          checkAssertions(testCase, context, potentialIssues, visitedNodes, visitedTSNodes);
         }
       },
       'Program:exit': () => {
@@ -68,11 +73,12 @@ function checkAssertions(
   testCase: Mocha.TestCase,
   context: Rule.RuleContext,
   potentialIssues: Rule.ReportDescriptor[],
-  visitedNodes: Set<estree.Node>,
+  visitedNodes: Map<estree.Node, boolean>,
+  visitedTSNodes: Map<ts.Node, boolean>,
 ) {
   const { node, callback } = testCase;
   const visitor = new TestCaseAssertionVisitor(context);
-  visitor.visit(context, callback.body, visitedNodes);
+  visitor.visit(context, callback.body, visitedNodes, visitedTSNodes);
   if (visitor.missingAssertions()) {
     potentialIssues.push({ node, message: 'Add at least one assertion to this test case.' });
   }
@@ -87,44 +93,103 @@ class TestCaseAssertionVisitor {
     this.hasAssertions = false;
   }
 
-  visit(context: Rule.RuleContext, node: estree.Node, visitedNodes: Set<estree.Node>) {
+  visitTSNode(
+    services: ParserServicesWithTypeInformation,
+    node: ts.Node,
+    visitedTSNodes: Map<ts.Node, boolean>,
+  ): boolean {
+    if (visitedTSNodes.has(node)) {
+      return visitedTSNodes.get(node)!;
+    }
+    visitedTSNodes.set(node, false);
+    if (isGlobalTSAssertion(node)) {
+      this.hasAssertions = true;
+      visitedTSNodes.set(node, true);
+      return true;
+    }
+
+    let nodeHasAssertions = false;
+    if (node.kind === ts.SyntaxKind.CallExpression) {
+      const callNode = services.program
+        .getTypeChecker()
+        .getResolvedSignature(node as ts.CallLikeExpression);
+      if (callNode?.declaration) {
+        nodeHasAssertions ||= this.visitTSNode(services, callNode.declaration, visitedTSNodes);
+      }
+    }
+
+    node.forEachChild(child => {
+      nodeHasAssertions ||= this.visitTSNode(services, child, visitedTSNodes);
+    });
+    visitedTSNodes.set(node, nodeHasAssertions);
+    this.hasAssertions = this.hasAssertions || nodeHasAssertions;
+    return nodeHasAssertions;
+  }
+
+  visit(
+    context: Rule.RuleContext,
+    node: estree.Node,
+    visitedNodes: Map<estree.Node, boolean>,
+    visitedTSNodes: Map<ts.Node, boolean>,
+  ): boolean {
     if (visitedNodes.has(node)) {
-      return;
+      return visitedNodes.get(node)!;
     }
-    visitedNodes.add(node);
-    if (this.hasAssertions) {
-      return;
-    }
+    visitedNodes.set(node, false);
     if (
       Chai.isAssertion(context, node) ||
       Sinon.isAssertion(context, node) ||
       Vitest.isAssertion(context, node) ||
-      Supertest.isAssertion(context, node)
+      Supertest.isAssertion(context, node) ||
+      isGlobalAssertion(context, node)
     ) {
+      visitedNodes.set(node, true);
       this.hasAssertions = true;
-      return;
+      return true;
     }
 
-    if (isGlobalAssertion(context, node)) {
-      this.hasAssertions = true;
-      return;
-    }
-
+    let nodeHasAssertions = false;
     if (isFunctionCall(node)) {
       const { callee } = node;
       const functionDef = resolveFunction(this.context, callee);
       if (functionDef) {
-        this.visit(context, functionDef.body, visitedNodes);
+        nodeHasAssertions ||= this.visit(context, functionDef.body, visitedNodes, visitedTSNodes);
+      }
+      const parserServices = context.sourceCode.parserServices;
+      if (isRequiredParserServices(parserServices)) {
+        const signature = getSignatureFromCallee(node, parserServices);
+        if (signature?.getDeclaration()) {
+          nodeHasAssertions ||= this.visitTSNode(
+            parserServices,
+            signature.getDeclaration(),
+            visitedTSNodes,
+          );
+        }
       }
     }
     for (const child of childrenOf(node, this.visitorKeys)) {
-      this.visit(context, child, visitedNodes);
+      nodeHasAssertions ||= this.visit(context, child, visitedNodes, visitedTSNodes);
     }
+    visitedNodes.set(node, nodeHasAssertions);
+    this.hasAssertions = this.hasAssertions || nodeHasAssertions;
+    return nodeHasAssertions;
   }
 
   missingAssertions() {
     return !this.hasAssertions;
   }
+}
+
+function isGlobalTSAssertion(node: ts.Node) {
+  if (node.kind !== ts.SyntaxKind.CallExpression) {
+    return false;
+  }
+  const callExpressionNode = node as ts.CallExpression;
+  if (callExpressionNode.expression.kind !== ts.SyntaxKind.Identifier) {
+    return false;
+  }
+  const identifierNode = callExpressionNode.expression as ts.Identifier;
+  return identifierNode.text === 'expect' || identifierNode.text === 'assert';
 }
 
 function isGlobalAssertion(context: Rule.RuleContext, node: estree.Node): boolean {

--- a/packages/jsts/src/rules/S2699/typescript-detection/cb.test.ts
+++ b/packages/jsts/src/rules/S2699/typescript-detection/cb.test.ts
@@ -1,0 +1,25 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { check } from '../../../../tests/tools/testers/comment-based/index.js';
+import { rule } from '../index.js';
+import { describe } from 'node:test';
+import * as meta from '../generated-meta.js';
+
+describe('Rule S2699', () => {
+  process.chdir(import.meta.dirname); // change current working dir to avoid the package.json lookup to up in the tree
+  check(meta, rule, import.meta.dirname);
+});

--- a/packages/jsts/src/rules/S2699/typescript-detection/fixtures/a.ts
+++ b/packages/jsts/src/rules/S2699/typescript-detection/fixtures/a.ts
@@ -1,0 +1,13 @@
+import assert from "assert";
+
+export function functionWithAssertion() {
+  assert(true);
+}
+
+export function functionWithInnerAssertion() {
+  functionWithAssertion();
+}
+
+export function functionWithoutAssertion() {
+  console.log("Hello world");
+}

--- a/packages/jsts/src/rules/S2699/typescript-detection/fixtures/b.fixture.ts
+++ b/packages/jsts/src/rules/S2699/typescript-detection/fixtures/b.fixture.ts
@@ -6,9 +6,9 @@ describe("tests", () => {
     functionWithAssertion();
   });
 
-  // it("should traverse functions with inner assertions", () => { // Compliant
-  //   functionWithInnerAssertion();
-  // });
+  it("should traverse functions with inner assertions", () => { // Compliant
+    functionWithInnerAssertion();
+  });
 
   it("should traverse functions and identify missing assertions", () => { // Noncompliant {{Add at least one assertion to this test case.}}
     functionWithoutAssertion();

--- a/packages/jsts/src/rules/S2699/typescript-detection/fixtures/b.fixture.ts
+++ b/packages/jsts/src/rules/S2699/typescript-detection/fixtures/b.fixture.ts
@@ -1,0 +1,16 @@
+import vitest from "vitest";
+import {functionWithAssertion, functionWithoutAssertion, functionWithInnerAssertion} from "./a.js"
+
+describe("tests", () => {
+  it("should traverse functions with assertions", () => { // Compliant
+    functionWithAssertion();
+  });
+
+  // it("should traverse functions with inner assertions", () => { // Compliant
+  //   functionWithInnerAssertion();
+  // });
+
+  it("should traverse functions and identify missing assertions", () => { // Noncompliant {{Add at least one assertion to this test case.}}
+    functionWithoutAssertion();
+  });
+});


### PR DESCRIPTION
[JS-628](https://sonarsource.atlassian.net/browse/JS-628)

This update includes:
- Using Typescript to resolve function calls
- Fixing existing behavior, where a node is marked as visited, but doesn't carry the information that an assertion was found in it. This causes FP, when having multiple testcases use a separate method with an assertion. The first usecase, would correctly be marked as compliant, but the latter calls would be flagged as FP, as we don't visit their assertions.

TODO: 
- https://sonarsource.atlassian.net/browse/JS-705 - We should correctly identify the most popular framework assertions with the Typescript visitor. Currently, we only look at global 'expect' and 'assert'.

[JS-628]: https://sonarsource.atlassian.net/browse/JS-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ