### PR TITLE
JS-840 Fix handling of built-in modules in fully qualified name generation

### DIFF
--- a/packages/jsts/src/rules/S2699/supertest.fixture.js
+++ b/packages/jsts/src/rules/S2699/supertest.fixture.js
@@ -18,3 +18,14 @@ describe('supertest', function () { // Compliant
     return supertest(app).get(`/foo/bar`);
   });
 });
+
+// due to this line, the heuristic to get the fully qualified name, has a different list of declarations
+process.env.VARIABLE = 'some-token';
+
+describe("fail", () => {
+  it("should cause issues", () => {
+    const test_input = process.env.OTHER_VARIABLE.substring(0, 6); // this line can use any process.env var.
+    return supertest(app).get(`/foo/bar`).expect('Content-Type', /json/u).expect(200);
+  });
+});
+

--- a/packages/jsts/src/rules/helpers/module-ts.ts
+++ b/packages/jsts/src/rules/helpers/module-ts.ts
@@ -99,12 +99,12 @@ export function getFullyQualifiedNameTS(
       }
       case ts.SyntaxKind.Identifier: {
         const identifierSymbol = services.program.getTypeChecker().getSymbolAtLocation(node);
-        if (identifierSymbol?.declarations?.at(0)) {
-          node = identifierSymbol.declarations.at(0);
-          break;
-        } else {
+        if (isCompilerModule(identifierSymbol) || !identifierSymbol?.declarations?.length) {
           result.push((node as ts.Identifier).text);
           return returnResult();
+        } else {
+          node = identifierSymbol.declarations.at(0);
+          break;
         }
       }
       case ts.SyntaxKind.StringLiteral: {
@@ -139,5 +139,13 @@ function isRequireCall(callExpression: ts.CallExpression) {
     callExpression.expression.kind === ts.SyntaxKind.Identifier &&
     (callExpression.expression as ts.Identifier).text === 'require' &&
     callExpression.arguments.length === 1
+  );
+}
+
+function isCompilerModule(node: ts.Symbol | undefined) {
+  return (
+    node &&
+    (node.flags & ts.SymbolFlags.Module) !== 0 &&
+    (node.flags & ts.SymbolFlags.Assignment) !== 0
   );
 }


### PR DESCRIPTION
[JS-840](https://sonarsource.atlassian.net/browse/JS-840)

Based on the community ticket - https://community.sonarsource.com/t/sonar-scanner-hangs-and-exits-with-143-after-timeout/144205/26

The issue arose, as during the generation, an unforseen declaration was being added, due to the line `process.env.VARIABLE = 'some-token';`, then, we would get to an endless loop in the generation logic. Let us short-circuit it in the case we detect we get to a module assignment symbol.

[JS-840]: https://sonarsource.atlassian.net/browse/JS-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ