### PR TITLE
JS-1317 Fix changelog workflow permissions by using default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release_eslint_plugin.yml
+++ b/.github/workflows/release_eslint_plugin.yml
@@ -66,7 +66,6 @@ jobs:
     needs: publish
     uses: ./.github/workflows/update-eslint-plugin-changelog.yml
     permissions:
-      id-token: write
       contents: write
       pull-requests: write
     with:

--- a/.github/workflows/update-eslint-plugin-changelog.yml
+++ b/.github/workflows/update-eslint-plugin-changelog.yml
@@ -17,15 +17,9 @@ jobs:
   update-changelog:
     runs-on: github-ubuntu-latest-s
     permissions:
-      id-token: write
       contents: write
       pull-requests: write
     steps:
-      - id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
       - uses: actions/checkout@v6
       - name: Update changelog
         env:
@@ -33,7 +27,6 @@ jobs:
         run: node tools/update-changelog.js "$VERSION"
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
-          token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           author: ${{ github.actor }} <${{ github.actor }}>
           commit-message: "Update eslint-plugin-sonarjs changelog for ${{ inputs.version }}"
           title: "Update eslint-plugin-sonarjs changelog for ${{ inputs.version }}"


### PR DESCRIPTION
## Summary
- The `update-eslint-plugin-changelog` workflow was failing with a 403 error because it used a Vault-fetched Jira token (`hashicorp-vault-sonar-prod[bot]`) that lacks push permissions on the repo
- Removed the Vault secret step and `token:` override so the action uses the default `GITHUB_TOKEN`, which already has the required `contents:write` and `pull-requests:write` permissions
- Removed the now-unnecessary `id-token: write` permission from both the changelog workflow and its caller in `release_eslint_plugin.yml`

Failed run: https://github.com/SonarSource/SonarJS/actions/runs/21902454324/job/63233961431

## Test plan
- [x] Re-run the "Update ESLint Plugin Changelog" workflow manually and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)