### PR TITLE
Fix release workflow runner and add signing secrets

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -64,6 +64,7 @@ jobs:
       runner-environment: "github-ubuntu-latest-s"
       verbose: true
       use-jira-sandbox: false
+      is-draft-release: 'false'
 
   bump_versions:
     name: Bump versions

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -61,6 +61,7 @@ jobs:
       pm-email: "gabriel.vivas@sonarsource.com"
       slack-channel: "ask-squad-web"
       release-automation-secret-name: "SonarJS-release-automation"
+      runner-environment: "github-ubuntu-latest-s"
       verbose: true
       use-jira-sandbox: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,8 @@ jobs:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer username | ARTIFACTORY_DEPLOY_USERNAME;
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer access_token | ARTIFACTORY_DEPLOY_ACCESS_TOKEN;
+            development/kv/data/sign key | SIGN_KEY;
+            development/kv/data/sign passphrase | PGP_PASSPHRASE;
       - &java_coverage_cache
         name: Cache Java coverage
         uses: SonarSource/gh-action_cache@v1
@@ -186,6 +188,8 @@ jobs:
           ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.deployer-secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.deployer-secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
+          SIGN_KEY: ${{ fromJSON(steps.deployer-secrets.outputs.vault).SIGN_KEY }}
+          PGP_PASSPHRASE: ${{ fromJSON(steps.deployer-secrets.outputs.vault).PGP_PASSPHRASE }}
       - name: Upload SonarJS artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:


### PR DESCRIPTION
## Summary
- Set `runner-environment` to `github-ubuntu-latest-s` for automated-release workflow (was using default `sonar-m`)
- Add `SIGN_KEY` and `PGP_PASSPHRASE` secrets to the build workflow deploy step
- Disable draft release (`is-draft-release: false`)

## Test plan
- [x] Triggered automated-release workflow from this branch to verify runner environment change
- [ ] Verify build workflow uses signing secrets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)