### PR TITLE
JS-742 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/OrchestratorStarter.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/OrchestratorStarter.java
@@ -110,6 +110,7 @@ public final class OrchestratorStarter
   static SonarScanner getSonarScanner() {
     return SonarScanner.create()
       .setScannerVersion(SCANNER_VERSION)
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProperty(ANALYZE_PROJECT_ENABLED, getAnalyzeProjectEnabledFlag());
   }
 


### PR DESCRIPTION
[JS-742](https://sonarsource.atlassian.net/browse/JS-742)

On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.

[JS-742]: https://sonarsource.atlassian.net/browse/JS-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ