### PR TITLE
JS-1436 Fix S1126 suggestion dropping comments in if block

### DIFF
--- a/packages/jsts/src/rules/S1126/rule.ts
+++ b/packages/jsts/src/rules/S1126/rule.ts
@@ -90,9 +90,12 @@ export const rule: Rule.RuleModule = {
     }
 
     function hasCommentsInRange(range: [number, number]): boolean {
-      return context.sourceCode
-        .getAllComments()
-        .some(comment => comment.range[0] >= range[0] && comment.range[1] <= range[1]);
+      return context.sourceCode.getAllComments().some(comment => {
+        const commentRange = comment.range;
+        return (
+          commentRange !== undefined && commentRange[0] >= range[0] && commentRange[1] <= range[1]
+        );
+      });
     }
   },
 };

--- a/packages/jsts/src/rules/S1126/rule.ts
+++ b/packages/jsts/src/rules/S1126/rule.ts
@@ -42,16 +42,20 @@ export const rule: Rule.RuleModule = {
           returnsBoolean(node.consequent) &&
           alternateReturnsBoolean(node)
         ) {
+          const suggestions = getSuggestion(node, parent);
           context.report({
             messageId: 'replaceIfThenElseByReturn',
             node,
-            suggest: getSuggestion(node, parent),
+            ...(suggestions.length > 0 ? { suggest: suggestions } : {}),
           });
         }
       },
     };
 
     function getSuggestion(ifStmt: estree.IfStatement, parent: estree.Node) {
+      if (context.sourceCode.getCommentsInside(ifStmt.consequent).length > 0) {
+        return [];
+      }
       const getFix = (condition: string) => {
         return (fixer: Rule.RuleFixer) => {
           const singleReturn = `return ${condition};`;

--- a/packages/jsts/src/rules/S1126/rule.ts
+++ b/packages/jsts/src/rules/S1126/rule.ts
@@ -54,7 +54,7 @@ export const rule: Rule.RuleModule = {
 
     function getSuggestion(ifStmt: estree.IfStatement, parent: estree.Node) {
       const replacementRange = getReplacementRange(ifStmt, parent);
-      if (hasCommentsInRange(replacementRange)) {
+      if (replacementRange === null || hasCommentsInRange(replacementRange)) {
         return [];
       }
       const getFix = (condition: string) => {
@@ -79,16 +79,6 @@ export const rule: Rule.RuleModule = {
       }
     }
 
-    function getReplacementRange(ifStmt: estree.IfStatement, parent: estree.Node): [number, number] {
-      if (ifStmt.alternate || parent.type !== 'BlockStatement') {
-        return ifStmt.range!;
-      }
-
-      const ifStmtIndex = parent.body.indexOf(ifStmt);
-      const returnStmt = parent.body[ifStmtIndex + 1];
-      return [ifStmt.range![0], returnStmt.range![1]];
-    }
-
     function hasCommentsInRange(range: [number, number]): boolean {
       return context.sourceCode.getAllComments().some(comment => {
         const commentRange = comment.range;
@@ -99,6 +89,29 @@ export const rule: Rule.RuleModule = {
     }
   },
 };
+
+function getReplacementRange(
+  ifStmt: estree.IfStatement,
+  parent: estree.Node,
+): [number, number] | null {
+  const ifStmtRange = ifStmt.range;
+  if (ifStmtRange === undefined) {
+    return null;
+  }
+
+  if (ifStmt.alternate || parent.type !== 'BlockStatement') {
+    return ifStmtRange;
+  }
+
+  const ifStmtIndex = parent.body.indexOf(ifStmt);
+  const returnStmt = parent.body[ifStmtIndex + 1];
+  const returnStmtRange = returnStmt?.range;
+  if (returnStmtRange === undefined) {
+    return null;
+  }
+
+  return [ifStmtRange[0], returnStmtRange[1]];
+}
 
 function isBlockReturningBooleanLiteral(statement: estree.Statement) {
   return (

--- a/packages/jsts/src/rules/S1126/rule.ts
+++ b/packages/jsts/src/rules/S1126/rule.ts
@@ -53,20 +53,14 @@ export const rule: Rule.RuleModule = {
     };
 
     function getSuggestion(ifStmt: estree.IfStatement, parent: estree.Node) {
-      if (context.sourceCode.getCommentsInside(ifStmt.consequent).length > 0) {
+      const replacementRange = getReplacementRange(ifStmt, parent);
+      if (hasCommentsInRange(replacementRange)) {
         return [];
       }
       const getFix = (condition: string) => {
         return (fixer: Rule.RuleFixer) => {
           const singleReturn = `return ${condition};`;
-          if (ifStmt.alternate) {
-            return fixer.replaceText(ifStmt, singleReturn);
-          } else {
-            const ifStmtIndex = (parent as estree.BlockStatement).body.indexOf(ifStmt);
-            const returnStmt = (parent as estree.BlockStatement).body[ifStmtIndex + 1];
-            const range: [number, number] = [ifStmt.range![0], returnStmt.range![1]];
-            return fixer.replaceTextRange(range, singleReturn);
-          }
+          return fixer.replaceTextRange(replacementRange, singleReturn);
         };
       };
       const shouldNegate = isReturningFalse(ifStmt.consequent);
@@ -83,6 +77,22 @@ export const rule: Rule.RuleModule = {
       } else {
         return [{ messageId: 'suggest', fix: getFix(testText) }];
       }
+    }
+
+    function getReplacementRange(ifStmt: estree.IfStatement, parent: estree.Node): [number, number] {
+      if (ifStmt.alternate || parent.type !== 'BlockStatement') {
+        return ifStmt.range!;
+      }
+
+      const ifStmtIndex = parent.body.indexOf(ifStmt);
+      const returnStmt = parent.body[ifStmtIndex + 1];
+      return [ifStmt.range![0], returnStmt.range![1]];
+    }
+
+    function hasCommentsInRange(range: [number, number]): boolean {
+      return context.sourceCode
+        .getAllComments()
+        .some(comment => comment.range[0] >= range[0] && comment.range[1] <= range[1]);
     }
   },
 };

--- a/packages/jsts/src/rules/S1126/unit.test.ts
+++ b/packages/jsts/src/rules/S1126/unit.test.ts
@@ -692,6 +692,39 @@ function foo(condition) {
             },
           ],
         },
+        {
+          code: `
+function foo(condition) {
+  if (condition) {
+    return false;
+  } else {
+    // important comment
+    return true;
+  }
+}`,
+          errors: [
+            {
+              messageId: 'replaceIfThenElseByReturn',
+              suggestions: [],
+            },
+          ],
+        },
+        {
+          code: `
+function foo(condition) {
+  if (condition) {
+    return false;
+  }
+  // important comment
+  return true;
+}`,
+          errors: [
+            {
+              messageId: 'replaceIfThenElseByReturn',
+              suggestions: [],
+            },
+          ],
+        },
       ],
     });
   });

--- a/packages/jsts/src/rules/S1126/unit.test.ts
+++ b/packages/jsts/src/rules/S1126/unit.test.ts
@@ -675,6 +675,23 @@ function foo() {
             },
           ],
         },
+        {
+          code: `
+function foo(condition) {
+  if (condition) {
+    // important comment
+    return false;
+  } else {
+    return true;
+  }
+}`,
+          errors: [
+            {
+              messageId: 'replaceIfThenElseByReturn',
+              suggestions: [],
+            },
+          ],
+        },
       ],
     });
   });


### PR DESCRIPTION
## Summary
This PR fixes a false quick-fix behavior in S1126.
When the `if` consequent contains comments, S1126 now reports the issue but does not offer a suggestion that would drop those comments.

## Changes
- suppress S1126 suggestions when `sourceCode.getCommentsInside(ifStmt.consequent)` is non-empty
- only attach `suggest` in report payload when suggestions are available
- add unit test covering an `if` block with an inline comment and asserting `suggestions: []`

## Repro
Before this change, a case like:
```js
if (condition) {
  // important comment
  return false;
} else {
  return true;
}
```
still exposed a suggestion that replaced the flow with a single return and dropped the comment.

## Validation
- `npx tsx --test packages/jsts/src/rules/S1126/unit.test.ts`
