### PR TITLE
JS-786 Remove get-all-dependencies

### DIFF
--- a/packages/bridge/src/handle-request.ts
+++ b/packages/bridge/src/handle-request.ts
@@ -16,7 +16,7 @@
  */
 import { analyzeCSS } from '../../css/src/analysis/analyzer.js';
 import { analyzeHTML } from '../../html/src/index.js';
-import { analyzeJSTS, getTelemetry } from '../../jsts/src/analysis/analyzer.js';
+import { analyzeJSTS } from '../../jsts/src/analysis/analyzer.js';
 import {
   analyzeProject,
   cancelAnalysis,
@@ -72,10 +72,6 @@ export async function handleRequest(
       case 'on-cancel-analysis': {
         cancelAnalysis();
         return { type: 'success', result: 'OK' };
-      }
-      case 'on-get-telemetry': {
-        const output = getTelemetry();
-        return { type: 'success', result: output };
       }
     }
   } catch (err) {

--- a/packages/bridge/src/request.ts
+++ b/packages/bridge/src/request.ts
@@ -55,8 +55,7 @@ export type BridgeRequest =
   | EmbeddedRequest
   | ProjectAnalysisRequest
   | CancellationRequest
-  | InitLinterRequest
-  | GetTelemetryRequest;
+  | InitLinterRequest;
 
 type CssRequest = {
   type: 'on-analyze-css';
@@ -93,9 +92,6 @@ type InitLinterRequest = {
     bundles: string[];
     rulesWorkdir: string;
   };
-};
-type GetTelemetryRequest = {
-  type: 'on-get-telemetry';
 };
 
 type SerializedError = {

--- a/packages/bridge/src/request.ts
+++ b/packages/bridge/src/request.ts
@@ -22,7 +22,6 @@ import type {
 } from '../../jsts/src/analysis/projectAnalysis/projectAnalysis.js';
 import type { RuleConfig } from '../../jsts/src/linter/config/rule-config.js';
 import { APIError, ErrorCode, ErrorData } from '../../shared/src/errors/error.js';
-import type { NamedDependency } from '../../jsts/src/rules/index.js';
 import type { CssAnalysisInput } from '../../css/src/analysis/analysis.js';
 import type { JsTsAnalysisInput } from '../../jsts/src/analysis/analysis.js';
 import type { EmbeddedAnalysisInput } from '../../jsts/src/embedded/analysis/analysis.js';
@@ -30,7 +29,7 @@ import type { EmbeddedAnalysisInput } from '../../jsts/src/embedded/analysis/ana
 export type RequestResult =
   | {
       type: 'success';
-      result: string | AnalysisOutput | Telemetry;
+      result: string | AnalysisOutput;
     }
   | {
       type: 'failure';
@@ -42,10 +41,6 @@ type WsMetaResult = { messageType: 'meta' } & ProjectAnalysisMeta;
 type WsFileResult = { filename: string; messageType: 'fileResult' } & FileResult;
 type WsError = { messageType: 'error'; error: unknown };
 export type WsIncrementalResult = WsFileResult | WsMetaResult | WsAnalysisCancelled | WsError;
-
-export type Telemetry = {
-  dependencies: NamedDependency[];
-};
 
 export type RequestType = BridgeRequest['type'];
 

--- a/packages/bridge/src/router.ts
+++ b/packages/bridge/src/router.ts
@@ -51,7 +51,6 @@ export default function (
   router.post('/analyze-html', delegate('on-analyze-html'));
   router.post('/analyze-yaml', delegate('on-analyze-yaml'));
   router.post('/init-linter', delegate('on-init-linter'));
-  router.get('/get-telemetry', delegate('on-get-telemetry'));
 
   wss.on('connection', wsDelegate);
 

--- a/packages/bridge/tests/router.test.ts
+++ b/packages/bridge/tests/router.test.ts
@@ -245,12 +245,6 @@ describe('router', () => {
     const response = await request(server, '/cancel-analysis', 'POST');
     expect(response).toEqual('OK');
   });
-
-  it('should return empty get-telemetry on fresh server', async () => {
-    const response = (await request(server, '/get-telemetry', 'GET')) as string;
-    const json = JSON.parse(response);
-    expect(json).toEqual({ dependencies: [] });
-  });
 });
 
 function requestInitLinter(server: http.Server, rules: RuleConfig[]) {

--- a/packages/bridge/tests/worker.test.ts
+++ b/packages/bridge/tests/worker.test.ts
@@ -39,9 +39,7 @@ describe('worker', () => {
       try {
         expect(message).toEqual({
           type: 'success',
-          result: {
-            dependencies: [],
-          },
+          result: 'OK',
         });
         resolve();
       } catch (e) {
@@ -49,7 +47,7 @@ describe('worker', () => {
       }
     });
 
-    worker.postMessage({ type: 'on-get-telemetry' });
+    worker.postMessage({ type: 'on-init-linter', data: { rules: [] } });
     await promise;
   });
 

--- a/packages/jsts/src/analysis/analyzer.ts
+++ b/packages/jsts/src/analysis/analyzer.ts
@@ -31,8 +31,7 @@ import { SymbolHighlight } from '../linter/visitors/symbol-highlighting.js';
 import { computeMetrics, findNoSonarLines } from '../linter/visitors/metrics/index.js';
 import { getSyntaxHighlighting } from '../linter/visitors/syntax-highlighting.js';
 import { getCpdTokens } from '../linter/visitors/cpd.js';
-import { clearDependenciesCache, getAllDependencies } from '../rules/index.js';
-import { Telemetry } from '../../../bridge/src/request.js';
+import { clearDependenciesCache } from '../rules/index.js';
 import { fillFileContent } from '../../../shared/src/types/analysis.js';
 import { shouldIgnoreFile } from '../../../shared/src/helpers/filter/filter.js';
 import { setGlobalConfiguration } from '../../../shared/src/helpers/configuration.js';
@@ -160,10 +159,4 @@ function computeExtendedMetrics(
       metrics: findNoSonarLines(sourceCode),
     };
   }
-}
-
-export function getTelemetry(): Telemetry {
-  return {
-    dependencies: getAllDependencies(),
-  };
 }

--- a/packages/jsts/src/rules/helpers/package-json.ts
+++ b/packages/jsts/src/rules/helpers/package-json.ts
@@ -51,26 +51,6 @@ export const cache: Map<string, Set<Dependency>> = new Map();
  */
 const dirNameToClosestPackageJSONCache: Map<string, string> = new Map();
 
-/**
- * Returns the dependencies of all package.json files inside the root folder, collected in the cache.
- * As the cache is populated lazily, it could be null in case no rule execution has touched it.
- * This removes duplicate dependencies and keeps the last occurrence.
- */
-export function getAllDependencies(): NamedDependency[] {
-  const dependencies = [...cache.values()]
-    .flatMap(dependencies => [...dependencies])
-    .filter((dependency): dependency is NamedDependency => typeof dependency.name === 'string');
-  return Object.values(
-    dependencies.reduce(
-      (result, dependency) => ({
-        ...result,
-        [dependency.name]: dependency,
-      }),
-      {},
-    ),
-  );
-}
-
 export function getClosestPackageJSONDir(filename: string, cwd: string): string {
   const dirname = Path.dirname(toUnixPath(filename));
   if (!dirNameToClosestPackageJSONCache.has(dirname)) {

--- a/packages/jsts/src/rules/helpers/package-json.ts
+++ b/packages/jsts/src/rules/helpers/package-json.ts
@@ -35,7 +35,7 @@ type MinimatchDependency = {
   version?: string;
 };
 
-export type NamedDependency = {
+type NamedDependency = {
   name: string;
   version?: string;
 };

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
@@ -400,14 +400,7 @@ public interface BridgeServer extends Startable {
 
   record CpdToken(Location location, String image) {}
 
-  record TelemetryEslintBridgeResponse(List<Dependency> dependencies) {}
-
-  record TelemetryData(
-    List<Dependency> dependencies,
-    @Nullable RuntimeTelemetry runtimeTelemetry
-  ) {}
-
-  record Dependency(String name, String version) {}
+  record TelemetryData(@Nullable RuntimeTelemetry runtimeTelemetry) {}
 
   record RuntimeTelemetry(Version version, String nodeExecutableOrigin) {}
 }

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -481,24 +481,14 @@ public class BridgeServerImpl implements BridgeServer {
   @Override
   public TelemetryData getTelemetry() {
     if (nodeCommand == null) {
-      return new TelemetryData(getTelemetryEslintBridgeResponse().dependencies(), null);
+      return new TelemetryData(null);
     }
     return new TelemetryData(
-      getTelemetryEslintBridgeResponse().dependencies(),
       new RuntimeTelemetry(
         nodeCommand.getActualNodeVersion(),
         nodeCommand.getNodeExecutableOrigin()
       )
     );
-  }
-
-  private TelemetryEslintBridgeResponse getTelemetryEslintBridgeResponse() {
-    try {
-      var result = http.get(url("get-telemetry"));
-      return GSON.fromJson(result, TelemetryEslintBridgeResponse.class);
-    } catch (IOException e) {
-      return new TelemetryEslintBridgeResponse(List.of());
-    }
   }
 
   @Override

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -63,7 +63,6 @@ import org.sonar.api.utils.TempFolder;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.javascript.api.AnalysisMode;
 import org.sonar.plugins.javascript.bridge.BridgeServer.CssAnalysisRequest;
-import org.sonar.plugins.javascript.bridge.BridgeServer.Dependency;
 import org.sonar.plugins.javascript.bridge.BridgeServer.JsAnalysisRequest;
 import org.sonar.plugins.javascript.bridge.protobuf.Node;
 import org.sonar.plugins.javascript.nodejs.NodeCommandBuilder;
@@ -609,7 +608,6 @@ class BridgeServerImplTest {
     bridgeServer = createBridgeServer(START_SERVER_SCRIPT);
     bridgeServer.startServer(serverConfig);
     var telemetry = bridgeServer.getTelemetry();
-    assertThat(telemetry.dependencies()).isEqualTo(List.of(new Dependency("pkg1", "1.0.0")));
     var runtimeTelemetry = telemetry.runtimeTelemetry();
 
     // todo: we should test here against either a controlled version of Node.js, or the lowest version that we officially support

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
@@ -153,7 +153,6 @@ class JsTsSensorTest {
     when(bridgeServerMock.getCommandInfo()).thenReturn("bridgeServerMock command info");
     when(bridgeServerMock.getTelemetry()).thenReturn(
       new BridgeServer.TelemetryData(
-        List.of(),
         new BridgeServer.RuntimeTelemetry(Version.create(22, 9), "host")
       )
     );
@@ -1222,7 +1221,6 @@ class JsTsSensorTest {
   void should_add_telemetry_for_scanner_analysis() {
     when(bridgeServerMock.getTelemetry()).thenReturn(
       new BridgeServer.TelemetryData(
-        List.of(new BridgeServer.Dependency("pkg1", "1.1.0")),
         new BridgeServer.RuntimeTelemetry(Version.create(22, 9), "embedded")
       )
     );

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/PluginTelemetryTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/PluginTelemetryTest.java
@@ -22,26 +22,23 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.javascript.bridge.BridgeServer;
-import org.sonar.plugins.javascript.bridge.BridgeServer.Dependency;
 import org.sonar.plugins.javascript.bridge.BridgeServer.RuntimeTelemetry;
 import org.sonar.plugins.javascript.bridge.BridgeServer.TelemetryData;
 
 class PluginTelemetryTest {
 
-  private JsTsContext<SensorContext> jsTsContext;
   private SensorContext ctx;
   private PluginTelemetry pluginTelemetry;
 
   @BeforeEach
   void setUp() {
-    jsTsContext = mock(JsTsContext.class);
+    JsTsContext<SensorContext> jsTsContext = mock(JsTsContext.class);
     ctx = mock(SensorContext.class);
     SonarRuntime sonarRuntime = mock(SonarRuntime.class);
     when(ctx.runtime()).thenReturn(sonarRuntime);
@@ -49,10 +46,7 @@ class PluginTelemetryTest {
 
     BridgeServer server = mock(BridgeServer.class);
     when(server.getTelemetry()).thenReturn(
-      new TelemetryData(
-        List.of(new Dependency("pkg1", "1.0.0")),
-        new RuntimeTelemetry(Version.create(22, 9), "embedded")
-      )
+      new TelemetryData(new RuntimeTelemetry(Version.create(22, 9), "embedded"))
     );
     pluginTelemetry = new PluginTelemetry(jsTsContext, server);
   }


### PR DESCRIPTION
[JS-786](https://sonarsource.atlassian.net/browse/JS-786)

While trying to understand why kibana is failing on peachee, it turned out it was due to the Telemetry gathering of all dependencies. With the existing implemnetaiton, the dependencies gathering would take multiple hours.
The numbers are:
> cache size: 21736
> total number of dependency per base_dir: 40499493

No wonder with this implementation we were timing out.

That being said, we currently don't log the telemetry data and we don't use it during the analysis. It had a brief period in the end of 2024, where we logged it and benefitted from the data.

When we want to re-enable this ,we should be mindful about the time complexity of it.

[JS-786]: https://sonarsource.atlassian.net/browse/JS-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ