### PR TITLE
USER-1469 Fix S3735 false positive for Thenable with function property syntax

### DIFF
--- a/packages/jsts/src/rules/S3735/unit.test.ts
+++ b/packages/jsts/src/rules/S3735/unit.test.ts
@@ -91,6 +91,26 @@ describe('S3735', () => {
             void f();
             `,
         },
+        {
+          // Thenable with method signature (standard Promise-like)
+          code: `
+            interface Thenable<T> {
+              then<TResult>(onfulfilled?: (value: T) => TResult): Thenable<TResult>;
+            }
+            declare function executeCommand(): Thenable<void>;
+            void executeCommand();
+            `,
+        },
+        {
+          // Thenable with function property style (e.g., VSCode API)
+          code: `
+            interface ThenableFn<T> {
+              then: <TResult>(onfulfilled?: (value: T) => TResult) => ThenableFn<TResult>;
+            }
+            declare function executeCommand(): ThenableFn<void>;
+            void executeCommand();
+            `,
+        },
       ],
       invalid: [
         {

--- a/packages/jsts/src/rules/helpers/type.ts
+++ b/packages/jsts/src/rules/helpers/type.ts
@@ -144,7 +144,17 @@ export function isThenable(node: estree.Node, services: RequiredParserServices) 
   const mapped = services.esTreeNodeToTSNodeMap.get(node as TSESTree.Node);
   const tp = services.program.getTypeChecker().getTypeAtLocation(mapped);
   const thenProperty = tp.getProperty('then');
-  return Boolean(thenProperty && thenProperty.flags & ts.SymbolFlags.Method);
+  if (!thenProperty) {
+    return false;
+  }
+  // Check if it's declared as a method
+  if (thenProperty.flags & ts.SymbolFlags.Method) {
+    return true;
+  }
+  // Check if 'then' is a callable property (function type)
+  const checker = services.program.getTypeChecker();
+  const thenType = checker.getTypeOfSymbol(thenProperty);
+  return thenType.getCallSignatures().length > 0;
 }
 
 export function isAny(type: ts.Type) {

--- a/packages/jsts/src/rules/helpers/type.ts
+++ b/packages/jsts/src/rules/helpers/type.ts
@@ -142,17 +142,12 @@ export function isUndefinedOrNull(node: estree.Node, services: RequiredParserSer
 
 export function isThenable(node: estree.Node, services: RequiredParserServices) {
   const mapped = services.esTreeNodeToTSNodeMap.get(node as TSESTree.Node);
-  const tp = services.program.getTypeChecker().getTypeAtLocation(mapped);
+  const checker = services.program.getTypeChecker();
+  const tp = checker.getTypeAtLocation(mapped);
   const thenProperty = tp.getProperty('then');
   if (!thenProperty) {
     return false;
   }
-  // Check if it's declared as a method
-  if (thenProperty.flags & ts.SymbolFlags.Method) {
-    return true;
-  }
-  // Check if 'then' is a callable property (function type)
-  const checker = services.program.getTypeChecker();
   const thenType = checker.getTypeOfSymbol(thenProperty);
   return thenType.getCallSignatures().length > 0;
 }


### PR DESCRIPTION
## Summary
- Fix `isThenable` helper to recognize `then` defined as function property (not just method signature)
- Resolves false positives for VSCode's `Thenable` interface and similar types
- Adds test cases for both Thenable styles

## Test plan
- [x] S3735 unit tests pass with new Thenable test cases
- [x] S4822 tests pass (also uses `isThenable`)
- [x] S7059 tests pass (also uses `isThenable`)

Fixes USER-1469

🤖 Generated with [Claude Code](https://claude.com/claude-code)