### PR TITLE
JS-1458 Use PR base SHA for ruling report comparison

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1082,9 +1082,17 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           RULING_FAILED: ${{ steps.ruling.outcome == 'failure' }}
         run: |
           git fetch origin "$BASE_REF"
+          if [ -n "$BASE_SHA" ]; then
+            git fetch origin "$BASE_SHA" || true
+            if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+              echo "::error::Failed to fetch PR base SHA: $BASE_SHA"
+              exit 1
+            fi
+          fi
 
           # If ruling failed, sync the actual results first to get the differences
           if [ "$RULING_FAILED" = "true" ]; then

--- a/tools/ruling-report.js
+++ b/tools/ruling-report.js
@@ -20,9 +20,10 @@
  *
  * Usage: node tools/ruling-report.js
  *
- * Compares ruling JSON files against the PR base branch (via BASE_REF env var,
- * defaults to master) and generates a report showing all changes introduced by
- * the current branch.
+ * Compares ruling JSON files against the PR base snapshot:
+ * - BASE_SHA (exact PR base commit) when provided
+ * - otherwise origin/BASE_REF (defaults to origin/master)
+ * and generates a report showing all changes introduced by the current branch.
  */
 
 import { execSync } from 'child_process';
@@ -33,14 +34,14 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
 const SOURCES_DIR = join(ROOT_DIR, 'its/sources');
-const BASE_REF = `origin/${process.env.BASE_REF ?? 'master'}`;
+const BASE_COMMIT = process.env.BASE_SHA ?? `origin/${process.env.BASE_REF ?? 'master'}`;
 const SOURCES_REPO_URL = 'https://github.com/SonarSource/jsts-test-sources/blob/master';
 const RSPEC_URL = 'https://musical-adventure-r9qk65j.pages.github.io/rspec/#';
 
 function getChangedRulingFiles() {
   try {
     // Compare against base branch to show all changes introduced by this branch
-    const output = execSync(`git diff ${BASE_REF} --name-only its/ruling/src/test/expected/`, {
+    const output = execSync(`git diff ${BASE_COMMIT} --name-only its/ruling/src/test/expected/`, {
       cwd: ROOT_DIR,
       encoding: 'utf-8',
     });
@@ -76,7 +77,7 @@ function getRulingChanges(filePath) {
   // Get base branch version (suppress stderr for new files)
   let baseData = {};
   try {
-    const baseContent = execSync(`git show ${BASE_REF}:${filePath} 2>/dev/null`, {
+    const baseContent = execSync(`git show ${BASE_COMMIT}:${filePath} 2>/dev/null`, {
       cwd: ROOT_DIR,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
Use the PR base commit SHA to generate ruling report diffs, so the report is stable and does not drift when `master` advances during the workflow run.

## Changes
- pass `github.event.pull_request.base.sha` to the ruling report step as `BASE_SHA`
- fetch and validate the base commit SHA before generating the report
- update `tools/ruling-report.js` to prefer `BASE_SHA` and fallback to `origin/$BASE_REF`

## Motivation
This avoids false ruling comment diffs caused by comparing against the moving tip of `master` instead of the PR's exact base snapshot.
