### PR TITLE
JS-1439 Fix S2068: detect hardcoded credentials in static template literals

### DIFF
--- a/packages/jsts/src/rules/S2068/rule.ts
+++ b/packages/jsts/src/rules/S2068/rule.ts
@@ -20,7 +20,7 @@ import type { Rule } from 'eslint';
 import type estree from 'estree';
 import type { TSESTree } from '@typescript-eslint/utils';
 import { generateMeta } from '../helpers/generate-meta.js';
-import { isLogicalExpression, isStringLiteral } from '../helpers/ast.js';
+import { isLogicalExpression, isStaticTemplateLiteral, isStringLiteral } from '../helpers/ast.js';
 import { shannonEntropy } from '../helpers/entropy.js';
 import path from 'node:path';
 import type { FromSchema } from 'json-schema-to-ts';
@@ -71,6 +71,10 @@ export const rule: Rule.RuleModule = {
         const literal = node as estree.Literal;
         checkLiteral(context, literalRegExp, literal);
       },
+      TemplateLiteral: (node: estree.Node) => {
+        const templateLiteral = node as estree.TemplateLiteral;
+        checkTemplateLiteral(context, literalRegExp, templateLiteral);
+      },
       PropertyDefinition: (node: estree.Node) => {
         const property = node as TSESTree.PropertyDefinition;
         checkAssignment(
@@ -108,6 +112,15 @@ function findValueSuspect(node: estree.Node | undefined | null): boolean {
   if (!node) {
     return false;
   }
+  if (isStaticTemplateLiteral(node)) {
+    const value = node.quasis[0].value.cooked;
+    return (
+      value != null &&
+      value.length >= MIN_PASSWORD_LENGTH &&
+      !NON_CREDENTIAL_CHARS.test(value) &&
+      hasHighEntropy(value)
+    );
+  }
   if (isStringLiteral(node)) {
     const value = node.value as string;
     return (
@@ -133,6 +146,30 @@ function checkLiteral(context: Rule.RuleContext, patterns: RegExp[], literal: es
     return;
   }
   const value = literal.value as string;
+  checkStringValue(context, patterns, value, literal);
+}
+
+function checkTemplateLiteral(
+  context: Rule.RuleContext,
+  patterns: RegExp[],
+  templateLiteral: estree.TemplateLiteral,
+) {
+  if (!isStaticTemplateLiteral(templateLiteral)) {
+    return;
+  }
+  const value = templateLiteral.quasis[0].value.cooked;
+  if (value == null) {
+    return;
+  }
+  checkStringValue(context, patterns, value, templateLiteral);
+}
+
+function checkStringValue(
+  context: Rule.RuleContext,
+  patterns: RegExp[],
+  value: string,
+  node: estree.Node,
+) {
   const lowerValue = value.toLowerCase();
   for (const pattern of patterns) {
     const match = pattern.exec(lowerValue);
@@ -147,7 +184,7 @@ function checkLiteral(context: Rule.RuleContext, patterns: RegExp[], literal: es
     if (passwordValue.length >= MIN_PASSWORD_LENGTH && hasHighEntropy(passwordValue)) {
       context.report({
         messageId: 'reviewPassword',
-        node: literal,
+        node,
       });
       return;
     }

--- a/packages/jsts/src/rules/S2068/unit.test.ts
+++ b/packages/jsts/src/rules/S2068/unit.test.ts
@@ -216,6 +216,10 @@ describe('S2068', () => {
           code: `const password = isDev ? 'pass' : 'pass';`,
           options,
         },
+        {
+          code: 'const password = `${env.PASSWORD}`;',
+          options,
+        },
         // URL with low-entropy password value
         {
           code: `let url = "https://example.com?password=foo";`,
@@ -241,6 +245,11 @@ describe('S2068', () => {
         },
         {
           code: `const servicePassword = 'Jx!9kL#mP2vN5qW8';`,
+          options,
+          errors: 1,
+        },
+        {
+          code: 'const servicePassword = `Jx!9kL#mP2vN5qW8`;',
           options,
           errors: 1,
         },
@@ -296,6 +305,11 @@ describe('S2068', () => {
         },
         {
           code: `let url = "https://example.com?PASSword=hl2OAIXXZ60";`,
+          options,
+          errors: 1,
+        },
+        {
+          code: 'let url = `https://example.com?password=hl2OAIXXZ60`;',
           options,
           errors: 1,
         },


### PR DESCRIPTION
## Summary
This PR fixes `S2068` to detect hardcoded credentials in static template literals, matching existing behavior for string literals.

## What changed
- Added `TemplateLiteral` handling in S2068 for static templates (no expressions).
- Extended assignment-value checks so static template literals are evaluated for entropy and filtering.
- Refactored shared string scanning logic to reuse the same detection path for literals and static template literals.

## Tests
- Added reproducer test for static template literal password assignment (failed before fix).
- Added static template literal URL case with `password=`.
- Added dynamic template literal case to assert we do not report non-static values.
- Ran: `npx tsx --test packages/jsts/src/rules/S2068/**/*.test.ts`
