### PR TITLE
JS-1141 Enhance workflow to always comment on PRs with ruling changes summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -822,63 +822,84 @@ jobs:
           npm run generate-meta
           npm run ruling
       - name: Update ruling and notify
-        if: failure() && steps.ruling.outcome == 'failure' && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
+          RULING_FAILED: ${{ steps.ruling.outcome == 'failure' }}
         run: |
-          # Check if last commit was already an auto-update (prevent infinite loop)
-          LAST_COMMIT_MSG=$(git log -1 --format=%B)
-          if echo "$LAST_COMMIT_MSG" | grep -q "🤖 Generated with GitHub Actions"; then
-            echo "Last commit was an auto-update, skipping to prevent infinite loop"
-            exit 0
-          fi
-
-          # Sync ruling results (this modifies its/ruling/...)
-          npm run ruling-sync
-
           # Generate report comparing against master
           git fetch origin master
           node tools/ruling-report.js > ruling-report.md
 
-          # Stash changes before checkout
-          git stash push -m "ruling-sync-changes" -- its/ruling/src/test/expected/jsts/
-
-          # Checkout PR branch
-          git fetch origin "$HEAD_REF"
-          git checkout "$HEAD_REF"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Pop the stashed changes
-          git stash pop
-
-          git add its/ruling/src/test/expected/jsts/
-
-          if git diff --staged --quiet; then
-            echo "No ruling changes to commit"
-            exit 0
+          # Check if there are ruling differences
+          if [ -s ruling-report.md ]; then
+            HAS_DIFFERENCES=true
+          else
+            HAS_DIFFERENCES=false
           fi
 
-          git commit -m "Update ruling results
+          # Only auto-update ruling files when the ruling test failed
+          if [ "$RULING_FAILED" = "true" ] && [ "$HAS_DIFFERENCES" = "true" ]; then
+            # Check if last commit was already an auto-update (prevent infinite loop)
+            LAST_COMMIT_MSG=$(git log -1 --format=%B)
+            if echo "$LAST_COMMIT_MSG" | grep -q "🤖 Generated with GitHub Actions"; then
+              echo "Last commit was an auto-update, skipping to prevent infinite loop"
+              exit 0
+            fi
+
+            # Sync ruling results (this modifies its/ruling/...)
+            npm run ruling-sync
+
+            # Stash changes before checkout
+            git stash push -m "ruling-sync-changes" -- its/ruling/src/test/expected/jsts/
+
+            # Checkout PR branch
+            git fetch origin "$HEAD_REF"
+            git checkout "$HEAD_REF"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            # Pop the stashed changes
+            git stash pop
+
+            git add its/ruling/src/test/expected/jsts/
+
+            if git diff --staged --quiet; then
+              echo "No ruling changes to commit"
+            else
+              git commit -m "Update ruling results
 
           🤖 Generated with GitHub Actions"
-          git push origin "$HEAD_REF"
+              git push origin "$HEAD_REF"
+            fi
+          fi
 
           # Build comment with marker for identification
           MARKER="<!-- ruling-report -->"
-          {
-            echo "$MARKER"
-            if [ -s ruling-report.md ]; then
+          if [ "$HAS_DIFFERENCES" = "true" ]; then
+            # Build comment with ruling changes
+            {
+              echo "$MARKER"
               cat ruling-report.md
               echo ""
-            fi
-            echo "---"
-            echo "✅ **Ruling has been updated.** To re-run CI, either:"
-            echo "- Close and reopen this PR, or"
-            echo "- Run: \`git pull && git commit --allow-empty -m 'Trigger CI' && git push\`"
-          } > comment.md
+              if [ "$RULING_FAILED" = "true" ]; then
+                echo "---"
+                echo "✅ **Ruling has been updated.** To re-run CI, either:"
+                echo "- Close and reopen this PR, or"
+                echo "- Run: \`git pull && git commit --allow-empty -m 'Trigger CI' && git push\`"
+              fi
+            } > comment.md
+          else
+            # Build comment for no changes
+            {
+              echo "$MARKER"
+              echo "## Ruling Report"
+              echo ""
+              echo "✅ **No changes to ruling expected issues in this PR**"
+            } > comment.md
+          fi
 
           # Find existing ruling comment and update it, or create new one
           EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \


### PR DESCRIPTION
## Summary
Enhances the GitHub workflow to always post ruling change comments on all PRs, regardless of whether the ruling test passes or fails.

## Changes
- Modified `.github/workflows/build.yml` to always run the "Update ruling and notify" step on PRs
- Added conditional logic to handle three scenarios:
  1. **Test fails with differences**: Auto-update ruling files + commit + post detailed report with re-run instructions
  2. **Test passes with differences**: Post detailed report only (no auto-update)
  3. **No differences**: Post "No changes to ruling expected issues in this PR" message

## Implementation Details
- Changed condition from `if: failure() && steps.ruling.outcome == 'failure'` to `if: always()`
- Added `RULING_FAILED` environment variable to track test outcome
- Moved report generation to top of script (before conditionals)
- Preserved existing features:
  - Infinite loop prevention
  - Comment marker for updating existing comments
  - Auto-update functionality (only on failures)

## Benefits
- Consistent visibility into ruling changes for all PRs
- Explicit confirmation when PR has no impact on rule behavior
- Reduces manual effort to verify ruling changes
- Maintains auto-update safety net for failed tests

## Testing
The workflow logic has been verified for correct bash syntax and YAML structure. Once merged, it will need integration testing with actual PRs.

Fixes JS-1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)