### PR TITLE
JS-711 NOJIRA small type change for ast in output analysis

### DIFF
--- a/packages/bridge/src/delegate.ts
+++ b/packages/bridge/src/delegate.ts
@@ -91,6 +91,6 @@ function sendFormData(result: JsTsAnalysisOutputWithAst, response: express.Respo
   fd.pipe(response);
 }
 
-function outputContainsAst(result: AnalysisOutput): result is JsTsAnalysisOutputWithAst {
+export function outputContainsAst(result: AnalysisOutput): result is JsTsAnalysisOutputWithAst {
   return 'ast' in result;
 }

--- a/packages/jsts/src/analysis/analysis.ts
+++ b/packages/jsts/src/analysis/analysis.ts
@@ -72,7 +72,6 @@ export interface JsTsAnalysisOutput extends AnalysisOutput {
   metrics?: Metrics;
   cpdTokens?: CpdToken[];
   ucfgPaths?: string[];
-  ast?: Uint8Array;
 }
 
 export interface JsTsAnalysisOutputWithAst extends JsTsAnalysisOutput {

--- a/packages/jsts/src/analysis/analyzer.ts
+++ b/packages/jsts/src/analysis/analyzer.ts
@@ -75,7 +75,7 @@ export async function analyzeJSTS(
       cognitiveComplexity,
     );
 
-    const result: JsTsAnalysisOutput = {
+    const result = {
       issues,
       ucfgPaths,
       ...extendedMetrics,
@@ -84,7 +84,10 @@ export async function analyzeJSTS(
     if (!input.skipAst) {
       const ast = serializeAst(parseResult.sourceCode, filePath);
       if (ast) {
-        result.ast = ast;
+        return {
+          ast,
+          ...result,
+        };
       }
     }
 

--- a/packages/jsts/src/analysis/projectAnalysis/projectAnalysis.ts
+++ b/packages/jsts/src/analysis/projectAnalysis/projectAnalysis.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { JsTsAnalysisInput, JsTsAnalysisOutput } from '../analysis.js';
+import { JsTsAnalysisInput, JsTsAnalysisOutput, JsTsAnalysisOutputWithAst } from '../analysis.js';
 import { RuleConfig } from '../../linter/config/rule-config.js';
 import { EmbeddedAnalysisOutput } from '../../embedded/analysis/analysis.js';
 import { ErrorCode } from '../../../../shared/src/errors/error.js';
@@ -32,6 +32,7 @@ export type ProjectAnalysisOutput = {
 
 export type FileResult =
   | JsTsAnalysisOutput
+  | JsTsAnalysisOutputWithAst
   | EmbeddedAnalysisOutput
   | ParsingError
   | { error: string };

--- a/packages/jsts/tests/analysis/analyzer.test.ts
+++ b/packages/jsts/tests/analysis/analyzer.test.ts
@@ -27,6 +27,8 @@ import { createAndSaveProgram } from '../../src/program/program.js';
 import { deserializeProtobuf } from '../../src/parsers/ast.js';
 import { jsTsInput } from '../tools/helpers/input.js';
 import { parseJavaScriptSourceFile } from '../tools/helpers/parsing.js';
+import { outputContainsAst } from '../../../bridge/src/delegate.js';
+import assert from 'assert';
 
 const currentPath = toUnixPath(import.meta.dirname);
 
@@ -1036,7 +1038,9 @@ describe('await analyzeJSTS', () => {
 
     const filePath = path.join(currentPath, 'fixtures', 'code.js');
 
-    const { ast } = await analyzeJSTS(await jsTsInput({ filePath }));
+    const analysisResult = await analyzeJSTS(await jsTsInput({ filePath }));
+    assert(outputContainsAst(analysisResult));
+    const { ast } = analysisResult;
     const protoMessage = deserializeProtobuf(ast as Uint8Array);
     expect(protoMessage.program).toBeDefined();
     expect(protoMessage.program.body).toHaveLength(1);
@@ -1057,7 +1061,7 @@ describe('await analyzeJSTS', () => {
 
     const filePath = path.join(currentPath, 'fixtures', 'code.js');
 
-    const { ast } = await analyzeJSTS(await jsTsInput({ filePath, skipAst: true }));
-    expect(ast).toBeUndefined();
+    const analysisResult = await analyzeJSTS(await jsTsInput({ filePath, skipAst: true }));
+    assert(!outputContainsAst(analysisResult));
   });
 });


### PR DESCRIPTION
[JS-711](https://sonarsource.atlassian.net/browse/JS-711)

Trying to dig into the ast code. Noticed that 'ast' was defined in the output, where there is a separate interface to denote the type with the ast. Let us use it.

[JS-711]: https://sonarsource.atlassian.net/browse/JS-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ