### PR TITLE
JS-754 Fix S6418: Handle ternary expressions and string literal keys

### DIFF
--- a/packages/jsts/src/rules/S6418/cb.fixture.ts
+++ b/packages/jsts/src/rules/S6418/cb.fixture.ts
@@ -51,3 +51,15 @@ function defaultValues(foo) {
 function customSecretWord() {
   const yolo = '1IfHMPanImzX8ZxC-Ud6+YhXiLwlXq$f_-3v~.='; // Noncompliant {{"yolo" detected here, make sure this is not a hard-coded secret.}}
 }
+
+function ternaryExpression(condition: boolean) {
+  const secret = condition ? '1IfHMPanImzX8ZxC-Ud6+YhXiLwlXq$f_-3v~.=' : 'fallback'; // Noncompliant {{"secret" detected here, make sure this is not a hard-coded secret.}}
+  const token = condition ? 'fallback' : '1IfHMPanImzX8ZxC-Ud6+YhXiLwlXq$f_-3v~.='; // Noncompliant {{"token" detected here, make sure this is not a hard-coded secret.}}
+  const safe = condition ? 'not-a-secret' : 'also-not-a-secret';
+}
+
+const objectWithStringKeys = {
+  'api-key': '1IfHMPanImzX8ZxC-Ud6+YhXiLwlXq$f_-3v~.=', // Noncompliant {{"api-key" detected here, make sure this is not a hard-coded secret.}}
+  'auth-token': '1IfHMPanImzX8ZxC-Ud6+YhXiLwlXq$f_-3v~.=', // Noncompliant {{"auth-token" detected here, make sure this is not a hard-coded secret.}}
+  'not-secret': 'some-value',
+}


### PR DESCRIPTION
## Summary

Fix S6418 (no-hardcoded-secrets) to detect secrets in two additional patterns:

1. **Ternary expressions**: Secrets assigned via conditional expressions
2. **String literal property keys**: Object properties with string keys like `'api-key'`

## Changes

- `findValueSuspect()`: Now recursively checks both branches of `ConditionalExpression` (ternary)
- `findKeySuspect()`: Now also checks string literals that match secret word patterns

## Examples now detected

```javascript
// Ternary expression - now detected
const secret = condition ? 'rf6acB24J//1FZL...' : 'fallback';

// String literal key - now detected  
const obj = {
  'api-key': 'rf6acB24J//1FZL...',
};
```

## Related

- Community post: https://community.sonarsource.com/t/typescript-disclosed-api-key/141956/2

## Test plan

- [x] Added test cases to cb.fixture.ts
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)