### PR TITLE
JS-839 Clean up Maven dependencies

### DIFF
--- a/its/plugin/plugins/consumer-plugin/pom.xml
+++ b/its/plugin/plugins/consumer-plugin/pom.xml
@@ -21,14 +21,23 @@
       <artifactId>sonar-plugin-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.javascript</groupId>
       <artifactId>api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope></dependency>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/plugin/plugins/eslint-custom-rules-plugin/pom.xml
+++ b/its/plugin/plugins/eslint-custom-rules-plugin/pom.xml
@@ -21,6 +21,10 @@
       <artifactId>sonar-plugin-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.javascript</groupId>
       <artifactId>api</artifactId>
     </dependency>

--- a/its/plugin/sonarlint-tests/pom.xml
+++ b/its/plugin/sonarlint-tests/pom.xml
@@ -54,6 +54,11 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sonar-javascript-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/plugin/sonarlint-tests/pom.xml
+++ b/its/plugin/sonarlint-tests/pom.xml
@@ -23,24 +23,16 @@
   -->
   <dependencies>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.analyzer-commons</groupId>
-      <artifactId>sonar-analyzer-commons</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarlint.core</groupId>
-      <artifactId>sonarlint-core</artifactId>
-      <version>${sonarlint.plugin.api.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.sonarlint.core</groupId>
       <artifactId>sonarlint-core-test-utils</artifactId>
       <version>${sonarlint.plugin.api.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-rpc-java-client</artifactId>
+      <version>${sonarlint.plugin.api.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarlint.core</groupId>
@@ -55,22 +47,12 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>sonar-javascript-plugin</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -60,14 +60,15 @@
       <artifactId>assertj-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.orchestrator</groupId>
-      <artifactId>sonar-orchestrator</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>2.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sonar-javascript-plugin</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -37,13 +37,18 @@
       <artifactId>sonar-ws</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -55,27 +60,14 @@
       <artifactId>assertj-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <scope>provided</scope>
+      <groupId>org.sonarsource.orchestrator</groupId>
+      <artifactId>sonar-orchestrator</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>2.0.17</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>sonar-javascript-plugin</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -27,36 +27,38 @@
     <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator-junit5</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.orchestrator</groupId>
+      <artifactId>sonar-orchestrator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-ws</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarlint.core</groupId>
-      <artifactId>sonarlint-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>sonar-javascript-plugin</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>sonar-orchestrator-junit5</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.orchestrator</groupId>
-      <artifactId>sonar-orchestrator</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-ws</artifactId>
     </dependency>
@@ -59,6 +55,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sonar-javascript-plugin</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/its/ruling/src/test/java/org/sonar/javascript/it/JsTsRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/JsTsRulingTest.java
@@ -38,7 +38,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
@@ -351,7 +350,7 @@ class JsTsRulingTest {
       .findFirst()
       .orElse(null);
 
-    if (!StringUtils.isEmpty(profileKey)) {
+    if (profileKey != null && !profileKey.isEmpty()) {
       newAdminWsClient(orchestrator)
         .qualityprofiles()
         .activateRule(
@@ -374,12 +373,11 @@ class JsTsRulingTest {
   }
 
   static WsClient newAdminWsClient(Orchestrator orchestrator) {
-    return WsClientFactories.getDefault()
-      .newClient(
-        HttpConnector.newBuilder()
-          .credentials(Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD)
-          .url(orchestrator.getServer().getUrl())
-          .build()
-      );
+    return WsClientFactories.getDefault().newClient(
+      HttpConnector.newBuilder()
+        .credentials(Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD)
+        .url(orchestrator.getServer().getUrl())
+        .build()
+    );
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <junit.version>5.13.4</junit.version>
     <mockito.version>5.19.0</mockito.version>
     <slf4j.version>2.0.17</slf4j.version>
+    <jetbrains.annotations.version>25.0.0</jetbrains.annotations.version>
     <sonar.version>25.8.0.112029</sonar.version>
     <sonar.api.version>13.0.0.3026</sonar.api.version>
     <sonar-orchestrator.version>5.6.2.2625</sonar-orchestrator.version>
@@ -150,11 +151,6 @@
         <version>2.20.0</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.sonarsource.sslr</groupId>
         <artifactId>sslr-core</artifactId>
         <version>${sslr.version}</version>
@@ -174,6 +170,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${jetbrains.annotations.version}</version>
       </dependency>
 
 
@@ -210,8 +211,32 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.sonarsource.sonarlint.core</groupId>
+        <artifactId>sonarlint-analysis-engine</artifactId>
+        <version>${sonarlint.plugin.api.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.sonarlint.core</groupId>
+        <artifactId>sonarlint-commons</artifactId>
+        <version>${sonarlint.plugin.api.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.sonarlint.core</groupId>
+        <artifactId>sonarlint-plugin-commons</artifactId>
+        <version>${sonarlint.plugin.api.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.sonarsource.orchestrator</groupId>
         <artifactId>sonar-orchestrator-junit5</artifactId>
+        <version>${sonar-orchestrator.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.orchestrator</groupId>
+        <artifactId>sonar-orchestrator</artifactId>
         <version>${sonar-orchestrator.version}</version>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
         <version>2.20.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.18.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.sonarsource.sslr</groupId>
         <artifactId>sslr-core</artifactId>
         <version>${sslr.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,16 +150,6 @@
         <version>2.20.0</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.sonarsource.sslr</groupId>
         <artifactId>sslr-core</artifactId>
         <version>${sslr.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -235,12 +235,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.sonarsource.orchestrator</groupId>
-        <artifactId>sonar-orchestrator</artifactId>
-        <version>${sonar-orchestrator.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.sonarsource.sonarqube</groupId>
         <artifactId>sonar-ws</artifactId>
         <version>${sonar.version}</version>

--- a/sonar-plugin/api/pom.xml
+++ b/sonar-plugin/api/pom.xml
@@ -25,7 +25,7 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-plugin/bridge/pom.xml
+++ b/sonar-plugin/bridge/pom.xml
@@ -44,7 +44,12 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -68,9 +73,8 @@
       <artifactId>sonar-plugin-api-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.java-websocket</groupId>

--- a/sonar-plugin/css/pom.xml
+++ b/sonar-plugin/css/pom.xml
@@ -29,6 +29,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/sonar-plugin/css/pom.xml
+++ b/sonar-plugin/css/pom.xml
@@ -42,12 +42,6 @@
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api-impl</artifactId>

--- a/sonar-plugin/css/pom.xml
+++ b/sonar-plugin/css/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/sonar-plugin/css/pom.xml
+++ b/sonar-plugin/css/pom.xml
@@ -52,11 +52,11 @@
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarlint.core</groupId>
-      <artifactId>sonarlint-core</artifactId>
+      <artifactId>sonarlint-analysis-engine</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -66,6 +66,10 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/sonar-plugin/css/src/test/java/org/sonar/css/metrics/TokenizerTest.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/metrics/TokenizerTest.java
@@ -19,7 +19,6 @@ package org.sonar.css.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
 
 class TokenizerTest {
@@ -108,7 +107,7 @@ class TokenizerTest {
     );
 
     int numberOfChars = 1000000;
-    String seedCode = StringUtils.repeat("a", numberOfChars);
+    String seedCode = "a".repeat(numberOfChars);
 
     String testCode = "\"" + seedCode + "\"";
     assertToken(testCode, 0, testCode, CssTokenType.STRING, 1, 0, 1, testCode.length());
@@ -159,7 +158,7 @@ class TokenizerTest {
     assertToken(code, 0, code, CssTokenType.COMMENT, 1, 0, 5, 2);
 
     int numberOfLineReturn = 1000000;
-    code = "/*" + StringUtils.repeat(" *\n", numberOfLineReturn) + " */";
+    code = "/*" + " *\n".repeat(numberOfLineReturn) + " */";
     assertToken(code, 0, code, CssTokenType.COMMENT, 1, 0, numberOfLineReturn + 1, 3);
   }
 

--- a/sonar-plugin/javascript-checks/pom.xml
+++ b/sonar-plugin/javascript-checks/pom.xml
@@ -26,26 +26,13 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.analyzer-commons</groupId>
-      <artifactId>sonar-analyzer-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
 

--- a/sonar-plugin/sonar-javascript-plugin/pom.xml
+++ b/sonar-plugin/sonar-javascript-plugin/pom.xml
@@ -53,7 +53,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/sonar-plugin/sonar-javascript-plugin/pom.xml
+++ b/sonar-plugin/sonar-javascript-plugin/pom.xml
@@ -47,8 +47,21 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -66,14 +79,14 @@
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -93,12 +106,24 @@
       <artifactId>sonarlint-plugin-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-analysis-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-plugin-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarlint.core</groupId>
-      <artifactId>sonarlint-core</artifactId>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sonar-plugin/standalone/pom.xml
+++ b/sonar-plugin/standalone/pom.xml
@@ -22,14 +22,24 @@
         <artifactId>sonar-plugin-api</artifactId>
       </dependency>
       <dependency>
-        <groupId>org.sonarsource.api.plugin</groupId>
-        <artifactId>sonar-plugin-api-test-fixtures</artifactId>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.javascript</groupId>
+        <artifactId>api</artifactId>
+        <version>${project.version}</version>
       </dependency>
 
       <!-- Test dependencies -->
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
[JS-839](https://sonarsource.atlassian.net/browse/JS-839)


we were only using Apache commons lang in tests and there was a [CVE](https://sonarsource.atlassian.net/browse/SSF-863). For the usage we need I think we better don't have this dependency

Making sure that running `mvn dependency:analyze` now does not show any "used and undeclared" or "unused and declared" dependencies in any of the maven modules of the project.

Apache lang3 is not explicitly mentioned in our pom files any more. Using `mvn dependency:tree -Dverbose` it was visible which version of lang3 was picked up, and ordering of dependency declaration matters in Maven.

[JS-839]: https://sonarsource.atlassian.net/browse/JS-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ