### PR TITLE
JS-1144 Document custom rules APIs and add inline comments to JsTsChecks

### DIFF
--- a/docs/SONARQUBE_VERSION_MATRIX.md
+++ b/docs/SONARQUBE_VERSION_MATRIX.md
@@ -6,127 +6,169 @@ This document maps SonarQube versions to their bundled SonarJS plugin versions.
 
 ### Source
 
-The SonarJS version is defined in SonarQube's `build.gradle` file:
+The SonarJS version is defined in SonarQube's `build.gradle` file.
 
-- Repository: https://github.com/SonarSource/sonarqube
-- File: `build.gradle` (look for `sonar-javascript-plugin`)
+**Two different repositories/products:**
+
+| Product                     | Repository                               | Tag Format           | Example               |
+| --------------------------- | ---------------------------------------- | -------------------- | --------------------- |
+| Community Edition           | `SonarSource/sonarqube` (public)         | `YY.R.P.BUILD`       | `25.9.0.112764`       |
+| Server/Developer/Enterprise | `SonarSource/sonar-enterprise` (private) | `sqs-YYYY.R.P.BUILD` | `sqs-2025.4.4.119049` |
 
 ### Getting Tags
 
 ```bash
-# List all version tags (sorted)
+# Community Edition tags
 gh api repos/SonarSource/sonarqube/tags --paginate --jq '.[].name' | grep -E "^[0-9]" | sort -V
 
-# Tag naming conventions:
-# - Community Edition: numeric versions like 25.9.0.112764
-# - All editions use the same public repo tags
+# Enterprise tags (requires access)
+gh api repos/SonarSource/sonar-enterprise/tags --paginate --jq '.[].name' | grep "^sqs-" | sort -V
 ```
 
 ### Getting SonarJS Version for a Tag
 
 ```bash
-# Single version
+# Community Edition (public repo, can use curl)
 curl -s "https://raw.githubusercontent.com/SonarSource/sonarqube/<TAG>/build.gradle" | grep "sonar-javascript-plugin"
 
-# Batch lookup
+# Community Edition batch lookup
 for tag in 25.12.0.117093 25.11.0.114957; do
   echo -n "$tag: "
   curl -s "https://raw.githubusercontent.com/SonarSource/sonarqube/$tag/build.gradle" | grep "sonar-javascript-plugin" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
+done
+
+# Server/Enterprise (private repo, requires gh CLI with access)
+gh api repos/SonarSource/sonar-enterprise/contents/build.gradle?ref=<TAG> --jq '.content' | base64 -d | grep "sonar-javascript-plugin"
+
+# Server/Enterprise batch lookup
+for tag in sqs-2025.6.1.117629 sqs-2025.5.0.113872; do
+  echo -n "$tag: "
+  gh api repos/SonarSource/sonar-enterprise/contents/build.gradle?ref=$tag --jq '.content' | base64 -d | grep "sonar-javascript-plugin" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
 done
 ```
 
 ## Version Matrix
 
-> **Last updated**: 2026-01-22
+> **Last updated**: 2026-01-26
 
-### SonarQube 26.x (Current)
+### SonarQube Community Edition (from `sonarqube` repo)
 
-| SonarQube Version | SonarJS Version | Notable Changes |
-| ----------------- | --------------- | --------------- |
-| 26.1.0            | 11.7.1.36988    |                 |
+These versions are from the public `SonarSource/sonarqube` repository.
 
-### SonarQube 25.x
+#### Community 26.x
 
-| SonarQube Version | SonarJS Version   | Notable Changes                   |
-| ----------------- | ----------------- | --------------------------------- |
-| 25.12.0           | 11.7.1.36988      |                                   |
-| 25.11.0           | 11.5.0.35357      |                                   |
-| 25.10.0           | 11.4.1.34873      |                                   |
-| 25.9.0            | 11.3.0.34350      | **First SonarJS 11.x**            |
-| 25.8.0            | 10.25.0.33900     |                                   |
-| 25.7.0            | 10.23.0.32711     |                                   |
-| 25.6.0            | 10.23.0.32711     | **First with `EslintHook` API**   |
-| 25.5.0            | 10.22.0.32148     | `languages()` deprecated          |
-| **25.4.0 (LTA)**  | **10.21.1.30825** | **LTA version** - no `EslintHook` |
-| 25.3.0            | 10.20.x           |                                   |
-| 25.2.0            | 10.19.x           |                                   |
-| 25.1.0            | 10.18.x           |                                   |
+| Version | Tag             | SonarJS Version | Notable Changes |
+| ------- | --------------- | --------------- | --------------- |
+| 26.1.0  | `26.1.0.118079` | 11.7.1.36988    |                 |
 
-### SonarQube 24.x
+#### Community 25.x
 
-| SonarQube Version | SonarJS Version | Notable Changes |
-| ----------------- | --------------- | --------------- |
-| 24.12.0           | 10.18.0.28572   |                 |
+| Version | Tag              | SonarJS Version | Notable Changes                 |
+| ------- | ---------------- | --------------- | ------------------------------- |
+| 25.12.0 | `25.12.0.117093` | 11.7.1.36988    |                                 |
+| 25.11.0 | `25.11.0.114957` | 11.5.0.35357    |                                 |
+| 25.10.0 | `25.10.0.114319` | 11.4.1.34873    |                                 |
+| 25.9.0  | `25.9.0.112764`  | 11.3.0.34350    | **First SonarJS 11.x**          |
+| 25.8.0  | `25.8.0.112029`  | 10.25.0.33900   |                                 |
+| 25.7.0  | `25.7.0.110598`  | 10.23.0.32711   |                                 |
+| 25.6.0  | `25.6.0.109173`  | 10.23.0.32711   | **First with `EslintHook` API** |
+| 25.5.0  | `25.5.0.107428`  | 10.22.0.32148   | `languages()` deprecated        |
+| 25.4.0  | `25.4.0.105899`  | 10.21.1.30825   | No `EslintHook`                 |
+| 25.3.0  | `25.3.0.104237`  | 10.20.x         |                                 |
+| 25.2.0  | `25.2.0.102705`  | 10.19.x         |                                 |
+| 25.1.0  | `25.1.0.102122`  | 10.20.0.29356   |                                 |
 
-### SonarQube 10.x
+#### Community 24.x
 
-| SonarQube Version | SonarJS Version | Notable Changes |
-| ----------------- | --------------- | --------------- |
-| 10.7.0            | 10.16.0.27621   |                 |
-| 10.6.0            | 10.14.0.26080   |                 |
-| 10.5.1            | 10.13.2.25981   |                 |
-| 10.4.1            | 10.11.1.25225   |                 |
-| 10.3.0            | 10.9.0.24449    |                 |
-| 10.2.1            | 10.5.1.22382    |                 |
-| 10.1.0            | 10.3.1.21905    |                 |
-| 10.0.0            | 10.1.0.21143    |                 |
+| Version | Tag              | SonarJS Version | Notable Changes |
+| ------- | ---------------- | --------------- | --------------- |
+| 24.12.0 | `24.12.0.100206` | 10.18.0.28572   |                 |
 
-### SonarQube 9.9.x (Previous LTA)
+#### Community 10.x
 
-| SonarQube Version | SonarJS Version  | Notable Changes                                      |
-| ----------------- | ---------------- | ---------------------------------------------------- |
-| **9.9.8 (LTA)**   | **9.13.0.20537** | **Previous LTA** - API in `javascript-checks` module |
-| 9.9.6             | 9.13.0.20537     |                                                      |
+| Version | Tag            | SonarJS Version | Notable Changes |
+| ------- | -------------- | --------------- | --------------- |
+| 10.7.0  | `10.7.0.96327` | 10.16.0.27621   |                 |
+| 10.6.0  | `10.6.0.92116` | 10.14.0.26080   |                 |
+| 10.5.1  | `10.5.1.90531` | 10.13.2.25981   |                 |
+| 10.4.1  | `10.4.1.88267` | 10.11.1.25225   |                 |
+| 10.3.0  | `10.3.0.82913` | 10.9.0.24449    |                 |
+| 10.2.1  | `10.2.1.78527` | 10.5.1.22382    |                 |
+| 10.1.0  | `10.1.0.73491` | 10.3.1.21905    |                 |
+| 10.0.0  | `10.0.0.68432` | 10.1.0.21143    |                 |
+
+#### Community 9.9.x
+
+| Version | Tag            | SonarJS Version | Notable Changes                   |
+| ------- | -------------- | --------------- | --------------------------------- |
+| 9.9.8   | `9.9.8.100196` | 9.13.0.20537    | API in `javascript-checks` module |
+| 9.9.6   | `9.9.6.92038`  | 9.13.0.20537    |                                   |
+
+### SonarQube Server/Developer/Enterprise (from `sonar-enterprise` repo)
+
+These versions are from the private `SonarSource/sonar-enterprise` repository.
+
+#### Server 2025.x
+
+| Version  | Tag                   | SonarJS Version | Notable Changes             |
+| -------- | --------------------- | --------------- | --------------------------- |
+| 2025.6.1 | `sqs-2025.6.1.117629` | 11.7.1.36988    |                             |
+| 2025.6.0 | `sqs-2025.6.0.117042` | 11.7.1.36988    |                             |
+| 2025.5.0 | `sqs-2025.5.0.113872` | 11.4.0.34681    |                             |
+| 2025.4.4 | `sqs-2025.4.4.119049` | 10.26.0.35551   |                             |
+| 2025.4.3 | `sqs-2025.4.3.113915` | 10.25.0.33900   |                             |
+| 2025.4.2 | `sqs-2025.4.2.112048` | 10.25.0.33900   |                             |
+| 2025.4.1 | `sqs-2025.4.1.111832` | 10.25.0.33900   |                             |
+| 2025.4.0 | `sqs-2025.4.0.111749` | 10.25.0.33900   | **First with `EslintHook`** |
+| 2025.3.1 | `sqs-2025.3.1.109879` | 10.23.0.32711   |                             |
+| 2025.3.0 | `sqs-2025.3.0.108892` | 10.23.0.32711   |                             |
+| 2025.2.0 | `sqs-2025.2.0.105476` | 10.21.1.30825   | No `EslintHook`             |
+| 2025.1.5 | `sqs-2025.1.5.119025` | 10.21.2.35552   |                             |
+| 2025.1.4 | `sqs-2025.1.4.113907` | 10.21.1.30825   |                             |
+| 2025.1.3 | `sqs-2025.1.3.110580` | 10.21.1.30825   |                             |
+| 2025.1.2 | `sqs-2025.1.2.108896` | 10.21.1.30825   |                             |
+| 2025.1.1 | `sqs-2025.1.1.104738` | 10.21.1.30825   |                             |
+| 2025.1.0 | `sqs-2025.1.0.102418` | 10.20.0.29356   |                             |
+
+#### Server 10.8.x
+
+| Version | Tag                 | SonarJS Version | Notable Changes |
+| ------- | ------------------- | --------------- | --------------- |
+| 10.8.1  | `sqs-10.8.1.101195` | 10.18.0.28572   |                 |
+| 10.8.0  | `sqs-10.8.0.100206` | 10.18.0.28572   |                 |
 
 ## SonarJS API Milestones
 
-| SonarJS Version | Change                                                | Impact                                               |
-| --------------- | ----------------------------------------------------- | ---------------------------------------------------- |
-| 9.x             | API classes in `javascript-checks` module             | Dependency: `javascript-checks` artifact             |
-| 10.x            | API moved to `sonar-plugin/api` module                | Dependency: `sonar-javascript-plugin:api` classifier |
-| 10.22.0         | `CustomRuleRepository.languages()` deprecated         | Use `compatibleLanguages()` instead                  |
-| **10.23.0**     | **`EslintHook` and `EslintHookRegistrar` introduced** | New API for hooks                                    |
-| 10.23.0+        | `languages()` method removed                          | Breaking change for old plugins                      |
-| 11.6.0          | `EslintBasedCheck`, `JavaScriptCheck` deprecated      | Use `EslintHook` instead                             |
-
-## LTA (Long Term Active) Versions
-
-| LTA Version      | SonarJS Version | Support Status |
-| ---------------- | --------------- | -------------- |
-| SonarQube 25.4.0 | 10.21.1.30825   | Current LTA    |
-| SonarQube 9.9.x  | 9.13.0.20537    | Previous LTA   |
+| SonarJS Version | Change                                                | Impact                                   |
+| --------------- | ----------------------------------------------------- | ---------------------------------------- |
+| 9.x             | API classes in `javascript-checks` module             | Dependency: `javascript-checks` artifact |
+| 10.15.0+        | API moved to `sonar-plugin/api` module                | Dependency: `api` artifact               |
+| 10.22.0         | `CustomRuleRepository.languages()` deprecated         | Use `compatibleLanguages()` instead      |
+| **10.23.0**     | **`EslintHook` and `EslintHookRegistrar` introduced** | New API for hooks                        |
+| 10.23.0+        | `languages()` method removed                          | Breaking change for old plugins          |
+| 11.6.0          | `EslintBasedCheck`, `JavaScriptCheck` deprecated      | Use `EslintHook` instead                 |
 
 ## Compatibility Notes for Plugin Developers
 
-### Minimum SonarQube Version for Features
+### Minimum SonarJS Version for Features
 
-| Feature                 | Minimum SonarJS | Minimum SonarQube |
-| ----------------------- | --------------- | ----------------- |
-| `EslintHook` API        | 10.23.0         | 25.6.0            |
-| `EslintHookRegistrar`   | 10.23.0         | 25.6.0            |
-| `compatibleLanguages()` | 10.22.0         | 25.5.0            |
-| Separate API module     | ~10.x           | ~10.x             |
+| Feature                 | Minimum SonarJS |
+| ----------------------- | --------------- |
+| `EslintHook` API        | 10.23.0         |
+| `EslintHookRegistrar`   | 10.23.0         |
+| `compatibleLanguages()` | 10.22.0         |
+| Separate API module     | 10.15.0         |
 
 ### Breaking Changes Timeline
 
-1. **SonarQube 25.5.0+** (SonarJS 10.22+): `languages()` deprecated
-2. **SonarQube 25.6.0+** (SonarJS 10.23+): `languages()` removed, `EslintHook` available
-3. **SonarQube 25.9.0+** (SonarJS 11.x): `EslintBasedCheck`/`JavaScriptCheck` deprecated
+1. **SonarJS 10.22+**: `languages()` deprecated
+2. **SonarJS 10.23+**: `languages()` removed, `EslintHook` available
+3. **SonarJS 11.6+**: `EslintBasedCheck`/`JavaScriptCheck` deprecated, `JsTsChecks` uses `checkFactory.<EslintHook>`
 
 ### Plugin Compatibility Matrix
 
-| Plugin compiled against           | Works with SQ 25.4 LTA? | Works with SQ 25.9+?                |
-| --------------------------------- | ----------------------- | ----------------------------------- |
-| SonarJS 9.x (`javascript-checks`) | ❌ ClassLoader issues   | ❌ ClassCastException               |
-| SonarJS 10.21.x                   | ✅ Yes                  | ⚠️ Maybe (if using deprecated APIs) |
-| SonarJS 10.23.x+ (`api` module)   | ❌ No `EslintHook`      | ✅ Yes                              |
+| Plugin compiled against           | Implements         | SonarJS 10.23-11.5                        | SonarJS 11.6+         |
+| --------------------------------- | ------------------ | ----------------------------------------- | --------------------- |
+| SonarJS 9.x (`javascript-checks`) | `EslintBasedCheck` | ❌ ClassCastException                     | ❌ ClassCastException |
+| SonarJS 10.23+ (`api` module)     | `EslintBasedCheck` | ✅                                        | ✅ (deprecated)       |
+| SonarJS 10.23+ (`api` module)     | `EslintHook` only  | ❌ CheckFactory expects `JavaScriptCheck` | ✅                    |

--- a/docs/SONARQUBE_VERSION_MATRIX.md
+++ b/docs/SONARQUBE_VERSION_MATRIX.md
@@ -1,0 +1,132 @@
+# SonarQube ↔ SonarJS Version Matrix
+
+This document maps SonarQube versions to their bundled SonarJS plugin versions.
+
+## How to Update This Document
+
+### Source
+
+The SonarJS version is defined in SonarQube's `build.gradle` file:
+
+- Repository: https://github.com/SonarSource/sonarqube
+- File: `build.gradle` (look for `sonar-javascript-plugin`)
+
+### Getting Tags
+
+```bash
+# List all version tags (sorted)
+gh api repos/SonarSource/sonarqube/tags --paginate --jq '.[].name' | grep -E "^[0-9]" | sort -V
+
+# Tag naming conventions:
+# - Community Edition: numeric versions like 25.9.0.112764
+# - All editions use the same public repo tags
+```
+
+### Getting SonarJS Version for a Tag
+
+```bash
+# Single version
+curl -s "https://raw.githubusercontent.com/SonarSource/sonarqube/<TAG>/build.gradle" | grep "sonar-javascript-plugin"
+
+# Batch lookup
+for tag in 25.12.0.117093 25.11.0.114957; do
+  echo -n "$tag: "
+  curl -s "https://raw.githubusercontent.com/SonarSource/sonarqube/$tag/build.gradle" | grep "sonar-javascript-plugin" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
+done
+```
+
+## Version Matrix
+
+> **Last updated**: 2026-01-22
+
+### SonarQube 26.x (Current)
+
+| SonarQube Version | SonarJS Version | Notable Changes |
+| ----------------- | --------------- | --------------- |
+| 26.1.0            | 11.7.1.36988    |                 |
+
+### SonarQube 25.x
+
+| SonarQube Version | SonarJS Version   | Notable Changes                   |
+| ----------------- | ----------------- | --------------------------------- |
+| 25.12.0           | 11.7.1.36988      |                                   |
+| 25.11.0           | 11.5.0.35357      |                                   |
+| 25.10.0           | 11.4.1.34873      |                                   |
+| 25.9.0            | 11.3.0.34350      | **First SonarJS 11.x**            |
+| 25.8.0            | 10.25.0.33900     |                                   |
+| 25.7.0            | 10.23.0.32711     |                                   |
+| 25.6.0            | 10.23.0.32711     | **First with `EslintHook` API**   |
+| 25.5.0            | 10.22.0.32148     | `languages()` deprecated          |
+| **25.4.0 (LTA)**  | **10.21.1.30825** | **LTA version** - no `EslintHook` |
+| 25.3.0            | 10.20.x           |                                   |
+| 25.2.0            | 10.19.x           |                                   |
+| 25.1.0            | 10.18.x           |                                   |
+
+### SonarQube 24.x
+
+| SonarQube Version | SonarJS Version | Notable Changes |
+| ----------------- | --------------- | --------------- |
+| 24.12.0           | 10.18.0.28572   |                 |
+
+### SonarQube 10.x
+
+| SonarQube Version | SonarJS Version | Notable Changes |
+| ----------------- | --------------- | --------------- |
+| 10.7.0            | 10.16.0.27621   |                 |
+| 10.6.0            | 10.14.0.26080   |                 |
+| 10.5.1            | 10.13.2.25981   |                 |
+| 10.4.1            | 10.11.1.25225   |                 |
+| 10.3.0            | 10.9.0.24449    |                 |
+| 10.2.1            | 10.5.1.22382    |                 |
+| 10.1.0            | 10.3.1.21905    |                 |
+| 10.0.0            | 10.1.0.21143    |                 |
+
+### SonarQube 9.9.x (Previous LTA)
+
+| SonarQube Version | SonarJS Version  | Notable Changes                                      |
+| ----------------- | ---------------- | ---------------------------------------------------- |
+| **9.9.8 (LTA)**   | **9.13.0.20537** | **Previous LTA** - API in `javascript-checks` module |
+| 9.9.6             | 9.13.0.20537     |                                                      |
+
+## SonarJS API Milestones
+
+| SonarJS Version | Change                                                | Impact                                               |
+| --------------- | ----------------------------------------------------- | ---------------------------------------------------- |
+| 9.x             | API classes in `javascript-checks` module             | Dependency: `javascript-checks` artifact             |
+| 10.x            | API moved to `sonar-plugin/api` module                | Dependency: `sonar-javascript-plugin:api` classifier |
+| 10.22.0         | `CustomRuleRepository.languages()` deprecated         | Use `compatibleLanguages()` instead                  |
+| **10.23.0**     | **`EslintHook` and `EslintHookRegistrar` introduced** | New API for hooks                                    |
+| 10.23.0+        | `languages()` method removed                          | Breaking change for old plugins                      |
+| 11.6.0          | `EslintBasedCheck`, `JavaScriptCheck` deprecated      | Use `EslintHook` instead                             |
+
+## LTA (Long Term Active) Versions
+
+| LTA Version      | SonarJS Version | Support Status |
+| ---------------- | --------------- | -------------- |
+| SonarQube 25.4.0 | 10.21.1.30825   | Current LTA    |
+| SonarQube 9.9.x  | 9.13.0.20537    | Previous LTA   |
+
+## Compatibility Notes for Plugin Developers
+
+### Minimum SonarQube Version for Features
+
+| Feature                 | Minimum SonarJS | Minimum SonarQube |
+| ----------------------- | --------------- | ----------------- |
+| `EslintHook` API        | 10.23.0         | 25.6.0            |
+| `EslintHookRegistrar`   | 10.23.0         | 25.6.0            |
+| `compatibleLanguages()` | 10.22.0         | 25.5.0            |
+| Separate API module     | ~10.x           | ~10.x             |
+
+### Breaking Changes Timeline
+
+1. **SonarQube 25.5.0+** (SonarJS 10.22+): `languages()` deprecated
+2. **SonarQube 25.6.0+** (SonarJS 10.23+): `languages()` removed, `EslintHook` available
+3. **SonarQube 25.9.0+** (SonarJS 11.x): `EslintBasedCheck`/`JavaScriptCheck` deprecated
+
+### Plugin Compatibility Matrix
+
+| Plugin compiled against           | Works with SQ 25.4 LTA? | Works with SQ 25.9+?                |
+| --------------------------------- | ----------------------- | ----------------------------------- |
+| SonarJS 9.x (`javascript-checks`) | ❌ ClassLoader issues   | ❌ ClassCastException               |
+| SonarJS 10.21.x                   | ✅ Yes                  | ⚠️ Maybe (if using deprecated APIs) |
+| SonarJS 10.23.x+ (`api` module)   | ❌ No `EslintHook`      | ✅ Yes                              |

--- a/docs/custom-rules/CUSTOM_RULES_API_CHANGELOG.md
+++ b/docs/custom-rules/CUSTOM_RULES_API_CHANGELOG.md
@@ -1,0 +1,280 @@
+# SonarJS Custom Rules API Changelog
+
+This document tracks all changes to the SonarJS Custom Rules API that may impact external plugin developers.
+
+## How to Update This Document
+
+### Finding API Changes
+
+```bash
+# Find history of a specific API file
+git log --oneline --all -- "**/api/**/FileName.java"
+
+# Find which version introduced a commit
+git tag --contains <commit-hash> | head -3
+
+# Find which version does NOT have a commit (last version before change)
+git tag --no-contains <commit-hash> | tail -3
+
+# View commit details
+git show <commit-hash> --stat
+```
+
+### Key API Files to Track
+
+- `sonar-plugin/api/src/main/java/org/sonar/plugins/javascript/api/`
+  - `EslintHook.java` - New hook interface (10.23.0+)
+  - `EslintHookRegistrar.java` - Hook registration (10.23.0+)
+  - `EslintBasedCheck.java` - Check interface (deprecated 11.6.0)
+  - `JavaScriptCheck.java` - Marker interface (deprecated 11.6.0)
+  - `CustomRuleRepository.java` - Rule repository interface
+  - `RulesBundle.java` - JS bundle interface
+  - `Language.java` - Language enum (10.22.0+)
+
+## API Changes Timeline
+
+### Legend
+
+| Symbol | Meaning          |
+| ------ | ---------------- |
+| ✅     | Added/Introduced |
+| ⚠️     | Deprecated       |
+| ❌     | Removed          |
+| 🔄     | Changed/Modified |
+
+---
+
+### SonarJS 11.6.0 (November 2025)
+
+| Change                                 | Details                                                            | Commit        |
+| -------------------------------------- | ------------------------------------------------------------------ | ------------- |
+| ⚠️ `EslintBasedCheck` deprecated       | Use `EslintHook` instead                                           | `9324ae345fc` |
+| ⚠️ `JavaScriptCheck` deprecated        | Use `EslintHook` instead                                           | `9324ae345fc` |
+| ⚠️ `TypeScriptCheck` deprecated        | Use `EslintHook` instead                                           | `9324ae345fc` |
+| ⚠️ `TestFileCheck` deprecated          | Use `EslintHook` instead                                           | `9324ae345fc` |
+| 🔄 `JsTsChecks` uses `EslintHook` type | `checkFactory.<EslintHook>create()` instead of `<JavaScriptCheck>` | `9324ae345fc` |
+
+**Migration**: Replace `implements EslintBasedCheck` with `implements EslintHook`.
+
+**Impact**: Plugins must implement `EslintHook` (directly or via `EslintBasedCheck`) for the CheckFactory cast to succeed.
+
+---
+
+### SonarJS 11.1.0 (July 2025)
+
+| Change                                          | Details                                                 | Commit        |
+| ----------------------------------------------- | ------------------------------------------------------- | ------------- |
+| ❌ `CustomRuleRepository.languages()` removed   | Method and inner `Language` enum removed                | `0218b04b5ca` |
+| ❌ `CustomRuleRepository.Language` enum removed | Use `org.sonar.plugins.javascript.api.Language` instead | `0218b04b5ca` |
+
+**Breaking Change**: Plugins using `languages()` will fail at runtime.
+
+**Migration**:
+
+```java
+// OLD (broken)
+@Override
+public Set<CustomRuleRepository.Language> languages() {
+  return EnumSet.of(Language.JAVASCRIPT);
+}
+
+// NEW
+@Override
+public Set<org.sonar.plugins.javascript.api.Language> compatibleLanguages() {
+  return EnumSet.of(org.sonar.plugins.javascript.api.Language.JAVASCRIPT);
+}
+```
+
+---
+
+### SonarJS 10.23.0 (April 2025)
+
+| Change                                         | Details                                                | Commit        |
+| ---------------------------------------------- | ------------------------------------------------------ | ------------- |
+| ✅ `EslintHook` interface added                | New base interface for all checks/hooks                | `83ef267372c` |
+| ✅ `EslintHookRegistrar` interface added       | For registering hooks without `@Rule` annotation       | `83ef267372c` |
+| 🔄 `EslintBasedCheck` now extends `EslintHook` | `EslintBasedCheck extends EslintHook, JavaScriptCheck` | `83ef267372c` |
+
+**Note**: `JsTsChecks` still uses `checkFactory.<JavaScriptCheck>` in this version. The change to `<EslintHook>` happened in 11.6.0.
+
+**New Features in `EslintHook`**:
+
+- `analysisModes()` - Control when hook runs (DEFAULT, SKIP_UNCHANGED)
+- `blacklistedExtensions()` - Skip certain file extensions
+- `isEnabled()` - Dynamically enable/disable hook
+
+---
+
+### SonarJS 10.22.0 (March 2025)
+
+| Change                                  | Details                                     | Commit        |
+| --------------------------------------- | ------------------------------------------- | ------------- |
+| ✅ `Language` enum added (standalone)   | `org.sonar.plugins.javascript.api.Language` | `2f9168ca008` |
+| ✅ `compatibleLanguages()` method added | New method in `CustomRuleRepository`        | `2f9168ca008` |
+| ⚠️ `languages()` method deprecated      | Use `compatibleLanguages()` instead         | `2f9168ca008` |
+| 🔄 `CustomRuleRepository` undeprecated  | Interface itself is no longer deprecated    | `2f9168ca008` |
+
+**Migration**: Start using `compatibleLanguages()` to prepare for 11.x.
+
+---
+
+### SonarJS 10.15.0 (May 2024)
+
+| Change                          | Details                           | Commit        |
+| ------------------------------- | --------------------------------- | ------------- |
+| 🔄 API moved to separate module | `sonar-plugin/api` module created | `968bed25aeb` |
+
+**Impact**: Dependency artifact changed.
+
+```xml
+<!-- OLD (before 10.15) -->
+<dependency>
+  <groupId>org.sonarsource.javascript</groupId>
+  <artifactId>javascript-checks</artifactId>
+</dependency>
+
+<!-- NEW (10.15+) -->
+<dependency>
+  <groupId>org.sonarsource.javascript</groupId>
+  <artifactId>sonar-javascript-plugin</artifactId>
+  <classifier>api</classifier>
+  <scope>provided</scope>
+</dependency>
+```
+
+---
+
+### SonarJS 6.x (September 2020)
+
+| Change                           | Details                                  | Commit        |
+| -------------------------------- | ---------------------------------------- | ------------- |
+| ✅ `RulesBundle` interface added | For providing custom ESLint rule bundles | `18a8b1e9481` |
+
+---
+
+### SonarJS 6.x (September 2019)
+
+| Change                               | Details                     | Commit        |
+| ------------------------------------ | --------------------------- | ------------- |
+| ⚠️ `CustomRuleRepository` deprecated | Entire interface deprecated | `175e1fef5e7` |
+
+**Note**: This deprecation was later reversed in 10.22.0.
+
+---
+
+### SonarJS 5.0.0 (September 2018)
+
+| Change                                | Details                | Commit        |
+| ------------------------------------- | ---------------------- | ------------- |
+| ✅ `EslintBasedCheck` interface added | For ESLint-based rules | `123780d706d` |
+
+---
+
+### SonarJS 5.0.0 (July 2018)
+
+| Change                                    | Details                                    | Commit        |
+| ----------------------------------------- | ------------------------------------------ | ------------- |
+| ✅ `CustomRuleRepository` interface added | Replaced `CustomJavaScriptRulesDefinition` | `5be9a033e66` |
+
+---
+
+### SonarJS 2.x (March 2015)
+
+| Change                               | Details                              | Commit        |
+| ------------------------------------ | ------------------------------------ | ------------- |
+| ✅ `JavaScriptCheck` interface added | Base marker interface for all checks | `64437c38b04` |
+
+---
+
+## Interface Hierarchy Evolution
+
+### Before 10.23.0
+
+```
+JavaScriptCheck (marker interface)
+    └── EslintBasedCheck
+            └── Your custom check
+```
+
+### 10.23.0 - 11.5.x
+
+```
+EslintHook (new base interface)
+    │
+    └── EslintBasedCheck (extends EslintHook, JavaScriptCheck)
+            └── Your custom check (either interface works)
+
+JavaScriptCheck (marker, still functional)
+```
+
+### 11.6.0+ (Current)
+
+```
+EslintHook (recommended)
+    └── Your custom check
+
+EslintBasedCheck (deprecated, extends EslintHook)
+    └── Legacy custom checks (still works)
+
+JavaScriptCheck (deprecated, marker only)
+```
+
+---
+
+## Compatibility Matrix
+
+| Compiled Against                      | SQ 9.9 LTA | SQ 25.4 LTA      | SQ 25.6-25.8   | SQ 25.9+       |
+| ------------------------------------- | ---------- | ---------------- | -------------- | -------------- |
+| SonarJS 5.x-6.x (`javascript-checks`) | ✅         | ❌ ClassLoader   | ❌ ClassLoader | ❌ ClassLoader |
+| SonarJS 9.x (`javascript-checks`)     | ✅         | ❌ ClassLoader   | ❌ ClassLoader | ❌ ClassLoader |
+| SonarJS 10.15-10.21 (`api` module)    | ❌         | ✅               | ⚠️             | ⚠️             |
+| SonarJS 10.22-10.26 (`api` module)    | ❌         | ❌ No EslintHook | ✅             | ✅             |
+| SonarJS 11.x (`api` module)           | ❌         | ❌ No EslintHook | ✅             | ✅             |
+
+**Legend**: ✅ Works | ⚠️ May work with deprecated APIs | ❌ Does not work
+
+---
+
+## Minimum Version Requirements
+
+| Feature                              | Min SonarJS | Min SonarQube |
+| ------------------------------------ | ----------- | ------------- |
+| `CustomRuleRepository`               | 5.0.0       | -             |
+| `EslintBasedCheck`                   | 5.0.0       | -             |
+| `RulesBundle`                        | 6.x         | -             |
+| Separate API module                  | 10.15.0     | -             |
+| `compatibleLanguages()`              | 10.22.0     | 25.5.0        |
+| `EslintHook` / `EslintHookRegistrar` | 10.23.0     | 25.6.0        |
+| `languages()` removed                | 11.1.0      | 25.9.0        |
+| `EslintBasedCheck` deprecated        | 11.6.0      | 25.12.0       |
+
+---
+
+## Migration Guides
+
+### Migrating from SonarJS 9.x to 11.x
+
+1. **Change dependency artifact**:
+
+   ```xml
+   <artifactId>sonar-javascript-plugin</artifactId>
+   <classifier>api</classifier>
+   ```
+
+2. **Update `CustomRuleRepository`**:
+   - Replace `languages()` with `compatibleLanguages()`
+   - Use `org.sonar.plugins.javascript.api.Language` enum
+
+3. **Update check classes** (recommended):
+   - Replace `implements EslintBasedCheck` with `implements EslintHook`
+   - Or keep `EslintBasedCheck` (deprecated but functional)
+
+4. **Recompile** against the new API version
+
+### Supporting Multiple SonarQube Versions
+
+Due to classloader isolation, you **cannot** support both SonarQube 9.9 LTA and 25.x with a single JAR. Options:
+
+1. **Separate releases**: Maintain different plugin versions for different SQ versions
+2. **Drop old LTA support**: Only support SonarQube 25.4+ (current LTA)
+3. **Minimum 25.6+**: If using `EslintHook` API, require SonarQube 25.6+

--- a/docs/custom-rules/CUSTOM_RULES_LEGACY.md
+++ b/docs/custom-rules/CUSTOM_RULES_LEGACY.md
@@ -1,6 +1,6 @@
 # Custom Rules API (Legacy)
 
-> **Deprecated since 11.6** - This API is deprecated and marked for removal. Use the [ESLint Hooks API](ESLINT_HOOKS.md) instead for new integrations.
+> **Deprecated since 11.6** - This API uses deprecated interfaces (`EslintBasedCheck`, `JavaScriptCheck`). Use the [EslintHook API](ESLINT_HOOKS.md) instead, which provides the same functionality with the modern `EslintHook` interface.
 
 This document describes the legacy approach for creating custom rules that integrate with SonarJS analysis.
 
@@ -400,14 +400,15 @@ See the integration test plugin in SonarJS for a complete working example:
 | `Check`            | Deprecated | `EslintHook`                         |
 | `TestFileCheck`    | Deprecated | `EslintHook` with custom `targets()` |
 
-## Migration to ESLint Hooks
+## Migration to EslintHook API
 
-To migrate from this API to ESLint Hooks:
+To migrate from this API to the modern EslintHook API:
 
-1. Replace `EslintBasedCheck` implementations with `EslintHook`
-2. Replace `CustomRuleRepository` with `EslintHookRegistrar`
-3. Remove `@Rule` annotations (hooks don't raise issues directly)
-4. Use `register()` to register for multiple languages in one class
+1. Replace `implements EslintBasedCheck` with `implements EslintHook`
+2. Keep `CustomRuleRepository` and `@Rule` annotations (they work with `EslintHook`)
+3. Optionally use a single repository for both languages via `compatibleLanguages()`
+
+The migration is straightforward because `EslintHook` provides the same capabilities as `EslintBasedCheck`.
 
 See [ESLINT_HOOKS.md](ESLINT_HOOKS.md) for the new API documentation.
 

--- a/docs/custom-rules/CUSTOM_RULES_LEGACY.md
+++ b/docs/custom-rules/CUSTOM_RULES_LEGACY.md
@@ -378,9 +378,8 @@ public class MyCustomRulesPlugin implements Plugin {
 ```xml
 <dependency>
   <groupId>org.sonarsource.javascript</groupId>
-  <artifactId>sonar-javascript-plugin</artifactId>
+  <artifactId>api</artifactId>
   <version>11.6.0</version>
-  <classifier>api</classifier>
   <scope>provided</scope>
 </dependency>
 ```

--- a/docs/custom-rules/CUSTOM_RULES_LEGACY.md
+++ b/docs/custom-rules/CUSTOM_RULES_LEGACY.md
@@ -1,0 +1,772 @@
+# Custom Rules API (Legacy)
+
+> **Deprecated since 11.6** - This API is deprecated and marked for removal. Use the [ESLint Hooks API](ESLINT_HOOKS.md) instead for new integrations.
+
+This document describes the legacy approach for creating custom rules that integrate with SonarJS analysis.
+
+## Overview
+
+The legacy Custom Rules API allows external plugins to define rules that:
+
+- Are **associated with Sonar rule keys** via `@Rule` annotation
+- **Raise Sonar issues** during analysis
+- Are **activated through quality profiles**
+- Require **separate repositories** for JavaScript and TypeScript
+
+## When to Use
+
+This API should only be used for maintaining existing integrations. For new projects, use the [ESLint Hooks API](ESLINT_HOOKS.md).
+
+## Components
+
+A complete legacy custom rules integration requires:
+
+1. **Check Classes** - implement `EslintBasedCheck` or extend `Check`
+2. **Rule Repository** - implements `CustomRuleRepository`
+3. **Rules Bundle** - packages the ESLint-side JavaScript code
+4. **Rules Definition** - defines rule metadata for SonarQube
+5. **Plugin Class** - registers all components
+
+## Implementation Guide
+
+### 1. Create Check Classes
+
+Each rule requires a Java class with the `@Rule` annotation:
+
+```java
+package com.example.plugin.rules;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.javascript.api.Check;
+
+@Rule(key = "S1234")
+public class MyCustomCheck extends Check {
+  // The Check base class provides eslintKey() from @Rule annotation
+}
+```
+
+For rules that need custom configuration:
+
+```java
+package com.example.plugin.rules;
+
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.plugins.javascript.api.AnalysisMode;
+import org.sonar.plugins.javascript.api.EslintBasedCheck;
+import org.sonar.plugins.javascript.api.JavaScriptRule;
+import org.sonar.plugins.javascript.api.TypeScriptRule;
+
+@Rule(key = "S5678")
+@JavaScriptRule // Enable for JavaScript
+@TypeScriptRule // Enable for TypeScript
+public class MyAdvancedCheck implements EslintBasedCheck {
+
+  @Override
+  public String eslintKey() {
+    // Must match the rule name in your ESLint plugin
+    return "my-advanced-rule";
+  }
+
+  @Override
+  public List<Object> configurations() {
+    // Optional configuration passed to the ESLint rule
+    return List.of();
+  }
+
+  @Override
+  public List<AnalysisMode> analysisModes() {
+    return List.of(AnalysisMode.DEFAULT, AnalysisMode.SKIP_UNCHANGED);
+  }
+
+  @Override
+  public List<String> blacklistedExtensions() {
+    return List.of(".htm", ".html");
+  }
+}
+```
+
+For rules targeting test files only:
+
+```java
+package com.example.plugin.rules;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.javascript.api.TestFileCheck;
+
+@Rule(key = "S9999")
+public class MyTestOnlyCheck extends TestFileCheck {
+  // Automatically targets InputFile.Type.TEST
+}
+```
+
+### 2. Create an Abstract Base Class (Optional)
+
+For multiple rules sharing common configuration:
+
+```java
+package com.example.plugin.rules;
+
+import java.util.List;
+import org.sonar.plugins.javascript.api.AnalysisMode;
+import org.sonar.plugins.javascript.api.EslintBasedCheck;
+import org.sonar.plugins.javascript.api.JavaScriptRule;
+import org.sonar.plugins.javascript.api.TypeScriptRule;
+
+@JavaScriptRule
+@TypeScriptRule
+public abstract class AbstractSecurityCheck implements EslintBasedCheck {
+
+  @Override
+  public String eslintKey() {
+    return "security-analyzer"; // Shared ESLint rule
+  }
+
+  @Override
+  public List<AnalysisMode> analysisModes() {
+    return List.of(AnalysisMode.DEFAULT, AnalysisMode.SKIP_UNCHANGED);
+  }
+
+  @Override
+  public List<String> blacklistedExtensions() {
+    return List.of(".htm", ".html");
+  }
+}
+```
+
+```java
+package com.example.plugin.rules;
+
+import org.sonar.check.Rule;
+
+@Rule(key = "S3649")
+public class SQLInjectionCheck extends AbstractSecurityCheck {
+  // Inherits all configuration from AbstractSecurityCheck
+}
+
+@Rule(key = "S5131")
+public class XSSCheck extends AbstractSecurityCheck {
+  // Inherits all configuration from AbstractSecurityCheck
+}
+```
+
+### 3. Create the Rules List
+
+```java
+package com.example.plugin;
+
+import com.example.plugin.rules.*;
+import java.util.List;
+
+public class RulesList {
+
+  public static List<Class<?>> allRules() {
+    return List.of(
+      MyCustomCheck.class,
+      MyAdvancedCheck.class,
+      SQLInjectionCheck.class,
+      XSSCheck.class
+    );
+  }
+
+  public static List<Class<?>> jsRules() {
+    // Return rules applicable to JavaScript
+    return allRules();
+  }
+
+  public static List<Class<?>> tsRules() {
+    // Return rules applicable to TypeScript
+    return allRules();
+  }
+}
+```
+
+### 4. Create the Rule Repositories
+
+You need **separate repositories** for JavaScript and TypeScript:
+
+```java
+package com.example.plugin;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.sonar.plugins.javascript.api.CustomRuleRepository;
+import org.sonar.plugins.javascript.api.Language;
+
+public class JsRuleRepository implements CustomRuleRepository {
+
+  public static final String REPOSITORY_KEY = "my-js-rules";
+
+  @Override
+  public Set<Language> compatibleLanguages() {
+    return EnumSet.of(Language.JAVASCRIPT);
+  }
+
+  @Override
+  public String repositoryKey() {
+    return REPOSITORY_KEY;
+  }
+
+  @Override
+  public List<?> checkClasses() {
+    return RulesList.jsRules();
+  }
+}
+```
+
+```java
+package com.example.plugin;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.sonar.plugins.javascript.api.CustomRuleRepository;
+import org.sonar.plugins.javascript.api.Language;
+
+public class TsRuleRepository implements CustomRuleRepository {
+
+  public static final String REPOSITORY_KEY = "my-ts-rules";
+
+  @Override
+  public Set<Language> compatibleLanguages() {
+    return EnumSet.of(Language.TYPESCRIPT);
+  }
+
+  @Override
+  public String repositoryKey() {
+    return REPOSITORY_KEY;
+  }
+
+  @Override
+  public List<?> checkClasses() {
+    return RulesList.tsRules();
+  }
+}
+```
+
+### 5. Create the Rules Bundle
+
+```java
+package com.example.plugin;
+
+import org.sonar.plugins.javascript.api.RulesBundle;
+
+public class MyRulesBundle implements RulesBundle {
+
+  @Override
+  public String bundlePath() {
+    return "/my-eslint-rules-1.0.0.tgz";
+  }
+}
+```
+
+### 6. Create the Rules Definition
+
+Define rule metadata for SonarQube:
+
+```java
+package com.example.plugin;
+
+import org.sonar.api.server.rule.RulesDefinition;
+
+public class MyRulesDefinition implements RulesDefinition {
+
+  @Override
+  public void define(Context context) {
+    defineJsRules(context);
+    defineTsRules(context);
+  }
+
+  private void defineJsRules(Context context) {
+    NewRepository repository = context
+      .createRepository(JsRuleRepository.REPOSITORY_KEY, "js")
+      .setName("My JavaScript Rules");
+
+    // Define each rule
+    repository
+      .createRule("S1234")
+      .setName("My Custom Rule")
+      .setHtmlDescription("<p>Description of the rule</p>")
+      .setSeverity("MAJOR")
+      .setType(RuleType.CODE_SMELL);
+
+    repository.done();
+  }
+
+  private void defineTsRules(Context context) {
+    NewRepository repository = context
+      .createRepository(TsRuleRepository.REPOSITORY_KEY, "ts")
+      .setName("My TypeScript Rules");
+
+    // Define rules for TypeScript...
+
+    repository.done();
+  }
+}
+```
+
+### 7. Create the ESLint Plugin (JavaScript)
+
+```javascript
+// src/rules/my-custom-rule.js
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'My custom rule description',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (isViolation(node)) {
+          context.report({
+            node,
+            message: 'This is a violation',
+          });
+        }
+      },
+    };
+  },
+};
+
+function isViolation(node) {
+  // Your detection logic
+  return false;
+}
+```
+
+```javascript
+// index.js
+module.exports = {
+  rules: {
+    'my-custom-rule': require('./rules/my-custom-rule'),
+    'my-advanced-rule': require('./rules/my-advanced-rule'),
+    'security-analyzer': require('./rules/security-analyzer'),
+  },
+};
+```
+
+### 8. Create the Plugin Class
+
+```java
+package com.example.plugin;
+
+import org.sonar.api.Plugin;
+
+public class MyCustomRulesPlugin implements Plugin {
+
+  @Override
+  public void define(Context context) {
+    context.addExtensions(
+      // Rules bundle
+      MyRulesBundle.class,
+      // Rule repositories
+      JsRuleRepository.class,
+      TsRuleRepository.class,
+      // Rules definition
+      MyRulesDefinition.class
+    );
+  }
+}
+```
+
+### 9. Configure Maven Dependencies
+
+```xml
+<dependency>
+  <groupId>org.sonarsource.javascript</groupId>
+  <artifactId>sonar-javascript-plugin</artifactId>
+  <version>11.6.0</version>
+  <classifier>api</classifier>
+  <scope>provided</scope>
+</dependency>
+```
+
+## Complete Example
+
+See the integration test plugin in SonarJS for a complete working example:
+
+- `its/plugin/plugins/eslint-custom-rules-plugin-legacy/`
+
+## Deprecated Classes Reference
+
+| Class/Interface    | Status     | Replacement                          |
+| ------------------ | ---------- | ------------------------------------ |
+| `JavaScriptCheck`  | Deprecated | `EslintHook`                         |
+| `EslintBasedCheck` | Deprecated | `EslintHook`                         |
+| `Check`            | Deprecated | `EslintHook`                         |
+| `TestFileCheck`    | Deprecated | `EslintHook` with custom `targets()` |
+
+## Migration to ESLint Hooks
+
+To migrate from this API to ESLint Hooks:
+
+1. Replace `EslintBasedCheck` implementations with `EslintHook`
+2. Replace `CustomRuleRepository` with `EslintHookRegistrar`
+3. Remove `@Rule` annotations (hooks don't raise issues directly)
+4. Use `register()` to register for multiple languages in one class
+
+See [ESLINT_HOOKS.md](ESLINT_HOOKS.md) for the new API documentation.
+
+## Technical Details: How Legacy Custom Rules Are Integrated
+
+This section explains how the legacy Custom Rules API is wired into the SonarJS analysis pipeline.
+
+### 1. Discovery via SonarQube Dependency Injection
+
+The `CustomRuleRepository` interface is annotated with `@ScannerSide` and `@SonarLintSide`:
+
+```java
+@ScannerSide
+@SonarLintSide
+public interface CustomRuleRepository {
+  Set<Language> compatibleLanguages();
+  String repositoryKey();
+  List<?> checkClasses();
+}
+```
+
+When your plugin is loaded, SonarQube automatically:
+
+1. Discovers all `CustomRuleRepository` implementations
+2. Instantiates them via reflection
+3. Injects them as an array into `JsTsChecks`
+
+### 2. Processing in JsTsChecks
+
+The `JsTsChecks` class (`sonar-plugin/sonar-javascript-plugin/.../JsTsChecks.java`) receives all `CustomRuleRepository` implementations:
+
+```java
+public JsTsChecks(
+  CheckFactory checkFactory,
+  @Nullable CustomRuleRepository[] customRuleRepositories,
+  @Nullable EslintHookRegistrar[] eslintHookRegistrars
+) {
+  // ...
+  // Add built-in checks
+  doAddChecks(Language.TYPESCRIPT, CheckList.TS_REPOSITORY_KEY, CheckList.getTypeScriptChecks());
+  addCustomChecks(Language.TYPESCRIPT);  // <-- Custom rules added here
+
+  doAddChecks(Language.JAVASCRIPT, CheckList.JS_REPOSITORY_KEY, CheckList.getJavaScriptChecks());
+  addCustomChecks(Language.JAVASCRIPT);  // <-- Custom rules added here
+}
+
+private void addCustomChecks(Language language) {
+  for (CustomRuleRepository repo : customRuleRepositories) {
+    if (repo.compatibleLanguages().contains(language)) {
+      doAddChecks(language, repo.repositoryKey(), repo.checkClasses());
+    }
+  }
+}
+```
+
+### 3. CheckFactory: The Heart of Quality Profile Filtering
+
+`CheckFactory` is a **SonarQube-provided component** (`org.sonar.api.batch.rule.CheckFactory`) that bridges the gap between:
+
+- **SonarJS**: Knows what rule classes exist (compiled into the plugin)
+- **SonarQube**: Knows which rules are active (configured by users in quality profiles)
+
+When the scanner starts, SonarQube injects a `CheckFactory` instance that is **pre-loaded with the active quality profile data**.
+
+#### Input: All Rule Classes (No Filtering)
+
+`CheckList.getJavaScriptChecks()` returns **ALL** rule classes - it's a static list with no knowledge of quality profiles:
+
+```java
+// AllChecks.java (auto-generated, ~300+ rules)
+protected static final List<Class<? extends EslintHook>> rules = Arrays.asList(
+  S100.class,
+  S101.class,
+  S103.class,
+  // ... 300+ rule classes
+);
+```
+
+#### CheckFactory Filters by Quality Profile
+
+The `doAddChecks()` method uses `CheckFactory` to filter and instantiate only active rules:
+
+```java
+private void doAddChecks(Language language, String repositoryKey, Iterable<?> checkClasses) {
+  // checkClasses contains ALL rule classes (300+)
+  // chks will contain only ACTIVE rule instances (e.g., 50-100)
+  var chks = checkFactory.<EslintHook>create(repositoryKey).addAnnotatedChecks(checkClasses);
+
+  var key = new LanguageAndRepository(language, repositoryKey);
+  this.checks.put(key, chks);
+
+  // Build the eslintKey → RuleKey mapping for active rules only
+  chks
+    .all()
+    .forEach(check ->
+      eslintKeyToRuleKey
+        .computeIfAbsent(check.eslintKey(), k -> new EnumMap<>(Language.class))
+        .put(language, chks.ruleKey(check))
+    );
+}
+```
+
+**What `CheckFactory.create(repositoryKey).addAnnotatedChecks(checkClasses)` does:**
+
+1. Takes all check classes you pass in (e.g., 300+ rules)
+2. Reads the `@Rule(key = "...")` annotation from each class
+3. **Checks the quality profile**: Is this rule active?
+4. **Only instantiates active rules**: Skips inactive ones entirely
+5. Returns `Checks<EslintHook>` containing only the active check instances
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         SonarQube Server                                    │
+│  Quality Profile "Sonar Way":  S100 ✓, S101 ✗, S102 ✓, S103 ✗ ...          │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    │ Scanner downloads QP
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  CheckFactory (injected by SonarQube, knows which rules are active)         │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Input: CheckList.getJavaScriptChecks()                                     │
+│         [S100.class, S101.class, S102.class, S103.class, ... 300+ classes]  │
+│                                                                             │
+│                    checkFactory.create("javascript")                        │
+│                        .addAnnotatedChecks(checkClasses)                    │
+│                                    │                                        │
+│                                    ▼                                        │
+│  Output: Checks<EslintHook>                                                 │
+│          [S100 instance, S102 instance]  ← Only 2 active rules              │
+│          (S101, S103 skipped - not active in QP)                            │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+#### Why This Separation?
+
+| Component                 | Source               | Knows Rules          | Knows Quality Profile |
+| ------------------------- | -------------------- | -------------------- | --------------------- |
+| `CheckList` / `AllChecks` | SonarJS (static)     | ✅ All rule classes  | ❌ No                 |
+| `CheckFactory`            | SonarQube (injected) | ❌ No                | ✅ Yes (pre-loaded)   |
+| `Checks<T>`               | Result of filtering  | ✅ Active rules only | N/A                   |
+
+This is a key difference from `EslintHookRegistrar`: custom rules are only executed if they are activated in the quality profile, while hooks bypass `CheckFactory` entirely and always execute when `isEnabled()` returns true.
+
+### 4. The Three Purposes of JsTsChecks
+
+`JsTsChecks` serves three distinct purposes during the analysis lifecycle:
+
+#### 4.1. Building the Mapping Table (Constructor)
+
+When `JsTsChecks` is instantiated, `doAddChecks()` builds the `eslintKeyToRuleKey` map:
+
+```java
+// Maps: eslintKey → (Language → RuleKey)
+private final Map<String, Map<Language, RuleKey>> eslintKeyToRuleKey = new HashMap<>();
+```
+
+This map is populated only with **active rules** (filtered by `CheckFactory`).
+
+#### 4.2. Providing Rules to the Bridge (`enabledEslintRules()`)
+
+Called by `JsTsSensor` when building the analysis request:
+
+```java
+// JsTsSensor.AnalyzeProjectHandler.getRequest()
+return new BridgeServer.ProjectAnalysisRequest(
+  files,
+  checks.enabledEslintRules(),  // ← Returns rules to send to bridge
+  configuration
+);
+```
+
+This returns the list of `EslintRule` objects to send to the Node.js bridge. Only active rules are included because the `checks` map only contains active rules.
+
+#### 4.3. Converting Issues Back (`ruleKeyByEslintKey()`)
+
+Called by `AnalysisProcessor` when processing issues returned from the bridge:
+
+```java
+// AnalysisProcessor.findRuleKey()
+private RuleKey findRuleKey(Issue issue) {
+  return checks.ruleKeyByEslintKey(issue.ruleId(), Language.of(issue.language()));
+}
+```
+
+This looks up the Sonar `RuleKey` for an ESLint issue using the mapping built in step 4.1.
+
+### 5. Complete Analysis Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         JsTsChecks CONSTRUCTOR                              │
+│                                                                             │
+│  CheckList.getJavaScriptChecks() ──┐                                        │
+│  CheckList.getTypeScriptChecks() ──┼──► doAddChecks()                       │
+│  CustomRuleRepository.checkClasses()┘        │                              │
+│                                              ▼                              │
+│                              CheckFactory (filters by QP)                   │
+│                                              │                              │
+│                                              ▼                              │
+│                    ┌─────────────────────────────────────────┐              │
+│                    │  checks: Map<LanguageAndRepo, Checks>   │              │
+│                    │  eslintKeyToRuleKey: Map<eslintKey,     │              │
+│                    │                      Map<Language,      │              │
+│                    │                          RuleKey>>      │              │
+│                    └─────────────────────────────────────────┘              │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                       │
+          ┌────────────────────────────┼────────────────────────────┐
+          │                            │                            │
+          ▼                            ▼                            ▼
+┌───────────────────────┐  ┌────────────────────────┐  ┌────────────────────────┐
+│ enabledEslintRules()  │  │ ruleKeyByEslintKey()   │  │ parsingErrorRuleKey()  │
+│                       │  │                        │  │                        │
+│ Returns List of       │  │ Looks up Sonar         │  │ Returns RuleKey for    │
+│ EslintRule to send    │  │ RuleKey from           │  │ parsing errors (S2260) │
+│ to bridge             │  │ eslintKey              │  │                        │
+└───────────┬───────────┘  └───────────┬────────────┘  └────────────────────────┘
+            │                          │
+            ▼                          ▼
+┌───────────────────────┐  ┌────────────────────────┐
+│ JsTsSensor            │  │ AnalysisProcessor      │
+│ .getRequest()         │  │ .findRuleKey()         │
+│                       │  │                        │
+│ Sends rules to        │  │ Converts ESLint        │
+│ Node.js bridge        │  │ issues to Sonar        │
+│                       │  │ issues                 │
+└───────────────────────┘  └────────────────────────┘
+```
+
+### 6. Issue Transformation Details
+
+When the bridge returns an issue, `AnalysisProcessor` converts it to a Sonar issue:
+
+```java
+// AnalysisProcessor.saveIssue()
+var ruleKey = findRuleKey(issue);  // Calls checks.ruleKeyByEslintKey()
+if (ruleKey != null) {
+  newIssue.at(location).forRule(ruleKey).save();
+}
+// If ruleKey is null, the issue is silently discarded
+```
+
+This is why hooks cannot raise issues: their `eslintKey` is not in the `eslintKeyToRuleKey` map, so `ruleKeyByEslintKey()` returns `null` and the issue is discarded.
+
+### 6. Bundle Deployment (Same as Hooks API)
+
+The `RulesBundle` mechanism works identically for both APIs:
+
+```java
+// RulesBundles.java
+public List<Path> deploy(Path target) {
+  // 1. Extract .tgz from plugin JAR
+  // 2. Return path to package/dist/rules.js
+}
+```
+
+### Data Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           JAVA SIDE (SonarQube)                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌──────────────────────┐     ┌──────────────────────┐                      │
+│  │  CustomRuleRepository│     │     RulesBundle      │                      │
+│  │   (your plugin)      │     │    (your plugin)     │                      │
+│  │                      │     │                      │                      │
+│  │  - repositoryKey()   │     │  - bundlePath()      │                      │
+│  │  - checkClasses()    │     │                      │                      │
+│  │  - compatibleLangs() │     │                      │                      │
+│  └──────────┬───────────┘     └──────────┬───────────┘                      │
+│             │                            │                                  │
+│             │ @ScannerSide               │ @ScannerSide                     │
+│             │ auto-discovery             │ auto-discovery                   │
+│             ▼                            │                                  │
+│  ┌──────────────────────┐                │                                  │
+│  │     CheckFactory     │                │                                  │
+│  │  - Reads @Rule       │                │                                  │
+│  │  - Filters by QP     │◄── Quality Profile (only active rules)            │
+│  │  - Instantiates      │                │                                  │
+│  └──────────┬───────────┘                │                                  │
+│             │                            │                                  │
+│             ▼                            ▼                                  │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │                      JsTsChecks                              │           │
+│  │  - addCustomChecks() processes each CustomRuleRepository     │           │
+│  │  - Maps: eslintKey() <-> @Rule(key) for issue conversion     │           │
+│  │  - enabledEslintRules() aggregates all active rules          │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│             │                            │                                  │
+│             │                            ▼                                  │
+│             │              ┌─────────────────────────┐                      │
+│             │              │     RulesBundles        │                      │
+│             │              │  - Deploys .tgz files   │                      │
+│             │              │  - Returns paths to JS  │                      │
+│             │              └───────────┬─────────────┘                      │
+│             │                          │                                    │
+│             ▼                          ▼                                    │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │                   BridgeServerImpl                           │           │
+│  │  - Sends ProjectAnalysisRequest via WebSocket                │           │
+│  │  - Request contains: rules[], bundles[], files{}             │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│                                   │                                         │
+└───────────────────────────────────┼─────────────────────────────────────────┘
+                                    │ WebSocket
+                                    │ { type: "on-analyze-project", data: {...} }
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        NODE.JS SIDE (Bridge)                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │                        Linter                                │           │
+│  │  1. loadRulesFromBundle() - dynamic import of rules.js       │           │
+│  │  2. getRulesForFile() - filters rules by file type/language  │           │
+│  │  3. lint() - executes ESLint with configured rules           │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│                                   │                                         │
+│                                   ▼                                         │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │              Your ESLint Rule (from bundle)                  │           │
+│  │  - Receives parsed AST                                       │           │
+│  │  - context.report() raises issues                            │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│                                   │                                         │
+│                                   ▼                                         │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │                   Issue Transformation                       │           │
+│  │  - ESLint messages converted to Sonar issues                 │           │
+│  │  - eslintKey mapped back to Sonar rule key                   │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Differences from ESLint Hooks API
+
+| Aspect                    | Legacy Custom Rules                           | ESLint Hooks                        |
+| ------------------------- | --------------------------------------------- | ----------------------------------- |
+| **Activation**            | Only if active in quality profile             | Always (when `isEnabled()` is true) |
+| **Rule keys**             | Has Sonar rule key via `@Rule`                | No rule key association             |
+| **Issues**                | Can raise Sonar issues via `context.report()` | Cannot raise issues directly        |
+| **Language registration** | Separate repository per language              | Single registrar for all languages  |
+| **Discovery**             | `CustomRuleRepository.checkClasses()`         | `EslintHookRegistrar.register()`    |
+
+### Key Integration Points
+
+| Component                      | File                                                               | Purpose                              |
+| ------------------------------ | ------------------------------------------------------------------ | ------------------------------------ |
+| `CustomRuleRepository`         | `sonar-plugin/api/.../CustomRuleRepository.java`                   | Interface for rule repositories      |
+| `EslintBasedCheck`             | `sonar-plugin/api/.../EslintBasedCheck.java`                       | Deprecated check interface           |
+| `Check`                        | `sonar-plugin/api/.../Check.java`                                  | Deprecated base class                |
+| `JsTsChecks.addCustomChecks()` | `sonar-plugin/sonar-javascript-plugin/.../JsTsChecks.java:110-116` | Processes custom repositories        |
+| `JsTsChecks.doAddChecks()`     | `sonar-plugin/sonar-javascript-plugin/.../JsTsChecks.java:95-108`  | Instantiates checks via CheckFactory |
+| `JsTsChecks.ruleKey()`         | `sonar-plugin/sonar-javascript-plugin/.../JsTsChecks.java`         | Maps eslintKey to Sonar RuleKey      |
+| `RulesBundles`                 | `sonar-plugin/bridge/.../RulesBundles.java`                        | Deploys JS bundles                   |
+| `Linter`                       | `packages/jsts/src/linter/linter.ts`                               | Loads and executes rules             |

--- a/docs/custom-rules/ESLINT_HOOKS.md
+++ b/docs/custom-rules/ESLINT_HOOKS.md
@@ -1,0 +1,485 @@
+# ESLint Hooks API (Recommended)
+
+This document describes the recommended approach for integrating custom ESLint-based logic into SonarJS analysis using the `EslintHook` and `EslintHookRegistrar` APIs.
+
+## Overview
+
+ESLint hooks provide a mechanism for external plugins to execute custom logic during SonarJS analysis with full parser context available. Unlike the legacy Custom Rules API, hooks are:
+
+- **Not associated with rule keys** - they don't raise Sonar issues directly
+- **Executed independently of rule activation** - always run when enabled
+- **Designed for data collection** - ideal for cross-file analysis, IR generation, metrics collection
+
+## When to Use
+
+Use ESLint Hooks when you need to:
+
+- Collect data across multiple files for later analysis
+- Generate intermediate representations (IR) for security analysis
+- Integrate with external analysis tools
+- Execute logic that doesn't map directly to Sonar rules
+
+## Components
+
+A complete ESLint Hook integration requires:
+
+1. **Java Hook Class** - implements `EslintHook` and `EslintHookRegistrar`
+2. **Rules Bundle** - packages the ESLint-side JavaScript code
+3. **Plugin Class** - registers the hook with SonarQube
+
+## Implementation Guide
+
+### 1. Create the ESLint Hook Class
+
+```java
+package com.example.plugin;
+
+import java.util.List;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.plugins.javascript.api.AnalysisMode;
+import org.sonar.plugins.javascript.api.EslintHook;
+import org.sonar.plugins.javascript.api.EslintHookRegistrar;
+import org.sonar.plugins.javascript.api.Language;
+
+public class MyEslintHook implements EslintHook, EslintHookRegistrar {
+
+  @Override
+  public String eslintKey() {
+    // Must match the rule name exported by your ESLint plugin
+    return "my-custom-hook";
+  }
+
+  @Override
+  public List<InputFile.Type> targets() {
+    // Which file types to analyze
+    return List.of(InputFile.Type.MAIN, InputFile.Type.TEST);
+  }
+
+  @Override
+  public List<AnalysisMode> analysisModes() {
+    // When to run the hook
+    return List.of(AnalysisMode.DEFAULT, AnalysisMode.SKIP_UNCHANGED);
+  }
+
+  @Override
+  public List<String> blacklistedExtensions() {
+    // File extensions to skip
+    return List.of(".htm", ".html");
+  }
+
+  @Override
+  public boolean isEnabled() {
+    // Conditionally enable/disable the hook
+    return true;
+  }
+
+  @Override
+  public List<Object> configurations() {
+    // Optional configuration passed to the ESLint rule
+    return List.of();
+  }
+
+  @Override
+  public void register(RegistrarContext registrarContext) {
+    // Register for JavaScript and/or TypeScript analysis
+    registrarContext.registerEslintHook(Language.JAVASCRIPT, this);
+    registrarContext.registerEslintHook(Language.TYPESCRIPT, this);
+  }
+}
+```
+
+### 2. Create the Rules Bundle
+
+The `RulesBundle` tells SonarJS where to find your ESLint plugin code:
+
+```java
+package com.example.plugin;
+
+import org.sonar.plugins.javascript.api.RulesBundle;
+
+public class MyRulesBundle implements RulesBundle {
+
+  @Override
+  public String bundlePath() {
+    // Path to your bundled ESLint plugin (relative to JAR root)
+    return "/my-eslint-plugin-1.0.0.tgz";
+  }
+}
+```
+
+### 3. Create the ESLint Plugin (JavaScript)
+
+Create an ESLint plugin that exports your rule:
+
+```javascript
+// src/rules/my-custom-hook.js
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Custom hook for data collection',
+    },
+  },
+  create(context) {
+    return {
+      Program(node) {
+        // Your analysis logic here
+        // Access the parsed AST, collect data, etc.
+      },
+
+      CallExpression(node) {
+        // Visit specific node types
+      },
+
+      'Program:exit'(node) {
+        // Finalize analysis for this file
+      },
+    };
+  },
+};
+```
+
+```javascript
+// index.js
+module.exports = {
+  rules: {
+    'my-custom-hook': require('./rules/my-custom-hook'),
+  },
+};
+```
+
+Bundle your plugin as a `.tgz` file and include it in your JAR resources.
+
+### 4. Create the Plugin Class
+
+```java
+package com.example.plugin;
+
+import org.sonar.api.Plugin;
+
+public class MyPlugin implements Plugin {
+
+  @Override
+  public void define(Context context) {
+    context.addExtensions(MyRulesBundle.class, MyEslintHook.class);
+  }
+}
+```
+
+### 5. Configure Maven Dependencies
+
+Add the SonarJS API dependency to your `pom.xml`:
+
+```xml
+<dependency>
+  <groupId>org.sonarsource.javascript</groupId>
+  <artifactId>sonar-javascript-plugin</artifactId>
+  <version>11.6.0</version>
+  <classifier>api</classifier>
+  <scope>provided</scope>
+</dependency>
+```
+
+## Complete Example
+
+See the [sonar-architecture](https://github.com/SonarSource/sonar-architecture) repository for a complete working example:
+
+- `ArchitectureJsEslintHook.java` - Hook implementation
+- `ArchitectureJsRulesBundle.java` - Bundle configuration
+- `ArchitectureJsFrontendPlugin.java` - Plugin registration
+
+## API Reference
+
+### EslintHook Interface
+
+| Method                    | Description                           | Default      |
+| ------------------------- | ------------------------------------- | ------------ |
+| `eslintKey()`             | ESLint rule name to execute           | Required     |
+| `configurations()`        | Configuration passed to the rule      | Empty list   |
+| `targets()`               | File types to analyze (MAIN, TEST)    | MAIN only    |
+| `analysisModes()`         | When to run (DEFAULT, SKIP_UNCHANGED) | DEFAULT only |
+| `blacklistedExtensions()` | Extensions to skip                    | Empty list   |
+| `isEnabled()`             | Whether the hook should run           | `true`       |
+
+### EslintHookRegistrar Interface
+
+| Method                       | Description                                |
+| ---------------------------- | ------------------------------------------ |
+| `register(RegistrarContext)` | Called to register hooks for each language |
+
+### RegistrarContext Interface
+
+| Method                                     | Description                              |
+| ------------------------------------------ | ---------------------------------------- |
+| `registerEslintHook(Language, EslintHook)` | Registers a hook for a specific language |
+
+## Best Practices
+
+1. **Single hook for multiple languages** - Register the same hook instance for both JavaScript and TypeScript when the analysis logic is identical.
+
+2. **Use `isEnabled()` for conditional execution** - Check configuration or context to determine if the hook should run.
+
+3. **Handle analysis modes appropriately** - If your hook supports incremental analysis, include `AnalysisMode.SKIP_UNCHANGED`.
+
+4. **Blacklist unsupported file types** - Use `blacklistedExtensions()` to skip files that your analysis doesn't support (e.g., HTML files for module-resolution-dependent analysis).
+
+## Technical Details: How Hooks Are Integrated
+
+This section explains how the ESLint Hooks API is wired into the SonarJS analysis pipeline.
+
+### 1. Discovery via SonarQube Dependency Injection
+
+Both `EslintHookRegistrar` and `RulesBundle` interfaces are annotated with `@ScannerSide`, which enables automatic discovery by SonarQube's dependency injection container:
+
+```java
+@ScannerSide
+public interface EslintHookRegistrar { ... }
+
+@ScannerSide
+@SonarLintSide
+public interface RulesBundle { ... }
+```
+
+When your plugin is loaded, SonarQube automatically:
+
+1. Discovers all implementations of these interfaces
+2. Instantiates them via reflection
+3. Injects them as arrays into dependent components
+
+### 2. Hook Registration in JsTsChecks (Bypasses CheckFactory)
+
+The `JsTsChecks` class (`sonar-plugin/sonar-javascript-plugin/.../JsTsChecks.java`) receives all `EslintHookRegistrar` implementations via constructor injection:
+
+```java
+public JsTsChecks(
+  CheckFactory checkFactory,
+  @Nullable CustomRuleRepository[] customRuleRepositories,
+  @Nullable EslintHookRegistrar[] eslintHookRegistrars
+) {
+  // Process each registrar - hooks are stored DIRECTLY, bypassing CheckFactory
+  for (var registrar : eslintHookRegistrars) {
+    registrar.register(
+      (language, hook) -> eslintHooksByLanguage
+        .computeIfAbsent(language, it -> new HashSet<>())
+        .add(hook)
+    );
+  }
+
+  // Built-in and custom rules go through CheckFactory (quality profile filtering)
+  doAddChecks(Language.TYPESCRIPT, CheckList.TS_REPOSITORY_KEY, CheckList.getTypeScriptChecks());
+  doAddChecks(Language.JAVASCRIPT, CheckList.JS_REPOSITORY_KEY, CheckList.getJavaScriptChecks());
+  // ...
+}
+```
+
+**Key difference from legacy API:** Hooks are stored directly in `eslintHooksByLanguage` map without going through `CheckFactory`. This means:
+
+1. **No quality profile filtering**: Hooks always run when `isEnabled()` returns true
+2. **No `eslintKey → RuleKey` mapping**: Hooks are not added to the `eslintKeyToRuleKey` map
+3. **Cannot raise issues**: When the bridge returns issues, `ruleKeyByEslintKey()` won't find a mapping for hook eslintKeys, so issues are discarded
+
+```
+Legacy Rules (CustomRuleRepository):
+  checkClasses → CheckFactory → filters by QP → checks map + eslintKeyToRuleKey map
+                                                     ↓
+                                              Can raise issues ✓
+
+Hooks (EslintHookRegistrar):
+  register() → directly stored → eslintHooksByLanguage map
+                                        ↓
+                                 Cannot raise issues ✗
+                                 (no eslintKey → RuleKey mapping)
+```
+
+### 3. Bundle Deployment
+
+The `RulesBundles` class (`sonar-plugin/bridge/.../RulesBundles.java`) handles deploying JavaScript bundles:
+
+```java
+public List<Path> deploy(Path target) {
+  // For each bundle URL:
+  // 1. Extract .tgz to temporary directory
+  // 2. Return path to package/dist/rules.js
+}
+```
+
+Bundles are extracted from the plugin JAR and deployed to a temporary directory before analysis starts.
+
+### 4. Aggregating Enabled Rules
+
+The `enabledEslintRules()` method in `JsTsChecks` combines all sources:
+
+```java
+public List<EslintRule> enabledEslintRules() {
+  // 1. Built-in rules from CheckList
+  // 2. Custom rules from CustomRuleRepository (legacy)
+  // 3. Hooks from EslintHookRegistrar (new API)
+
+  var eslintHooks = eslintHooksByLanguage
+    .entrySet()
+    .stream()
+    .flatMap(entry ->
+      entry
+        .getValue()
+        .stream()
+        .filter(EslintHook::isEnabled) // Only enabled hooks
+        .map(hook ->
+          new EslintRule(
+            hook.eslintKey(),
+            hook.configurations(),
+            hook.targets(),
+            hook.analysisModes(),
+            hook.blacklistedExtensions(),
+            languageKey
+          )
+        )
+    );
+
+  return Stream.concat(eslintRules, eslintHooks).toList();
+}
+```
+
+### 5. Sending to the Node.js Bridge
+
+The analysis request is sent via WebSocket to the Node.js bridge:
+
+```
+JsTsSensor.analyzeFiles()
+    └── Creates AnalyzeProjectHandler
+    └── handler.getRequest() includes checks.enabledEslintRules()
+            └── BridgeServerImpl.analyzeProject()
+                    └── Serializes request to JSON
+                    └── Sends via WebSocket: { type: "on-analyze-project", data: request }
+```
+
+The request includes:
+
+- `files`: Map of files to analyze
+- `rules`: List of `EslintRule` objects (includes hooks)
+- `bundles`: Paths to deployed JavaScript bundles
+- `rulesWorkdir`: Working directory for rules accessing the filesystem
+
+### 6. Node.js Bridge Processing
+
+On the JavaScript side (`packages/bridge/src/handle-request.ts`):
+
+```typescript
+case 'on-analyze-project': {
+  const output = await analyzeProject(request.data, incrementalResultsChannel);
+  return { type: 'success', result: output };
+}
+```
+
+The `Linter` class (`packages/jsts/src/linter/linter.ts`) loads bundles dynamically:
+
+```typescript
+static async initialize({ bundles, ... }: InitializeParams) {
+  for (const ruleBundle of bundles) {
+    await Linter.loadRulesFromBundle(ruleBundle);
+  }
+}
+
+private static async loadRulesFromBundle(ruleBundle: string) {
+  const { rules: bundleRules } = await import(pathToFileURL(ruleBundle).toString());
+  for (const rule of bundleRules) {
+    Linter.rules[rule.ruleId] = rule.ruleModule;
+  }
+}
+```
+
+### 7. Rule Filtering During Linting
+
+When linting a file, rules are filtered based on the `RuleConfig` properties:
+
+```typescript
+const rules = Linter.ruleConfigs?.filter(ruleConfig => {
+  const { fileTypeTargets, analysisModes, language, blacklistedExtensions } = ruleConfig;
+  return (
+    fileTypeTargets.includes(fileType) &&
+    analysisModes.includes(analysisMode) &&
+    fileLanguage === language &&
+    !(blacklistedExtensions || []).includes(extname(filePath))
+  );
+});
+```
+
+### Data Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           JAVA SIDE (SonarQube)                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌──────────────────────┐     ┌──────────────────────┐                      │
+│  │  EslintHookRegistrar │     │     RulesBundle      │                      │
+│  │   (your plugin)      │     │    (your plugin)     │                      │
+│  └──────────┬───────────┘     └──────────┬───────────┘                      │
+│             │                            │                                  │
+│             │ @ScannerSide               │ @ScannerSide                     │
+│             │ auto-discovery             │ auto-discovery                   │
+│             ▼                            ▼                                  │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │                      JsTsChecks                              │           │
+│  │  - Calls registrar.register() to collect hooks               │           │
+│  │  - enabledEslintRules() aggregates all rules + hooks         │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│             │                            │                                  │
+│             │                            ▼                                  │
+│             │              ┌─────────────────────────┐                      │
+│             │              │     RulesBundles        │                      │
+│             │              │  - Deploys .tgz files   │                      │
+│             │              │  - Returns paths to JS  │                      │
+│             │              └───────────┬─────────────┘                      │
+│             │                          │                                    │
+│             ▼                          ▼                                    │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │                   BridgeServerImpl                           │           │
+│  │  - Sends ProjectAnalysisRequest via WebSocket                │           │
+│  │  - Request contains: rules[], bundles[], files{}             │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│                                   │                                         │
+└───────────────────────────────────┼─────────────────────────────────────────┘
+                                    │ WebSocket
+                                    │ { type: "on-analyze-project", data: {...} }
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        NODE.JS SIDE (Bridge)                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │                    handle-request.ts                         │           │
+│  │  case 'on-analyze-project':                                  │           │
+│  │    analyzeProject(request.data)                              │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│                                   │                                         │
+│                                   ▼                                         │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │                        Linter                                │           │
+│  │  1. loadRulesFromBundle() - dynamic import of rules.js       │           │
+│  │  2. getRulesForFile() - filters rules by file type/language  │           │
+│  │  3. lint() - executes ESLint with configured rules           │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│                                   │                                         │
+│                                   ▼                                         │
+│  ┌──────────────────────────────────────────────────────────────┐           │
+│  │              Your ESLint Rule (from bundle)                  │           │
+│  │  - Receives parsed AST                                       │           │
+│  │  - Executes analysis logic                                   │           │
+│  │  - Can write data to rulesWorkdir                            │           │
+│  └──────────────────────────────────────────────────────────────┘           │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Integration Points
+
+| Component             | File                                                             | Purpose                                |
+| --------------------- | ---------------------------------------------------------------- | -------------------------------------- |
+| `EslintHookRegistrar` | `sonar-plugin/api/.../EslintHookRegistrar.java`                  | Interface for hook registration        |
+| `EslintHook`          | `sonar-plugin/api/.../EslintHook.java`                           | Hook descriptor interface              |
+| `RulesBundle`         | `sonar-plugin/api/.../RulesBundle.java`                          | Interface for JS bundle location       |
+| `JsTsChecks`          | `sonar-plugin/sonar-javascript-plugin/.../JsTsChecks.java:74-93` | Processes registrars, aggregates rules |
+| `RulesBundles`        | `sonar-plugin/bridge/.../RulesBundles.java:70-91`                | Deploys JS bundles to filesystem       |
+| `BridgeServerImpl`    | `sonar-plugin/bridge/.../BridgeServerImpl.java:422-429`          | Sends analysis request via WebSocket   |
+| `handle-request.ts`   | `packages/bridge/src/handle-request.ts:66-70`                    | Receives and routes analysis request   |
+| `Linter`              | `packages/jsts/src/linter/linter.ts:147-158`                     | Loads bundle rules dynamically         |

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsChecks.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsChecks.java
@@ -43,20 +43,83 @@ import org.sonar.plugins.javascript.bridge.EslintRule;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
 /**
- * Wrapper around Check Object to ease the manipulation of the different JavaScript rule repositories.
+ * Central registry for all JavaScript/TypeScript rules and hooks.
+ *
+ * <p>This class serves three main purposes during the analysis lifecycle:</p>
+ * <ol>
+ *   <li><b>Building the rule registry</b> (constructor): Collects all active rules from built-in checks,
+ *       custom rule repositories, and ESLint hooks. Rules are filtered by the quality profile.</li>
+ *   <li><b>Providing rules to the bridge</b> ({@link #enabledEslintRules()}): Returns the list of
+ *       ESLint rules to send to the Node.js bridge for execution.</li>
+ *   <li><b>Converting issues back</b> ({@link #ruleKeyByEslintKey(String, Language)}): Maps ESLint
+ *       rule keys back to Sonar rule keys when processing issues returned from the bridge.</li>
+ * </ol>
+ *
+ * <h2>Two Types of Rule Sources</h2>
+ *
+ * <h3>1. Rules (via CheckFactory) - Can raise issues</h3>
+ * <p>Rules from {@link CheckList} and {@link CustomRuleRepository} go through {@link CheckFactory},
+ * which filters them by the active quality profile. Only active rules are instantiated and added
+ * to the {@link #eslintKeyToRuleKey} mapping, allowing issues to be raised.</p>
+ *
+ * <h3>2. Hooks (via EslintHookRegistrar) - Cannot raise issues</h3>
+ * <p>Hooks from {@link EslintHookRegistrar} bypass {@link CheckFactory} entirely. They always run
+ * when {@link EslintHook#isEnabled()} returns true, regardless of quality profile. Since they're
+ * not added to {@link #eslintKeyToRuleKey}, any issues they report are silently discarded.</p>
+ *
+ * @see CheckFactory SonarQube component that filters rules by quality profile
+ * @see CustomRuleRepository Legacy API for external plugins to contribute rules
+ * @see EslintHookRegistrar New API for data collection hooks (cannot raise issues)
  */
 @ScannerSide
 @SonarLintSide
 public class JsTsChecks {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsTsChecks.class);
+
+  /**
+   * SonarQube-provided component that knows which rules are active in the quality profile.
+   * When we call {@code checkFactory.create(repoKey).addAnnotatedChecks(classes)}, it only
+   * instantiates checks whose rules are active in the current quality profile.
+   */
   private final CheckFactory checkFactory;
+
+  /**
+   * External plugins can contribute custom rules by implementing {@link CustomRuleRepository}.
+   * These are discovered via SonarQube's dependency injection (@ScannerSide annotation).
+   */
   private final CustomRuleRepository[] customRuleRepositories;
+
+  /**
+   * Hooks registered via {@link EslintHookRegistrar}. These bypass {@link CheckFactory} and
+   * always run when enabled. They cannot raise Sonar issues because they're not in
+   * {@link #eslintKeyToRuleKey}.
+   *
+   * <p>Use case: Data collection for cross-file analysis (e.g., architecture analysis).</p>
+   */
   private final Map<Language, Set<EslintHook>> eslintHooksByLanguage = new EnumMap<>(
     Language.class
   );
+
+  /**
+   * Active rule instances, filtered by quality profile via {@link CheckFactory}.
+   * Key: (language, repository) → Value: Checks containing only active rule instances.
+   *
+   * <p>This map only contains rules that passed quality profile filtering.</p>
+   */
   private final Map<LanguageAndRepository, Checks<EslintHook>> checks = new HashMap<>();
+
+  /**
+   * Mapping from ESLint rule key to Sonar rule key, used when converting issues.
+   * Key: eslintKey → Value: (Language → RuleKey).
+   *
+   * <p>This mapping is built from active rules only. When an issue comes back from the bridge,
+   * we look up the Sonar RuleKey here. If not found (e.g., for hooks), the issue is discarded.</p>
+   *
+   * @see #ruleKeyByEslintKey(String, Language) Used by AnalysisProcessor to convert issues
+   */
   private final Map<String, Map<Language, RuleKey>> eslintKeyToRuleKey = new HashMap<>();
+
   private RuleKey parseErrorRuleKey;
 
   public JsTsChecks(CheckFactory checkFactory) {
@@ -71,6 +134,13 @@ public class JsTsChecks {
     this(checkFactory, new CustomRuleRepository[] {}, eslintHookRegistrars);
   }
 
+  /**
+   * Main constructor - builds the complete rule registry.
+   *
+   * @param checkFactory SonarQube-provided component with quality profile data
+   * @param customRuleRepositories External plugins' custom rules (legacy API, can raise issues)
+   * @param eslintHookRegistrars External plugins' hooks (new API, cannot raise issues)
+   */
   public JsTsChecks(
     CheckFactory checkFactory,
     CustomRuleRepository[] customRuleRepositories,
@@ -79,27 +149,68 @@ public class JsTsChecks {
     this.checkFactory = checkFactory;
     this.customRuleRepositories = customRuleRepositories;
 
+    // ====================================================================================
+    // STEP 1: Register hooks (bypass CheckFactory - no quality profile filtering)
+    // ====================================================================================
+    // Hooks are stored directly without going through CheckFactory. This means:
+    // - They always run when isEnabled() returns true (no QP filtering)
+    // - They are NOT added to eslintKeyToRuleKey (cannot raise issues)
+    // - Use case: data collection for cross-file analysis (e.g., architecture IR generation)
     for (var registrar : eslintHookRegistrars) {
       registrar.register(
         ((language, hook) ->
           eslintHooksByLanguage.computeIfAbsent(language, it -> new HashSet<>()).add(hook))
       );
     }
+
+    // ====================================================================================
+    // STEP 2: Register rules (through CheckFactory - filtered by quality profile)
+    // ====================================================================================
+    // Rules go through CheckFactory which:
+    // - Takes ALL rule classes (e.g., 300+ from CheckList)
+    // - Filters by quality profile (only active rules are instantiated)
+    // - Builds the eslintKey → RuleKey mapping (allows issues to be raised)
+    //
+    // Built-in rules from CheckList:
     doAddChecks(Language.TYPESCRIPT, CheckList.TS_REPOSITORY_KEY, CheckList.getTypeScriptChecks());
     addCustomChecks(Language.TYPESCRIPT);
     doAddChecks(Language.JAVASCRIPT, CheckList.JS_REPOSITORY_KEY, CheckList.getJavaScriptChecks());
     addCustomChecks(Language.JAVASCRIPT);
+
     initParsingErrorRuleKey();
   }
 
-  private void doAddChecks(Language language, String repositoryKey, Iterable<?> checkClass) {
-    var chks = checkFactory.<EslintHook>create(repositoryKey).addAnnotatedChecks(checkClass);
+  /**
+   * Registers rule classes through CheckFactory (quality profile filtering).
+   *
+   * <p>This method does three things:</p>
+   * <ol>
+   *   <li>Passes all rule classes to CheckFactory, which instantiates only active rules</li>
+   *   <li>Stores the active rule instances in {@link #checks}</li>
+   *   <li>Builds the {@link #eslintKeyToRuleKey} mapping for issue conversion</li>
+   * </ol>
+   *
+   * @param language The language (JS or TS)
+   * @param repositoryKey The Sonar repository key (e.g., "javascript", "typescript", or custom)
+   * @param checkClasses ALL rule classes (not filtered) - CheckFactory will filter by QP
+   */
+  private void doAddChecks(Language language, String repositoryKey, Iterable<?> checkClasses) {
+    // CheckFactory.create(repoKey).addAnnotatedChecks(classes):
+    // - Input: ALL rule classes (e.g., 300+ classes from CheckList.getJavaScriptChecks())
+    // - Reads @Rule(key = "...") annotation from each class
+    // - Checks if that rule is ACTIVE in the quality profile
+    // - Output: Checks<EslintHook> containing only ACTIVE rule instances (e.g., 50-100)
+    var chks = checkFactory.<EslintHook>create(repositoryKey).addAnnotatedChecks(checkClasses);
+
     var key = new LanguageAndRepository(language, repositoryKey);
     this.checks.put(key, chks);
     LOG.debug("Added {} checks for {}", chks.all().size(), key);
+
+    // Build the eslintKey → RuleKey mapping for active rules only.
+    // This mapping is used later by ruleKeyByEslintKey() to convert ESLint issues to Sonar issues.
+    // If an eslintKey is not in this map, the issue will be silently discarded.
     chks
       .all()
-      .stream()
       .forEach(check ->
         eslintKeyToRuleKey
           .computeIfAbsent(check.eslintKey(), k -> new EnumMap<>(Language.class))
@@ -107,14 +218,24 @@ public class JsTsChecks {
       );
   }
 
+  /**
+   * Registers custom rules from external plugins (legacy API).
+   *
+   * <p>External plugins implement {@link CustomRuleRepository} to contribute their rules.
+   * These go through the same CheckFactory filtering as built-in rules.</p>
+   */
   private void addCustomChecks(Language language) {
     for (CustomRuleRepository repo : customRuleRepositories) {
       if (repo.compatibleLanguages().contains(language)) {
+        // Custom rules also go through CheckFactory - same QP filtering as built-in rules
         doAddChecks(language, repo.repositoryKey(), repo.checkClasses());
       }
     }
   }
 
+  /**
+   * Returns all active rule instances (does not include hooks).
+   */
   Stream<EslintHook> all() {
     return checks
       .values()
@@ -133,6 +254,20 @@ public class JsTsChecks {
       .orElse(null);
   }
 
+  /**
+   * Looks up the Sonar RuleKey for an ESLint rule key.
+   *
+   * <p>This method is called by {@code AnalysisProcessor} when converting issues returned
+   * from the Node.js bridge back to Sonar issues.</p>
+   *
+   * <p><b>Important:</b> This only returns a RuleKey for rules that went through CheckFactory
+   * (i.e., active rules from CheckList or CustomRuleRepository). Hooks are not in this map,
+   * so their issues will return null and be silently discarded.</p>
+   *
+   * @param eslintKey The ESLint rule key (e.g., "S1234" or "no-unused-vars")
+   * @param language The language (JS or TS)
+   * @return The Sonar RuleKey, or null if not found (issue will be discarded)
+   */
   @Nullable
   public RuleKey ruleKeyByEslintKey(String eslintKey, Language language) {
     var k = eslintKeyToRuleKey.get(eslintKey);
@@ -157,7 +292,24 @@ public class JsTsChecks {
       .orElse(null);
   }
 
+  /**
+   * Returns all ESLint rules to send to the Node.js bridge for execution.
+   *
+   * <p>This method is called by {@code JsTsSensor} when building the analysis request.
+   * It combines two sources:</p>
+   * <ol>
+   *   <li><b>Rules</b> from {@link #checks} (filtered by QP, can raise issues)</li>
+   *   <li><b>Hooks</b> from {@link #eslintHooksByLanguage} (no QP filtering, cannot raise issues)</li>
+   * </ol>
+   *
+   * <p>Note: Even though hooks are included here (their ESLint rules will execute), any issues
+   * they report will be discarded because they're not in {@link #eslintKeyToRuleKey}.</p>
+   *
+   * @return List of ESLint rules to execute on the bridge
+   */
   List<EslintRule> enabledEslintRules() {
+    // Rules from checks map (went through CheckFactory, can raise issues)
+    // These are only the ACTIVE rules - CheckFactory already filtered by quality profile
     var eslintRules = checks
       .entrySet()
       .stream()
@@ -179,6 +331,9 @@ public class JsTsChecks {
           )
       );
 
+    // Hooks from eslintHooksByLanguage (bypassed CheckFactory, cannot raise issues)
+    // These always run when isEnabled() is true - no quality profile filtering
+    // Use case: data collection for cross-file analysis (e.g., architecture)
     var eslintHooks = eslintHooksByLanguage
       .entrySet()
       .stream()
@@ -199,6 +354,8 @@ public class JsTsChecks {
             )
           );
       });
+
+    // Combine both sources - all will be sent to the bridge for execution
     return Stream.concat(eslintRules, eslintHooks).toList();
   }
 
@@ -208,9 +365,8 @@ public class JsTsChecks {
     final String repository;
 
     LanguageAndRepository(Language language, String repository) {
-      this.language = language == Language.JAVASCRIPT
-        ? JavaScriptLanguage.KEY
-        : TypeScriptLanguage.KEY;
+      this.language =
+        language == Language.JAVASCRIPT ? JavaScriptLanguage.KEY : TypeScriptLanguage.KEY;
       this.repository = repository;
     }
 

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsChecks.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsChecks.java
@@ -68,8 +68,8 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
  * not added to {@link #eslintKeyToRuleKey}, any issues they report are silently discarded.</p>
  *
  * @see CheckFactory SonarQube component that filters rules by quality profile
- * @see CustomRuleRepository Legacy API for external plugins to contribute rules
- * @see EslintHookRegistrar New API for data collection hooks (cannot raise issues)
+ * @see CustomRuleRepository API for external plugins to contribute rules (can raise issues)
+ * @see EslintHookRegistrar API for data collection hooks (cannot raise issues)
  */
 @ScannerSide
 @SonarLintSide
@@ -138,8 +138,8 @@ public class JsTsChecks {
    * Main constructor - builds the complete rule registry.
    *
    * @param checkFactory SonarQube-provided component with quality profile data
-   * @param customRuleRepositories External plugins' custom rules (legacy API, can raise issues)
-   * @param eslintHookRegistrars External plugins' hooks (new API, cannot raise issues)
+   * @param customRuleRepositories External plugins' custom rules (can raise issues)
+   * @param eslintHookRegistrars External plugins' data collection hooks (cannot raise issues)
    */
   public JsTsChecks(
     CheckFactory checkFactory,
@@ -219,7 +219,7 @@ public class JsTsChecks {
   }
 
   /**
-   * Registers custom rules from external plugins (legacy API).
+   * Registers custom rules from external plugins.
    *
    * <p>External plugins implement {@link CustomRuleRepository} to contribute their rules.
    * These go through the same CheckFactory filtering as built-in rules.</p>


### PR DESCRIPTION
## Summary

- Add `docs/custom-rules/ESLINT_HOOKS.md` documenting the recommended `EslintHookRegistrar` API for data collection hooks
- Add `docs/custom-rules/CUSTOM_RULES_LEGACY.md` documenting the legacy `CustomRuleRepository` API for issue-raising rules  
- Add comprehensive inline comments to `JsTsChecks.java` explaining:
  - The role of `CheckFactory` in quality profile filtering
  - How rules vs hooks are processed differently
  - The `eslintKeyToRuleKey` mapping for issue conversion
  - The complete analysis flow from registration to issue creation

## Context

This documentation clarifies the two approaches for external plugins to integrate custom rules/hooks into SonarJS:

1. **Legacy API (`CustomRuleRepository`)**: Rules go through `CheckFactory`, are filtered by quality profile, and can raise Sonar issues
2. **New API (`EslintHookRegistrar`)**: Hooks bypass `CheckFactory`, always run when enabled, and are designed for data collection (cannot raise issues)

## Test plan

- [ ] Documentation renders correctly in GitHub
- [ ] Code compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)