### PR TITLE
JS-1135 Fix FP on S3735: Union types containing Promise and void/undefined

### DIFF
--- a/packages/jsts/src/rules/S3735/rule.ts
+++ b/packages/jsts/src/rules/S3735/rule.ts
@@ -22,7 +22,7 @@ import {
   generateMeta,
   isFunctionCall,
   isRequiredParserServices,
-  isThenable,
+  isThenableOrVoidUnion,
 } from '../helpers/index.js';
 import * as meta from './generated-meta.js';
 
@@ -67,7 +67,7 @@ function isIIFE(expr: estree.UnaryExpression) {
 function isPromiseLike(context: Rule.RuleContext, expr: estree.UnaryExpression) {
   const services = context.sourceCode.parserServices;
   if (isRequiredParserServices(services)) {
-    return isThenable(expr.argument, services);
+    return isThenableOrVoidUnion(expr.argument, services);
   } else {
     // If we don't have typescript types, we can't reason if it's a promise.
     // Therefore, if this is a function call, assume it is a promise.

--- a/packages/jsts/src/rules/S3735/unit.test.ts
+++ b/packages/jsts/src/rules/S3735/unit.test.ts
@@ -110,11 +110,67 @@ describe('S3735', () => {
             declare function executeCommand(): ThenableFn<void>;
             void executeCommand();
             `,
+        },        {
+          code: `
+            // Union with void: () => void | Promise<void>
+            type VoidOrPromiseFunction = () => void | Promise<void>;
+            const myFunction = async () => { return Promise.resolve(); };
+            const typedFunction: VoidOrPromiseFunction = myFunction;
+            void typedFunction();
+            `,
+        },
+        {
+          code: `
+            // Optional chaining: Promise<void> | undefined
+            interface SomeInterface {
+              someFunction(): Promise<void>;
+            }
+            const maybeUndefined: SomeInterface | undefined = undefined;
+            void maybeUndefined?.someFunction();
+            `,
+        },
+        {
+          code: `
+            // Union with undefined
+            const x: Promise<void> | undefined = Promise.resolve();
+            void x;
+            `,
+        },
+        {
+          code: `
+            // Union with null
+            const y: Promise<void> | null = null;
+            void y;
+            `,
+        },
+        {
+          code: `
+            // Union with void and undefined
+            const z: void | undefined | Promise<void> = undefined;
+            void z;
+            `,
         },
       ],
       invalid: [
         {
           code: `void 42;`,
+          errors: 1,
+        },
+        {
+          code: `
+            // Union with meaningful value (string)
+            const z: string | Promise<void> = "hello";
+            void z;
+            `,
+          errors: 1,
+        },
+        {
+          code: `
+            // Union with boolean (logical expressions)
+            declare const skipCheck: boolean;
+            declare const checkPromise: Promise<void>;
+            void (skipCheck || checkPromise);
+            `,
           errors: 1,
         },
       ],


### PR DESCRIPTION
## Summary

Fixes false positives in S3735 (`void-use` rule) for legitimate TypeScript union type patterns involving Promises.

**Jira Issue:** [JS-1135](https://sonarsource.atlassian.net/browse/JS-1135)

### Problem
The rule was incorrectly flagging `void` operator usage in these valid scenarios:
- Functions returning `void | Promise<void>` (optional async callbacks)
- Optional chaining with async methods: `obj?.asyncMethod()` → `Promise<T> | undefined`
- Union types combining Promises with "nothing" types (void, undefined, null)

### Solution
- Added new helper function `isThenableOrVoidUnion()` in `type.ts`
- Updated S3735 to use this new function instead of `isThenable()`
- The new function allows `void` when ALL union members are either:
  - Thenable (Promise-like), OR
  - "Nothing" types (void, undefined, null)
- Preserves existing `isThenable()` unchanged to avoid impacting other rules (S4822, S7059)

### Changes
- `packages/jsts/src/rules/helpers/type.ts` - Added `isThenableOrVoidUnion()` function
- `packages/jsts/src/rules/S3735/rule.ts` - Updated to use new helper
- `packages/jsts/src/rules/S3735/unit.test.ts` - Added comprehensive test cases

## Test plan

- [x] Added test cases for valid patterns (union types with Promise and void/undefined/null)
- [x] Added test cases for invalid patterns (unions with meaningful values like string/boolean)
- [x] All S3735 unit tests pass
- [x] Verified original false positive examples from the issue report

### Test coverage added:
**Valid (no false positives):**
- `void | Promise<void>` function returns
- Optional chaining: `maybeObject?.asyncMethod()`
- `Promise<void> | undefined/null`

**Invalid (correctly raises issues):**
- `string | Promise<void>` - meaningful value shouldn't be discarded
- `boolean | Promise<void>` - from logical expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[JS-1135]: https://sonarsource.atlassian.net/browse/JS-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ