### PR TITLE
JS-1411 Fix invalid Renovate schedule config for @typescript/native-preview

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,7 +43,7 @@
     {
       "description": "@typescript/native-preview - dev builds update daily, limit to weekly",
       "matchPackageNames": ["@typescript/native-preview"],
-      "schedule": ["once a week"]
+      "extends": ["schedule:weekly"]
     }
   ],
   "hostRules": [


### PR DESCRIPTION
## Summary

- Renovate was logging a warning on every run due to an invalid schedule value:
  ```
  WARN: Repository has invalid config
  "validationError": "The renovate configuration file contains some invalid settings",
  "validationMessage": "Invalid packageRules[4].schedule: `Invalid schedule: Failed to parse \"once a week\"`"
  ```
- `"once a week"` is not a valid [later.js](https://bunkat.github.io/later/parsers.html#text) expression recognised by Renovate
- Replace it with the official `schedule:weekly` preset which is valid and conveys the same intent

## Test plan

- [ ] Verify Renovate no longer logs the `config-validation` warning after this change is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)