### PR TITLE
JS-876 Migrate CssIssuesTest to scanner-integration-tester

### DIFF
--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.sonarsource.scanner.integrationtester</groupId>
       <artifactId>sonar-scanner-integration-tester</artifactId>
-      <version>0.1.0.142</version>
+      <version>0.2.0.152</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
[JS-876](https://sonarsource.atlassian.net/browse/JS-876)

Testing out the new scanner-integration-tester. 
As quick as a normal Java test. For now, it needs some boilerplate to get all of the rules and such, but this will be soon abstracted away.

[JS-876]: https://sonarsource.atlassian.net/browse/JS-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ