### PR TITLE
JS-685 Modify S2301 (`no-selector-parameter`): Add exception when selector parameter is an object property

### DIFF
--- a/its/ruling/src/test/expected/jsts/vuetify/typescript-S2301.json
+++ b/its/ruling/src/test/expected/jsts/vuetify/typescript-S2301.json
@@ -1,5 +1,0 @@
-{
-"vuetify:packages/vuetify/src/composables/nested/openStrategies.ts": [
-27
-]
-}

--- a/packages/jsts/src/rules/S2301/rule.ts
+++ b/packages/jsts/src/rules/S2301/rule.ts
@@ -28,6 +28,7 @@ import {
 } from '../helpers/index.js';
 import type { BlockStatement, Node as ESTreeNode } from 'estree';
 import * as meta from './generated-meta.js';
+import { TSESTree } from '@typescript-eslint/utils';
 
 type Node = ESTreeNode & Rule.NodeParentExtension;
 
@@ -103,8 +104,9 @@ export const rule: Rule.RuleModule = {
 
           if (definition?.type === 'Parameter') {
             const type = getTypeFromTreeNode(definition.name, context.sourceCode.parserServices);
+            const definitionParent = (definition.name as TSESTree.Identifier).parent;
 
-            if (isBooleanType(type)) {
+            if (isBooleanType(type) && definitionParent?.type !== 'Property') {
               report(
                 context,
                 {

--- a/packages/jsts/src/rules/S2301/unit.test.ts
+++ b/packages/jsts/src/rules/S2301/unit.test.ts
@@ -118,6 +118,12 @@ function tempt3(name: string, ofAge: boolean) {
       ],
       valid: [
         {
+          code: `
+function foo({ isField }: {isField: boolean}) {
+    return isField ? console.log(1) : console.log(2);
+}`,
+        },
+        {
           name: `RSPEC compliant code example`,
           settings: { sonarRuntime: true },
           code: `function temptAdult(name: string) {


### PR DESCRIPTION
[JS-685](https://sonarsource.atlassian.net/browse/JS-685)



[JS-685]: https://sonarsource.atlassian.net/browse/JS-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ