### PR TITLE
JS-1173 Fix S2301 false positive for boolean parameters in JSX contexts

### DIFF
--- a/packages/jsts/src/rules/S2301/rule.ts
+++ b/packages/jsts/src/rules/S2301/rule.ts
@@ -174,7 +174,10 @@ export const rule: Rule.RuleModule = {
 function isCallbackArgument(
   node: (ArrowFunctionExpression | FunctionExpression) & Rule.NodeParentExtension,
 ) {
-  return node.parent.type === 'CallExpression' && node.parent.arguments.includes(node);
+  return (
+    (node.parent.type === 'CallExpression' && node.parent.arguments.includes(node)) ||
+    node.parent.type === 'JSXExpressionContainer'
+  );
 }
 
 /**

--- a/packages/jsts/src/rules/S2301/unit.test.ts
+++ b/packages/jsts/src/rules/S2301/unit.test.ts
@@ -297,6 +297,41 @@ function tempt8(name: string, ofAge: boolean) {
   }
 })`,
         },
+        {
+          // JSX attribute with boolean parameter (arrow function)
+          code: `
+<ToggleButton
+  onActiveChange={(isActive) => {
+    if (isActive) {
+      setActiveKey(key);
+    } else if (activeKey === key) {
+      setActiveKey(null);
+    }
+  }}
+/>`,
+        },
+        {
+          // JSX attribute with function expression
+          code: `
+<Component
+  onChange={function(isEnabled: boolean) {
+    if (isEnabled) {
+      enable();
+    } else {
+      disable();
+    }
+  }}
+/>`,
+        },
+        {
+          // JSX children with inline function
+          code: `
+<Container>
+  {(isVisible) => {
+    return isVisible ? <Content /> : <Placeholder />;
+  }}
+</Container>`,
+        },
       ],
     });
 


### PR DESCRIPTION
## Summary

Fixes a false positive in rule **S2301** ("Methods should not use boolean parameters as selector") that incorrectly flagged inline arrow/function expressions with boolean parameters when used in JSX contexts.

## Problem

The rule was applying imperative "Clean Code" logic to declarative React/JSX patterns, flagging code like:

```tsx
<ToggleButton
  onActiveChange={(isActive) => {
    if (isActive) {
      setActiveKey(key);
    } else if (activeKey === key) {
      setActiveKey(null);
    }
  }}
/>
```

Boolean parameters like `isActive`, `isOpen`, `isEnabled` are idiomatic in React inline handlers and render props. These cannot be "split into multiple methods" as the rule suggests - they're prop values, not methods.

## Solution

Extended the existing `isCallbackArgument()` helper function to also exempt functions whose parent is `JSXExpressionContainer`. This aligns with the existing callback exemption logic and recognizes that JSX inline handlers have different design constraints.

**Changed**: `packages/jsts/src/rules/S2301/rule.ts` (lines 174-181)

## Test Coverage

Added three test cases covering:
- JSX attribute with boolean parameter (arrow function)
- JSX attribute with function expression  
- JSX children with inline function

All existing tests continue to pass. ✅

## Verification

```bash
npx tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec packages/jsts/src/rules/S2301/unit.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)