### PR TITLE
JS-1429 Fix S4030 crash on Svelte use: directives

### DIFF
--- a/its/eslint10-plugin-sonarjs/fixtures/file.svelte
+++ b/its/eslint10-plugin-sonarjs/fixtures/file.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let x = 0
+  function action() {}
+</script>
+
+<div use:action={x}></div>

--- a/its/eslint10-plugin-sonarjs/index.test.js
+++ b/its/eslint10-plugin-sonarjs/index.test.js
@@ -62,3 +62,17 @@ test('should work with TSESLint config', async t => {
   );
   verifyErrors(result.stdout);
 });
+
+test('should not crash on Svelte use: directives (JS-1429)', async t => {
+  // Regression test: S4030 crashed with TypeError when linting a Svelte file
+  // containing a use: action directive parsed by svelte-eslint-parser.
+  const result = spawn.sync(
+    'npx',
+    ['eslint', '-c', 'svelte.config.mjs', path.join(fixturesDir, 'file.svelte')],
+    {
+      cwd: __dirname,
+      encoding: 'utf-8',
+    },
+  );
+  assert(!result.stderr.includes('TypeError'), `ESLint crashed:\n${result.stderr}`);
+});

--- a/its/eslint10-plugin-sonarjs/index.test.js
+++ b/its/eslint10-plugin-sonarjs/index.test.js
@@ -75,4 +75,5 @@ test('should not crash on Svelte use: directives (JS-1429)', async t => {
     },
   );
   assert(!result.stderr.includes('TypeError'), `ESLint crashed:\n${result.stderr}`);
+  assert.notStrictEqual(result.status, 2, `ESLint exited with fatal error:\n${result.stderr}`);
 });

--- a/its/eslint10-plugin-sonarjs/package.json
+++ b/its/eslint10-plugin-sonarjs/package.json
@@ -10,6 +10,8 @@
     "eslint": "^10",
     "typescript": "^5",
     "typescript-eslint": "^8",
-    "@typescript-eslint/parser": "^8"
+    "@typescript-eslint/parser": "^8",
+    "svelte": "^5",
+    "svelte-eslint-parser": "^1"
   }
 }

--- a/its/eslint10-plugin-sonarjs/svelte.config.mjs
+++ b/its/eslint10-plugin-sonarjs/svelte.config.mjs
@@ -1,0 +1,32 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import plugin from 'eslint-plugin-sonarjs';
+import svelteParser from 'svelte-eslint-parser';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  plugin.configs.recommended,
+  {
+    files: ['**/*.svelte'],
+    languageOptions: {
+      parser: svelteParser,
+      parserOptions: {
+        parser: tsParser,
+      },
+    },
+  },
+];

--- a/packages/jsts/src/rules/S4030/rule.ts
+++ b/packages/jsts/src/rules/S4030/rule.ts
@@ -103,7 +103,7 @@ function isReferenceAssigningCollection(ref: Scope.Reference) {
     if (declOrExprStmt.type === 'ExpressionStatement') {
       const { expression } = declOrExprStmt;
       return (
-        expression.type === 'AssignmentExpression' &&
+        expression?.type === 'AssignmentExpression' &&
         isReferenceTo(ref, expression.left as estree.Node) &&
         isCollectionType(expression.right)
       );

--- a/packages/jsts/src/rules/S4030/rule.ts
+++ b/packages/jsts/src/rules/S4030/rule.ts
@@ -143,7 +143,7 @@ function isRead(ref: Scope.Reference) {
  * myArray.push(1);
  */
 function isWritingMethodCall(statement: estree.ExpressionStatement, ref: Scope.Reference) {
-  if (statement.expression.type === 'CallExpression') {
+  if (statement.expression?.type === 'CallExpression') {
     const { callee } = statement.expression;
     if (callee.type === 'MemberExpression') {
       const { property } = callee;

--- a/packages/jsts/src/rules/helpers/ast.ts
+++ b/packages/jsts/src/rules/helpers/ast.ts
@@ -251,7 +251,7 @@ export function isElementWrite(
   ref: Scope.Reference,
   recursive = true,
 ): boolean {
-  if (statement.expression.type === 'AssignmentExpression') {
+  if (statement.expression?.type === 'AssignmentExpression') {
     const assignmentExpression = statement.expression;
     const lhs = assignmentExpression.left;
     return isMemberExpressionReference(lhs, ref, recursive);


### PR DESCRIPTION
## Summary

- S4030 (`no-unused-collection`) crashed with `TypeError: Cannot read properties of null (reading 'type')` when linting Svelte files containing a `use:` action directive
- Svelte-specific AST nodes can match `type === 'ExpressionStatement'` but have `expression: null`, which `isElementWrite` and `isWritingMethodCall` did not guard against
- Fix: add optional chaining (`?.`) on `statement.expression` in both functions

## Test plan

- Integration test added to `its/eslint10-plugin-sonarjs`: lints the exact repro from the community report using `svelte-eslint-parser` and asserts no crash
- Lifecycle: `npm run bbf` → `npm run bridge:test` → `npm run eslint-plugin:build` → `cd its/eslint10-plugin-sonarjs && npm install && node index.test.js`

Fixes https://sonarsource.atlassian.net/browse/JS-1429
Community report: https://community.sonarsource.com/t/javascript-s4030-no-unused-collection-crashes-on-svelte-use-directive/179385

🤖 Generated with [Claude Code](https://claude.com/claude-code)