### PR TITLE
JS-1385 fix: Exclude protobuf generated files from Sonar analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 
     <!-- sonar analysis -->
     <sonar.sources>packages/</sonar.sources>
-    <sonar.exclusions>packages/**/*.test.ts,packages/**/*.fixture.*,packages/**/fixtures/**/*,packages/**/fixtures-*/**/*,packages/grpc/src/proto/*</sonar.exclusions>
+    <sonar.exclusions>packages/**/*.test.ts,packages/**/*.fixture.*,packages/**/fixtures/**/*,packages/**/fixtures-*/**/*,packages/grpc/src/proto/*,packages/jsts/src/parsers/estree.js,packages/jsts/src/parsers/estree.d.ts</sonar.exclusions>
     <sonar.tests>packages/</sonar.tests>
     <sonar.test.inclusions>packages/**/*.test.ts</sonar.test.inclusions>
     <sonar.javascript.lcov.reportPaths>coverage/js/lcov.info</sonar.javascript.lcov.reportPaths>


### PR DESCRIPTION
## Summary
- Add `packages/jsts/src/parsers/estree.js` and `packages/jsts/src/parsers/estree.d.ts` to `sonar.exclusions` in `pom.xml`
- These protobuf-generated files exist on disk after the build and were being picked up by the analyzer
- The grpc proto files (`packages/grpc/src/proto/*`) were already excluded

## Test plan
- [ ] Verify Sonar analysis no longer reports on `estree.js` / `estree.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)