### PR TITLE
JS-1234 Use new jacoco aggregate report paths property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <jdk.min.version>17</jdk.min.version>
     <version.surefire.plugin>3.1.2</version.surefire.plugin>
-    <sonar.coverage.jacoco.aggregateXmlReportPath>${maven.multiModuleProjectDirectory}/coverage/java/jacoco.xml</sonar.coverage.jacoco.aggregateXmlReportPath>
+    <sonar.coverage.jacoco.aggregateXmlReportPaths>${maven.multiModuleProjectDirectory}/coverage/java/jacoco.xml</sonar.coverage.jacoco.aggregateXmlReportPaths>
 
     <!-- FIXME fix javadoc errors -->
     <doclint>none</doclint>


### PR DESCRIPTION
After the update of the jacoco plugin to properly support multiple aggregate report paths, the analysis parameter changed to a plural form, requiring the update of existing configurations.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
