### PR TITLE
JS-713 S2699 new implementation could cause endless loop

### DIFF
--- a/packages/jsts/src/rules/S2699/chai.fixture.js
+++ b/packages/jsts/src/rules/S2699/chai.fixture.js
@@ -1,5 +1,6 @@
 const chai = require('chai');
 const chaiExpect = require('chai').expect;
+const shouldFunc = require('chai').should();
 const { assert, expect, should, expect: chaiExpectRenamed } = chai;
 
 should();
@@ -67,6 +68,15 @@ describe('chai test cases', () => {
 
   it('transitive assertion', () => { // Compliant
     check();
+  });
+
+  const throwsTypeError = () => { throw new TypeError() }
+
+  it("uses chai 'should'", function() { // Noncompliant {{Add at least one assertion to this test case.}}
+    // The same is true for "should" assertions.
+    throwsTypeError.should.to.not.throw(ReferenceError)
+
+    // ...
   });
 
   function check() {

--- a/packages/jsts/src/rules/helpers/module-ts.ts
+++ b/packages/jsts/src/rules/helpers/module-ts.ts
@@ -114,7 +114,6 @@ export function getFullyQualifiedNameTS(
       case ts.SyntaxKind.ImportClause: // Fallthrough
       case ts.SyntaxKind.ObjectBindingPattern: // Fallthrough
       case ts.SyntaxKind.Block: // Fallthrough
-      case ts.SyntaxKind.ArrowFunction: // Fallthrough
       case ts.SyntaxKind.ExpressionStatement: // Fallthrough
       case ts.SyntaxKind.NamedImports: // Fallthrough
       case ts.SyntaxKind.ModuleBlock: {


### PR DESCRIPTION
[JS-713](https://sonarsource.atlassian.net/browse/JS-713)

Fuond based on peachee job - and failing on the last test-case here - https://github.com/SonarSource/expected-issues/blob/master/javascript/test/RSPEC_6092/uncertainAssertion.test.js

If we jump to 'ArrowExpression', we already know its a local variable and we don't need to extract the fqn.

[JS-713]: https://sonarsource.atlassian.net/browse/JS-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ