### PR TITLE
JS-1219 Add ignoreFunctions option to S4653 (unit-no-unknown)

### DIFF
--- a/sonar-plugin/css/src/main/java/org/sonar/css/rules/UnitNoUnknown.java
+++ b/sonar-plugin/css/src/main/java/org/sonar/css/rules/UnitNoUnknown.java
@@ -16,13 +16,43 @@
  */
 package org.sonar.css.rules;
 
+import static org.sonar.css.rules.RuleUtils.splitAndTrim;
+
+import java.util.Arrays;
+import java.util.List;
 import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
 
 @Rule(key = "S4653")
 public class UnitNoUnknown implements CssRule {
 
+  private static final String DEFAULT_IGNORED_FUNCTIONS =
+    "image-set, spacer, spacing, size, rem, em, fluid";
+
+  @RuleProperty(
+    key = "ignoreFunctions",
+    description = "Comma-separated list of function names and/or regular expressions for functions whose arguments should be ignored.",
+    defaultValue = "" + DEFAULT_IGNORED_FUNCTIONS
+  )
+  String ignoreFunctions = DEFAULT_IGNORED_FUNCTIONS;
+
   @Override
   public String stylelintKey() {
     return "unit-no-unknown";
+  }
+
+  @Override
+  public List<Object> stylelintOptions() {
+    return Arrays.asList(true, new StylelintIgnoreOption(splitAndTrim(ignoreFunctions)));
+  }
+
+  private static class StylelintIgnoreOption {
+
+    // Used by GSON serialization
+    private final List<String> ignoreFunctions;
+
+    StylelintIgnoreOption(List<String> ignoreFunctions) {
+      this.ignoreFunctions = ignoreFunctions;
+    }
   }
 }

--- a/sonar-plugin/css/src/test/java/org/sonar/css/rules/CssRuleTest.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/rules/CssRuleTest.java
@@ -28,7 +28,7 @@ import org.sonar.css.CssRules;
 
 class CssRuleTest {
 
-  private static final int RULES_PROPERTIES_COUNT = 9;
+  private static final int RULES_PROPERTIES_COUNT = 10;
   private static final Gson GSON = new Gson();
 
   @Test
@@ -56,7 +56,8 @@ class CssRuleTest {
       PropertyNoUnknown.class,
       SelectorPseudoClassNoUnknown.class,
       SelectorPseudoElementNoUnknown.class,
-      SelectorTypeNoUnknown.class
+      SelectorTypeNoUnknown.class,
+      UnitNoUnknown.class
     );
 
     for (Class ruleClass : CssRules.getRuleClasses()) {
@@ -195,5 +196,21 @@ class CssRuleTest {
     assertThat(optionsAsJson).isEqualTo(
       "[true,{\"ignoreFontFamilies\":[\"Icon Font\",\"/icon$/\"]}]"
     );
+  }
+
+  @Test
+  void unit_no_unknown_default() {
+    String optionsAsJson = GSON.toJson(new UnitNoUnknown().stylelintOptions());
+    assertThat(optionsAsJson).isEqualTo(
+      "[true,{\"ignoreFunctions\":[\"image-set\",\"spacer\",\"spacing\",\"size\",\"rem\",\"em\",\"fluid\"]}]"
+    );
+  }
+
+  @Test
+  void unit_no_unknown_custom() {
+    UnitNoUnknown instance = new UnitNoUnknown();
+    instance.ignoreFunctions = "spacer, /^my-/";
+    String optionsAsJson = GSON.toJson(instance.stylelintOptions());
+    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreFunctions\":[\"spacer\",\"/^my-/\"]}]");
   }
 }


### PR DESCRIPTION
## Summary

- Add configurable `ignoreFunctions` option to S4653 to prevent false positives when SCSS/Sass functions use design tokens that look like invalid units
- Default ignored functions: `image-set`, `spacer`, `spacing`, `size`, `rem`, `em`, `fluid`
- Users can customize by adding their own function names or regex patterns (e.g., `/^my-/`)

## Problem

User feedback reported a false positive on:
```scss
height: spacer(3xl) !important;  // FP: "3xl" flagged as unknown unit
```

The `spacer()` is a custom SCSS function that takes a design token name (`3xl`), but stylelint sees `3xl` and incorrectly flags it as an invalid unit.

## Solution

Leverage stylelint's `unit-no-unknown` rule's `ignoreFunctions` option to ignore arguments inside specified functions. This follows the same pattern used by other CSS rules like `SelectorPseudoClassNoUnknown` and `AtRuleNoUnknown`.

## Test plan

- [x] Unit tests added for default and custom configurations
- [x] All CSS module tests pass (`mvn test -pl sonar-plugin/css`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)