### PR TITLE
JS-1336 Fix infinite loop in getFullyQualifiedNameTS when import is shadowed

### DIFF
--- a/packages/jsts/src/rules/S2077/unit.test.ts
+++ b/packages/jsts/src/rules/S2077/unit.test.ts
@@ -257,7 +257,13 @@ describe('S2077', () => {
   it('S2077 with type information', () => {
     const ruleTester = new RuleTester();
     ruleTester.run('Formatting SQL queries is security-sensitive [TS]', rule, {
-      valid: [],
+      valid: [
+        // No infinite loop when local variable shadows imported name
+        {
+          code: `import { geolocation as geo } from "@vercel/functions";
+      const geo = geo(request);`,
+        },
+      ],
       invalid: [
         // mysql: ESM namespace import with concatenation
         {

--- a/packages/jsts/src/rules/helpers/ancestor.ts
+++ b/packages/jsts/src/rules/helpers/ancestor.ts
@@ -17,6 +17,7 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import { Rule, SourceCode } from 'eslint';
 import type { Node } from 'estree';
+import ts from 'typescript';
 import { functionLike } from './ast.js';
 
 export function findFirstMatchingLocalAncestor(
@@ -98,4 +99,15 @@ export function childrenOf(node: Node, visitorKeys: SourceCode.VisitorKeys): Nod
     }
   }
   return children.filter(Boolean);
+}
+
+export function isTsAncestor(candidate: ts.Node, node: ts.Node): boolean {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (current === candidate) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary
- Fix infinite loop in `getFullyQualifiedNameTS` when a local variable shadows an imported name (e.g., `const geo = geo(request)` where `geo` is also an import alias)
- The FQN resolution loop: `Identifier` → `VariableDeclaration` → `CallExpression` → same `Identifier` → forever
- Added `isTsAncestor()` check: if the resolved declaration is an ancestor of the root node, treat the identifier as terminal instead of following it

## Test plan
- [x] Added test case for shadowed import in S2077
- [x] S2077 tests pass
- [x] S2699 tests pass (also uses `getFullyQualifiedNameTS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)