### PR TITLE
JS-1203 Restore regex pattern in S4662 ignore list

### DIFF
--- a/sonar-plugin/css/src/main/java/org/sonar/css/rules/AtRuleNoUnknown.java
+++ b/sonar-plugin/css/src/main/java/org/sonar/css/rules/AtRuleNoUnknown.java
@@ -27,7 +27,7 @@ import org.sonar.check.RuleProperty;
 public class AtRuleNoUnknown implements CssRule {
 
   private static final String DEFAULT_IGNORED_AT_RULES =
-    "value,at-root,content,debug,each,else,error,for,function,if,include,mixin,return,warn,while,extend,use,forward,tailwind,apply,layer,container,theme,utility,custom-variant,source,plugin,config,reference,variant";
+    "value,at-root,content,debug,each,else,error,for,function,if,include,mixin,return,warn,while,extend,use,forward,tailwind,apply,layer,container,theme,utility,custom-variant,source,plugin,config,reference,variant,/^@.*/";
 
   @RuleProperty(
     key = "ignoreAtRules",

--- a/sonar-plugin/css/src/test/java/org/sonar/css/rules/CssRuleTest.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/rules/CssRuleTest.java
@@ -149,7 +149,7 @@ class CssRuleTest {
   void at_rule_unknown_default() {
     String optionsAsJson = GSON.toJson(new AtRuleNoUnknown().stylelintOptions());
     assertThat(optionsAsJson).isEqualTo(
-      "[true,{\"ignoreAtRules\":[\"value\",\"at-root\",\"content\",\"debug\",\"each\",\"else\",\"error\",\"for\",\"function\",\"if\",\"include\",\"mixin\",\"return\",\"warn\",\"while\",\"extend\",\"use\",\"forward\",\"tailwind\",\"apply\",\"layer\",\"container\",\"theme\",\"utility\",\"custom-variant\",\"source\",\"plugin\",\"config\",\"reference\",\"variant\"]}]"
+      "[true,{\"ignoreAtRules\":[\"value\",\"at-root\",\"content\",\"debug\",\"each\",\"else\",\"error\",\"for\",\"function\",\"if\",\"include\",\"mixin\",\"return\",\"warn\",\"while\",\"extend\",\"use\",\"forward\",\"tailwind\",\"apply\",\"layer\",\"container\",\"theme\",\"utility\",\"custom-variant\",\"source\",\"plugin\",\"config\",\"reference\",\"variant\",\"/^@.*/\"]}]"
     );
   }
 


### PR DESCRIPTION
## Summary
- Restores the `/^@.*/` regex pattern to the S4662 (at-rule-no-unknown) ignore list
- This pattern was inadvertently removed in #6308, causing the CssRulingTest to fail

## Test plan
- [x] CssRuleTest unit test passes
- [x] CssRulingTest integration test passes

🤖 Generated with [Claude Code](https://claude.ai/code)