### PR TITLE
JS-1446 Fix: compare ruling against PR base branch, not latest master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1081,9 +1081,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
           RULING_FAILED: ${{ steps.ruling.outcome == 'failure' }}
         run: |
-          git fetch origin master
+          git fetch origin "$BASE_REF"
 
           # If ruling failed, sync the actual results first to get the differences
           if [ "$RULING_FAILED" = "true" ]; then
@@ -1098,7 +1099,7 @@ jobs:
             npm run ruling-sync
           fi
 
-          # Generate report comparing against master (after sync if ruling failed)
+          # Generate report comparing against base branch (after sync if ruling failed)
           node tools/ruling-report.js > ruling-report.md
 
           # Check if there are ruling differences

--- a/tools/ruling-report.js
+++ b/tools/ruling-report.js
@@ -20,8 +20,9 @@
  *
  * Usage: node tools/ruling-report.js
  *
- * Compares ruling JSON files against origin/master and generates a report
- * showing all changes introduced by the current branch.
+ * Compares ruling JSON files against the PR base branch (via BASE_REF env var,
+ * defaults to master) and generates a report showing all changes introduced by
+ * the current branch.
  */
 
 import { execSync } from 'child_process';
@@ -32,13 +33,13 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
 const SOURCES_DIR = join(ROOT_DIR, 'its/sources');
-const BASE_REF = 'origin/master';
+const BASE_REF = `origin/${process.env.BASE_REF ?? 'master'}`;
 const SOURCES_REPO_URL = 'https://github.com/SonarSource/jsts-test-sources/blob/master';
 const RSPEC_URL = 'https://musical-adventure-r9qk65j.pages.github.io/rspec/#';
 
 function getChangedRulingFiles() {
   try {
-    // Compare against master to show all changes introduced by this branch
+    // Compare against base branch to show all changes introduced by this branch
     const output = execSync(`git diff ${BASE_REF} --name-only its/ruling/src/test/expected/`, {
       cwd: ROOT_DIR,
       encoding: 'utf-8',
@@ -72,27 +73,27 @@ function getRulingChanges(filePath) {
   // Get current (staged/working) version
   const currentData = parseRulingJson(fullPath);
 
-  // Get master version (suppress stderr for new files)
-  let masterData = {};
+  // Get base branch version (suppress stderr for new files)
+  let baseData = {};
   try {
-    const masterContent = execSync(`git show ${BASE_REF}:${filePath} 2>/dev/null`, {
+    const baseContent = execSync(`git show ${BASE_REF}:${filePath} 2>/dev/null`, {
       cwd: ROOT_DIR,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    masterData = JSON.parse(masterContent);
+    baseData = JSON.parse(baseContent);
   } catch {
     // File might be new
   }
 
-  // Find added lines (in current but not in master)
+  // Find added lines (in current but not in base branch)
   for (const [fileKey, lines] of Object.entries(currentData)) {
-    const masterLines = new Set(masterData[fileKey] || []);
+    const baseLines = new Set(baseData[fileKey] || []);
     // Extract relative path from "project:path" format
     const relativePath = fileKey.includes(':') ? fileKey.split(':')[1] : fileKey;
 
     for (const line of lines) {
-      if (!masterLines.has(line)) {
+      if (!baseLines.has(line)) {
         changes.push({
           type: 'added',
           project,
@@ -105,8 +106,8 @@ function getRulingChanges(filePath) {
     }
   }
 
-  // Find removed lines (in master but not in current)
-  for (const [fileKey, lines] of Object.entries(masterData)) {
+  // Find removed lines (in base branch but not in current)
+  for (const [fileKey, lines] of Object.entries(baseData)) {
     const currentLines = new Set(currentData[fileKey] || []);
     const relativePath = fileKey.includes(':') ? fileKey.split(':')[1] : fileKey;
 


### PR DESCRIPTION
## Summary
- `ruling-report.js` hardcoded `origin/master` as the comparison ref
- `build.yml` fetched `origin/master` for the same purpose
- If master advances between PR creation and the ruling job running, unrelated ruling changes on master appear as differences on the PR — even when the PR itself changed nothing

## Fix
- Pass `github.base_ref` as `BASE_REF` env var in the workflow
- `ruling-report.js` reads `BASE_REF` (falls back to `master` for local runs)
- Both fetch and diff now use the PR's actual base branch

## Test plan
- [x] Open a PR targeting a non-master branch and verify the ruling report compares against that branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)