### PR TITLE
JS-1168 Automate eslint-plugin-sonarjs changelog update

### DIFF
--- a/.github/workflows/.npmrc
+++ b/.github/workflows/.npmrc
@@ -1,0 +1,3 @@
+always-auth=true
+email=helpdesk+npmjs@sonarsource.com
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.github/workflows/release_eslint_plugin.yml
+++ b/.github/workflows/release_eslint_plugin.yml
@@ -60,3 +60,13 @@ jobs:
           jfrog config use repox
           jfrog rt bpr --status it-passed $PACKAGE $RELEASE_TAG sonarsource-npm-public-builds
           jfrog rt bpr --status released $PACKAGE $RELEASE_TAG sonarsource-npm-public-releases
+
+  update_changelog:
+    name: Update Changelog
+    needs: publish
+    uses: ./.github/workflows/update-eslint-plugin-changelog.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      version: ${{ github.event.inputs.release_version }}

--- a/.github/workflows/update-eslint-plugin-changelog.yml
+++ b/.github/workflows/update-eslint-plugin-changelog.yml
@@ -1,0 +1,36 @@
+name: Update ESLint Plugin Changelog
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: The eslint-plugin-sonarjs version
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The eslint-plugin-sonarjs version
+        required: true
+        type: string
+
+jobs:
+  update-changelog:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update changelog
+        env:
+          VERSION: ${{ inputs.version }}
+        run: node tools/update-changelog.js "$VERSION"
+      - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        with:
+          author: ${{ github.actor }} <${{ github.actor }}>
+          commit-message: "Update eslint-plugin-sonarjs changelog for ${{ inputs.version }}"
+          title: "Update eslint-plugin-sonarjs changelog for ${{ inputs.version }}"
+          branch: bot/update-eslint-changelog
+          branch-suffix: timestamp
+          base: master
+          reviewers: ${{ github.actor }}

--- a/.github/workflows/update-eslint-plugin-changelog.yml
+++ b/.github/workflows/update-eslint-plugin-changelog.yml
@@ -17,9 +17,15 @@ jobs:
   update-changelog:
     runs-on: github-ubuntu-latest-s
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
       - uses: actions/checkout@v6
       - name: Update changelog
         env:
@@ -27,6 +33,7 @@ jobs:
         run: node tools/update-changelog.js "$VERSION"
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
+          token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           author: ${{ github.actor }} <${{ github.actor }}>
           commit-message: "Update eslint-plugin-sonarjs changelog for ${{ inputs.version }}"
           title: "Update eslint-plugin-sonarjs changelog for ${{ inputs.version }}"


### PR DESCRIPTION
## Summary
- Fix `update-changelog.js` to use Jira API v3 (`/rest/api/3/search/jql`) - the old v2 endpoint was deprecated
- Add `fields=key,summary` parameter since the new API only returns IDs by default
- Create new reusable workflow `update-eslint-plugin-changelog.yml`
- Integrate changelog update into `release_eslint_plugin.yml` workflow

Now when the eslint-plugin-sonarjs release workflow runs, it will automatically create a PR with the updated changelog.

## Test plan
- [x] Tested `node tools/update-changelog.js 3.0.6` locally - works correctly
- [x] Run the `update-eslint-plugin-changelog` workflow manually to verify PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)