### PR TITLE
JS-880 update gh release actions

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -1,27 +1,25 @@
-name: Releasability status
-'on':
-  check_suite:
-    types:
-      - completed
+name: Releasability Status
+on:
+  workflow_run:
+    workflows: [ "Build" ]  # Name must match the name of the build workflow
+    types: [ completed ]
+    branches:
+      - master
+      - dogfood-*
+      - branch-*
+
 jobs:
-  update_releasability_status:
-    runs-on: github-ubuntu-latest-s
+  releasability-status:
     name: Releasability status
+    runs-on: sonar-xs # Use any runner
     permissions:
       id-token: write
       statuses: write
       contents: read
-    if: >-
-      (contains(fromJSON('["main", "master"]'),
-      github.event.check_suite.head_branch) ||
-      startsWith(github.event.check_suite.head_branch, 'dogfood-') ||
-      startsWith(github.event.check_suite.head_branch, 'branch-')) &&
-      github.event.check_suite.conclusion == 'success' &&
-      github.event.check_suite.app.slug == 'cirrus-ci'
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
-      -   uses: >-
-            SonarSource/gh-action_releasability/releasability-status@v2
+      -   uses: SonarSource/gh-action_releasability/releasability-status@v3
           with:
             optional_checks: "Jira"
           env:
-            GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+            GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -1,25 +1,26 @@
-name: Releasability Status
-on:
-  workflow_run:
-    workflows: [ "Build" ]  # Name must match the name of the build workflow
-    types: [ completed ]
-    branches:
-      - master
-      - dogfood-*
-      - branch-*
-
+name: Releasability status
+'on':
+  check_suite:
+    types:
+      - completed
 jobs:
-  releasability-status:
+  update_releasability_status:
+    runs-on: github-ubuntu-latest-s
     name: Releasability status
-    runs-on: sonar-xs # Use any runner
     permissions:
       id-token: write
       statuses: write
       contents: read
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >-
+      (contains(fromJSON('["main", "master"]'),
+      github.event.check_suite.head_branch) ||
+      startsWith(github.event.check_suite.head_branch, 'dogfood-') ||
+      startsWith(github.event.check_suite.head_branch, 'branch-')) &&
+      github.event.check_suite.conclusion == 'success' &&
+      github.event.check_suite.app.slug == 'cirrus-ci'
     steps:
       -   uses: SonarSource/gh-action_releasability/releasability-status@v3
           with:
             optional_checks: "Jira"
           env:
-            GITHUB_TOKEN: ${{ github.token }}
+            GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
[JS-880](https://sonarsource.atlassian.net/browse/JS-880)

Now that ws is removed, we need to migrate to the newest release actions

[JS-880]: https://sonarsource.atlassian.net/browse/JS-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ