### PR TITLE
SC-41129 Refactor customForConfiguration from Java expression to JS function

### DIFF
--- a/packages/grpc/src/transformers/rule-configurations/jsts.ts
+++ b/packages/grpc/src/transformers/rule-configurations/jsts.ts
@@ -120,6 +120,16 @@ function parseParamValue(value: string, defaultValue: unknown) {
   return value;
 }
 
+function getParseTarget(fieldDef: {
+  default: unknown;
+  customDefault?: unknown;
+  customForConfiguration?: (value: unknown) => unknown;
+}) {
+  return fieldDef.customForConfiguration && fieldDef.customDefault !== undefined
+    ? fieldDef.customDefault
+    : fieldDef.default;
+}
+
 /**
  * Build an object configuration from an array of field definitions.
  *
@@ -166,13 +176,7 @@ function buildObjectConfiguration(fieldDefs: FieldDef[], paramsLookup: Map<strin
     const paramValue = paramsLookup.get(sqKey);
 
     if (paramValue !== undefined) {
-      // When customForConfiguration exists, parse against customDefault type
-      // so the linter receives the raw SQ value in the right type for transformation.
-      const parseTarget =
-        fieldDef.customForConfiguration && fieldDef.customDefault !== undefined
-          ? fieldDef.customDefault
-          : fieldDef.default;
-      paramsObj[fieldDef.field] = parseParamValue(paramValue, parseTarget);
+      paramsObj[fieldDef.field] = parseParamValue(paramValue, getParseTarget(fieldDef));
     }
   }
 
@@ -238,13 +242,7 @@ function buildPrimitiveConfiguration(
   if (sqKey) {
     const paramValue = paramsLookup.get(sqKey);
     if (paramValue !== undefined) {
-      // When customForConfiguration exists, parse against customDefault type
-      // so the linter receives the raw SQ value in the right type for transformation.
-      const parseTarget =
-        element.customForConfiguration && element.customDefault !== undefined
-          ? element.customDefault
-          : element.default;
-      return parseParamValue(paramValue, parseTarget);
+      return parseParamValue(paramValue, getParseTarget(element));
     }
   } else if (params.length > 0 && index === 0) {
     // Fallback for Type B primitives without displayName.

--- a/packages/jsts/src/linter/linter.ts
+++ b/packages/jsts/src/linter/linter.ts
@@ -38,7 +38,7 @@ import { APIError } from '../../../shared/src/errors/error.js';
 import { pathToFileURL } from 'node:url';
 import * as ruleMetas from '../rules/metas.js';
 import { extname } from 'node:path/posix';
-import { defaultOptions } from '../rules/helpers/configs.js';
+import { defaultOptions, applyTransformations } from '../rules/helpers/configs.js';
 import merge from 'lodash.merge';
 import { getDependencies } from '../rules/helpers/package-jsons/dependencies.js';
 import { getClosestPackageJSONDir } from '../rules/helpers/package-jsons/closest.js';
@@ -307,7 +307,10 @@ export class Linter {
         if (ruleMeta && 'fields' in ruleMeta) {
           rules[`sonarjs/${rule.key}`] = [
             'error',
-            ...merge(defaultOptions(ruleMeta.fields), rule.configurations),
+            ...applyTransformations(
+              ruleMeta.fields,
+              merge(defaultOptions(ruleMeta.fields), rule.configurations),
+            ),
           ];
         } else {
           rules[`sonarjs/${rule.key}`] = ['error'];

--- a/packages/jsts/src/rules/S1441/config.ts
+++ b/packages/jsts/src/rules/S1441/config.ts
@@ -24,7 +24,7 @@ export const fields = [
     default: 'single',
     customDefault: true,
     displayName: 'singleQuotes',
-    customForConfiguration: `value ? "single" : "double"`,
+    customForConfiguration: (value: unknown) => (value ? 'single' : 'double'),
   },
   [
     {

--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -30,7 +30,7 @@ export const fields = [
       description: 'Minimum shannon entropy threshold of the secret',
       default: 5,
       customDefault: '5.0',
-      customForConfiguration: (value: unknown) => Number(value),
+      customForConfiguration: Number,
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -30,7 +30,7 @@ export const fields = [
       description: 'Minimum shannon entropy threshold of the secret',
       default: 5,
       customDefault: '5.0',
-      customForConfiguration: `Double.parseDouble(randomnessSensibility)`,
+      customForConfiguration: (value: unknown) => Number(value),
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -222,8 +222,6 @@ function generateBody(
             const castTo = namedProperty.items.type === 'string' ? 'String' : 'Integer';
             imports.add('import java.util.Arrays;');
             value = `Arrays.stream(${fieldName}.split(",")).map(String::trim).toArray(${castTo}[]::new)`;
-          } else if (namedProperty.customForConfiguration) {
-            value = namedProperty.customForConfiguration;
           } else {
             value = fieldName;
           }
@@ -236,10 +234,7 @@ function generateBody(
         configurations.push(`Map.of(${mapContents})`);
       }
     } else {
-      let value = generateRuleProperty(config);
-      if (isSonarSQProperty(config) && config.customForConfiguration) {
-        value = config.customForConfiguration;
-      }
+      const value = generateRuleProperty(config);
       configurations.push(value);
     }
   });


### PR DESCRIPTION
## Summary
- Moved `customForConfiguration` from a Java expression string to a JS function, so parameter transformations apply in both HTTP bridge and gRPC paths
- S1441 (quotes) now correctly transforms boolean `true`/`false` to `"single"`/`"double"` in gRPC path
- S6418 (hard-coded secrets) `randomnessSensibility` string-to-number conversion now handled in JS
- Removed Java expression inlining from `generate-java-rule-classes.ts`; generated Java classes now send raw field values

## Test plan
- [x] S1441 gRPC test now passes (was previously failing)
- [x] S6418 and S7718 gRPC tests still pass
- [x] Full gRPC server test suite passes (31/31)
- [x] Type-check passes (`npx tsc -b packages`)
- [ ] Verify Java integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)