### PR TITLE
JS-793 Add SensorContext as parameter to JsAnalysisConsumer::doneAnalysis

### DIFF
--- a/its/plugin/plugins/consumer-plugin/src/main/java/org/sonar/samples/javascript/consumer/Consumer.java
+++ b/its/plugin/plugins/consumer-plugin/src/main/java/org/sonar/samples/javascript/consumer/Consumer.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.plugins.javascript.api.JsAnalysisConsumer;
 import org.sonar.plugins.javascript.api.JsFile;
 
@@ -37,7 +38,7 @@ public class Consumer implements JsAnalysisConsumer {
   }
 
   @Override
-  public void doneAnalysis() {
+  public void doneAnalysis(SensorContext context) {
     LOG.info("Done analysis");
     done = true;
   }

--- a/its/plugin/plugins/consumer-plugin/src/test/java/org/sonar/samples/javascript/consumer/ConsumerTest.java
+++ b/its/plugin/plugins/consumer-plugin/src/test/java/org/sonar/samples/javascript/consumer/ConsumerTest.java
@@ -25,7 +25,7 @@ class ConsumerTest {
   @Test
   void test() {
     var consumer = new Consumer();
-    consumer.doneAnalysis();
+    consumer.doneAnalysis(null);
     assertTrue(consumer.isDone());
   }
 }

--- a/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/JsAnalysisConsumer.java
+++ b/sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/JsAnalysisConsumer.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.javascript.api;
 
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.scanner.ScannerSide;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
@@ -36,7 +37,7 @@ public interface JsAnalysisConsumer {
    *
    * Called at the end of the analysis.
    */
-  void doneAnalysis();
+  void doneAnalysis(SensorContext context);
 
   /**
    * Called only once per analysis.

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisConsumers.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisConsumers.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.javascript.analysis;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.scanner.ScannerSide;
 import org.sonar.plugins.javascript.api.JsAnalysisConsumer;
 import org.sonar.plugins.javascript.api.JsFile;
@@ -49,8 +50,8 @@ public class AnalysisConsumers implements JsAnalysisConsumer {
   }
 
   @Override
-  public void doneAnalysis() {
-    consumers.forEach(JsAnalysisConsumer::doneAnalysis);
+  public void doneAnalysis(SensorContext context) {
+    consumers.forEach(c -> c.doneAnalysis(context));
   }
 
   @Override

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsSensor.java
@@ -118,7 +118,7 @@ public class JsTsSensor extends AbstractBridgeSensor {
       var handler = new AnalyzeProjectHandler(context, inputFiles, externalIssues);
       bridgeServer.analyzeProject(handler);
       new PluginTelemetry(context, bridgeServer).reportTelemetry();
-      consumers.doneAnalysis();
+      consumers.doneAnalysis(context.getSensorContext());
     } catch (CompletionException e) {
       if (e.getCause() instanceof CancellationException nestedException) {
         throw nestedException;

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisConsumersTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisConsumersTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.plugins.javascript.api.JsAnalysisConsumer;
 import org.sonar.plugins.javascript.api.JsFile;
@@ -86,7 +87,7 @@ public class AnalysisConsumersTest {
     public void accept(JsFile jsFile) {}
 
     @Override
-    public void doneAnalysis() {}
+    public void doneAnalysis(SensorContext context) {}
 
     @Override
     public boolean isEnabled() {

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
@@ -62,6 +62,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
 import org.sonar.api.batch.rule.internal.NewActiveRule;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.cache.ReadCache;
 import org.sonar.api.batch.sensor.cache.WriteCache;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
@@ -1598,7 +1599,7 @@ class JsTsSensorTest {
     }
 
     @Override
-    public void doneAnalysis() {
+    public void doneAnalysis(SensorContext context) {
       done = true;
     }
 


### PR DESCRIPTION
org.sonar.api.batch.sensor.Sensor is a module sensor, invoked as many times as modules are in a project. This seems to have caused the problem in Jasmine/.Net scanner, as modules were set up by the dotnet scanner and this caused the JsTsSensor to be invoked multiple times (with different workDir paths). While we explore the option to use ProjectSensor, we can add the context (which contains `workdir`) so that consumers can orchestrate what files belong together my module

[JS-793](https://sonarsource.atlassian.net/browse/JS-793)



[JS-793]: https://sonarsource.atlassian.net/browse/JS-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ