### PR TITLE
JS-1298 Allow bot PRs to trigger eslint-plugin Jira labeling

### DIFF
--- a/.github/workflows/LabelEslintPlugin.yml
+++ b/.github/workflows/LabelEslintPlugin.yml
@@ -14,10 +14,8 @@ jobs:
       id-token: write
       pull-requests: read
       contents: read
-    # Only run for internal PRs (not forks) and not from bots
-    if: |
-        github.event.pull_request.head.repo.full_name == github.repository
-        && github.event.sender.type != 'Bot'
+    # Only run for internal PRs (not forks)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Remove bot restriction from LabelEslintPlugin workflow
- PRs created by `ss-vibe-bot` will now have the `eslint-plugin` label added to their Jira tickets

## Test plan
- [ ] Verify workflow runs on bot-created PRs that modify rules

🤖 Generated with [Claude Code](https://claude.ai/code)