### PR TITLE
JS-868 remove fixtures from sca analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <sonar.version>25.9.0.112764</sonar.version>
     <sonar.api.version>13.2.0.3137</sonar.api.version>
     <sonar-orchestrator.version>5.6.2.2625</sonar-orchestrator.version>
-    <sonar.sca.exclusions>its/**</sonar.sca.exclusions>
+    <sonar.sca.exclusions>its/**,packages/**/*.fixture.*,packages/**/fixtures/**/*</sonar.sca.exclusions>
     <gson.version>2.13.2</gson.version>
     <analyzer-commons.version>2.18.0.3393</analyzer-commons.version>
     <sslr.version>1.24.0.633</sslr.version>


### PR DESCRIPTION
[JS-868](https://sonarsource.atlassian.net/browse/JS-868)

The accepting of issues on SonarCloud doesn't carry over to Next - https://next.sonarqube.com/sonarqube/dashboard?id=org.sonarsource.javascript%3Ajavascript&codeScope=overall. Therefore, adding these exclusions in the pom.xml to avoid the fixtures.

[JS-868]: https://sonarsource.atlassian.net/browse/JS-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ