### PR TITLE
JS-1378 Improve Claude Code skills for SonarJS development

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -7,6 +7,7 @@ description: Build pipeline for SonarJS. Use when asked to build the project, re
 
 ```bash
 npm ci                          # Install dependencies
+npx tsc -b packages             # Quickest way to spot compilation errors (no output generated)
 npm run bbf                     # Fast JS/TS build (no tests): clear lib + generate-meta + compile
 npm run generate-meta           # Regenerate generated-meta.ts files from RSPEC JSON
 npm run generate-java-rule-classes  # Regenerate Java check classes
@@ -84,7 +85,7 @@ SONARSOURCE_QA=true mvn clean install   # With integration tests (qa profile)
 
 ## Notes
 
-- Do not run `npm run bridge:test` or `npm run ruling` — they take too long
+- Do not run `npm run bridge:test` or `npm run ruling` — they take too long; if needed, run specific unit tests with `npx tsx --test $test_file`
 - `generated-meta.ts` files are auto-generated; do not edit manually
-- Java check classes in `sonar-plugin/javascript-checks/` are auto-generated
+- Java check classes in `sonar-plugin/javascript-checks/` are auto-generated; CSS check classes are also auto-generated
 - Requires `GITHUB_TOKEN` env var with read access to `SonarSource/rspec` for Maven builds

--- a/.claude/skills/rule-implementation/SKILL.md
+++ b/.claude/skills/rule-implementation/SKILL.md
@@ -96,6 +96,25 @@ External rules (identified by `implementation = 'external'` in `meta.ts`) can ha
 2. **Arrays need `items`**: Must specify `{ type: 'string' }` or similar
 3. **No RegExp Objects**: Use string patterns (e.g., `'^pattern$'`), not JS RegExp objects (`/^pattern$/`)
 4. **Double Escaping**: Backslashes in `customDefault` for Java must be double-escaped (e.g., `^\\\\w+$` to match `\w`)
+5. **Value Translation with `customForConfiguration`**: When SonarQube exposes a property in a different type than what ESLint expects, use `customForConfiguration` (a `(value: unknown) => unknown` function) paired with `customDefault` (the SQ-side parse target):
+
+```typescript
+// S1441: SQ exposes boolean "singleQuotes", ESLint expects 'single' | 'double'
+{
+  default: 'single',          // ESLint default
+  customDefault: true,        // SQ-side default (boolean — used for parsing)
+  displayName: 'singleQuotes',
+  customForConfiguration: (value: unknown) => (value ? 'single' : 'double'),
+}
+
+// S6418: SQ sends '5.0' as a string, ESLint expects a number
+{
+  field: 'randomnessSensibility',
+  default: 5,                 // ESLint default
+  customDefault: '5.0',       // SQ-side default (string — used for parsing)
+  customForConfiguration: Number,
+}
+```
 
 ### Workflow for Exposing Configuration
 

--- a/.claude/skills/test-rule/SKILL.md
+++ b/.claude/skills/test-rule/SKILL.md
@@ -18,6 +18,7 @@ Replace `S1234` with the actual rule number. Do not run the full test suite (`np
 | `DefaultParserRuleTester` | Pure JavaScript rules, no TypeScript syntax |
 | `NoTypeCheckingRuleTester` | JS/TS rules that don't need type information |
 | `RuleTester` | Rules requiring TypeScript type information |
+| `RuleTester` with `@babel/eslint-parser` | Legacy JavaScript or Babel-specific syntax (e.g. Flow types, decorator proposals) |
 
 ## Comment-Based Tests (preferred)
 

--- a/.claude/skills/tests/SKILL.md
+++ b/.claude/skills/tests/SKILL.md
@@ -57,7 +57,7 @@ problematicCode();
 
 - **`valid` array**: Code that should NOT raise an issue (compliant code)
 - **`invalid` array**: Code that SHOULD raise an issue (non-compliant code)
-- **`errors`**: Number of expected issues in an invalid case
+- **`errors`**: Number of expected issues in an invalid case, or an array of ESLint error objects (useful for asserting quickfixes and suggestions, e.g. `errors: [{ messageId: 'errorKey', suggestions: [...] }]`)
 - **`options`**: Pass rule configuration options if needed
 
 When fixing false positives, add test cases to the `valid` array - the false positive is code that should be treated as valid.

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ lcov.info
 .claude/*
 !.claude/*.md
 !.claude/skills/
+
+# Claude Code sensitive settings
+.claude/settings.json
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,3 @@ lcov.info
 .claude/*
 !.claude/*.md
 !.claude/skills/
-
-# Claude Code sensitive settings
-.claude/settings.json
-.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Track `.claude/skills/` directory in git while keeping Claude settings files (`.claude/settings.json`, `.claude/settings.local.json`) ignored
- Improve skill files based on PR review feedback:
  - **build**: add `npx tsc -b packages` for quick compilation check, mention `npx tsx --test $file` for targeted unit tests, note CSS checks are also auto-generated
  - **rule-implementation**: document `customForConfiguration` field for SonarQube→ESLint value translation with real-world examples
  - **test-rule**: add Babel parser row to RuleTester Selection table
  - **tests**: expand `errors` docs to cover array form for quickfix/suggestion assertions

## Test plan

- [ ] Verify `.claude/skills/` files are tracked by git
- [ ] Verify `.claude/settings.json` and `.claude/settings.local.json` remain ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)