### PR TITLE
JS-1378 Add Claude Code skills for SonarJS development

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: build
+description: Build pipeline for SonarJS. Use when asked to build the project, regenerate metadata, understand the build pipeline, or run npm build scripts.
+---
+
+## Quick Reference
+
+```bash
+npm ci                          # Install dependencies
+npm run bbf                     # Fast JS/TS build (no tests): clear lib + generate-meta + compile
+npm run generate-meta           # Regenerate generated-meta.ts files from RSPEC JSON
+npm run generate-java-rule-classes  # Regenerate Java check classes
+mvn install -DskipTests         # Full Maven build without tests
+mvn clean install               # Full clean build with tests
+```
+
+## When to Run What
+
+| Goal | Command |
+|------|---------|
+| After editing rule TS code | `npm run bbf` |
+| After modifying `config.ts` or `meta.ts` | `npm run generate-meta && npm run bbf` |
+| After modifying `fields` array | `npm run generate-meta && npm run generate-java-rule-classes` |
+| Full plugin build | `mvn install -DskipTests` |
+
+## Build Pipeline Overview
+
+### `npm run bbf` (bridge:build:fast)
+
+```
+bbf
+├── rimraf lib/*
+├── npm run generate-meta        # RSPEC JSON → generated-meta.ts per rule
+└── npm run bridge:compile       # tsgo TypeScript compilation
+```
+
+### `npm run generate-meta`
+
+Reads RSPEC metadata from:
+```
+sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/
+```
+
+Writes to (gitignored):
+```
+packages/jsts/src/rules/SXXXX/generated-meta.ts
+```
+
+### Maven Build Phases (relevant for rule work)
+
+1. **javascript-checks** (generate-resources): Downloads RSPEC → deploys to `sonar-plugin/javascript-checks/src/main/resources/`, runs `generate-java-rule-classes`
+2. **bridge** (generate-resources): Runs `npm run bbf` (which includes `generate-meta`)
+3. **Compile**: Java compilation of all modules
+
+## RSPEC Metadata Chain
+
+```
+Remote RSPEC repo
+       ↓  (rspec-maven-plugin, gitignored)
+resources/rule-data/
+       ↓  (npm run deploy-rule-data, committed)
+sonar-plugin/javascript-checks/src/main/resources/…/javascript/*.json
+       ↓  (npm run generate-meta, gitignored)
+packages/jsts/src/rules/SXXXX/generated-meta.ts
+```
+
+**Key:** The `sonar-plugin/javascript-checks/src/main/resources/…/javascript/` directory is **committed** (526 files). It is the source of truth for `generate-meta`.
+
+## Generated vs. Committed Files
+
+| Path | Status |
+|------|--------|
+| `resources/rule-data/` | Gitignored (fresh RSPEC download) |
+| `sonar-plugin/javascript-checks/src/main/resources/…/javascript/*.json` | **Committed** |
+| `packages/jsts/src/rules/*/generated-meta.ts` | Gitignored |
+| `lib/` | Gitignored |
+
+## Build Profiles
+
+```bash
+mvn clean install -P coverage-report    # With JaCoCo coverage
+SONARSOURCE_QA=true mvn clean install   # With integration tests (qa profile)
+```
+
+## Notes
+
+- Do not run `npm run bridge:test` or `npm run ruling` — they take too long
+- `generated-meta.ts` files are auto-generated; do not edit manually
+- Java check classes in `sonar-plugin/javascript-checks/` are auto-generated
+- Requires `GITHUB_TOKEN` env var with read access to `SonarSource/rspec` for Maven builds

--- a/.claude/skills/helpers/SKILL.md
+++ b/.claude/skills/helpers/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: helpers
+description: Provides JavaScript/TypeScript helper functions and utilities for SonarJS rule implementation. Use when implementing rule fixes, searching for existing utilities, or needing to check available helper functions.
+---
+
+# JavaScript/TypeScript Rule Helper Functions
+
+Helper functions are located in `packages/jsts/src/rules/helpers/`. These provide common utilities for rule implementations.
+
+## Helper Categories
+
+- **AST Utilities**: Functions for traversing and querying the AST
+- **Type Checking**: Helpers for checking types via TypeScript parser services
+- **Module Helpers**: Functions for analyzing imports and exports
+- **String/Regex Utilities**: Common string and pattern matching helpers
+
+## Common Helper Functions
+
+- `isCallingMethod()` - Check if a call expression is calling a specific method
+- `getUniqueWriteUsageOrNode()` - Track variable assignments
+- `isRequiredParserServices()` - Check if TypeScript type information is available
+- `isArray()`, `isString()`, etc. - Type checking helpers
+- `getImportDeclarations()` - Get import declarations from the context
+
+## Usage Guidance
+
+When implementing a fix:
+1. Review the `packages/jsts/src/rules/helpers/` directory for existing utilities
+2. Use existing helpers instead of writing custom logic where possible
+3. This ensures consistency and reduces code duplication
+
+## Finding Helpers
+
+To explore available helpers:
+```bash
+ls packages/jsts/src/rules/helpers/
+```
+
+Read helper implementations to understand their usage and parameters.

--- a/.claude/skills/new-rule/SKILL.md
+++ b/.claude/skills/new-rule/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: new-rule
+description: Implement a new SonarJS rule from scratch. Use when creating a new rule, scaffolding rule files, or understanding the full rule implementation workflow.
+disable-model-invocation: true
+---
+
+## Overview
+
+New rules follow the pattern: RSPEC description → scaffold → implement → test → ruling.
+
+## Step 1: Scaffold the Rule
+
+```bash
+npm run new-rule
+```
+
+This interactive script generates in `packages/jsts/src/rules/SXXXX/`:
+- `index.ts` — rule export
+- `rule.ts` — ESLint rule implementation (skeleton)
+- `cb.fixture.js` — empty comment-based test fixture
+- `cb.test.js` — test launcher
+
+It also auto-generates (not tracked by git):
+- Java check class `SXXXX.java`
+- Updates `rules/rules.ts` and `rules/plugin-rules.ts`
+- Updates `AllRules.java`
+
+## Step 2: Configure the Java Check Class
+
+In the generated Java class, verify:
+- `@JavaScriptRule` and/or `@TypeScriptRule` annotations match target languages
+- If rule has options, override `configurations()` method (see `/rule-options` skill)
+- If rule targets test files, extend `TestFileCheck` instead of `Check`
+
+## Step 3: Implement the Rule
+
+### File Structure
+
+| File | Purpose |
+|------|---------|
+| `rule.ts` | ESLint rule implementation |
+| `meta.ts` | Manual metadata: `implementation`, `eslintId`, `schema`, re-exports `fields` |
+| `config.ts` | Option definitions with `fields` array (if rule has options) |
+| `generated-meta.ts` | Auto-generated from RSPEC — do not edit |
+
+### Rule Template
+
+```typescript
+import { generateMeta } from '../helpers/index.js';
+import { meta } from './meta.js';
+
+const messages = {
+  errorKey: 'Error message to display',
+};
+
+export const rule: Rule.RuleModule = {
+  meta: generateMeta(meta, { messages }),
+  create(context: Rule.RuleContext) {
+    return {
+      Identifier(node: estree.Identifier) {
+        if (/* violation detected */) {
+          context.report({ messageId: 'errorKey', node });
+        }
+      },
+    };
+  },
+};
+```
+
+### Be Conservative
+
+**Never report when uncertain.** False positives are worse than missed detections.
+
+```typescript
+const services = context.sourceCode.parserServices;
+if (!isRequiredParserServices(services)) {
+  return; // No type info — don't report
+}
+```
+
+When in doubt: skip.
+
+## Step 4: Check Shared Helpers
+
+**Before writing any utility code**, check `packages/jsts/src/rules/helpers/`:
+
+| File | Contains |
+|------|----------|
+| `ast.ts` | `isFunctionNode`, `isIdentifier`, `hasTypePredicateReturn`, AST traversal |
+| `module.ts` | `isESModule`, `getImportDeclarations`, `getFullyQualifiedName` |
+| `package-jsons/dependencies.ts` | `getDependencies`, `getReactVersion` |
+| `index.ts` | Re-exports all helpers — check here first |
+
+If a new utility would benefit multiple rules, add it to the appropriate helper file.
+
+## Step 5: Generate Metadata
+
+After setting up `meta.ts` and optionally `config.ts`:
+
+```bash
+npm run generate-meta
+```
+
+This creates/updates `generated-meta.ts` with `defaultOptions`, `sonarKey`, `scope`, `languages`.
+
+## Step 6: Write Tests
+
+See `/test-rule` skill for full testing documentation.
+
+Quick start — write `cb.fixture.js`:
+```javascript
+someCleanCode();                            // no issue raised
+
+someFaultyCode(); // Noncompliant {{message}}
+//  ^^^^^^^^^^
+```
+
+Run:
+```bash
+npx tsx --test packages/jsts/src/rules/S1234/**/*.test.ts
+```
+
+## Step 7: Run Ruling
+
+See `/ruling` skill. Required before merging new or modified rules.
+
+## Rule Implementation Patterns
+
+### Wrapping an ESLint Rule (`decorated`)
+
+```typescript
+// meta.ts
+export const implementation = 'decorated';
+export const eslintId = 'no-magic-numbers';
+export const externalRules = [
+  { externalPlugin: 'typescript-eslint', externalRule: 'no-magic-numbers' },
+];
+export * from './config.js';
+```
+
+### Original Rule
+
+```typescript
+// meta.ts
+export const implementation = 'original';
+export const eslintId = 'function-name';
+export * from './config.js';
+import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
+export const schema = {
+  type: 'array',
+  items: [{ type: 'object', properties: { format: { type: 'string' } } }],
+} as const satisfies JSONSchema4;
+```
+
+### RSPEC Tags
+
+When creating the RSPEC PR:
+- Tag `type-dependent` if the rule uses TypeScript type information
+- Add `dependencies` field if rule requires a specific import (e.g., `'react'`, `'jest'`)
+- Add `compatibleLanguages: ['js', 'ts']` as appropriate
+
+## References
+
+- Security Hotspot: [PR #3148](https://github.com/SonarSource/SonarJS/pull/3148)
+- Rule with quickfix: [PR #3141](https://github.com/SonarSource/SonarJS/pull/3141)
+- Wrapping ESLint rule: [PR #3134](https://github.com/SonarSource/SonarJS/pull/3134)

--- a/.claude/skills/rule-implementation/SKILL.md
+++ b/.claude/skills/rule-implementation/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: rule-implementation
+description: Provides guidance on implementing and fixing SonarJS rules. Use also when tracing false positives, working with rule configuration, or understanding native vs external rule implementations.
+---
+
+# Rule Implementation
+
+Use this skill when you need to understand how to implement or fix SonarJS rules. This covers tracing false positives, identifying where issues are raised, and working with rule configuration.
+
+## Identifying Where Issues Are Raised
+
+When analyzing why a false positive occurs, look for `context.report()` calls in the rule implementation:
+
+```typescript
+context.report({
+  node,
+  messageId: 'issue',
+});
+```
+
+## Tracing the Root Cause of a False Positive
+
+To identify why a false positive occurs, work backwards from the `context.report()` call:
+
+### Step 1: Find All Report Calls
+
+Search for `context.report` in the rule file. A rule may have multiple report locations for different scenarios.
+
+### Step 2: Trace the Control Flow
+
+For each `context.report()` call, trace backwards through the code:
+
+1. **Identify the immediate condition** - What `if` statement or condition guards the report?
+2. **Trace variable origins** - Where do the variables in that condition come from?
+3. **Find the AST visitor** - Which visitor function (`CallExpression`, `Identifier`, etc.) triggers this path?
+4. **Map the full path** - Document the complete path from AST node to report
+
+### Step 3: Identify What's Missing
+
+Compare the false positive scenario against the traced path:
+
+- **Missing type check** - Does the rule assume a type without verifying it?
+- **Missing context check** - Does the rule ignore the surrounding code context?
+- **Missing pattern check** - Does the rule fail to recognize a valid code pattern?
+- **Overly broad condition** - Is a condition too permissive?
+
+### Step 4: Determine the Fix Location
+
+Based on the analysis, identify where to add the fix:
+
+- **Early return** - Add a guard clause before the report to skip false positive cases
+- **Additional condition** - Tighten the existing condition that leads to the report
+- **New helper check** - Create a helper function to detect the false positive pattern
+
+### Example Analysis
+
+```typescript
+// Rule reports here:
+if (isUnusedVariable(node)) {
+  context.report({ node, messageId: 'unused' });
+}
+
+// Tracing back:
+// 1. isUnusedVariable() returns true
+// 2. But it doesn't check if variable is used in a type annotation
+// 3. Fix: Add check for type annotation usage before reporting
+```
+
+## Rule Configuration Architecture
+
+Rule configuration flows through multiple layers: `TypeScript config.ts` → `Java @RuleProperty` → `SonarQube UI` → `Bridge` → `ESLint context.options`.
+
+### Configuration Layers
+
+1. **TypeScript Configuration (`config.ts`)**: Defines parameters
+```typescript
+export const fields = [[{
+  field: 'format',
+  description: 'Description visible in SonarQube.', // REQUIRED for visibility
+  default: '^[_a-z][a-zA-Z0-9]*$',
+  items: { type: 'string' } // REQUIRED for arrays
+}]] as const satisfies ESLintConfiguration;
+```
+
+2. **ESLint Schema (`meta.ts`)**: Defines JSON schema for validation
+3. **Generated Metadata**: `npm run generate-meta` creates `generated-meta.ts`
+4. **Java Classes**: `npm run generate-java-rule-classes` creates Java files with `@RuleProperty`
+
+### External Rule Configuration
+
+External rules (identified by `implementation = 'external'` in `meta.ts`) can have their configuration exposed to SonarQube.
+
+**Requirements for External Config:**
+
+1. **Must include `description`**: Without it, no `@RuleProperty` is generated
+2. **Arrays need `items`**: Must specify `{ type: 'string' }` or similar
+3. **No RegExp Objects**: Use string patterns (e.g., `'^pattern$'`), not JS RegExp objects (`/^pattern$/`)
+4. **Double Escaping**: Backslashes in `customDefault` for Java must be double-escaped (e.g., `^\\\\w+$` to match `\w`)
+
+### Workflow for Exposing Configuration
+
+If your fix requires exposing a new option:
+
+1. **Create/Update `config.ts`**: Define fields, descriptions, and defaults
+2. **Export in `meta.ts`**: Add `export * from './config.js';`
+3. **Generate Java**: Run `npm run generate-java-rule-classes`
+4. **Verify**: Check the generated Java file in `sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/`
+
+## Regenerating Metadata
+
+After modifying configuration or metadata files, regenerate the derived files:
+
+- `npm run generate-meta` - Regenerate rule metadata after changes to `meta.ts` or `config.ts`
+- `npm run generate-java-rule-classes` - Regenerate Java rule classes (required after `config.ts` changes)

--- a/.claude/skills/rule-options/SKILL.md
+++ b/.claude/skills/rule-options/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: rule-options
+description: Add or modify rule options in SonarJS, including the fields array, SonarQube UI visibility, and Java check class configuration. Use when working on rule configurations.
+---
+
+## Architecture Overview
+
+Rule options flow through two parallel paths:
+
+**SonarQube (HTTP/WebSocket):**
+```
+SonarQube UI → Java Check Class → configurations() → analyzeProject() → ESLint Linter
+```
+
+**External/gRPC:**
+```
+External Client → gRPC → transformers.ts → parseParamValue() → ESLint Linter
+```
+
+SonarQube sends typed values; gRPC sends string key-value pairs that need type parsing.
+
+## Key Files per Rule
+
+| File | Purpose |
+|------|---------|
+| `rule.ts` | ESLint rule implementation |
+| `meta.ts` | `implementation`, `eslintId`, `schema`, re-exports `fields` |
+| `config.ts` | `fields` array — source of truth for options |
+| `generated-meta.ts` | Auto-generated `defaultOptions` — do not edit |
+
+## The `fields` Array (`config.ts`)
+
+The `fields` array defines options for SonarQube integration and default values.
+
+```typescript
+import type { ESLintConfiguration } from '../helpers/configs.js';
+
+export const fields = [
+  [                         // outer array = one ESLint options object
+    {
+      field: 'max',                         // ESLint option name
+      displayName: 'maximumFunctionParameters', // SonarQube key (if different)
+      description: 'Maximum authorized...', // REQUIRED for SQ visibility
+      default: 7,                           // default value; determines type
+    },
+    {
+      field: 'ignoreIIFE',
+      default: false,                       // no description = internal only
+    },
+  ],
+] as const satisfies ESLintConfiguration;
+```
+
+### Field Properties
+
+| Property | Required | Purpose |
+|----------|----------|---------|
+| `field` | Yes | ESLint/schema key name |
+| `default` | Yes | Default value; also determines type (`number`, `string`, `boolean`, array) |
+| `description` | **For SQ visibility** | Makes option visible in SonarQube UI |
+| `displayName` | No | SonarQube key if different from `field` |
+| `items` | For arrays | `{ type: 'string' }` or `{ type: 'integer' }` |
+| `customDefault` | No | Different default for SQ than ESLint |
+| `fieldType` | No | Override SQ field type (e.g., `'TEXT'`) |
+
+## Making Options Visible in SonarQube
+
+**A field appears in the SonarQube UI only if it has a `description`.**
+
+Fields without `description` are internal defaults invisible to users.
+
+```typescript
+// S109/config.ts — NOT visible in SQ (no descriptions)
+export const fields = [
+  [
+    { field: 'ignore', default: [0, 1, -1, 24, 60] },
+    { field: 'ignoreDefaultValues', default: true },
+  ],
+] as const satisfies ESLintConfiguration;
+
+// S2068/config.ts — VISIBLE in SQ (has description)
+export const fields = [
+  [
+    {
+      field: 'passwordWords',
+      items: { type: 'string' },
+      description: 'Comma separated list of words identifying potential passwords.',
+      default: ['password', 'pwd', 'passwd', 'passphrase'],
+    },
+  ],
+] as const satisfies ESLintConfiguration;
+```
+
+## Configuration Shapes
+
+### Object-style (most common)
+
+```typescript
+export const fields = [
+  [
+    { field: 'max', description: '...', default: 7 },
+    { field: 'ignoreIIFE', description: '...', default: false },
+  ],
+] as const satisfies ESLintConfiguration;
+// ESLint receives: [{ max: 7, ignoreIIFE: false }]
+```
+
+### Primitive (single value)
+
+```typescript
+export const fields = [
+  { default: '^[a-z]+$' },
+] as const satisfies ESLintConfiguration;
+// ESLint receives: ['^[a-z]+$']
+```
+
+### Array options (comma-separated in SQ)
+
+```typescript
+export const fields = [
+  [
+    {
+      field: 'passwordWords',
+      items: { type: 'string' },          // required for Java codegen
+      description: 'Comma separated list...',
+      default: ['password', 'pwd'],
+    },
+  ],
+] as const satisfies ESLintConfiguration;
+// SQ sends: "password,pwd,secret" → ESLint: [{ passwordWords: ['password','pwd','secret'] }]
+```
+
+## Type Parsing (gRPC)
+
+String params from gRPC are parsed based on `default` type:
+
+| Default Type | Input | Parsed |
+|-------------|-------|--------|
+| `number` | `"5"` | `5` |
+| `boolean` | `"true"` | `true` |
+| `string` | `"pattern"` | `"pattern"` |
+| `string[]` | `"a,b,c"` | `["a","b","c"]` |
+| `number[]` | `"1,2,3"` | `[1,2,3]` |
+
+## JSON Schema vs `fields`
+
+| Aspect | JSON Schema (`meta.ts`) | `fields` (`config.ts`) |
+|--------|------------------------|----------------------|
+| Purpose | ESLint validation | SQ UI + defaults + key mapping |
+| Used by | ESLint at runtime | Java codegen, meta generation, linter |
+| Required for | `original` rules with options | All rules with options |
+
+For `original` rules, schema and fields must be kept in sync manually.
+For `decorated`/`external` rules, schema is inherited from the external rule.
+
+## Adding Options to an Existing Rule
+
+1. Update `config.ts` — add field to `fields` array
+2. Add `description` if it should be visible in SonarQube
+3. Update `meta.ts` schema (for `original`/`decorated` rules)
+4. Run `npm run generate-meta` — updates `generated-meta.ts` with new `defaultOptions`
+5. Run `npm run generate-java-rule-classes` — updates Java check classes
+6. Verify Java class has correct `configurations()` method
+
+## Java Check Class (`configurations()`)
+
+```java
+// Example: S107Check.java
+@Override
+public List<Object> configurations() {
+  return List.of(Map.of("max", maximum));
+}
+
+@RuleProperty(
+  key = "maximumFunctionParameters",
+  description = "Maximum authorized number of parameters",
+  defaultValue = "" + DEFAULT_MAX
+)
+private int maximum = DEFAULT_MAX;
+```
+
+Use `MyRuleCheckTest.java` to verify serialization:
+```java
+assertThat(new MyRuleCheck().configurations()).containsExactly(Map.of("max", 7));
+```
+
+## Key Mapping: SonarQube ↔ ESLint
+
+When SQ and ESLint use different names:
+
+```typescript
+// config.ts
+{ field: 'max', displayName: 'maximumFunctionParameters', ... }
+```
+
+`transformers.ts` handles the SQ key → ESLint key mapping at runtime.

--- a/.claude/skills/ruling/SKILL.md
+++ b/.claude/skills/ruling/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: ruling
+description: Run ruling integration tests and update expected results for SonarJS rules. Use when running ruling tests or syncing expected ruling output.
+disable-model-invocation: true
+---
+
+## Overview
+
+Ruling tests analyze large third-party codebases (JS/TS and CSS) and compare issues against expected output. Run them when adding or modifying rules to verify real-world behavior.
+
+> **Warning:** Running ruling tests removes `node_modules` from the project root. Run `npm ci` afterward.
+
+## Running Ruling
+
+```bash
+# Prerequisite: rebuild the jar first
+mvn install -DskipTests
+
+# Run ruling (JS/TS and CSS)
+npm run ruling
+
+# Sync actual → expected (after reviewing output)
+npm run ruling-sync
+
+# Debug differences
+sh tools/ruling-debug-script.sh
+```
+
+Results:
+- Actual: `packages/ruling/actual/`
+- Expected: `its/ruling/src/test/expected/`
+
+## Java Ruling (Old Way)
+
+```bash
+cd its/ruling
+mvn verify -Dtest=RulingTest -Dmaven.test.redirectTestOutputToFile=false
+```
+
+Copy actual to expected:
+```bash
+cp -R target/actual/ src/test/expected/
+```
+
+Review diff:
+```bash
+diff -rq src/test/expected target/actual
+```
+
+## Custom Source Files for New Rules
+
+If a new rule raises no issues on existing sources, add test code:
+
+- `its/sources/custom/jsts/S1234.js` — regular code
+- `its/sources/custom/jsts/tests/S1234.js` — test code
+
+Copy from RSPEC HTML description (compliant/non-compliant examples).
+
+## Debugging with Node Process
+
+To debug the Node.js bridge during ruling:
+
+1. Start your Node.js process manually
+2. Set `SONARJS_EXISTING_NODE_PROCESS_PORT=<port>`
+3. Remove `@Execution(ExecutionMode.CONCURRENT)` from the ruling test class (for serial execution)
+
+## Submodule Setup
+
+If submodules aren't checked out:
+
+```bash
+git submodule init
+git submodule update
+```

--- a/.claude/skills/test-quality-standards/SKILL.md
+++ b/.claude/skills/test-quality-standards/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: test-quality-standards
+description: Provides test quality standards and best practices. Use when writing test cases, creating unit tests, implementing tests, or refining/reviewing test code. Essential for test generation and test refinement phases.
+---
+
+# Test Quality Standards for Vibe Bot
+
+When writing or reviewing test cases, follow these standards:
+
+## Core Principles
+
+**Minimal code:** Each test case should be the simplest possible code that demonstrates the pattern. Avoid elaborate setups, complex methods, or unnecessary fields.
+
+**Focused:** One test case per distinct scenario. Don't combine multiple patterns in a single test.
+
+**Brief comments:** Use `// Compliant` or `// Compliant: [2-4 words]`. Avoid lengthy explanations. If a URL reference gives context, use that instead of block comments.
+
+**Integrate into existing methods:** Add new test cases to existing test methods when the scenario belongs there, rather than creating separate methods with full setups.
+
+**Scope-appropriate:** Match test code style to the rule's scope. Tests scope → test-style code (test classes, assertions). Main scope → production-style code. All scope → either is acceptable.
+
+**Follow existing conventions:** Match the patterns, naming, and structure already established in the test file and similar test files.
+
+**No redundancy:** If multiple variations test essentially the same thing, keep the clearest version. Each test must add unique coverage.
+
+## Code Simplicity
+
+- **Only include necessary code**: Each test case should contain only the code needed to trigger the false positive
+- **One pattern per test case**: Each test case should cover one distinct FP pattern
+- **Use realistic names**: Use realistic variable/function names from the Jira ticket if available
+
+## Comments
+
+- **Keep comments short**: Use `// Compliant` or `// Compliant: [2-4 words]`
+- **Avoid lengthy explanations**: If the test case is self-explanatory or a URL gives the needed context, a short annotation is enough
+- **Avoid block comments above test cases**: Don't add multi-line `// FP scenario: ...` comments. A brief inline comment suffices
+- **Include reference URLs when available**: If a community report link exists, add it as a single-line comment instead of paraphrasing the report
+
+## Structure
+
+- **Integrate into existing methods**: Add new test cases to existing test methods when the scenario belongs there, rather than creating separate test methods
+- **Follow existing conventions**: Match the test structure, naming, and annotation patterns already used in the codebase. Refer to the guidance document for details
+- **Scope-appropriate code**: Test cases must use code patterns that match the rule's scope. If the scope is "Tests", write test-style code. If "Main", write production-style code. If "All", either is acceptable
+
+## No Redundancy
+
+- **Check for duplicates**: Before finalizing, compare all test cases — new and existing — for identical or near-identical patterns
+- **Remove duplicates**: If two test cases test the same scenario, keep the one that was already there or the clearer one
+- **Assess test value**: Each test case should add unique coverage, not just noise
+
+## Examples
+
+**Minimal code:**
+```csharp
+[TestMethod]
+public void ForLoop_NoIssue() => builder.AddSnippet("for (int i = 0; i < 10; i++) { }");
+```
+
+**Brief comment:**
+```javascript
+foreach (int x in items) { } // Compliant: collection iteration
+```
+
+## Application
+
+1. **During test creation:** Apply these standards from the start
+2. **During test refinement:** Review existing tests against these standards and simplify
+3. **When reviewing test coverage:** Ensure each test adds unique value without redundancy

--- a/.claude/skills/test-rule/SKILL.md
+++ b/.claude/skills/test-rule/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: test-rule
+description: Write and run tests for a SonarJS rule. Use when working on rule tests, writing test fixtures, or running unit tests for a specific rule.
+---
+
+## Running Tests
+
+```bash
+npx tsx --test packages/jsts/src/rules/S1234/**/*.test.ts
+```
+
+Replace `S1234` with the actual rule number. Do not run the full test suite (`npm run bridge:test`) — it takes too long.
+
+## RuleTester Selection
+
+| RuleTester | Use When |
+|------------|----------|
+| `DefaultParserRuleTester` | Pure JavaScript rules, no TypeScript syntax |
+| `NoTypeCheckingRuleTester` | JS/TS rules that don't need type information |
+| `RuleTester` | Rules requiring TypeScript type information |
+
+## Comment-Based Tests (preferred)
+
+Test files are named `*.fixture.*` (e.g., `cb.fixture.js`, `cb.fixture.ts`) and live in the rule folder.
+
+### Basic Syntax
+
+```javascript
+some.clean.code();                          // no issue
+some.faulty.code(); // Noncompliant {{Message to assert}}
+//   ^^^^^^
+```
+
+The `// ^^^^^^` underline marks the primary location (optional but recommended).
+
+### With Quick Fixes
+
+```javascript
+some.faulty.code(); // Noncompliant [[qf1]] {{Message}}
+// fix@qf1 {{Suggestion description}}
+// edit@qf1 [[sc=1;ec=5]] {{replacement text}}
+```
+
+For ESLint fixes (not suggestions), use `!` suffix: `[[qf1!]]`. ESLint fixes must **not** have a `fix@` comment.
+
+### Secondary Locations
+
+```javascript
+context.report({
+  node,
+  message: toEncodedMessage(message, [secondaryNode], ['secondary message']),
+});
+```
+
+In fixture:
+```javascript
+primary.node();     // Noncompliant {{primary message}}
+secondary.node();   // ^^^^^^^^^^^^^^< {{secondary message}}
+```
+
+Arrow direction: `<` means secondary is after primary; `>` means secondary is before primary.
+
+### Line Reference Modifiers
+
+```javascript
+// Noncompliant@+1 {{message}}   ← issue is on next line
+some.faulty.code();
+
+// Noncompliant@-1               ← issue is on previous line
+some.faulty.code();
+some.faulty.code(); // Noncompliant@2  ← absolute line number
+```
+
+### Rule Options in Tests
+
+Add a `cb.options.json` file in the rule folder:
+```json
+[7, { "ignoreIIFE": true }]
+```
+
+### Package.json Dependency Testing
+
+```javascript
+process.chdir(__dirname); // use local package.json for dependency detection
+```
+
+## ESLint RuleTester Format
+
+For rules needing TypeScript type checking:
+
+```typescript
+import { RuleTester } from '../../../tests/tools/sonar-rule-tester.js';
+
+const ruleTester = new RuleTester();
+ruleTester.run('rule-name', rule, {
+  valid: [
+    { code: 'valid code here' },
+  ],
+  invalid: [
+    {
+      code: 'invalid code here',
+      errors: [{ messageId: 'errorKey' }],
+    },
+  ],
+});
+```
+
+## Quick Fix Operation Syntax
+
+| Syntax | Effect |
+|--------|--------|
+| `// edit@qf [[sc=1;ec=5]] {{text}}` | Replace column 1–5 with text |
+| `// edit@qf {{whole line replacement}}` | Replace entire line |
+| `// add@qf {{new line content}}` | Add new line after issue line |
+| `// del@qf` | Delete the line |
+| `// add@qf@+1 {{content}}` | Add after line+1 |
+
+## Multiple Issues / Multiple Quick Fixes
+
+```javascript
+// Three issues, fix for 1st and 3rd:
+code(); // Noncompliant [[qf1,,qf3]] {{msg1}} {{msg2}} {{msg3}}
+// edit@qf1 {{fix for msg1}}
+// edit@qf3 {{fix for msg3}}
+
+// Or with explicit index:
+code(); // Noncompliant [[qf1,qf3=2]] {{msg1}} {{msg2}} {{msg3}}
+```

--- a/.claude/skills/tests/SKILL.md
+++ b/.claude/skills/tests/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: tests
+description: Provides JavaScript/TypeScript test file structure and patterns for SonarJS rule testing. Use when writing tests, understanding test structure, or debugging test failures.
+---
+
+# JavaScript/TypeScript Rule Test Structure
+
+## Test File Location
+
+Test files for rules are located alongside the rule implementation:
+- `unit.test.ts` - Unit tests using the rule tester
+- Test fixtures in `packages/jsts/src/rules/{RULE_ID}/fixtures/` (if applicable)
+
+## Test Structure
+
+Tests use the ESLint rule tester pattern with `valid` and `invalid` arrays:
+
+```typescript
+import { rule } from './index.js';
+import { DefaultParserRuleTester } from '../../../tests/tools/testers/rule-tester.js';
+import { describe, it } from 'node:test';
+
+describe('S1234', () => {
+  it('S1234', () => {
+    const ruleTester = new DefaultParserRuleTester();
+    ruleTester.run('Rule description', rule, {
+      valid: [
+        {
+          code: `
+// Valid code that should NOT raise an issue
+const x = 1;
+          `,
+        },
+        {
+          // False positive scenario: [brief description]
+          // This should NOT raise an issue because [reason]
+          code: `
+const myVar = someFunction();
+          `,
+        },
+      ],
+      invalid: [
+        {
+          code: `
+// Invalid code that SHOULD raise an issue
+problematicCode();
+          `,
+          errors: 1,
+        },
+      ],
+    });
+  });
+});
+```
+
+## Key Concepts
+
+- **`valid` array**: Code that should NOT raise an issue (compliant code)
+- **`invalid` array**: Code that SHOULD raise an issue (non-compliant code)
+- **`errors`**: Number of expected issues in an invalid case
+- **`options`**: Pass rule configuration options if needed
+
+When fixing false positives, add test cases to the `valid` array - the false positive is code that should be treated as valid.
+
+## Isolating Failing Test Cases
+
+When tests fail and you need to identify which specific test case is causing the failure:
+
+1. Create a backup of the test file
+2. Comment out all cases from the `valid` and `invalid` arrays EXCEPT the one being tested
+3. Record whether this specific test case passes or fails (the orchestration harness will run the tests)
+4. Restore the test file from backup
+5. Repeat for each suspect test case
+
+This isolation technique helps identify exactly which test cases are failing when the test output is unclear.
+
+**IMPORTANT**: Do NOT run unit tests directly. The orchestration harness will run them after each recipe step completes.
+
+## Ruling Tests
+
+Ruling tests (integration tests against real-world code) are in the separate SonarJS-Ruling repository.

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,3 @@ lcov.info
 .claude/*
 !.claude/*.md
 !.claude/skills/
-
-# Claude Code sensitive settings
-.claude/settings.json
-.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,8 @@ lcov.info
 
 .claude/*
 !.claude/*.md
+!.claude/skills/
+
+# Claude Code sensitive settings
+.claude/settings.json
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,32 +36,16 @@ SonarJS/
 ## Build Commands
 
 ```bash
-npm ci                          # Install dependencies
 npm run bbf                     # Fast JS/TS build (no tests)
 mvn install -DskipTests         # Complete build without Java tests
-
-# Generate code (after modifying rule metadata)
-npm run generate-meta
-npm run generate-java-rule-classes
-npm run new-rule                # Scaffold a new rule
 ```
 
-**Important:** Do not run full unit tests (`npm run bridge:test`) or ruling tests (`npm run ruling`) - they take too long. Run only specific tests for rules you're working on.
+See `/build` for the full build pipeline reference.
 
 ## Code Style
 
 - 2 spaces indentation, LF line endings, single quotes, trailing commas
 - Formatting enforced via pre-commit hooks
-
-## Shared Helpers
-
-The `packages/jsts/src/rules/helpers/` folder contains shared utility functions for rule implementations. **Before writing utility code in a rule, check if a similar helper already exists.** If you need a new utility that could benefit other rules, add it to the appropriate helper file rather than keeping it in the rule.
-
-Key helper files:
-
-- `ast.ts` - AST traversal and node type checking (`isFunctionNode`, `isIdentifier`, `hasTypePredicateReturn`, etc.)
-- `module.ts` - Module detection (`isESModule`, `getImportDeclarations`, `getFullyQualifiedName`, etc.)
-- `package-jsons/dependencies.ts` - Dependency detection (`getDependencies`, `getReactVersion`, etc.)
 
 ## Pull Requests
 
@@ -69,8 +53,9 @@ Key helper files:
 
 ## Important Notes
 
-- `generated-meta.ts` files are auto-generated from RSPEC - do not edit manually
+- `generated-meta.ts` files are auto-generated from RSPEC — do not edit manually
 - Java check classes in `sonar-plugin/javascript-checks/` are auto-generated
 - Rules use ESLint's visitor pattern
 - **Keep docs up to date** when changing build processes or workflows
 - See `.claude/rules.md` for rule development guidelines
+- See `.claude/skills/` for task-specific skills: `/build`, `/test-rule`, `/ruling`, `/new-rule`, `/rule-options`, `/rule-implementation`, `/helpers`, `/tests`, `/test-quality-standards`


### PR DESCRIPTION
## Summary

- Adds 9 Claude Code skill files under `.claude/skills/` for task-specific AI assistance
- Skills cover the full rule development lifecycle: build, test, ruling, new rules, rule options, implementation, helpers, and test quality standards
- Updates `CLAUDE.md` to list available skills and removes inlined guidance (now in skill files)

## Skills added

| Skill | Purpose |
|-------|---------|
| `/build` | Build pipeline reference |
| `/test-rule` | Writing and running rule tests |
| `/ruling` | Ruling test workflow |
| `/new-rule` | Creating new rules end-to-end |
| `/rule-options` | Rule options configuration |
| `/rule-implementation` | Rule implementation guidance |
| `/helpers` | Available helper utilities |
| `/tests` | Test file structure and patterns |
| `/test-quality-standards` | Test quality best practices |

## Test plan

- [ ] Verify all 9 skill files are present under `.claude/skills/`
- [ ] Verify `CLAUDE.md` references each skill correctly
- [ ] Test a skill invocation (e.g. `/build`) in Claude Code to confirm it loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)