### PR TITLE
JS-805 Catch tsconfig processing errors

### DIFF
--- a/packages/jsts/tests/analysis/tsconfigs.test.ts
+++ b/packages/jsts/tests/analysis/tsconfigs.test.ts
@@ -106,7 +106,7 @@ describe('tsconfigs', () => {
         allowJs: true,
         noImplicitAny: true,
       },
-      files: [`${baseDir}/file.ts`, `${baseDir}/string42.ts`],
+      files: expect.arrayContaining([`${baseDir}/file.ts`, `${baseDir}/string42.ts`]),
     });
     expect(tsConfigStore.getCacheOrigin()).toEqual('fallback');
   });

--- a/packages/jsts/tests/analysis/tsconfigs.test.ts
+++ b/packages/jsts/tests/analysis/tsconfigs.test.ts
@@ -106,7 +106,7 @@ describe('tsconfigs', () => {
         allowJs: true,
         noImplicitAny: true,
       },
-      files: expect.arrayContaining([`${baseDir}/file.ts`, `${baseDir}/string42.ts`]),
+      files: [`${baseDir}/file.ts`, `${baseDir}/string42.ts`],
     });
     expect(tsConfigStore.getCacheOrigin()).toEqual('fallback');
   });


### PR DESCRIPTION
[JS-805](https://sonarsource.atlassian.net/browse/JS-805)

Trying to get into debugging SonarLint, started with running on SonarJS. What I found is:
If we try to go through a file that is not a part of any tsconfig, we will try to construct all of these tsconfig program's and receive the files that they cover. However, if any of these Typescript Program creation throws an exception (with SonarJS I got reasons like: invalid option in tsconfig, tsconfig doesn't match any files), then we don't get to the end of the request as we didn't have any catch in the process.

wdyt?

[JS-805]: https://sonarsource.atlassian.net/browse/JS-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ