### PR TITLE
JS-1419 Update dependency @types/node to v24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "@types/express": "5.0.6",
         "@types/functional-red-black-tree": "1.0.6",
         "@types/lodash.merge": "4.6.9",
-        "@types/node": "22.19.15",
+        "@types/node": "24.12.0",
         "@types/semver": "7.7.1",
         "@types/ws": "8.18.1",
         "cpy-cli": "7.0.0",
@@ -4683,12 +4683,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "24.12.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/qs": {
@@ -14195,9 +14195,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/express": "5.0.6",
     "@types/functional-red-black-tree": "1.0.6",
     "@types/lodash.merge": "4.6.9",
-    "@types/node": "22.19.15",
+    "@types/node": "24.12.0",
     "@types/semver": "7.7.1",
     "@types/ws": "8.18.1",
     "cpy-cli": "7.0.0",


### PR DESCRIPTION
## Summary
- Bumps `@types/node` from `22.19.15` to `24.12.0`

## Test plan
- [ ] Verify build passes with `npm run bbf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)