### PR TITLE
JS-1062 Fix reliability issues (S7723, S7727)

### DIFF
--- a/packages/jsts/src/rules/S3500/rule.ts
+++ b/packages/jsts/src/rules/S3500/rule.ts
@@ -27,7 +27,9 @@ export const rule: Rule.RuleModule = {
     return {
       'VariableDeclaration[kind="const"]': (node: estree.Node) => {
         for (const variable of context.sourceCode.getDeclaredVariables(node)) {
-          for (const reference of variable.references.filter(isModifyingReference)) {
+          for (const reference of variable.references.filter((ref, i, refs) =>
+            isModifyingReference(ref, i, refs),
+          )) {
             report(
               context,
               {

--- a/packages/jsts/src/rules/S3800/rule.ts
+++ b/packages/jsts/src/rules/S3800/rule.ts
@@ -133,7 +133,7 @@ function isMixingTypes(type: ts.Type, checker: ts.TypeChecker): boolean {
     type.types
       .filter(tp => !isNullLike(tp))
       .map(tp => prettyPrint(tp, checker))
-      .filter(distinct).length > 1
+      .filter((val, i, arr) => distinct(val, i, arr)).length > 1
   );
 }
 
@@ -154,7 +154,7 @@ function prettyPrint(type: ts.Type, checker: ts.TypeChecker): string {
     const delimiter = type.isUnion() ? ' | ' : ' & ';
     return type.types
       .map(tp => prettyPrint(tp, checker))
-      .filter(distinct)
+      .filter((val, i, arr) => distinct(val, i, arr))
       .join(delimiter);
   }
   const typeNode = checker.typeToTypeNode(type, undefined, undefined);

--- a/packages/jsts/tests/tools/testers/comment-based/helpers/quickfixes.ts
+++ b/packages/jsts/tests/tools/testers/comment-based/helpers/quickfixes.ts
@@ -22,7 +22,7 @@ const STARTS_WITH_QUICKFIX = /^ *(edit|del|add|fix)@/;
 export const QUICKFIX_SEPARATOR = '[,\\s]+';
 export const QUICKFIX_ID =
   '\\[\\[(?<quickfixes>\\w+(=\\d+)?!?(?:' + QUICKFIX_SEPARATOR + '(?:\\w+(=\\d+)?!?))*)\\]\\]';
-const QUICKFIX_DESCRIPTION_PATTERN = RegExp(
+const QUICKFIX_DESCRIPTION_PATTERN = new RegExp(
   ' *' +
     // quickfix description, ex: fix@qf1 {{Replace with foo}}
     'fix@(?<quickfixId>\\w+)' +
@@ -31,7 +31,7 @@ const QUICKFIX_DESCRIPTION_PATTERN = RegExp(
     '(?:\\r(\\n?)|\\n)?',
 );
 
-const QUICKFIX_CHANGE_PATTERN = RegExp(
+const QUICKFIX_CHANGE_PATTERN = new RegExp(
   ' *' +
     // quickfix edit, ex: edit@qf1
     '(?<type>edit|add|del)@(?<quickfixId>\\w+)' +


### PR DESCRIPTION
## Summary
- Fix S7723: Add `new` keyword to `RegExp()` calls in quickfixes.ts
- Fix S7727: Wrap function callbacks passed directly to `.filter()` in arrow functions in S3500/rule.ts and S3800/rule.ts

## Test plan
- [x] Verify builds pass
- [ ] Verify SonarQube issues are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)