### PR TITLE
JS-1160 Fix bump-versions workflow to update revision property

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -26,8 +26,8 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           snapshot_version="${VERSION}-SNAPSHOT"
-          # Update only root pom.xml to the new snapshot version
-          sed -i "s/<version>.*-SNAPSHOT<\/version>/<version>${snapshot_version}<\/version>/" pom.xml
+          # Update the revision property in root pom.xml to the new snapshot version
+          sed -i "s/<revision>.*-SNAPSHOT<\/revision>/<revision>${snapshot_version}<\/revision>/" pom.xml
       - uses: peter-evans/create-pull-request@v8
         with:
           author: ${{ github.actor }} <${{ github.actor }}>


### PR DESCRIPTION
## Summary
Fix the `bump-versions` workflow to update the `<revision>` property instead of `<version>` tag.

The `pom.xml` uses:
```xml
<revision>11.8.0-SNAPSHOT</revision>
```

Not:
```xml
<version>11.8.0-SNAPSHOT</version>
```

The previous regex was not matching anything, causing the workflow to complete without making changes.

## Test plan
- [ ] Run the bump-versions workflow manually to verify it creates a PR with the version change

🤖 Generated with [Claude Code](https://claude.com/claude-code)