### PR TITLE
JS-849 USER-902 add exception for @cdktf

### DIFF
--- a/packages/jsts/src/rules/S1848/rule.ts
+++ b/packages/jsts/src/rules/S1848/rule.ts
@@ -101,7 +101,7 @@ function isException(
     return false;
   }
   const exactExceptions = ['vue', '@ag-grid-community.core.Grid'];
-  const startsWithExceptions = ['aws-cdk-lib', 'cdk8s', '@pulumi'];
+  const startsWithExceptions = ['aws-cdk-lib', 'cdk8s', '@pulumi', '@cdktf'];
   return (
     exactExceptions.includes(fqn) ||
     startsWithExceptions.some(exception => fqn.startsWith(exception))

--- a/packages/jsts/src/rules/S1848/unit.test.ts
+++ b/packages/jsts/src/rules/S1848/unit.test.ts
@@ -112,6 +112,14 @@ new KubeService(chart, 'MyService', {
 
 app.synth();`,
           },
+          {
+            code: `import {AwsProvider} from "@cdktf/provider-aws/lib/provider";
+new AwsProvider(this, 'aws', {
+            region: 'ap-east-1', // Update the region as needed
+            accessKey: '', // your accessKey
+            secretKey: '' // your secretKey
+        });`,
+          },
         ],
         invalid: [
           {


### PR DESCRIPTION
[JS-849](https://sonarsource.atlassian.net/browse/JS-849)
[USER-902](https://sonarsource.atlassian.net/browse/USER-902)

The screenshot didn't show how it is imported, however some googling showed to that @cdktf might be the necessary prefix. Looking at this blog post - https://medium.com/@jimmywcho/cdktf-deploy-serverless-application-5c4aa1c764e3

[JS-849]: https://sonarsource.atlassian.net/browse/JS-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USER-902]: https://sonarsource.atlassian.net/browse/USER-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ