### PR TITLE
JS-1356 Validate rule scope is Main or Tests during generate-meta

### DIFF
--- a/tools/helpers.ts
+++ b/tools/helpers.ts
@@ -59,7 +59,7 @@ type rspecMeta = {
   title: string;
   quickfix: 'covered' | undefined;
   tags: string[];
-  scope: 'Main' | 'Tests' | 'All';
+  scope: 'Main' | 'Tests';
   compatibleLanguages: ('js' | 'ts')[];
   extra?: {
     requiredDependency?: string[];
@@ -127,7 +127,7 @@ export async function getRspecMeta(
   if (!rspecFileExists) {
     console.log(`RSPEC metadata not found for rule ${sonarKey}.`);
   }
-  return rspecFileExists
+  const meta: rspecMeta = rspecFileExists
     ? JSON.parse(await readFile(rspecFile, 'utf-8'))
     : {
         // Dummy data to create compilable new rule metadata
@@ -140,6 +140,12 @@ export async function getRspecMeta(
         quickfix: undefined,
         ...defaults,
       };
+  if (meta.scope !== 'Main' && meta.scope !== 'Tests') {
+    throw new Error(
+      `Invalid scope '${meta.scope}' for rule ${sonarKey}. Scope must be 'Main' or 'Tests'.`,
+    );
+  }
+  return meta;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds build-time validation that RSPEC rule scope must be `Main` or `Tests`
- Rejects `All` scope which is not supported — rules must target one or the other
- Removes `All` from the `rspecMeta` type definition

## Test plan
- [x] `npm run generate-meta` passes (no existing rules have scope `All`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)