### PR TITLE
JS-814 Remove stale script

### DIFF
--- a/check-license-compliance.sh
+++ b/check-license-compliance.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-# See https://xtranet.sonarsource.com/display/DEV/Open+Source+Licenses
-
-mvn org.codehaus.mojo:license-maven-plugin:aggregate-add-third-party


### PR DESCRIPTION
[JS-814](https://sonarsource.atlassian.net/browse/JS-814)

Noticed we have this stray script that has been there for 7 years, probably unused. Now that we have some license checks in an automated way. Let us remove this.

[JS-814]: https://sonarsource.atlassian.net/browse/JS-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ