### PR TITLE
JS-1203 Add Tailwind CSS v4 at-rules to S4662 ignore list

### DIFF
--- a/sonar-plugin/css/src/main/java/org/sonar/css/rules/AtRuleNoUnknown.java
+++ b/sonar-plugin/css/src/main/java/org/sonar/css/rules/AtRuleNoUnknown.java
@@ -27,7 +27,7 @@ import org.sonar.check.RuleProperty;
 public class AtRuleNoUnknown implements CssRule {
 
   private static final String DEFAULT_IGNORED_AT_RULES =
-    "value,at-root,content,debug,each,else,error,for,function,if,include,mixin,return,warn,while,extend,use,forward,tailwind,apply,layer,container,theme,/^@.*/";
+    "value,at-root,content,debug,each,else,error,for,function,if,include,mixin,return,warn,while,extend,use,forward,tailwind,apply,layer,container,theme,utility,custom-variant,source,plugin,config,reference,variant";
 
   @RuleProperty(
     key = "ignoreAtRules",

--- a/sonar-plugin/css/src/test/java/org/sonar/css/rules/CssRuleTest.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/rules/CssRuleTest.java
@@ -149,7 +149,7 @@ class CssRuleTest {
   void at_rule_unknown_default() {
     String optionsAsJson = GSON.toJson(new AtRuleNoUnknown().stylelintOptions());
     assertThat(optionsAsJson).isEqualTo(
-      "[true,{\"ignoreAtRules\":[\"value\",\"at-root\",\"content\",\"debug\",\"each\",\"else\",\"error\",\"for\",\"function\",\"if\",\"include\",\"mixin\",\"return\",\"warn\",\"while\",\"extend\",\"use\",\"forward\",\"tailwind\",\"apply\",\"layer\",\"container\",\"theme\",\"/^@.*/\"]}]"
+      "[true,{\"ignoreAtRules\":[\"value\",\"at-root\",\"content\",\"debug\",\"each\",\"else\",\"error\",\"for\",\"function\",\"if\",\"include\",\"mixin\",\"return\",\"warn\",\"while\",\"extend\",\"use\",\"forward\",\"tailwind\",\"apply\",\"layer\",\"container\",\"theme\",\"utility\",\"custom-variant\",\"source\",\"plugin\",\"config\",\"reference\",\"variant\"]}]"
     );
   }
 


### PR DESCRIPTION
## Summary
- Add missing Tailwind CSS v4 directives to the default ignore list for rule S4662: `utility`, `custom-variant`, `source`, `plugin`, `config`, `reference`, `variant`
- Remove the incorrect regex `/^@.*/` which never matched anything because stylelint provides at-rule names without the `@` prefix

## Context
Rule S4662 generates false positives for legitimate Tailwind CSS v4 directives. User feedback shows 39 false positive reports (100% of all feedback) with a 41.1% FP rate, affecting 6,923 projects.

**Dashboard**: https://sonarsource.github.io/issue-feedback-dashboard/?rule=S4662&team=css

The most frequently reported at-rules:
- `@utility` - 14 reports
- `@custom-variant` - 13 reports
- `@source` - 8 reports
- `@plugin` - 4 reports
- `@reference` - 3 reports
- `@config` - 2 reports

## Test plan
- [x] Run `CssRuleTest#at_rule_unknown_default` - verifies the new default configuration
- [x] Run full `CssRuleTest` - ensures no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)