### PR TITLE
JS-1346 Restore release.yml with only workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+---
+name: sonar-release
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: Version
+        required: true
+      releaseId:
+        type: string
+        description: Release ID
+        required: true
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
+        required: false
+
+jobs:
+  release:
+    permissions:
+      id-token: write
+      contents: write
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    with:
+      publishToBinaries: true
+      mavenCentralSync: true
+      slackChannel: ask-squad-web
+      version: ${{ inputs.version }}
+      releaseId: ${{ inputs.releaseId }}
+      dryRun: ${{ inputs.dryRun == true }}

--- a/its/ruling/src/test/expected/jsts/TypeScript/typescript-S7728.json
+++ b/its/ruling/src/test/expected/jsts/TypeScript/typescript-S7728.json
@@ -42,10 +42,5 @@
 "TypeScript:src/harness/test262Runner.ts": [
 113,
 118
-],
-"TypeScript:src/services/formatting/rulesMap.ts": [
-32,
-46,
-47
 ]
 }

--- a/its/ruling/src/test/expected/jsts/TypeScript/typescript-S7728.json
+++ b/its/ruling/src/test/expected/jsts/TypeScript/typescript-S7728.json
@@ -42,5 +42,10 @@
 "TypeScript:src/harness/test262Runner.ts": [
 113,
 118
+],
+"TypeScript:src/services/formatting/rulesMap.ts": [
+32,
+46,
+47
 ]
 }


### PR DESCRIPTION
## Summary
- Restores `release.yml` that was removed in #6406
- Removes the `release: published` trigger (no longer needed since `automated-release.yml` handles that)
- Keeps `workflow_dispatch` as it will be invoked by the `automated-release.yml` using the gh cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)