### PR TITLE
JS-1329 Fix promote job being skipped on non-schedule builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1111,7 +1111,9 @@ jobs:
       - css_ruling
       - ruling
       - js_ts_ruling
-    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    if: >-
+      !failure() && !cancelled() &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     permissions: *read_permissions
     steps:
       - *checkout


### PR DESCRIPTION
## Summary

- The `promote` job was being skipped on push events (e.g. `dogfood-on-peach`) because it depends on schedule-only jobs (`plugin_qa_without_node_alpine`, `plugin_qa_fast_without_node_alpine`) that are skipped on non-schedule events
- Added `!failure() && !cancelled()` to the `promote` job's `if` condition to tolerate skipped dependencies

## Why this works

By default, GitHub Actions implicitly wraps every job's `if` condition with `success()`, which requires **all** `needs` jobs to have succeeded. Since `skipped != succeeded`, the `promote` job was also skipped.

When you use an explicit status function like `!failure()`, GitHub **stops prepending** the implicit `success()`. Since a skipped job is neither a failure nor a cancellation, `!failure() && !cancelled()` evaluates to `true` and the job proceeds. Actual failures and cancellations still block promotion as expected.

Example run where promote was skipped: https://github.com/SonarSource/SonarJS/actions/runs/21989803608

## Test plan

- [ ] Verify promote runs on a push to a non-default branch (e.g. dogfood-on-peach)
- [ ] Verify promote is still blocked when a required job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)