### PR TITLE
JS-1330 Fix CSS issues with invalid line/column positions

### DIFF
--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/CssIssuesTest.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/CssIssuesTest.java
@@ -112,6 +112,7 @@ class CssIssuesTest {
         tuple("css:S4667", "src/empty1.css"),
         tuple("css:S4667", "src/empty2.less"),
         tuple("css:S4667", "src/empty3.scss"),
+        tuple("css:S4667", "src/emptySass.vue"),
         tuple("css:S1128", "src/file1.css"),
         tuple("css:S1116", "src/file1.css"),
         tuple("css:S4664", "src/file1.css"),

--- a/its/plugin/projects/css-issues-project/src/emptySass.vue
+++ b/its/plugin/projects/css-issues-project/src/emptySass.vue
@@ -1,0 +1,1 @@
+<style scoped lang="sass"></style>

--- a/packages/css/tests/linter/issues/transform.test.ts
+++ b/packages/css/tests/linter/issues/transform.test.ts
@@ -76,4 +76,37 @@ describe('transform', () => {
       `DEBUG For file [${filePath}] received issues with [${source}] as a source. They will not be reported.`,
     );
   });
+
+  it('should default to line 1 and column 1 for invalid positions', ({ mock }) => {
+    console.log = mock.fn(console.log);
+
+    const filePath = normalizeToAbsolutePath('/tmp/path');
+    const results = [
+      {
+        source: filePath as string,
+        warnings: [
+          {
+            rule: 'no-empty-source',
+            text: 'Unexpected empty source',
+            line: NaN,
+            column: undefined,
+          },
+        ],
+      },
+    ] as unknown as stylelint.LintResult[];
+
+    const issues = transform(results, filePath);
+
+    expect(issues).toEqual([
+      {
+        ruleId: 'no-empty-source',
+        message: 'Unexpected empty source',
+        line: 1,
+        column: 1,
+      },
+    ]);
+    expect((console.log as Mock<typeof console.log>).mock.calls[0].arguments[0]).toMatch(
+      /^WARN Invalid position for rule no-empty-source/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Handle invalid line/column positions from Stylelint by defaulting to line 1, column 1
- Log a warning when defaulting occurs for debugging purposes
- Add integration test with empty SASS style block in Vue file

## Root Cause

When parsing empty SASS content in Vue files, `gonzales-pe` (the underlying SASS parser used by `postcss-sass`) returns source positions as arrays `[0, 0]` instead of objects `{ line, column }`. This causes Stylelint to report issues with `line: null` and `column: undefined`.

Both `gonzales-pe` (last updated 2020) and `postcss-sass` (last updated 2021) are unmaintained, so we handle this edge case in SonarJS.

## Related

- [USER-1614](https://sonarsource.atlassian.net/browse/USER-1614)

## Test plan

- [x] Unit tests for transform.ts with invalid position scenario
- [x] Integration test with emptySass.vue file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[USER-1614]: https://sonarsource.atlassian.net/browse/USER-1614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ