### PR TITLE
JS-1340 Add sonar.javascript.createTSProgramForOrphanFiles flag

### DIFF
--- a/packages/jsts/src/analysis/projectAnalysis/analyzeWithProgram.ts
+++ b/packages/jsts/src/analysis/projectAnalysis/analyzeWithProgram.ts
@@ -97,16 +97,22 @@ export async function analyzeWithProgram(
     );
   }
 
-  await analyzeFilesFromEntryPoint(
-    files,
-    results,
-    pendingFiles,
-    foundProgramOptions,
-    progressReport,
-    baseDir,
-    jsTsConfigFields,
-    incrementalResultsChannel,
-  );
+  if (jsTsConfigFields.createTSProgramForOrphanFiles) {
+    await analyzeFilesFromEntryPoint(
+      files,
+      results,
+      pendingFiles,
+      foundProgramOptions,
+      progressReport,
+      baseDir,
+      jsTsConfigFields,
+      incrementalResultsChannel,
+    );
+  } else if (pendingFiles.size) {
+    info(
+      `Skipping TypeScript program creation for ${pendingFiles.size} orphan file(s) (sonar.javascript.createTSProgramForOrphanFiles=false)`,
+    );
+  }
 
   if (foundProgramOptions.some(options => options.missingTsConfig)) {
     results.meta.warnings.push(MISSING_EXTENDED_TSCONFIG);

--- a/packages/jsts/tests/analysis/analyzeProject-sonarqube.test.ts
+++ b/packages/jsts/tests/analysis/analyzeProject-sonarqube.test.ts
@@ -489,6 +489,70 @@ describe('SonarQube project analysis', () => {
     expect('issues' in fileResult! && fileResult!.issues.length).toBeGreaterThan(0);
   });
 
+  it('should skip TypeScript program creation for orphan files when createTSProgramForOrphanFiles is false', async () => {
+    const baseDir = join(fixtures, 'no-tsconfig');
+    const filePath = join(baseDir, 'orphan.ts');
+
+    console.log = mock.fn(console.log);
+    const consoleLogMock = (console.log as Mock<typeof console.log>).mock;
+
+    const configuration = await initForTest(
+      { baseDir, createTSProgramForOrphanFiles: false },
+      { [filePath]: { filePath, fileType: 'MAIN' } },
+    );
+
+    const result = await analyzeProject({ rules, bundles: [] }, configuration);
+
+    // Should log the skipping message
+    expect(
+      consoleLogMock.calls.some(call =>
+        (call.arguments[0] as string)?.includes('Skipping TypeScript program creation for'),
+      ),
+    ).toBe(true);
+
+    // The file should still be analyzed (without type info, via analyzeWithoutProgram)
+    expect(result.files[normalizeToAbsolutePath(filePath)]).toBeDefined();
+
+    // Should NOT log "using default options" since we skip the entry point program creation
+    expect(
+      consoleLogMock.calls.some(call =>
+        (call.arguments[0] as string)?.includes('using default options'),
+      ),
+    ).toBe(false);
+  });
+
+  it('should create TypeScript program for orphan files when createTSProgramForOrphanFiles is true', async () => {
+    const baseDir = join(fixtures, 'no-tsconfig');
+    const filePath = join(baseDir, 'orphan.ts');
+
+    console.log = mock.fn(console.log);
+    const consoleLogMock = (console.log as Mock<typeof console.log>).mock;
+
+    const configuration = await initForTest(
+      { baseDir, createTSProgramForOrphanFiles: true },
+      { [filePath]: { filePath, fileType: 'MAIN' } },
+    );
+
+    const result = await analyzeProject({ rules, bundles: [] }, configuration);
+
+    // Should log the default options message (entry point analysis runs)
+    expect(
+      consoleLogMock.calls.some(call =>
+        (call.arguments[0] as string)?.includes('using default options'),
+      ),
+    ).toBe(true);
+
+    // Should NOT log the skipping message
+    expect(
+      consoleLogMock.calls.some(call =>
+        (call.arguments[0] as string)?.includes('Skipping TypeScript program creation for'),
+      ),
+    ).toBe(false);
+
+    // File should be analyzed
+    expect(result.files[normalizeToAbsolutePath(filePath)]).toBeDefined();
+  });
+
   it('should report parsing errors', async () => {
     const baseDir = join(fixtures, 'parsing-error');
     const filePath = join(baseDir, 'file.js');

--- a/packages/shared/src/helpers/configuration.ts
+++ b/packages/shared/src/helpers/configuration.ts
@@ -73,6 +73,7 @@ export type Configuration = {
   testInclusions: Minimatch[] /* sonar.test.inclusions - WILDCARD to narrow down sonar.tests */;
   testExclusions: Minimatch[] /* sonar.test.exclusions - WILDCARD to narrow down sonar.tests */;
   detectBundles: boolean /* sonar.javascript.detectBundles - whether files looking like bundled code should be ignored */;
+  createTSProgramForOrphanFiles: boolean /* sonar.javascript.createTSProgramForOrphanFiles - whether to create a TS program for orphan files */;
 };
 
 // Patterns enforced to be ignored no matter what the user configures on sonar.properties
@@ -206,6 +207,9 @@ export function createConfiguration(raw: unknown): Configuration {
     testInclusions: normalizeGlobs(raw.testInclusions, baseDir),
     testExclusions: normalizeGlobs(raw.testExclusions, baseDir),
     detectBundles: isBoolean(raw.detectBundles) ? raw.detectBundles : true,
+    createTSProgramForOrphanFiles: isBoolean(raw.createTSProgramForOrphanFiles)
+      ? raw.createTSProgramForOrphanFiles
+      : true,
   };
 }
 
@@ -348,6 +352,7 @@ export type JsTsConfigFields = {
   skipAst: boolean;
   sonarlint: boolean;
   shouldIgnoreParams: ShouldIgnoreFileParams;
+  createTSProgramForOrphanFiles: boolean;
 };
 
 /**
@@ -365,5 +370,6 @@ export function getJsTsConfigFields(configuration: Configuration): JsTsConfigFie
     skipAst: configuration.skipAst,
     sonarlint: configuration.sonarlint,
     shouldIgnoreParams: getShouldIgnoreParams(configuration),
+    createTSProgramForOrphanFiles: configuration.createTSProgramForOrphanFiles,
   };
 }

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalysisConfiguration.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalysisConfiguration.java
@@ -49,6 +49,8 @@ public interface AnalysisConfiguration {
 
   boolean canAccessFileSystem();
 
+  boolean shouldCreateTSProgramForOrphanFiles();
+
   List<String> getSources();
 
   List<String> getInclusions();

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
@@ -193,6 +193,7 @@ public interface BridgeServer extends Startable {
     List<String> testExclusions;
     boolean detectBundles;
     boolean canAccessFileSystem;
+    boolean createTSProgramForOrphanFiles;
 
     /*
     We do not set sources, inclusions, exclusions, tests, testInclusions nor testExclusions as Sonar Engine
@@ -227,6 +228,8 @@ public interface BridgeServer extends Startable {
       this.jsTsExclusions = analysisConfiguration.getJsTsExcludedPaths();
       this.detectBundles = analysisConfiguration.shouldDetectBundles();
       this.canAccessFileSystem = analysisConfiguration.canAccessFileSystem();
+      this.createTSProgramForOrphanFiles =
+        analysisConfiguration.shouldCreateTSProgramForOrphanFiles();
     }
 
     public boolean skipAst() {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -135,6 +135,8 @@ public class JavaScriptPlugin implements Plugin {
   public static final String SKIP_NODE_PROVISIONING_PROPERTY = "sonar.scanner.skipNodeProvisioning";
   public static final String DETECT_BUNDLES_PROPERTY = "sonar.javascript.detectBundles";
   public static final String NO_FS = "sonar.javascript.canAccessFileSystem";
+  public static final String CREATE_TS_PROGRAM_FOR_ORPHAN_FILES =
+    "sonar.javascript.createTSProgramForOrphanFiles";
 
   @Override
   public void define(Context context) {
@@ -252,6 +254,18 @@ public class JavaScriptPlugin implements Plugin {
         )
         .onConfigScopes(PropertyDefinition.ConfigScope.PROJECT)
         .subCategory(GENERAL)
+        .category(JS_TS_CATEGORY)
+        .type(PropertyType.BOOLEAN)
+        .build(),
+      PropertyDefinition.builder(CREATE_TS_PROGRAM_FOR_ORPHAN_FILES)
+        .defaultValue("true")
+        .name("Create TypeScript program for orphan files")
+        .description(
+          "Controls whether a TypeScript program should be created for files not included in any tsconfig.json. " +
+            "When disabled, orphan files are analyzed without type information, which is faster but may reduce analysis accuracy."
+        )
+        .onConfigScopes(PropertyDefinition.ConfigScope.PROJECT)
+        .subCategory(TS_SUB_CATEGORY)
         .category(JS_TS_CATEGORY)
         .type(PropertyType.BOOLEAN)
         .build()

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsContext.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsContext.java
@@ -230,6 +230,13 @@ public class JsTsContext<T extends SensorContext> implements AnalysisConfigurati
     return config.getBoolean(JavaScriptPlugin.NO_FS).orElse(true);
   }
 
+  public boolean shouldCreateTSProgramForOrphanFiles() {
+    return context
+      .config()
+      .getBoolean(JavaScriptPlugin.CREATE_TS_PROGRAM_FOR_ORPHAN_FILES)
+      .orElse(true);
+  }
+
   public List<String> getSources() {
     return stream(this.context.config().getStringArray("sonar.sources"))
       .filter(x -> !x.isBlank())

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
@@ -121,6 +121,23 @@ class JavaScriptPluginTest {
     assertThat(propertyDefinition.subCategory()).isEqualTo("General");
   }
 
+  @Test
+  void createTSProgramForOrphanFilesPropertyIsCorrectlyExposed() {
+    var propertyDefinition = properties()
+      .stream()
+      .filter(item -> {
+        return Objects.equals(item.key(), "sonar.javascript.createTSProgramForOrphanFiles");
+      })
+      .findFirst()
+      .get();
+
+    assertThat(propertyDefinition.name()).isEqualTo("Create TypeScript program for orphan files");
+    assertThat(propertyDefinition.type().toString()).isEqualTo("BOOLEAN");
+    assertThat(propertyDefinition.defaultValue()).isEqualTo("true");
+    assertThat(propertyDefinition.category()).isEqualTo("JavaScript / TypeScript");
+    assertThat(propertyDefinition.subCategory()).isEqualTo("TypeScript");
+  }
+
   private List<PropertyDefinition> properties() {
     var extensions = setupContext(
       SonarRuntimeImpl.forSonarQube(LTS_VERSION, SonarQubeSide.SERVER, SonarEdition.COMMUNITY)


### PR DESCRIPTION
## Summary
- Adds a new boolean property `sonar.javascript.createTSProgramForOrphanFiles` (default: `true`) to control whether a TypeScript program is created for orphan files (files not in any tsconfig.json)
- When set to `false`, orphan files skip the expensive TS program creation and are analyzed without type information via `analyzeWithoutProgram()` instead
- Plumbs the flag through Java plugin property registration, `AnalysisConfiguration` interface, `BridgeServer` DTO, Node.js `Configuration` type, and `analyzeWithProgram` logic

## Test plan
- [x] Java: `JavaScriptPluginTest` verifies property definition (name, type, default, category)
- [x] Node: Two new tests in `analyzeProject-sonarqube.test.ts`:
  - `createTSProgramForOrphanFiles: false` → skipping log appears, file still analyzed without type info
  - `createTSProgramForOrphanFiles: true` → existing behavior preserved
- [x] All existing tests pass (22/22 SonarQube analysis, 3/3 configuration, 7/7 Java plugin)
- [x] `npm run bbf` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)