### PR TITLE
Avoid repeated extractions of embedded node runtime

### DIFF
--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
@@ -194,7 +194,7 @@ public class EmbeddedNode {
       if (Files.exists(targetVersion) && !isDifferent(versionIs, targetVersion)) {
         LOG.debug("Skipping node deploy. Deployed node has latest version.");
       } else {
-        extractWithLocking(is, versionIs, targetRuntime, targetDirectory);
+        extractWithLocking(is, targetRuntime, targetDirectory);
       }
       // we try to run 'node -v' to test that node is working
       var detected = NodeVersion.getVersion(processWrapper, binary().toString());
@@ -231,14 +231,12 @@ public class EmbeddedNode {
    * Writes the version from `versionIs` to `targetDirectory`/VERSION_FILENAME
    *
    * @param source
-   * @param versionIs
    * @param targetRuntime
    * @param targetDirectory
    * @throws IOException
    */
   private void extractWithLocking(
     InputStream source,
-    InputStream versionIs,
     Path targetRuntime,
     Path targetDirectory
   ) throws IOException {
@@ -253,6 +251,7 @@ public class EmbeddedNode {
         try {
           LOG.debug("Lock acquired for extraction");
           extract(source, targetRuntime);
+          var versionIs = getClass().getResourceAsStream(platform.versionPathInJar());
           Files.copy(versionIs, deployLocation.resolve(VERSION_FILENAME), REPLACE_EXISTING);
         } finally {
           lock.release();


### PR DESCRIPTION
Greetings,

I noticed that our Sonar scans were showing the following debug logs
```
20:52:16.795 DEBUG Currently installed Node.js version: . Available version in analyzer: v22.11.0
20:52:16.795 DEBUG Lock acquired for extraction
20:52:16.803 DEBUG Extracting embedded node to /path/to/our/.sonar/js/node-runtime/node
```
As you can see the currently installed version seems to be empty and the scanner consequently doing the extraction of the node runtime. Unfortunately it does so for each scan.

On closer inspection, this seems to be caused by the `js/node-runtime/version.txt` file being empty. This is caused by the `InputStream` of the file from the JAR being already fully consumed in `EmbeddedNode::isDifferent` through `readAllBytes`. When the file should be then written via `Files.copy(...)` it's basically copying an "empty" stream.

For pragmatic reasons, this PR just opens the InputStream again before trying to copy things.

Would appreciate if this is picked up as it saves us from extracting ~110+ MB on each scan. Let me know if you need anything from me.

Cheers,
Christoph