### PR TITLE
JS-1347 Add propagation tests for createTSProgramForOrphanFiles flag

### DIFF
--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/OrphanTsFilesTest.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/OrphanTsFilesTest.java
@@ -1,0 +1,120 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2012-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package com.sonar.javascript.it.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sonarsource.scanner.integrationtester.dsl.Log;
+import com.sonarsource.scanner.integrationtester.dsl.ScannerInput;
+import com.sonarsource.scanner.integrationtester.dsl.SonarServerContext;
+import com.sonarsource.scanner.integrationtester.dsl.issue.TextRangeIssue;
+import com.sonarsource.scanner.integrationtester.runner.ScannerRunner;
+import com.sonarsource.scanner.integrationtester.runner.ScannerRunnerConfig;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.javascript.JavaScriptPlugin;
+import org.sonar.plugins.javascript.TypeScriptLanguage;
+
+/**
+ * Integration tests for the {@code sonar.javascript.createTSProgramForOrphanFiles} flag.
+ * Uses a project with no tsconfig.json so all files are orphans.
+ * The fixture triggers S3003 (strings-comparison) which requires type information
+ * to detect that both operands are strings.
+ */
+class OrphanTsFilesTest {
+
+  private static final String PROJECT_NAME = "orphan-ts-files";
+
+  private static final SonarServerContext SERVER_CONTEXT = SonarScannerIntegrationHelper.getContext(
+    List.of(TypeScriptLanguage.KEY),
+    List.of(SonarScannerIntegrationHelper.getJavascriptPlugin()),
+    List.of(Path.of("src", "test", "resources", "orphan-files-ts.xml"))
+  );
+
+  @Test
+  void should_find_type_aware_issue_with_ts_program_by_default() {
+    var result = ScannerRunner.run(
+      SERVER_CONTEXT,
+      getScanner().build(),
+      ScannerRunnerConfig.builder().build()
+    );
+
+    // Should analyze with a TypeScript program (default behavior)
+    assertThat(result.logOutput())
+      .extracting(Log::message)
+      .anyMatch(m -> m.contains("using default options"));
+
+    // Should NOT log skipping message
+    assertThat(result.logOutput())
+      .extracting(Log::message)
+      .noneMatch(m -> m.contains("Skipping TypeScript program creation for"));
+
+    // S3003 requires type info: with TS program, the issue should be found
+    var issues = result
+      .scannerOutputReader()
+      .getProject()
+      .getAllIssues()
+      .stream()
+      .filter(TextRangeIssue.class::isInstance)
+      .map(TextRangeIssue.class::cast)
+      .toList();
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).line()).isEqualTo(2);
+  }
+
+  @Test
+  void should_not_find_type_aware_issue_when_flag_is_false() {
+    var result = ScannerRunner.run(
+      SERVER_CONTEXT,
+      getScanner()
+        .withScannerProperty(JavaScriptPlugin.CREATE_TS_PROGRAM_FOR_ORPHAN_FILES, "false")
+        .build(),
+      ScannerRunnerConfig.builder().build()
+    );
+
+    // Should log that TS program creation is skipped
+    assertThat(result.logOutput())
+      .extracting(Log::message)
+      .anyMatch(m -> m.contains("Skipping TypeScript program creation for"));
+
+    // Should log that files are analyzed without type information
+    assertThat(result.logOutput())
+      .extracting(Log::message)
+      .anyMatch(m -> m.contains("not part of any tsconfig.json"));
+
+    // Should NOT create a TS program with default options
+    assertThat(result.logOutput())
+      .extracting(Log::message)
+      .noneMatch(m -> m.contains("using default options"));
+
+    // S3003 requires type info: without TS program, no issue should be found
+    var issues = result
+      .scannerOutputReader()
+      .getProject()
+      .getAllIssues()
+      .stream()
+      .filter(TextRangeIssue.class::isInstance)
+      .map(TextRangeIssue.class::cast)
+      .toList();
+    assertThat(issues).isEmpty();
+  }
+
+  private static ScannerInput.Builder getScanner() {
+    return ScannerInput.create(PROJECT_NAME, TestUtils.projectDir(PROJECT_NAME)).withScmDisabled();
+  }
+}

--- a/its/plugin/fast-tests/src/test/resources/orphan-files-ts.xml
+++ b/its/plugin/fast-tests/src/test/resources/orphan-files-ts.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile>
+  <name>orphan-files-ts-profile</name>
+  <language>ts</language>
+  <rules>
+    <rule>
+      <repositoryKey>typescript</repositoryKey>
+      <key>S3003</key> <!-- strings-comparison (requires type info) -->
+      <priority>INFO</priority>
+    </rule>
+  </rules>
+</profile>

--- a/its/plugin/projects/orphan-ts-files/src/main.ts
+++ b/its/plugin/projects/orphan-ts-files/src/main.ts
@@ -1,0 +1,2 @@
+let str1 = 'hello', str2 = 'world';
+str1 < str2; // S3003: strings should be compared using localeCompare

--- a/packages/jsts/tests/analysis/analyzeProject-sonarqube.test.ts
+++ b/packages/jsts/tests/analysis/analyzeProject-sonarqube.test.ts
@@ -513,6 +513,13 @@ describe('SonarQube project analysis', () => {
     // The file should still be analyzed (without type info, via analyzeWithoutProgram)
     expect(result.files[normalizeToAbsolutePath(filePath)]).toBeDefined();
 
+    // Should log that files are analyzed without type information
+    expect(
+      consoleLogMock.calls.some(call =>
+        (call.arguments[0] as string)?.includes('not part of any tsconfig.json'),
+      ),
+    ).toBe(true);
+
     // Should NOT log "using default options" since we skip the entry point program creation
     expect(
       consoleLogMock.calls.some(call =>

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
@@ -236,6 +236,10 @@ public interface BridgeServer extends Startable {
       return skipAst;
     }
 
+    public boolean createTSProgramForOrphanFiles() {
+      return createTSProgramForOrphanFiles;
+    }
+
     public void setSkipAst(boolean skipAst) {
       this.skipAst = skipAst;
     }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsSensorTest.java
@@ -492,6 +492,29 @@ class JsTsSensorTest {
   }
 
   @Test
+  void should_send_createTSProgramForOrphanFiles_true_by_default() {
+    assertThat(
+      executeSensorAndCaptureHandler(createSensor(), context)
+        .getRequest()
+        .getConfiguration()
+        .createTSProgramForOrphanFiles()
+    ).isTrue();
+  }
+
+  @Test
+  void should_send_createTSProgramForOrphanFiles_false_when_disabled() {
+    context.setSettings(
+      new MapSettings().setProperty(JavaScriptPlugin.CREATE_TS_PROGRAM_FOR_ORPHAN_FILES, "false")
+    );
+    assertThat(
+      executeSensorAndCaptureHandler(createSensor(), context)
+        .getRequest()
+        .getConfiguration()
+        .createTSProgramForOrphanFiles()
+    ).isFalse();
+  }
+
+  @Test
   void should_not_send_content() {
     assertThat(
       executeSensorAndCaptureHandler(createSensor(), context)


### PR DESCRIPTION
## Summary
Follow-up to #6411. Adds tests verifying the `createTSProgramForOrphanFiles` flag propagates correctly end-to-end:

- **Java**: `JsTsSensorTest` verifies the flag flows from `sonar.properties` → `JsTsContext` → `ProjectAnalysisConfiguration` DTO (defaults to `true`, propagates `false` when set)
- **Java**: Added `createTSProgramForOrphanFiles()` getter on `ProjectAnalysisConfiguration` for test accessibility
- **Node.js**: Added assertion that when flag is `false`, orphan files are still analyzed without type information (`"not part of any tsconfig.json"` log appears)

## Test plan
- [x] `JsTsSensorTest#should_send_createTSProgramForOrphanFiles_true_by_default` passes
- [x] `JsTsSensorTest#should_send_createTSProgramForOrphanFiles_false_when_disabled` passes
- [x] All 22 Node.js `analyzeProject-sonarqube` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)