### PR TITLE
JS-1339 Fix Jira labeling workflow failing on PR titles with backticks

### DIFF
--- a/.github/workflows/LabelEslintPlugin.yml
+++ b/.github/workflows/LabelEslintPlugin.yml
@@ -78,8 +78,9 @@ jobs:
       - name: Extract Jira key from PR title
         id: extract-jira-key
         if: steps.check-rules.outputs.should_label == 'true'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           # Extract Jira key (e.g., JS-1234) from the beginning of the title
           JIRA_KEY=$(echo "$PR_TITLE" | grep -oE '^[A-Z]+-[0-9]+' || echo "")
           if [ -z "$JIRA_KEY" ]; then

--- a/its/ruling/src/test/expected/jsts/TypeScript/typescript-S7728.json
+++ b/its/ruling/src/test/expected/jsts/TypeScript/typescript-S7728.json
@@ -42,10 +42,5 @@
 "TypeScript:src/harness/test262Runner.ts": [
 113,
 118
-],
-"TypeScript:src/services/formatting/rulesMap.ts": [
-32,
-46,
-47
 ]
 }

--- a/its/ruling/src/test/expected/jsts/TypeScript/typescript-S7728.json
+++ b/its/ruling/src/test/expected/jsts/TypeScript/typescript-S7728.json
@@ -42,5 +42,10 @@
 "TypeScript:src/harness/test262Runner.ts": [
 113,
 118
+],
+"TypeScript:src/services/formatting/rulesMap.ts": [
+32,
+46,
+47
 ]
 }


### PR DESCRIPTION
## Summary
- Fix `LabelEslintPlugin` workflow crashing when PR titles contain backticks (e.g., `` `code-eval` ``)
- The PR title was set via inline interpolation (`PR_TITLE="${{ ... }}"`), causing bash to interpret backticks as command substitution
- Pass the title via `env` instead, which avoids shell interpretation

Fixes the failure on PR #6401: https://github.com/SonarSource/SonarJS/actions/runs/22141417301/job/64006378863

## Test plan
- [x] Verified the fix handles backtick-containing titles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)