### PR TITLE
JS-1189 Add A3S Docker workflow for Repox publishing

### DIFF
--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -1,0 +1,93 @@
+name: Build A3S Docker Image (Repox)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        type: string
+        default: master
+
+env:
+  DOCKER_REPOX_BUILDS_REGISTRY: repox-sonarsource-docker-builds.jfrog.io
+  DOCKER_IMAGE: "sonarsource/a3s-analysis-javascript"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  get_build_number:
+    runs-on: github-ubuntu-latest-s
+    name: Get build number
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+    steps:
+      - uses: SonarSource/ci-github-actions/get-build-number@master
+        id: get-build-number
+
+  build_and_publish:
+    name: Build and publish Docker image
+    runs-on: github-ubuntu-latest-m
+    needs: get_build_number
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      BUILD_NUMBER: ${{ needs.get_build_number.outputs.BUILD_NUMBER }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: jdx/mise-action@v3.6.1
+        with:
+          version: 2025.11.2
+          mise_toml: |
+            [tools]
+            node = "24.11.0"
+
+      - name: Access vault secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release access_token | ARTIFACTORY_DEPLOY_PASSWORD;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release username | ARTIFACTORY_DEPLOY_USERNAME;
+
+      - name: Configure npm registry
+        run: |
+          npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+          npm config set registry https://repox.jfrog.io/artifactory/api/npm/npm/
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Build bundle for Docker
+        run: npm run grpc:build
+
+      - name: Docker login to Repox registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REPOX_BUILDS_REGISTRY }}
+          username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.DOCKER_REPOX_BUILDS_REGISTRY }}/${{ env.DOCKER_IMAGE }}:${{ env.BUILD_NUMBER }}

--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -61,8 +61,8 @@ jobs:
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release access_token | ARTIFACTORY_DEPLOY_PASSWORD;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release username | ARTIFACTORY_DEPLOY_USERNAME;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer access_token | ARTIFACTORY_DEPLOY_PASSWORD;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer username | ARTIFACTORY_DEPLOY_USERNAME;
 
       - name: Configure npm registry
         run: |

--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -1,6 +1,9 @@
 name: Build A3S Docker Image (Repox)
 
 on:
+  push:
+    branches:
+      - docker-a3s-repox-workflow  # Temporary: for testing, remove before merge
   workflow_dispatch:
     inputs:
       branch:
@@ -43,7 +46,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - uses: jdx/mise-action@v3.6.1
         with:

--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -1,9 +1,6 @@
 name: Build A3S Docker Image (Repox)
 
 on:
-  push:
-    branches:
-      - docker-a3s-repox-workflow  # Temporary: for testing, remove before merge
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   DOCKER_REPOX_BUILDS_REGISTRY: repox-sonarsource-docker-builds.jfrog.io
-  DOCKER_IMAGE: "sonarsource/a3s-analysis-javascript"
+  DOCKER_IMAGE: "a3s/analysis/javascript"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -76,21 +76,25 @@ jobs:
         run: npm run grpc:build
 
       - name: Docker login to Repox registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
         with:
           registry: ${{ env.DOCKER_REPOX_BUILDS_REGISTRY }}
           username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
 
+      - name: Setup Docker image
+        shell: bash
+        id: docker-image-setup
+        run: |
+          DOCKER_IMAGE_BUILD_NUMBER="${DOCKER_REPOX_BUILDS_REGISTRY}/${DOCKER_IMAGE}:${BUILD_NUMBER}"
+          echo "docker-image=${DOCKER_IMAGE_BUILD_NUMBER}" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          platforms: linux/arm64
-          tags: |
-            ${{ env.DOCKER_REPOX_BUILDS_REGISTRY }}/${{ env.DOCKER_IMAGE }}:${{ env.BUILD_NUMBER }}
+        shell: bash
+        env:
+          DOCKER_IMAGE_BUILD_NUMBER: ${{ steps.docker-image-setup.outputs.docker-image }}
+        run: |
+          docker buildx build --platform linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .

--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -44,7 +44,7 @@ jobs:
       BUILD_NUMBER: ${{ needs.get_build_number.outputs.BUILD_NUMBER }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ inputs.branch || github.ref }}
 
@@ -90,7 +90,7 @@ jobs:
           echo "docker-image=${DOCKER_IMAGE_BUILD_NUMBER}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build and push Docker image
         shell: bash

--- a/.github/workflows/docker-a3s.yml
+++ b/.github/workflows/docker-a3s.yml
@@ -1,4 +1,4 @@
-name: Build A3S Docker Image
+name: Build A3S Docker Image (AWS)
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow to build and publish the A3S Docker image to Repox (JFrog Artifactory)
- Similar to the existing ECR workflow but targeting Repox registry instead
- Uses Vault secrets for Artifactory authentication

## Test plan
- [ ] Trigger the workflow manually via `gh workflow run` specifying the branch
- [ ] Verify the Docker image is built and pushed to Repox

🤖 Generated with [Claude Code](https://claude.com/claude-code)