### PR TITLE
JS-1425 fix(grpc): prevent stale analysis across requests

### DIFF
--- a/packages/grpc/src/service.ts
+++ b/packages/grpc/src/service.ts
@@ -22,11 +22,28 @@ import {
 } from './transformers/request.js';
 import { transformProjectOutputToResponse } from './transformers/response.js';
 import { analyzeProject } from '../../jsts/src/analysis/projectAnalysis/analyzeProject.js';
-import { initFileStores } from '../../jsts/src/analysis/projectAnalysis/file-stores/index.js';
+import {
+  initFileStores,
+  sourceFileStore,
+  packageJsonStore,
+  tsConfigStore,
+} from '../../jsts/src/analysis/projectAnalysis/file-stores/index.js';
 import { info, error as logError } from '../../shared/src/helpers/logging.js';
 import { createConfiguration } from '../../shared/src/helpers/configuration.js';
 import { ROOT_PATH } from '../../shared/src/helpers/files.js';
 import { sanitizeRawInputFiles } from '../../shared/src/helpers/sanitize.js';
+import { clearSourceFileContentCache } from '../../jsts/src/program/cache/sourceFileCache.js';
+
+/**
+ * gRPC requests are independent analyses. Reset all shared caches to avoid
+ * leaking data between requests with overlapping file paths.
+ */
+function resetGrpcCaches() {
+  sourceFileStore.clearCache();
+  packageJsonStore.clearCache();
+  tsConfigStore.clearCache();
+  clearSourceFileContentCache();
+}
 
 /**
  * gRPC handler for the Analyze RPC
@@ -41,6 +58,8 @@ export async function analyzeFileHandler(
     info(
       `Received Analyze request (${request.analysisId ?? 'no id'}) with ${request.sourceFiles?.length ?? 0} files`,
     );
+
+    resetGrpcCaches();
 
     // Create configuration for gRPC context
     // gRPC requests contain all file contents inline - no filesystem access needed

--- a/packages/grpc/tests/server.test.ts
+++ b/packages/grpc/tests/server.test.ts
@@ -208,6 +208,51 @@ describe('gRPC server', () => {
     expect(issue.message).toBe('Unnecessary semicolon.');
   });
 
+  it('should not reuse previous issues when the same file path is analyzed with different content', async () => {
+    const filePath = '/project/src/cached-content.js';
+
+    const requestWithIssue: analyzer.IAnalyzeRequest = {
+      analysisId: generateAnalysisId(),
+      contextIds: {},
+      sourceFiles: [
+        {
+          relativePath: filePath,
+          content: 'const x = 1;;\n',
+        },
+      ],
+      activeRules: [
+        {
+          ruleKey: { repo: 'javascript', rule: 'S1116' },
+          params: [],
+        },
+      ],
+    };
+
+    const responseWithIssue = await client.analyze(requestWithIssue);
+    expect(responseWithIssue.issues?.length).toBe(1);
+    expect(responseWithIssue.issues?.[0].filePath).toBe(filePath);
+
+    const requestWithoutIssue: analyzer.IAnalyzeRequest = {
+      analysisId: generateAnalysisId(),
+      contextIds: {},
+      sourceFiles: [
+        {
+          relativePath: filePath,
+          content: 'const x = 1;\n',
+        },
+      ],
+      activeRules: [
+        {
+          ruleKey: { repo: 'javascript', rule: 'S1116' },
+          params: [],
+        },
+      ],
+    };
+
+    const responseWithoutIssue = await client.analyze(requestWithoutIssue);
+    expect(responseWithoutIssue.issues?.length).toBe(0);
+  });
+
   it('should handle multiple files in a single request', async () => {
     const request: analyzer.IAnalyzeRequest = {
       analysisId: generateAnalysisId(),

--- a/packages/jsts/src/program/compilerHost.ts
+++ b/packages/jsts/src/program/compilerHost.ts
@@ -58,7 +58,7 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
    * Returns true if the file content actually changed
    */
   updateFile(filePath: NormalizedAbsolutePath, content: string | undefined): boolean {
-    if (!content) {
+    if (content === undefined) {
       return false;
     }
     const normalized = path.normalize(filePath);
@@ -122,20 +122,23 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
   readFile(fileName: string): string | undefined {
     const normalized = path.normalize(fileName);
     const cache = getSourceFileContentCache();
-
-    // 1. Check global cache
-    if (cache.has(normalized)) {
-      this.trackFsCall('readFile-cache', fileName);
-      return cache.get(normalized);
-    }
-
-    // 2. Try to get from current files context (if content is already available)
     const filesContext = getCurrentFilesContext();
+
+    // 1. For files in the current request context, always prefer request content.
+    // This avoids serving stale contents from the global cache across requests.
     if (typeof filesContext?.[fileName]?.fileContent === 'string') {
       this.trackFsCall('readFile-context', fileName);
       const content = filesContext[fileName].fileContent;
-      cache.set(normalized, content);
+      if (cache.get(normalized) !== content) {
+        cache.set(normalized, content);
+      }
       return content;
+    }
+
+    // 2. For files outside the request context, use the global cache.
+    if (cache.has(normalized)) {
+      this.trackFsCall('readFile-cache', fileName);
+      return cache.get(normalized);
     }
 
     // 3. Fallback to real filesystem (and cache it)
@@ -184,6 +187,14 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
     shouldCreateNewSourceFile?: boolean,
   ): ts.SourceFile | undefined {
     const normalized = path.normalize(fileName);
+
+    // For files explicitly present in the current analysis context, make the
+    // request content authoritative before looking up cached parsed ASTs.
+    const contextContent = getCurrentFilesContext()?.[fileName]?.fileContent;
+    if (contextContent !== undefined) {
+      this.updateFile(normalized as NormalizedAbsolutePath, contextContent);
+    }
+
     const currentVersion = this.fileVersions.get(normalized) || 0;
     const contentHash = currentVersion.toString();
 
@@ -205,7 +216,7 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
     // Try to read content (will use global cache or lazy load)
     const content = this.readFile(fileName);
     let sourceFile: (ts.SourceFile & { version?: string }) | undefined;
-    if (content) {
+    if (content !== undefined) {
       // Parse the file
       sourceFile = ts.createSourceFile(
         fileName,


### PR DESCRIPTION
## Why
We are tackling 2 issues:
1. Request contents must always have precedence over cache.
2. gRPC requests come from different projects, so gRPC should not reuse analysis caches between requests.

## What Changed
- Reset gRPC caches at the start of each Analyze request (source file store, package.json store, tsconfig store, and source-file content/parsed AST cache).
- Ensure compiler host reads prefer current request context over shared cache entries.
- Ensure getSourceFile syncs request content before parsed SourceFile cache lookup.
- Add a gRPC regression test for same file path analyzed twice with different content.

## Validation
- cmd /c npx tsx --tsconfig packages/tsconfig.test.json --test --experimental-test-isolation=none --test-reporter=spec --test-reporter-destination=stdout packages/grpc/tests/server.test.ts
- Result: 34 passed, 0 failed.