### PR TITLE
Remove payload limit for WebSocket server

### DIFF
--- a/packages/bridge/src/server.ts
+++ b/packages/bridge/src/server.ts
@@ -88,7 +88,7 @@ export function start(
 
     const app = express();
     const server = http.createServer(app);
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({ noServer: true, maxPayload: 0 });
 
     server.on('upgrade', (request, socket, head) => {
       // Only handle upgrade requests for /ws


### PR DESCRIPTION
This should address this community issue: https://community.sonarsource.com/t/websocket-client-error-rangeerror-max-payload-size-exceeded/144174/4