### PR TITLE
JS-749 Changing AbstractBridgeSensor::analyzeFiles to not return issues.

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractBridgeSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractBridgeSensor.java
@@ -33,7 +33,6 @@ import org.sonar.plugins.javascript.bridge.BridgeServer;
 import org.sonar.plugins.javascript.bridge.BridgeServerConfig;
 import org.sonar.plugins.javascript.bridge.ServerAlreadyFailedException;
 import org.sonar.plugins.javascript.external.ExternalIssue;
-import org.sonar.plugins.javascript.external.ExternalIssueRepository;
 import org.sonar.plugins.javascript.nodejs.NodeCommandException;
 
 public abstract class AbstractBridgeSensor implements Sensor {
@@ -54,8 +53,6 @@ public abstract class AbstractBridgeSensor implements Sensor {
     CacheStrategies.reset();
     this.context = new JsTsContext<>(sensorContext);
 
-    var externalIssues = this.getESLintIssues(context);
-
     try {
       List<InputFile> inputFiles = getInputFiles();
       if (inputFiles.isEmpty()) {
@@ -67,8 +64,7 @@ public abstract class AbstractBridgeSensor implements Sensor {
         : "Analysis of unchanged files will not be skipped (current analysis requires all files to be analyzed)";
       LOG.debug(msg);
       bridgeServer.startServerLazily(BridgeServerConfig.fromSensorContext(sensorContext));
-      var issues = analyzeFiles(inputFiles);
-      ExternalIssueRepository.saveESLintIssues(sensorContext, externalIssues, issues);
+      analyzeFiles(inputFiles);
     } catch (CancellationException e) {
       // do not propagate the exception
       LOG.info(e.toString());
@@ -106,12 +102,7 @@ public abstract class AbstractBridgeSensor implements Sensor {
   /**
    * Analyze the passed input files, and return the list of persisted issues.
    */
-  protected abstract List<BridgeServer.Issue> analyzeFiles(List<InputFile> inputFiles)
-    throws IOException, InterruptedException;
+  protected abstract void analyzeFiles(List<InputFile> inputFiles) throws IOException;
 
   protected abstract List<InputFile> getInputFiles();
-
-  protected List<ExternalIssue> getESLintIssues(JsTsContext<?> context) {
-    return new ArrayList<>();
-  }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractBridgeSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AbstractBridgeSensor.java
@@ -19,7 +19,6 @@ package org.sonar.plugins.javascript.analysis;
 import static org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl.NODE_EXECUTABLE_PROPERTY;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +31,6 @@ import org.sonar.plugins.javascript.api.AnalysisMode;
 import org.sonar.plugins.javascript.bridge.BridgeServer;
 import org.sonar.plugins.javascript.bridge.BridgeServerConfig;
 import org.sonar.plugins.javascript.bridge.ServerAlreadyFailedException;
-import org.sonar.plugins.javascript.external.ExternalIssue;
 import org.sonar.plugins.javascript.nodejs.NodeCommandException;
 
 public abstract class AbstractBridgeSensor implements Sensor {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/CssRuleSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/CssRuleSensor.java
@@ -95,9 +95,7 @@ public class CssRuleSensor extends AbstractBridgeSensor {
   }
 
   @Override
-  protected List<Issue> analyzeFiles(List<InputFile> inputFiles) throws IOException {
-    var issues = new ArrayList<Issue>();
-
+  protected void analyzeFiles(List<InputFile> inputFiles) {
     ProgressReport progressReport = new ProgressReport(
       "Analysis progress",
       TimeUnit.SECONDS.toMillis(10)
@@ -113,9 +111,7 @@ public class CssRuleSensor extends AbstractBridgeSensor {
             "Analysis interrupted because the SensorContext is in cancelled state"
           );
         }
-        var fileIssues = analyzeFile(inputFile, context, rules);
-
-        issues.addAll(fileIssues);
+        analyzeFile(inputFile, context, rules);
 
         progressReport.nextFile(inputFile.toString());
       }
@@ -127,8 +123,6 @@ public class CssRuleSensor extends AbstractBridgeSensor {
         progressReport.cancel();
       }
     }
-
-    return issues;
   }
 
   List<Issue> analyzeFile(InputFile inputFile, JsTsContext<?> context, List<StylelintRule> rules) {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/HtmlSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/HtmlSensor.java
@@ -61,9 +61,7 @@ public class HtmlSensor extends AbstractBridgeSensor {
   }
 
   @Override
-  protected List<BridgeServer.Issue> analyzeFiles(List<InputFile> inputFiles) throws IOException {
-    var issues = new ArrayList<BridgeServer.Issue>();
-
+  protected void analyzeFiles(List<InputFile> inputFiles) throws IOException {
     var progressReport = new ProgressReport("Analysis progress", TimeUnit.SECONDS.toMillis(10));
     var success = false;
     try {
@@ -84,7 +82,7 @@ public class HtmlSensor extends AbstractBridgeSensor {
         progressReport.nextFile(inputFile.toString());
         var cacheStrategy = CacheStrategies.getStrategyFor(context, inputFile);
         if (cacheStrategy.isAnalysisRequired()) {
-          issues.addAll(analyze(inputFile, cacheStrategy));
+          analyze(inputFile, cacheStrategy);
         }
       }
       success = true;
@@ -95,8 +93,6 @@ public class HtmlSensor extends AbstractBridgeSensor {
         progressReport.cancel();
       }
     }
-
-    return issues;
   }
 
   @Override

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsSensor.java
@@ -50,6 +50,7 @@ import org.sonar.plugins.javascript.bridge.WebSocketMessageHandler;
 import org.sonar.plugins.javascript.bridge.protobuf.Node;
 import org.sonar.plugins.javascript.external.EslintReportImporter;
 import org.sonar.plugins.javascript.external.ExternalIssue;
+import org.sonar.plugins.javascript.external.ExternalIssueRepository;
 import org.sonar.plugins.javascript.sonarlint.FSListener;
 
 @DependedUpon("js-analysis")
@@ -112,7 +113,9 @@ public class JsTsSensor extends AbstractBridgeSensor {
   }
 
   @Override
-  protected List<BridgeServer.Issue> analyzeFiles(List<InputFile> inputFiles) throws IOException {
+  protected void analyzeFiles(List<InputFile> inputFiles) throws IOException {
+    var eslintImporter = new EslintReportImporter();
+    var externalIssues = eslintImporter.execute(context);
     if (!context.isAnalyzeProjectEnabled()) {
       bridgeServer.initLinter(
         checks.enabledEslintRules(),
@@ -125,44 +128,45 @@ public class JsTsSensor extends AbstractBridgeSensor {
       analysis.initialize(context, checks, consumers, analysisWarnings);
       var issues = analysis.analyzeFiles(inputFiles);
       consumers.doneAnalysis();
-
-      return issues;
+      ExternalIssueRepository.dedupeAndSaveESLintIssues(
+        this.context.getSensorContext(),
+        externalIssues,
+        issues
+      );
+      return;
     }
 
     try {
-      var handler = new AnalyzeProjectHandler(context, inputFiles);
+      var handler = new AnalyzeProjectHandler(context, inputFiles, externalIssues);
       bridgeServer.analyzeProject(handler);
-      var issues = handler.getFuture().join();
+      handler.getFuture().join();
       new PluginTelemetry(context.getSensorContext(), bridgeServer).reportTelemetry();
       consumers.doneAnalysis();
-      return issues;
     } catch (Exception e) {
       LOG.error("Failed to get response from analysis", e);
       throw e;
     }
   }
 
-  @Override
-  protected List<ExternalIssue> getESLintIssues(JsTsContext<?> context) {
-    var importer = new EslintReportImporter();
-
-    return importer.execute(context);
-  }
-
   class AnalyzeProjectHandler implements WebSocketMessageHandler {
 
     private final JsTsContext<?> context;
-    List<InputFile> inputFiles;
-    private final List<BridgeServer.Issue> issues = new ArrayList<>();
+    private final Map<String, List<ExternalIssue>> externalIssues;
+    private final List<InputFile> inputFiles;
     private final List<InputFile> filesToAnalyze = new ArrayList<>();
     private final Map<String, InputFile> fileToInputFile = new HashMap<>();
     private final HashMap<String, CacheStrategy> fileToCacheStrategy = new HashMap<>();
-    private final CompletableFuture<List<BridgeServer.Issue>> handle;
+    private final CompletableFuture<Void> handle;
 
-    AnalyzeProjectHandler(JsTsContext<?> context, List<InputFile> inputFiles) {
+    AnalyzeProjectHandler(
+      JsTsContext<?> context,
+      List<InputFile> inputFiles,
+      Map<String, List<ExternalIssue>> externalIssues
+    ) {
       this.inputFiles = inputFiles;
       this.context = context;
       this.handle = new CompletableFuture<>();
+      this.externalIssues = externalIssues;
     }
 
     @Override
@@ -221,7 +225,7 @@ public class JsTsSensor extends AbstractBridgeSensor {
       );
     }
 
-    public CompletableFuture<List<BridgeServer.Issue>> getFuture() {
+    public CompletableFuture<Void> getFuture() {
       return handle;
     }
 
@@ -236,7 +240,15 @@ public class JsTsSensor extends AbstractBridgeSensor {
           );
           var file = fileToInputFile.get(filePath);
           var cacheStrategy = fileToCacheStrategy.get(filePath);
-          issues.addAll(analysisProcessor.processResponse(context, checks, file, response));
+          var issues = analysisProcessor.processResponse(context, checks, file, response);
+          var dedupedIssues = ExternalIssueRepository.deduplicateIssues(
+            externalIssues.get(filePath),
+            issues
+          );
+          if (dedupedIssues != null && !dedupedIssues.isEmpty()) {
+            ExternalIssueRepository.saveESLintIssues(context.getSensorContext(), dedupedIssues);
+          }
+          externalIssues.remove(filePath);
           try {
             cacheStrategy.writeAnalysisToCache(
               CacheAnalysis.fromResponse(
@@ -254,7 +266,7 @@ public class JsTsSensor extends AbstractBridgeSensor {
         case "meta":
           var meta = GSON.fromJson(jsonObject, BridgeServer.ProjectAnalysisMetaResponse.class);
           meta.warnings().forEach(analysisWarnings::addUnique);
-          handle.complete(issues);
+          handle.complete(null);
           return true;
         default:
           return false;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsSensor.java
@@ -245,7 +245,7 @@ public class JsTsSensor extends AbstractBridgeSensor {
             externalIssues.get(filePath),
             issues
           );
-          if (dedupedIssues != null && !dedupedIssues.isEmpty()) {
+          if (!dedupedIssues.isEmpty()) {
             ExternalIssueRepository.saveESLintIssues(context.getSensorContext(), dedupedIssues);
           }
           externalIssues.remove(filePath);

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/YamlSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/YamlSensor.java
@@ -68,9 +68,7 @@ public class YamlSensor extends AbstractBridgeSensor {
   }
 
   @Override
-  protected List<BridgeServer.Issue> analyzeFiles(List<InputFile> inputFiles) throws IOException {
-    var issues = new ArrayList<BridgeServer.Issue>();
-
+  protected void analyzeFiles(List<InputFile> inputFiles) throws IOException {
     var progressReport = new ProgressReport("Analysis progress", TimeUnit.SECONDS.toMillis(10));
     var success = false;
     try {
@@ -89,7 +87,7 @@ public class YamlSensor extends AbstractBridgeSensor {
           );
         }
         progressReport.nextFile(inputFile.toString());
-        issues.addAll(analyze(inputFile));
+        analyze(inputFile);
       }
       success = true;
     } finally {
@@ -99,8 +97,6 @@ public class YamlSensor extends AbstractBridgeSensor {
         progressReport.cancel();
       }
     }
-
-    return issues;
   }
 
   @Override

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/YamlSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/YamlSensor.java
@@ -52,7 +52,6 @@ public class YamlSensor extends AbstractBridgeSensor {
   public YamlSensor(
     JsTsChecks checks,
     BridgeServer bridgeServer,
-    AnalysisWarningsWrapper analysisWarnings,
     AnalysisProcessor processAnalysis
   ) {
     // The monitoring sensor remains inactive during YAML files analysis, as the

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/EslintReportImporter.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/EslintReportImporter.java
@@ -26,7 +26,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicates;
@@ -69,25 +71,22 @@ public class EslintReportImporter {
   /**
    * Execute the importer, and return the list of external issues found.
    */
-  public List<ExternalIssue> execute(JsTsContext<?> context) {
-    var results = new ArrayList<ExternalIssue>();
+  public Map<String, List<ExternalIssue>> execute(JsTsContext<?> context) {
+    var results = new HashMap<String, List<ExternalIssue>>();
 
     List<File> reportFiles = ExternalReportProvider.getReportFiles(
       context.getSensorContext(),
       reportsPropertyName()
     );
-    reportFiles.forEach(report -> results.addAll(importReport(report, context)));
+    reportFiles.forEach(report -> results.putAll(importReportByFilePath(report, context)));
 
     return results;
   }
 
-  /**
-   * Import the passed report, and return the list of external issues found.
-   */
-  List<ExternalIssue> importReport(File report, JsTsContext<?> context) {
+  Map<String, List<ExternalIssue>> importReportByFilePath(File report, JsTsContext<?> context) {
     LOG.info("Importing {}", report.getAbsoluteFile());
 
-    var results = new ArrayList<ExternalIssue>();
+    var results = new HashMap<String, List<ExternalIssue>>();
     var serializer = new Gson();
 
     try (
@@ -104,6 +103,7 @@ public class EslintReportImporter {
       for (FileWithMessages fileWithMessages : filesWithMessages) {
         InputFile inputFile = getInputFile(context, fileWithMessages.filePath);
         if (inputFile != null) {
+          var externalIssuesForFile = new ArrayList<ExternalIssue>();
           for (EslintError eslintError : fileWithMessages.messages) {
             if (eslintError.ruleId == null) {
               LOG.warn(
@@ -111,8 +111,11 @@ public class EslintReportImporter {
                 inputFile.uri()
               );
             } else {
-              results.add(createIssue(eslintError, inputFile));
+              externalIssuesForFile.add(createIssue(eslintError, inputFile));
             }
+          }
+          if (!externalIssuesForFile.isEmpty()) {
+            results.put(fileWithMessages.filePath, externalIssuesForFile);
           }
         }
       }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/EslintReportImporter.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/EslintReportImporter.java
@@ -84,7 +84,7 @@ public class EslintReportImporter {
   }
 
   Map<String, List<ExternalIssue>> importReportByFilePath(File report, JsTsContext<?> context) {
-    LOG.info("Importing {}", report.getAbsoluteFile());
+    LOG.info("Importing external issues from: {}", report.getAbsoluteFile());
 
     var results = new HashMap<String, List<ExternalIssue>>();
     var serializer = new Gson();
@@ -115,7 +115,7 @@ public class EslintReportImporter {
             }
           }
           if (!externalIssuesForFile.isEmpty()) {
-            results.put(fileWithMessages.filePath, externalIssuesForFile);
+            results.put(inputFile.absolutePath(), externalIssuesForFile);
           }
         }
       }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/ExternalIssueRepository.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/ExternalIssueRepository.java
@@ -20,7 +20,6 @@ import static org.sonar.plugins.javascript.utils.UnicodeEscape.unicodeEscape;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -106,7 +105,7 @@ public class ExternalIssueRepository {
       return List.of();
     }
     var deduplicatedIssues = new ArrayList<ExternalIssue>();
-    // normalize issues of JS/TS analyzer into set of strigs
+    // normalize issues of JS/TS analyzer into a set of strings
     var normalizedIssues = new HashSet<>();
     for (BridgeServer.Issue issue : issues) {
       for (String ruleKey : issue.ruleESLintKeys()) {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/ExternalIssueRepository.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/ExternalIssueRepository.java
@@ -20,6 +20,7 @@ import static org.sonar.plugins.javascript.utils.UnicodeEscape.unicodeEscape;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -102,7 +103,7 @@ public class ExternalIssueRepository {
     List<BridgeServer.Issue> issues
   ) {
     if (externalIssues == null) {
-      return null;
+      return List.of();
     }
     var deduplicatedIssues = new ArrayList<ExternalIssue>();
     // normalize issues of JS/TS analyzer into set of strigs

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/YamlSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/YamlSensorTest.java
@@ -60,7 +60,6 @@ import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.javascript.checks.CheckList;
 import org.sonar.plugins.javascript.TestUtils;
 import org.sonar.plugins.javascript.analysis.cache.CacheTestUtils;
-import org.sonar.plugins.javascript.bridge.AnalysisWarningsWrapper;
 import org.sonar.plugins.javascript.bridge.BridgeServer;
 import org.sonar.plugins.javascript.bridge.BridgeServer.AnalysisResponse;
 import org.sonar.plugins.javascript.bridge.PluginInfo;
@@ -291,7 +290,6 @@ class YamlSensorTest {
     return new YamlSensor(
       checks(DUPLICATE_BRANCH_RULE_KEY, PARSING_ERROR_RULE_KEY),
       bridgeServerMock,
-      new AnalysisWarningsWrapper(),
       analysisProcessor
     );
   }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/EslintReportImporterTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/EslintReportImporterTest.java
@@ -70,13 +70,13 @@ class EslintReportImporterTest {
     var issues = eslintReportImporter.execute(new JsTsContext<SensorContext>(context));
     assertThat(issues).hasSize(2);
 
-    var firstIssues = issues.get(jsInputFile.getModuleRelativePath());
+    var firstIssues = issues.get(jsInputFile.absolutePath());
     assertThat(firstIssues).hasSize(3);
     var first = firstIssues.get(0);
     var second = firstIssues.get(1);
     var third = firstIssues.get(2);
 
-    var tsIssues = issues.get(tsInputFile.getModuleRelativePath());
+    var tsIssues = issues.get(tsInputFile.absolutePath());
     assertThat(tsIssues).hasSize(1);
     var fourth = tsIssues.get(0);
 


### PR DESCRIPTION
[JS-749](https://sonarsource.atlassian.net/browse/JS-749)

We are moving the issues downstream to be handled within the analyzeFiles. We do not need to return the issues from this method. It should decrease amount of memory necessary.

[JS-749]: https://sonarsource.atlassian.net/browse/JS-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ