### PR TITLE
JS-725 remove unused imports

### DIFF
--- a/its/ruling/src/test/java/org/sonar/javascript/it/CssRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/CssRulingTest.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.javascript.it;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.javascript.it.JsTsRulingTest.LITS_VERSION;
 

--- a/sonar-plugin/css/src/test/java/org/sonar/css/TestActiveRules.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/TestActiveRules.java
@@ -25,8 +25,6 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import org.sonar.api.batch.rule.ActiveRule;
 import org.sonar.api.batch.rule.ActiveRules;
-import org.sonar.api.issue.impact.Severity;
-import org.sonar.api.issue.impact.SoftwareQuality;
 import org.sonar.api.rule.RuleKey;
 
 public class TestActiveRules implements ActiveRules {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithWatchProgram.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisWithWatchProgram.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.plugins.javascript.bridge.AnalysisWarningsWrapper;
 import org.sonar.plugins.javascript.bridge.BridgeServer;
 import org.sonar.plugins.javascript.sonarlint.TsConfigCache;
 import org.sonar.plugins.javascript.utils.ProgressReport;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/TsConfigProvider.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/TsConfigProvider.java
@@ -19,7 +19,6 @@ package org.sonar.plugins.javascript.analysis;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.sonar.plugins.javascript.JavaScriptPlugin.MAX_FILES_PROPERTY;
-import static org.sonar.plugins.javascript.JavaScriptPlugin.TSCONFIG_PATHS;
 import static org.sonar.plugins.javascript.analysis.LookupConfigProviderFilter.FileFilter;
 import static org.sonar.plugins.javascript.analysis.LookupConfigProviderFilter.PathFilter;
 


### PR DESCRIPTION
[JS-725](https://sonarsource.atlassian.net/browse/JS-725)

Fixes current SQ releasability. As well, incorporating changes from https://github.com/SonarSource/SonarJS/pull/5368

[JS-725]: https://sonarsource.atlassian.net/browse/JS-725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ