### PR TITLE
JS-1193 Escape backslashes in generated Java rule classes

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -449,15 +449,14 @@ export const fields = [
 
 #### Field Properties
 
-| Property        | Required              | Purpose                                                                     |
-| --------------- | --------------------- | --------------------------------------------------------------------------- |
-| `field`         | Yes                   | ESLint/schema key name                                                      |
-| `default`       | Yes                   | Default value; also determines type (`number`, `string`, `boolean`, arrays) |
-| `description`   | **For SQ visibility** | Makes the option visible in SonarQube UI                                    |
-| `displayName`   | No                    | SonarQube key if different from `field`                                     |
-| `items`         | For arrays            | `{ type: 'string' }` or `{ type: 'integer' }`                               |
-| `customDefault` | No                    | Different default for SQ than JS/TS                                         |
-| `fieldType`     | No                    | Override SQ field type (e.g., `'TEXT'`)                                     |
+| Property      | Required              | Purpose                                                                     |
+| ------------- | --------------------- | --------------------------------------------------------------------------- |
+| `field`       | Yes                   | ESLint/schema key name                                                      |
+| `default`     | Yes                   | Default value; also determines type (`number`, `string`, `boolean`, arrays) |
+| `description` | **For SQ visibility** | Makes the option visible in SonarQube UI                                    |
+| `displayName` | No                    | SonarQube key if different from `field`                                     |
+| `items`       | For arrays            | `{ type: 'string' }` or `{ type: 'integer' }`                               |
+| `fieldType`   | No                    | Override SQ field type (e.g., `'TEXT'`)                                     |
 
 ### Making Options Visible in SonarQube
 

--- a/packages/grpc/src/transformers/rule-configurations/jsts.ts
+++ b/packages/grpc/src/transformers/rule-configurations/jsts.ts
@@ -53,7 +53,6 @@ type FieldDef = {
   field: string;
   displayName?: string;
   default: unknown;
-  customDefault?: unknown;
   customForConfiguration?: (value: unknown) => unknown;
 };
 
@@ -120,16 +119,6 @@ function parseParamValue(value: string, defaultValue: unknown) {
   return value;
 }
 
-function getParseTarget(fieldDef: {
-  default: unknown;
-  customDefault?: unknown;
-  customForConfiguration?: (value: unknown) => unknown;
-}) {
-  return fieldDef.customForConfiguration && fieldDef.customDefault !== undefined
-    ? fieldDef.customDefault
-    : fieldDef.default;
-}
-
 /**
  * Build an object configuration from an array of field definitions.
  *
@@ -176,7 +165,7 @@ function buildObjectConfiguration(fieldDefs: FieldDef[], paramsLookup: Map<strin
     const paramValue = paramsLookup.get(sqKey);
 
     if (paramValue !== undefined) {
-      paramsObj[fieldDef.field] = parseParamValue(paramValue, getParseTarget(fieldDef));
+      paramsObj[fieldDef.field] = parseParamValue(paramValue, fieldDef.default);
     }
   }
 
@@ -230,7 +219,6 @@ function buildPrimitiveConfiguration(
   element: {
     default: unknown;
     displayName?: string;
-    customDefault?: unknown;
     customForConfiguration?: (value: unknown) => unknown;
   },
   paramsLookup: Map<string, string>,
@@ -242,7 +230,7 @@ function buildPrimitiveConfiguration(
   if (sqKey) {
     const paramValue = paramsLookup.get(sqKey);
     if (paramValue !== undefined) {
-      return parseParamValue(paramValue, getParseTarget(element));
+      return parseParamValue(paramValue, element.default);
     }
   } else if (params.length > 0 && index === 0) {
     // Fallback for Type B primitives without displayName.

--- a/packages/grpc/tests/server.test.ts
+++ b/packages/grpc/tests/server.test.ts
@@ -719,6 +719,28 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
+  it('should handle escaped regex defaults with optional $ prefix (S101 — class names)', async () => {
+    // S101 default format is '^\\$?[A-Z][a-zA-Z0-9]*$' and should allow optional '$'.
+    // This verifies the default from Java is correctly unescaped on the JS side.
+    const content = 'interface $ZodCheckDef {}\ninterface my_interface {}\n';
+
+    const request: analyzer.IAnalyzeRequest = {
+      analysisId: generateAnalysisId(),
+      contextIds: {},
+      sourceFiles: [{ relativePath: '/project/src/interface-name.ts', content }],
+      activeRules: [
+        {
+          ruleKey: { repo: 'javascript', rule: 'S101' },
+          params: [],
+        },
+      ],
+    };
+
+    const response = await client.analyze(request);
+    expect(response.issues?.length).toBe(1);
+    expect(response.issues?.[0].rule?.rule).toBe('S101');
+  });
+
   it('should handle escaped regex defaults in arrays (S7718 — catch error name)', async () => {
     // S7718 config.ts has ignore field default as an array of regexes.
     // The gRPC path should split comma-separated values into an array.

--- a/packages/grpc/tests/server.test.ts
+++ b/packages/grpc/tests/server.test.ts
@@ -595,7 +595,7 @@ describe('gRPC server', () => {
   });
 
   it('should handle rule with customForConfiguration (S1441 — quotes)', async () => {
-    // S1441 has default: true and customForConfiguration: `value ? "single" : "double"`
+    // S1441 has default: 'single' and customForConfiguration handling SQ values 'true'/'false'.
     // When SQ sends singleQuotes='true', it should be transformed to 'single' for ESLint
     const content = 'const x = "hello";\n';
 
@@ -633,9 +633,9 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle customForConfiguration with number field in object config (S6418 — hard-coded secrets)', async () => {
-    // S6418 config.ts has randomnessSensibility with default: '5.0' (string) and customForConfiguration: Number.
-    // The gRPC path should parse 'randomnessSensibility' as string first, then transform it to number.
+  it('should handle number field in object config (S6418 — hard-coded secrets)', async () => {
+    // S6418 config.ts has randomnessSensibility with numeric default: 5.
+    // The gRPC path should parse 'randomnessSensibility' as number.
     // Also tests that 'secretWords' string param is passed correctly.
     // Needs a high-entropy string to exceed the sensibility threshold.
     const content =

--- a/packages/grpc/tests/server.test.ts
+++ b/packages/grpc/tests/server.test.ts
@@ -594,8 +594,8 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle rule with customForConfiguration and customDefault (S1441 — quotes)', async () => {
-    // S1441 has customDefault: true and customForConfiguration: `value ? "single" : "double"`
+  it('should handle rule with customForConfiguration (S1441 — quotes)', async () => {
+    // S1441 has default: true and customForConfiguration: `value ? "single" : "double"`
     // When SQ sends singleQuotes='true', it should be transformed to 'single' for ESLint
     const content = 'const x = "hello";\n';
 
@@ -633,9 +633,9 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle customDefault with number field in object config (S6418 — hard-coded secrets)', async () => {
-    // S6418 config.ts has randomnessSensibility with default: 5 (number) and customDefault: '5.0' (string for Java).
-    // The gRPC path should parse 'randomnessSensibility' as a number (from default: 5).
+  it('should handle customForConfiguration with number field in object config (S6418 — hard-coded secrets)', async () => {
+    // S6418 config.ts has randomnessSensibility with default: '5.0' (string) and customForConfiguration: Number.
+    // The gRPC path should parse 'randomnessSensibility' as string first, then transform it to number.
     // Also tests that 'secretWords' string param is passed correctly.
     // Needs a high-entropy string to exceed the sensibility threshold.
     const content =

--- a/packages/grpc/tests/server.test.ts
+++ b/packages/grpc/tests/server.test.ts
@@ -678,9 +678,8 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle customDefault with escaped regex string (S139 — trailing comments)', async () => {
-    // S139 (line-comment-position) config.ts has ignorePattern with default: '^\\s*[^\\s]+$'
-    // and customDefault: '^\\\\s*[^\\\\s]+$' (double-escaped for Java).
+  it('should handle escaped regex string defaults (S139 — trailing comments)', async () => {
+    // S139 (line-comment-position) config.ts has ignorePattern default: '^\\s*[^\\s]+$'.
     // The SQ key is 'pattern' (displayName).
 
     // Multi-word trailing comment doesn't match default ignorePattern → should trigger
@@ -720,9 +719,8 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle customDefault with array of escaped regexes (S7718 — catch error name)', async () => {
-    // S7718 config.ts has ignore field with default: array of regexes and
-    // customDefault: same array with double-escaped regexes (for Java).
+  it('should handle escaped regex defaults in arrays (S7718 — catch error name)', async () => {
+    // S7718 config.ts has ignore field default as an array of regexes.
     // The gRPC path should split comma-separated values into an array.
     const content = 'try { foo(); } catch (myVar) { throw myVar; }\n';
 

--- a/packages/jsts/src/rules/S101/config.ts
+++ b/packages/jsts/src/rules/S101/config.ts
@@ -24,7 +24,6 @@ export const fields = [
       field: 'format',
       description: 'Regular expression used to check the class names against.',
       default: String.raw`^\$?[A-Z][a-zA-Z0-9]*$`,
-      customDefault: String.raw`^\\$?[A-Z][a-zA-Z0-9]*$`,
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S139/config.ts
+++ b/packages/jsts/src/rules/S139/config.ts
@@ -24,7 +24,6 @@ export const fields = [
       field: 'ignorePattern',
       description: 'Pattern (JavaScript syntax) for text of trailing comments that are allowed.',
       default: `^\\s*[^\\s]+$`,
-      customDefault: `^\\\\s*[^\\\\s]+$`,
       displayName: 'pattern',
     },
   ],

--- a/packages/jsts/src/rules/S1441/config.ts
+++ b/packages/jsts/src/rules/S1441/config.ts
@@ -21,8 +21,7 @@ import type { ESLintConfiguration } from '../helpers/configs.js';
 export const fields = [
   {
     description: 'Set to true to require single quotes, false for double quotes.',
-    default: 'single',
-    customDefault: true,
+    default: true,
     displayName: 'singleQuotes',
     customForConfiguration: (value: unknown) => (value ? 'single' : 'double'),
   },

--- a/packages/jsts/src/rules/S1441/config.ts
+++ b/packages/jsts/src/rules/S1441/config.ts
@@ -21,9 +21,10 @@ import type { ESLintConfiguration } from '../helpers/configs.js';
 export const fields = [
   {
     description: 'Set to true to require single quotes, false for double quotes.',
-    default: true,
+    default: 'single',
     displayName: 'singleQuotes',
-    customForConfiguration: (value: unknown) => (value ? 'single' : 'double'),
+    customForConfiguration: (value: unknown) =>
+      value === false || value === 'false' || value === 'double' ? 'double' : 'single',
   },
   [
     {

--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -28,8 +28,7 @@ export const fields = [
     {
       field: 'randomnessSensibility',
       description: 'Minimum shannon entropy threshold of the secret',
-      default: '5.0',
-      customForConfiguration: Number,
+      default: 5,
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -28,8 +28,7 @@ export const fields = [
     {
       field: 'randomnessSensibility',
       description: 'Minimum shannon entropy threshold of the secret',
-      default: 5,
-      customDefault: '5.0',
+      default: '5.0',
       customForConfiguration: Number,
     },
   ],

--- a/packages/jsts/src/rules/S7718/config.ts
+++ b/packages/jsts/src/rules/S7718/config.ts
@@ -33,15 +33,6 @@ export const fields = [
         '^[cC][aA][uU][sS][eE]$',
         '^[rR][eE][aA][sS][oO][nN]$',
       ],
-      customDefault: [
-        '^(e|ex)$',
-        '[eE][xX][cC][eE][pP][tT][iI][oO][nN]$',
-        '[eE][rR][rR]$',
-        '^_',
-        String.raw`^\\w\\$\\d+$`,
-        '^[cC][aA][uU][sS][eE]$',
-        '^[rR][eE][aA][sS][oO][nN]$',
-      ],
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/helpers/configs.ts
+++ b/packages/jsts/src/rules/helpers/configs.ts
@@ -24,7 +24,6 @@ type ESLintConfigurationDefaultProperty = {
  * Necessary for the property to show up in the SonarQube interface.
  * @param description will explain to the user what the property configures
  * @param displayName only necessary if the name of the property is different from the `field` name
- * @param customDefault only necessary if different default in SQ different than in JS/TS
  * @param items only necessary if type is 'array'
  * @param fieldType only necessary if you need to override the default fieldType in SQ
  * @param customForConfiguration replacement content how to pass this variable to the Configuration object
@@ -32,7 +31,6 @@ type ESLintConfigurationDefaultProperty = {
 export type ESLintConfigurationSQProperty = ESLintConfigurationDefaultProperty & {
   description: string;
   displayName?: string;
-  customDefault?: Default;
   items?: {
     type: 'string' | 'integer';
   };
@@ -156,7 +154,7 @@ export function applyTransformations(
       // fieldDefinition is a single property: { default, customForConfiguration, ... }
       // mergedConfigEntry is a scalar value (string, number, boolean)
       //
-      // Example — S1441 fieldDefinition = { default: 'single', customDefault: true, customForConfiguration: (v) => v ? 'single' : 'double' }
+      // Example — S1441 fieldDefinition = { default: true, customForConfiguration: (v) => v ? 'single' : 'double' }
       // mergedConfigEntry = true (boolean from SQ)
       // After transform: 'single' (string expected by ESLint quotes rule)
       return fieldDefinition.customForConfiguration(mergedConfigEntry);

--- a/packages/jsts/src/rules/helpers/configs.ts
+++ b/packages/jsts/src/rules/helpers/configs.ts
@@ -154,8 +154,8 @@ export function applyTransformations(
       // fieldDefinition is a single property: { default, customForConfiguration, ... }
       // mergedConfigEntry is a scalar value (string, number, boolean)
       //
-      // Example — S1441 fieldDefinition = { default: true, customForConfiguration: (v) => v ? 'single' : 'double' }
-      // mergedConfigEntry = true (boolean from SQ)
+      // Example — S1441 fieldDefinition = { default: 'single', customForConfiguration: (v) => ... }
+      // mergedConfigEntry = 'true' (string from SQ)
       // After transform: 'single' (string expected by ESLint quotes rule)
       return fieldDefinition.customForConfiguration(mergedConfigEntry);
     }

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -150,12 +150,10 @@ function generateBody(
       return;
     }
 
-    const getSQDefault = () => {
-      return property.customDefault ?? property.default;
-    };
+    const sqDefault = property.customDefault ?? property.default;
 
     const getJavaType = () => {
-      const defaultValue = getSQDefault();
+      const defaultValue = sqDefault;
       switch (typeof defaultValue) {
         case 'number':
           return 'int';
@@ -169,7 +167,7 @@ function generateBody(
     };
 
     const getDefaultValueString = () => {
-      const defaultValue = getSQDefault();
+      const defaultValue = sqDefault;
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':
@@ -184,7 +182,7 @@ function generateBody(
     };
 
     const getDefaultValue = () => {
-      const defaultValue = getSQDefault();
+      const defaultValue = sqDefault;
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -150,10 +150,8 @@ function generateBody(
       return;
     }
 
-    const sqDefault = property.customDefault ?? property.default;
-
     const getJavaType = () => {
-      const defaultValue = sqDefault;
+      const defaultValue = property.default;
       switch (typeof defaultValue) {
         case 'number':
           return 'int';
@@ -167,7 +165,7 @@ function generateBody(
     };
 
     const getDefaultValueString = () => {
-      const defaultValue = sqDefault;
+      const defaultValue = property.default;
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':
@@ -182,7 +180,7 @@ function generateBody(
     };
 
     const getDefaultValue = () => {
-      const defaultValue = sqDefault;
+      const defaultValue = property.default;
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -175,10 +175,10 @@ function generateBody(
         case 'boolean':
           return `"" + ${defaultValue}`;
         case 'string':
-          return `"${defaultValue}"`;
+          return `"${escapeJavaString(defaultValue)}"`;
         case 'object': {
           assert(Array.isArray(defaultValue));
-          return `"${defaultValue.join(',')}"`;
+          return `"${escapeJavaString(defaultValue.join(','))}"`;
         }
       }
     };
@@ -190,10 +190,10 @@ function generateBody(
         case 'boolean':
           return `${defaultValue.toString()}`;
         case 'string':
-          return `"${defaultValue}"`;
+          return `"${escapeJavaString(defaultValue)}"`;
         case 'object':
           assert(Array.isArray(defaultValue));
-          return `"${defaultValue.join(',')}"`;
+          return `"${escapeJavaString(defaultValue.join(','))}"`;
       }
     };
 
@@ -201,7 +201,7 @@ function generateBody(
     const defaultValue = getDefaultValueString();
     imports.add('import org.sonar.check.RuleProperty;');
     result.push(
-      `@RuleProperty(key="${property.displayName ?? defaultFieldName}", description = "${property.description}", defaultValue = ${defaultValue}, type="${property.fieldType || ''}")`,
+      `@RuleProperty(key="${escapeJavaString(property.displayName ?? defaultFieldName)}", description = "${escapeJavaString(property.description)}", defaultValue = ${defaultValue}, type="${escapeJavaString(property.fieldType || '')}")`,
     );
     result.push(`${getJavaType()} ${defaultFieldName} = ${getDefaultValue()};`);
     hasSQProperties = true;


### PR DESCRIPTION
## Summary
- escape Java string literals when generating JS/TS Java check classes
- remove now-unnecessary `customDefault` workaround values from S139 and S7718 configs
- update related gRPC test descriptions to reflect escaped-default handling

## Validation
- npm run grpc:generate-proto
- npm run generate-meta
- npm run generate-java-rule-classes
- npx tsx --tsconfig packages/tsconfig.test.json --test packages/grpc/tests/server.test.ts --test-name-pattern "escaped regex string defaults|escaped regex defaults in arrays"