### PR TITLE
JS-1192 Do not crash when semver fails to get minimum version of react

### DIFF
--- a/packages/jsts/src/rules/S6957/fixtures/pnpm-catalog/package.json
+++ b/packages/jsts/src/rules/S6957/fixtures/pnpm-catalog/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-catalog-app",
+  "version": "1.0.0",
+  "author": "Your Name <email@example.com>",
+  "dependencies": {
+    "react": "catalog:frontend"
+  }
+}

--- a/packages/jsts/src/rules/S6957/unit.test.ts
+++ b/packages/jsts/src/rules/S6957/unit.test.ts
@@ -180,6 +180,40 @@ ReactDOM.render(<div></div>, container);
       ],
     });
 
+    // JS-1192: Test that pnpm catalog references (e.g., "catalog:frontend") don't crash the rule
+    const filenamePnpmCatalog = path.join(fixtures, 'pnpm-catalog/file.js');
+
+    ruleTester.run('pnpm catalog reference', rule, {
+      valid: [
+        {
+          // When React version cannot be determined (pnpm catalog), non-deprecated code should pass
+          code: `
+import React from 'react';
+const element = <div>Hello</div>;
+`,
+          filename: filenamePnpmCatalog,
+        },
+      ],
+      invalid: [
+        {
+          // When React version cannot be determined, the rule should still work
+          // (falls back to detecting all deprecations)
+          code: `
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+ReactDOM.render(<div></div>, container);
+`,
+          filename: filenamePnpmCatalog,
+          errors: [
+            {
+              message: 'ReactDOM.render is deprecated since React 18.0.0, use createRoot instead',
+            },
+          ],
+        },
+      ],
+    });
+
     shouldRaiseAllIssues(path.join(fixtures, 'noreact1/file.js'));
     shouldRaiseAllIssues(path.join(fixtures, 'noreact2/file.js'));
 

--- a/packages/jsts/src/rules/helpers/package-jsons/dependencies.ts
+++ b/packages/jsts/src/rules/helpers/package-jsons/dependencies.ts
@@ -69,9 +69,29 @@ export function getReactVersion(context: Rule.RuleContext): string | null {
   for (const packageJson of getManifests(dir, context.cwd, fs)) {
     const reactVersion = packageJson.dependencies?.react ?? packageJson.devDependencies?.react;
     if (reactVersion) {
-      // Coerce version ranges (e.g., "^18.0.0") to valid semver versions
-      return minVersion(reactVersion)?.version ?? null;
+      const parsed = parseReactVersion(reactVersion);
+      if (parsed) {
+        return parsed;
+      }
+      // Continue searching in parent package.json files if parsing fails
     }
   }
   return null;
+}
+
+/**
+ * Parses a React version string and returns a valid semver version.
+ * Exported for testing purposes.
+ *
+ * @param reactVersion Version string from package.json (e.g., "^18.0.0", "19.0", "catalog:frontend")
+ * @returns Valid semver version string or null if parsing fails
+ */
+export function parseReactVersion(reactVersion: string): string | null {
+  try {
+    // Coerce version ranges (e.g., "^18.0.0") to valid semver versions
+    return minVersion(reactVersion)?.version ?? null;
+  } catch {
+    // Handle non-semver strings like pnpm catalog references (e.g., "catalog:frontend")
+    return null;
+  }
 }

--- a/packages/jsts/tests/rules/helpers/dependencies.test.ts
+++ b/packages/jsts/tests/rules/helpers/dependencies.test.ts
@@ -1,0 +1,99 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { expect } from 'expect';
+import { parseReactVersion } from '../../../src/rules/helpers/package-jsons/dependencies.js';
+
+describe('parseReactVersion', () => {
+  it('should parse exact versions', () => {
+    expect(parseReactVersion('18.0.0')).toBe('18.0.0');
+    expect(parseReactVersion('19.1.0')).toBe('19.1.0');
+    expect(parseReactVersion('16.14.0')).toBe('16.14.0');
+  });
+
+  it('should parse partial versions', () => {
+    expect(parseReactVersion('18.0')).toBe('18.0.0');
+    expect(parseReactVersion('19')).toBe('19.0.0');
+  });
+
+  it('should parse version ranges with caret', () => {
+    expect(parseReactVersion('^18.0.0')).toBe('18.0.0');
+    expect(parseReactVersion('^19.1.0')).toBe('19.1.0');
+    expect(parseReactVersion('^16.8')).toBe('16.8.0');
+  });
+
+  it('should parse version ranges with tilde', () => {
+    expect(parseReactVersion('~18.0.0')).toBe('18.0.0');
+    expect(parseReactVersion('~19.1.0')).toBe('19.1.0');
+  });
+
+  it('should parse version ranges with comparison operators', () => {
+    expect(parseReactVersion('>=18.0.0')).toBe('18.0.0');
+    expect(parseReactVersion('>17.0.0')).toBe('17.0.1');
+    expect(parseReactVersion('>=18.0.0 <19.0.0')).toBe('18.0.0');
+  });
+
+  it('should parse x-range versions', () => {
+    expect(parseReactVersion('18.x')).toBe('18.0.0');
+    expect(parseReactVersion('18.*')).toBe('18.0.0');
+    expect(parseReactVersion('*')).toBe('0.0.0');
+  });
+
+  it('should parse hyphen range versions', () => {
+    expect(parseReactVersion('17.0.0 - 19.0.0')).toBe('17.0.0');
+  });
+
+  it('should return null for pnpm catalog references', () => {
+    expect(parseReactVersion('catalog:')).toBeNull();
+    expect(parseReactVersion('catalog:frontend')).toBeNull();
+    expect(parseReactVersion('catalog:default')).toBeNull();
+  });
+
+  it('should return null for workspace protocol', () => {
+    expect(parseReactVersion('workspace:*')).toBeNull();
+    expect(parseReactVersion('workspace:^')).toBeNull();
+  });
+
+  it('should return null for file protocol', () => {
+    expect(parseReactVersion('file:../react')).toBeNull();
+    expect(parseReactVersion('file:./packages/react')).toBeNull();
+  });
+
+  it('should return null for link protocol', () => {
+    expect(parseReactVersion('link:../react')).toBeNull();
+  });
+
+  it('should return null for git URLs', () => {
+    expect(parseReactVersion('git://github.com/facebook/react.git')).toBeNull();
+    expect(parseReactVersion('git+https://github.com/facebook/react.git')).toBeNull();
+    expect(parseReactVersion('github:facebook/react')).toBeNull();
+  });
+
+  it('should return null for npm aliases', () => {
+    expect(parseReactVersion('npm:preact@10.0.0')).toBeNull();
+  });
+
+  it('should return null for invalid strings', () => {
+    expect(parseReactVersion('invalid')).toBeNull();
+    expect(parseReactVersion('not-a-version')).toBeNull();
+  });
+
+  it('should handle empty string as wildcard', () => {
+    // semver treats empty string like '*' which resolves to 0.0.0
+    expect(parseReactVersion('')).toBe('0.0.0');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `TypeError: Invalid comparator: catalog:frontend` when using pnpm catalogs
- Wrap semver parsing in try-catch to handle non-semver strings gracefully
- Continue searching parent `package.json` files if parsing fails

## Test plan
- [x] Unit tests for `parseReactVersion` covering all version formats
- [x] S6957 fixture test with pnpm catalog reference

Fixes https://community.sonarsource.com/t/error-in-npm-sonar-scanner-with-pnpm-catalog-sonarjs-s6957/177008

🤖 Generated with [Claude Code](https://claude.com/claude-code)