### PR TITLE
JS-1136 Fix SonarCloud quality gate code smells

### DIFF
--- a/.github/workflows/LabelEslintPlugin.yml
+++ b/.github/workflows/LabelEslintPlugin.yml
@@ -44,10 +44,11 @@ jobs:
       - name: Add eslint-plugin label
         if: steps.extract-jira-key.outputs.has_jira_key == 'true'
         env:
-          JIRA_USER: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
-          JIRA_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          VAULT_OUTPUT: ${{ steps.secrets.outputs.vault }}
           JIRA_KEY: ${{ steps.extract-jira-key.outputs.jira_key }}
         run: |
+          JIRA_USER=$(echo "$VAULT_OUTPUT" | jq -r '.JIRA_USER')
+          JIRA_TOKEN=$(echo "$VAULT_OUTPUT" | jq -r '.JIRA_TOKEN')
           # Use Jira REST API to add label
           curl -s -X PUT \
             -H "Content-Type: application/json" \

--- a/packages/jsts/src/rules/S100/rule.ts
+++ b/packages/jsts/src/rules/S100/rule.ts
@@ -116,10 +116,7 @@ export const rule: Rule.RuleModule = {
         for (let i = ancestors.length - 1; i >= 0; i--) {
           if (functionLike.has(ancestors[i].type)) {
             const enclosingFunction = ancestors[i];
-            if (
-              knowledge?.func === enclosingFunction &&
-              (node.argument as any)?.type?.startsWith('JSX')
-            ) {
+            if (knowledge?.func === enclosingFunction && node.argument?.type.startsWith('JSX')) {
               knowledge.returnsJSX = true;
             }
             return;

--- a/packages/jsts/src/rules/S4721/rule.ts
+++ b/packages/jsts/src/rules/S4721/rule.ts
@@ -57,8 +57,8 @@ function checkOSCommand(context: Rule.RuleContext, call: estree.CallExpression) 
   const fqnParts = fqn.split('.');
   const module = fqnParts[0];
   // JS-638: Use the last part of the FQN as the method (the actual method being called).
-  const method = fqnParts[fqnParts.length - 1];
-  if (module === CHILD_PROCESS_MODULE && isQuestionable(method, args)) {
+  const method = fqnParts.at(-1);
+  if (method && module === CHILD_PROCESS_MODULE && isQuestionable(method, args)) {
     context.report({
       node: callee,
       messageId: 'safeOSCommand',


### PR DESCRIPTION
## Summary
- S4721: Use `.at(-1)` instead of `[length - 1]` for array access
- S100: Remove unnecessary `any` cast, use proper optional chaining
- LabelEslintPlugin.yml: Fix workflow failure when PR has no Jira key in title

### LabelEslintPlugin workflow fix
The `fromJSON()` in the `env` block was being evaluated **before** the `if` condition was checked. When there's no Jira key, the secrets step is skipped, leaving `steps.secrets.outputs.vault` empty, causing `fromJSON()` to fail on the empty string.

Fix: Move JSON parsing from `env` block into `run` block using `jq`.

## Test plan
- [x] S4721 unit tests pass
- [x] S100 unit tests pass
- [x] Project compiles without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)