### PR TITLE
JS-1327 Update CssMetricsTest expected ncloc for SonarHtml 3.24

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssMetricsTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssMetricsTest.java
@@ -42,7 +42,7 @@ class CssMetricsTest {
     assertThat(getMeasureAsDouble(PROJECT_KEY, "lines")).isEqualTo(89);
     assertThat(getMeasureAsDouble(PROJECT_KEY, "ncloc")).isEqualTo(58);
     assertThat(getMeasure(PROJECT_KEY, "ncloc_language_distribution").getValue()).isEqualTo(
-      "css=27;php=1;web=24"
+      "css=27;php=1;web=30"
     );
     assertThat(getMeasureAsDouble(PROJECT_KEY, "comment_lines")).isEqualTo(6);
   }

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssMetricsTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/CssMetricsTest.java
@@ -40,7 +40,7 @@ class CssMetricsTest {
   @Test
   void test() {
     assertThat(getMeasureAsDouble(PROJECT_KEY, "lines")).isEqualTo(89);
-    assertThat(getMeasureAsDouble(PROJECT_KEY, "ncloc")).isEqualTo(52);
+    assertThat(getMeasureAsDouble(PROJECT_KEY, "ncloc")).isEqualTo(58);
     assertThat(getMeasure(PROJECT_KEY, "ncloc_language_distribution").getValue()).isEqualTo(
       "css=27;php=1;web=24"
     );


### PR DESCRIPTION
## Summary
- SonarHtml 3.24 now analyzes `*.htm` files, which increases the expected `ncloc` in the CSS metrics integration test from 52 to 58.

## Test plan
- [ ] CI integration tests pass with the updated expected value

🤖 Generated with [Claude Code](https://claude.com/claude-code)