### PR TITLE
JS-769 Restrict nested node_modules lookups and remove ruling node_modules cleanup

### DIFF
--- a/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
@@ -29,12 +29,9 @@ import com.sonar.orchestrator.locator.MavenLocation;
 import com.sonar.orchestrator.util.Version;
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -167,7 +164,6 @@ class RulingTest {
 
   @BeforeAll
   public static void setUp() throws Exception {
-    cleanRootNodeModules();
     ProfileGenerator.RulesConfiguration jsRulesConfiguration =
       new ProfileGenerator.RulesConfiguration()
         .add(
@@ -232,32 +228,6 @@ class RulingTest {
 
     // install scanner before jobs to avoid race condition when unzipping in parallel
     installScanner();
-  }
-
-  /**
-   * Method to remove SonarJS root node_modules to avoid typescript picking up typings from SonarJS,
-   * as they are not available during CI and the results with and without node_modules are different.
-   *
-   * @throws IOException
-   */
-  private static void cleanRootNodeModules() throws IOException {
-    var nodeModules = Path.of("../../node_modules");
-    if (Files.exists(nodeModules)) {
-      var start = System.currentTimeMillis();
-      LOG.info("Cleaning node_modules");
-      try (var dirStream = Files.walk(nodeModules)) {
-        dirStream.sorted(Comparator.reverseOrder()).forEachOrdered(RulingTest::deleteUnchecked);
-      }
-      LOG.info("Done cleaning node_modules in {}ms", System.currentTimeMillis() - start);
-    }
-  }
-
-  private static void deleteUnchecked(Path path) {
-    try {
-      Files.delete(path);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
   }
 
   private static void installScanner() {

--- a/packages/jsts/src/program/compilerHost.ts
+++ b/packages/jsts/src/program/compilerHost.ts
@@ -121,7 +121,7 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
 
   readFile(fileName: string): string | undefined {
     const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
-    if (this.shouldSkipNestedNodeModulesLookup(normalized)) {
+    if (this.shouldSkipNodeModulesOutsideBaseDir(normalized)) {
       this.trackFsCall('readFile-node_modules-skip', fileName);
       return undefined;
     }
@@ -163,7 +163,7 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
 
   fileExists(fileName: string): boolean {
     const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
-    if (this.shouldSkipNestedNodeModulesLookup(normalized)) {
+    if (this.shouldSkipNodeModulesOutsideBaseDir(normalized)) {
       this.trackFsCall('fileExists-node_modules-skip', fileName);
       return false;
     }
@@ -195,7 +195,7 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
     shouldCreateNewSourceFile?: boolean,
   ): ts.SourceFile | undefined {
     const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
-    if (this.shouldSkipNestedNodeModulesLookup(normalized)) {
+    if (this.shouldSkipNodeModulesOutsideBaseDir(normalized)) {
       this.trackFsCall('getSourceFile-node_modules-skip', fileName);
       return undefined;
     }
@@ -257,14 +257,9 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
     return sourceFile;
   }
 
-  private shouldSkipNestedNodeModulesLookup(fileName: string): boolean {
+  private shouldSkipNodeModulesOutsideBaseDir(fileName: string): boolean {
     const baseDirPrefix = `${this.baseDir}/`;
-    const baseNodeModulesPrefix = `${this.baseDir}/node_modules/`;
-    return (
-      fileName.startsWith(baseDirPrefix) &&
-      fileName.includes('/node_modules/') &&
-      !fileName.startsWith(baseNodeModulesPrefix)
-    );
+    return fileName.includes('/node_modules/') && !fileName.startsWith(baseDirPrefix);
   }
 
   private trackFsCall(op: string, file: string): void {

--- a/packages/jsts/src/program/compilerHost.ts
+++ b/packages/jsts/src/program/compilerHost.ts
@@ -23,7 +23,7 @@ import {
   setCachedSourceFile,
   invalidateParsedSourceFile,
 } from './cache/sourceFileCache.js';
-import type { NormalizedAbsolutePath } from '../rules/helpers/files.js';
+import { normalizeToAbsolutePath, type NormalizedAbsolutePath } from '../rules/helpers/files.js';
 
 interface FsCall {
   op: string;
@@ -120,7 +120,11 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
   // CompilerHost implementation - intercept file reads
 
   readFile(fileName: string): string | undefined {
-    const normalized = path.normalize(fileName);
+    const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
+    if (this.shouldSkipNestedNodeModulesLookup(normalized)) {
+      this.trackFsCall('readFile-node_modules-skip', fileName);
+      return undefined;
+    }
     const cache = getSourceFileContentCache();
     const filesContext = getCurrentFilesContext();
 
@@ -158,7 +162,11 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
   }
 
   fileExists(fileName: string): boolean {
-    const normalized = path.normalize(fileName);
+    const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
+    if (this.shouldSkipNestedNodeModulesLookup(normalized)) {
+      this.trackFsCall('fileExists-node_modules-skip', fileName);
+      return false;
+    }
     const cache = getSourceFileContentCache();
 
     // 1. Check global cache
@@ -186,13 +194,17 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
     onError?: (message: string) => void,
     shouldCreateNewSourceFile?: boolean,
   ): ts.SourceFile | undefined {
-    const normalized = path.normalize(fileName);
+    const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
+    if (this.shouldSkipNestedNodeModulesLookup(normalized)) {
+      this.trackFsCall('getSourceFile-node_modules-skip', fileName);
+      return undefined;
+    }
 
     // For files explicitly present in the current analysis context, make the
     // request content authoritative before looking up cached parsed ASTs.
     const contextContent = getCurrentFilesContext()?.[fileName]?.fileContent;
     if (contextContent !== undefined) {
-      this.updateFile(normalized as NormalizedAbsolutePath, contextContent);
+      this.updateFile(normalized, contextContent);
     }
 
     const currentVersion = this.fileVersions.get(normalized) || 0;
@@ -243,6 +255,16 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
       sourceFile.version = contentHash;
     }
     return sourceFile;
+  }
+
+  private shouldSkipNestedNodeModulesLookup(fileName: string): boolean {
+    const baseDirPrefix = `${this.baseDir}/`;
+    const baseNodeModulesPrefix = `${this.baseDir}/node_modules/`;
+    return (
+      fileName.startsWith(baseDirPrefix) &&
+      fileName.includes('/node_modules/') &&
+      !fileName.startsWith(baseNodeModulesPrefix)
+    );
   }
 
   private trackFsCall(op: string, file: string): void {

--- a/packages/jsts/src/program/compilerHost.ts
+++ b/packages/jsts/src/program/compilerHost.ts
@@ -258,6 +258,9 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
   }
 
   private shouldSkipNodeModulesOutsideBaseDir(fileName: string): boolean {
+    if (fileName.startsWith(this.baseHost.getDefaultLibLocation!())) {
+      return false;
+    }
     const baseDirPrefix = `${this.baseDir}/`;
     return fileName.includes('/node_modules/') && !fileName.startsWith(baseDirPrefix);
   }

--- a/packages/jsts/src/program/compilerHost.ts
+++ b/packages/jsts/src/program/compilerHost.ts
@@ -121,10 +121,6 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
 
   readFile(fileName: string): string | undefined {
     const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
-    if (this.shouldSkipNodeModulesOutsideBaseDir(normalized)) {
-      this.trackFsCall('readFile-node_modules-skip', fileName);
-      return undefined;
-    }
     const cache = getSourceFileContentCache();
     const filesContext = getCurrentFilesContext();
 
@@ -163,10 +159,6 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
 
   fileExists(fileName: string): boolean {
     const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
-    if (this.shouldSkipNodeModulesOutsideBaseDir(normalized)) {
-      this.trackFsCall('fileExists-node_modules-skip', fileName);
-      return false;
-    }
     const cache = getSourceFileContentCache();
 
     // 1. Check global cache
@@ -195,10 +187,6 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
     shouldCreateNewSourceFile?: boolean,
   ): ts.SourceFile | undefined {
     const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
-    if (this.shouldSkipNodeModulesOutsideBaseDir(normalized)) {
-      this.trackFsCall('getSourceFile-node_modules-skip', fileName);
-      return undefined;
-    }
 
     // For files explicitly present in the current analysis context, make the
     // request content authoritative before looking up cached parsed ASTs.
@@ -255,14 +243,6 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
       sourceFile.version = contentHash;
     }
     return sourceFile;
-  }
-
-  private shouldSkipNodeModulesOutsideBaseDir(fileName: string): boolean {
-    if (fileName.startsWith(this.baseHost.getDefaultLibLocation!())) {
-      return false;
-    }
-    const baseDirPrefix = `${this.baseDir}/`;
-    return fileName.includes('/node_modules/') && !fileName.startsWith(baseDirPrefix);
   }
 
   private trackFsCall(op: string, file: string): void {

--- a/packages/jsts/src/program/compilerHost.ts
+++ b/packages/jsts/src/program/compilerHost.ts
@@ -308,6 +308,13 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
     includes: readonly string[],
     depth?: number,
   ): string[] {
+    const normalizedRootDir = normalizeToAbsolutePath(rootDir, this.baseDir);
+    if (this.shouldSkipNodeModulesOutsideBaseDir(normalizedRootDir)) {
+      this.trackFsCall('readDirectory-node_modules-skip', rootDir);
+      return [];
+    }
+
+    this.trackFsCall('readDirectory-disk', rootDir);
     return this.baseHost.readDirectory!(rootDir, extensions, excludes, includes, depth);
   }
 
@@ -321,5 +328,13 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
 
   getNewLine(): string {
     return this.baseHost.getNewLine();
+  }
+
+  private shouldSkipNodeModulesOutsideBaseDir(fileName: string): boolean {
+    if (fileName.startsWith(this.getDefaultLibLocation())) {
+      return false;
+    }
+    const baseDirPrefix = `${this.baseDir}/`;
+    return fileName.includes('/node_modules/') && !fileName.startsWith(baseDirPrefix);
   }
 }

--- a/packages/jsts/src/program/compilerHost.ts
+++ b/packages/jsts/src/program/compilerHost.ts
@@ -120,7 +120,7 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
   // CompilerHost implementation - intercept file reads
 
   readFile(fileName: string): string | undefined {
-    const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
+    const normalized = path.normalize(fileName);
     const cache = getSourceFileContentCache();
     const filesContext = getCurrentFilesContext();
 
@@ -158,7 +158,7 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
   }
 
   fileExists(fileName: string): boolean {
-    const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
+    const normalized = path.normalize(fileName);
     const cache = getSourceFileContentCache();
 
     // 1. Check global cache
@@ -186,13 +186,13 @@ export class IncrementalCompilerHost implements ts.CompilerHost {
     onError?: (message: string) => void,
     shouldCreateNewSourceFile?: boolean,
   ): ts.SourceFile | undefined {
-    const normalized = normalizeToAbsolutePath(fileName, this.baseDir);
+    const normalized = path.normalize(fileName);
 
     // For files explicitly present in the current analysis context, make the
     // request content authoritative before looking up cached parsed ASTs.
     const contextContent = getCurrentFilesContext()?.[fileName]?.fileContent;
     if (contextContent !== undefined) {
-      this.updateFile(normalized, contextContent);
+      this.updateFile(normalized as NormalizedAbsolutePath, contextContent);
     }
 
     const currentVersion = this.fileVersions.get(normalized) || 0;

--- a/packages/jsts/tests/program/compilerHost.test.ts
+++ b/packages/jsts/tests/program/compilerHost.test.ts
@@ -245,6 +245,38 @@ describe('IncrementalCompilerHost', () => {
     });
   });
 
+  describe('readDirectory', () => {
+    const extensions = ['.ts', '.d.ts'];
+    const includes = ['**/*'];
+
+    it('should skip node_modules lookups outside baseDir', () => {
+      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
+
+      const files = host.readDirectory(
+        '/external/node_modules/pkg',
+        extensions,
+        undefined,
+        includes,
+      );
+
+      expect(files).toEqual([]);
+      const calls = host.getTrackedFsCalls();
+      expect(calls.some(c => c.op === 'readDirectory-node_modules-skip')).toBe(true);
+      expect(calls.some(c => c.op === 'readDirectory-disk')).toBe(false);
+    });
+
+    it('should not skip node_modules lookups under baseDir', () => {
+      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
+      const nodeModulesUnderBaseDir = joinPaths(baseDir, 'node_modules');
+
+      host.readDirectory(nodeModulesUnderBaseDir, extensions, undefined, includes);
+
+      const calls = host.getTrackedFsCalls();
+      expect(calls.some(c => c.op === 'readDirectory-node_modules-skip')).toBe(false);
+      expect(calls.some(c => c.op === 'readDirectory-disk')).toBe(true);
+    });
+  });
+
   describe('getSourceFile', () => {
     it('should return cached source file when available', () => {
       const host = new IncrementalCompilerHost(compilerOptions, baseDir);

--- a/packages/jsts/tests/program/compilerHost.test.ts
+++ b/packages/jsts/tests/program/compilerHost.test.ts
@@ -24,7 +24,7 @@ import {
   clearSourceFileContentCache,
   getCachedSourceFile,
 } from '../../src/program/cache/sourceFileCache.js';
-import { normalizeToAbsolutePath } from '../../src/rules/helpers/files.js';
+import { joinPaths, normalizeToAbsolutePath } from '../../src/rules/helpers/files.js';
 
 describe('IncrementalCompilerHost', () => {
   const baseDir = normalizeToAbsolutePath('/project');
@@ -170,6 +170,19 @@ describe('IncrementalCompilerHost', () => {
 
       expect(cache.get(normalizeToAbsolutePath('/project/src/index.ts'))).toBe(content);
     });
+
+    it('should skip node_modules reads nested under baseDir', () => {
+      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
+      const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
+
+      const result = host.readFile(nestedNodeModulesFile);
+
+      expect(result).toBeUndefined();
+
+      const calls = host.getTrackedFsCalls();
+      expect(calls.some(c => c.op === 'readFile-node_modules-skip')).toBe(true);
+      expect(calls.some(c => c.op === 'readFile-disk')).toBe(false);
+    });
   });
 
   describe('fileExists', () => {
@@ -196,6 +209,41 @@ describe('IncrementalCompilerHost', () => {
 
       const calls = host.getTrackedFsCalls();
       expect(calls.some(c => c.op === 'fileExists-context')).toBe(true);
+    });
+
+    it('should skip node_modules lookups nested under baseDir', () => {
+      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
+      const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
+
+      expect(host.fileExists(nestedNodeModulesFile)).toBe(false);
+
+      const calls = host.getTrackedFsCalls();
+      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(true);
+      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(false);
+    });
+
+    it('should not skip node_modules lookups under baseDir', () => {
+      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
+      const fileInsideBaseNodeModules = joinPaths(baseDir, 'node_modules', 'pkg', 'index.d.ts');
+
+      host.fileExists(fileInsideBaseNodeModules);
+
+      const calls = host.getTrackedFsCalls();
+      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(false);
+      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(true);
+    });
+
+    it('should not skip node_modules lookups outside baseDir', () => {
+      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
+      const outsideNodeModulesFile = normalizeToAbsolutePath(
+        '/external/node_modules/pkg/index.d.ts',
+      );
+
+      host.fileExists(outsideNodeModulesFile);
+
+      const calls = host.getTrackedFsCalls();
+      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(false);
+      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(true);
     });
   });
 
@@ -263,6 +311,19 @@ describe('IncrementalCompilerHost', () => {
       );
 
       expect(sf?.languageVersion).toBe(ts.ScriptTarget.ES2020);
+    });
+
+    it('should skip source files from nested node_modules under baseDir', () => {
+      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
+      const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
+
+      const sf = host.getSourceFile(nestedNodeModulesFile, ts.ScriptTarget.ESNext);
+
+      expect(sf).toBeUndefined();
+
+      const calls = host.getTrackedFsCalls();
+      expect(calls.some(c => c.op === 'getSourceFile-node_modules-skip')).toBe(true);
+      expect(calls.some(c => c.op === 'getSourceFile-disk-fallback')).toBe(false);
     });
   });
 

--- a/packages/jsts/tests/program/compilerHost.test.ts
+++ b/packages/jsts/tests/program/compilerHost.test.ts
@@ -170,17 +170,6 @@ describe('IncrementalCompilerHost', () => {
 
       expect(cache.get(normalizeToAbsolutePath('/project/src/index.ts'))).toBe(content);
     });
-
-    it('should not skip node_modules reads nested under baseDir', () => {
-      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
-      const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
-
-      host.readFile(nestedNodeModulesFile);
-
-      const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'readFile-node_modules-skip')).toBe(false);
-      expect(calls.some(c => c.op === 'readFile-disk')).toBe(true);
-    });
   });
 
   describe('fileExists', () => {
@@ -209,29 +198,7 @@ describe('IncrementalCompilerHost', () => {
       expect(calls.some(c => c.op === 'fileExists-context')).toBe(true);
     });
 
-    it('should not skip node_modules lookups nested under baseDir', () => {
-      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
-      const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
-
-      host.fileExists(nestedNodeModulesFile);
-
-      const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(false);
-      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(true);
-    });
-
-    it('should not skip node_modules lookups under baseDir', () => {
-      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
-      const fileInsideBaseNodeModules = joinPaths(baseDir, 'node_modules', 'pkg', 'index.d.ts');
-
-      host.fileExists(fileInsideBaseNodeModules);
-
-      const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(false);
-      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(true);
-    });
-
-    it('should skip node_modules lookups outside baseDir', () => {
+    it('should query node_modules lookups outside baseDir', () => {
       const host = new IncrementalCompilerHost(compilerOptions, baseDir);
       const outsideNodeModulesFile = normalizeToAbsolutePath(
         '/external/node_modules/pkg/index.d.ts',
@@ -240,8 +207,7 @@ describe('IncrementalCompilerHost', () => {
       expect(host.fileExists(outsideNodeModulesFile)).toBe(false);
 
       const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(true);
-      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(false);
+      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(true);
     });
   });
 
@@ -341,19 +307,6 @@ describe('IncrementalCompilerHost', () => {
       );
 
       expect(sf?.languageVersion).toBe(ts.ScriptTarget.ES2020);
-    });
-
-    it('should not skip source files from nested node_modules under baseDir', () => {
-      const host = new IncrementalCompilerHost(compilerOptions, baseDir);
-      const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
-
-      const sf = host.getSourceFile(nestedNodeModulesFile, ts.ScriptTarget.ESNext);
-
-      expect(sf).toBeUndefined();
-
-      const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'getSourceFile-node_modules-skip')).toBe(false);
-      expect(calls.some(c => c.op === 'getSourceFile-disk-fallback')).toBe(true);
     });
   });
 

--- a/packages/jsts/tests/program/compilerHost.test.ts
+++ b/packages/jsts/tests/program/compilerHost.test.ts
@@ -171,17 +171,15 @@ describe('IncrementalCompilerHost', () => {
       expect(cache.get(normalizeToAbsolutePath('/project/src/index.ts'))).toBe(content);
     });
 
-    it('should skip node_modules reads nested under baseDir', () => {
+    it('should not skip node_modules reads nested under baseDir', () => {
       const host = new IncrementalCompilerHost(compilerOptions, baseDir);
       const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
 
-      const result = host.readFile(nestedNodeModulesFile);
-
-      expect(result).toBeUndefined();
+      host.readFile(nestedNodeModulesFile);
 
       const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'readFile-node_modules-skip')).toBe(true);
-      expect(calls.some(c => c.op === 'readFile-disk')).toBe(false);
+      expect(calls.some(c => c.op === 'readFile-node_modules-skip')).toBe(false);
+      expect(calls.some(c => c.op === 'readFile-disk')).toBe(true);
     });
   });
 
@@ -211,15 +209,15 @@ describe('IncrementalCompilerHost', () => {
       expect(calls.some(c => c.op === 'fileExists-context')).toBe(true);
     });
 
-    it('should skip node_modules lookups nested under baseDir', () => {
+    it('should not skip node_modules lookups nested under baseDir', () => {
       const host = new IncrementalCompilerHost(compilerOptions, baseDir);
       const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
 
-      expect(host.fileExists(nestedNodeModulesFile)).toBe(false);
+      host.fileExists(nestedNodeModulesFile);
 
       const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(true);
-      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(false);
+      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(false);
+      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(true);
     });
 
     it('should not skip node_modules lookups under baseDir', () => {
@@ -233,17 +231,17 @@ describe('IncrementalCompilerHost', () => {
       expect(calls.some(c => c.op === 'fileExists-disk')).toBe(true);
     });
 
-    it('should not skip node_modules lookups outside baseDir', () => {
+    it('should skip node_modules lookups outside baseDir', () => {
       const host = new IncrementalCompilerHost(compilerOptions, baseDir);
       const outsideNodeModulesFile = normalizeToAbsolutePath(
         '/external/node_modules/pkg/index.d.ts',
       );
 
-      host.fileExists(outsideNodeModulesFile);
+      expect(host.fileExists(outsideNodeModulesFile)).toBe(false);
 
       const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(false);
-      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(true);
+      expect(calls.some(c => c.op === 'fileExists-node_modules-skip')).toBe(true);
+      expect(calls.some(c => c.op === 'fileExists-disk')).toBe(false);
     });
   });
 
@@ -313,7 +311,7 @@ describe('IncrementalCompilerHost', () => {
       expect(sf?.languageVersion).toBe(ts.ScriptTarget.ES2020);
     });
 
-    it('should skip source files from nested node_modules under baseDir', () => {
+    it('should not skip source files from nested node_modules under baseDir', () => {
       const host = new IncrementalCompilerHost(compilerOptions, baseDir);
       const nestedNodeModulesFile = joinPaths(baseDir, 'src', 'node_modules', 'pkg', 'index.d.ts');
 
@@ -322,8 +320,8 @@ describe('IncrementalCompilerHost', () => {
       expect(sf).toBeUndefined();
 
       const calls = host.getTrackedFsCalls();
-      expect(calls.some(c => c.op === 'getSourceFile-node_modules-skip')).toBe(true);
-      expect(calls.some(c => c.op === 'getSourceFile-disk-fallback')).toBe(false);
+      expect(calls.some(c => c.op === 'getSourceFile-node_modules-skip')).toBe(false);
+      expect(calls.some(c => c.op === 'getSourceFile-disk-fallback')).toBe(true);
     });
   });
 

--- a/packages/ruling/testProject.ts
+++ b/packages/ruling/testProject.ts
@@ -26,15 +26,22 @@ import { RuleConfig } from '../jsts/src/linter/config/rule-config.js';
 import { expect } from 'expect';
 import * as metas from '../jsts/src/rules/metas.js';
 import { SonarMeta } from '../jsts/src/rules/helpers/generate-meta.js';
+import { symlink } from 'node:fs/promises';
 import { cssRulesMeta } from '../css/src/rules/metadata.js';
 import type { RuleConfig as CssRuleConfig } from '../css/src/linter/config.js';
 
 const currentPath = normalizePath(import.meta.dirname);
 
 const SONARJS_ROOT = join(currentPath, '..', '..');
-const sourcesPath = join(SONARJS_ROOT, 'its', 'sources');
+const sourcesPath = join(SONARJS_ROOT, '..', 'sonarjs-ruling-sources');
 const expectedBase = join(SONARJS_ROOT, 'its', 'ruling', 'src', 'test', 'expected');
 const actualBase = join(currentPath, 'actual');
+
+await symlink(join(SONARJS_ROOT, 'its', 'sources'), sourcesPath).catch(err => {
+  if (err.code !== 'EEXIST') {
+    throw err;
+  }
+});
 
 const DEFAULT_EXCLUSIONS = ['**/.*', '**/*.d.ts'];
 

--- a/packages/ruling/testProject.ts
+++ b/packages/ruling/testProject.ts
@@ -26,22 +26,15 @@ import { RuleConfig } from '../jsts/src/linter/config/rule-config.js';
 import { expect } from 'expect';
 import * as metas from '../jsts/src/rules/metas.js';
 import { SonarMeta } from '../jsts/src/rules/helpers/generate-meta.js';
-import { symlink } from 'node:fs/promises';
 import { cssRulesMeta } from '../css/src/rules/metadata.js';
 import type { RuleConfig as CssRuleConfig } from '../css/src/linter/config.js';
 
 const currentPath = normalizePath(import.meta.dirname);
 
 const SONARJS_ROOT = join(currentPath, '..', '..');
-const sourcesPath = join(SONARJS_ROOT, '..', 'sonarjs-ruling-sources');
+const sourcesPath = join(SONARJS_ROOT, 'its', 'sources');
 const expectedBase = join(SONARJS_ROOT, 'its', 'ruling', 'src', 'test', 'expected');
 const actualBase = join(currentPath, 'actual');
-
-await symlink(join(SONARJS_ROOT, 'its', 'sources'), sourcesPath).catch(err => {
-  if (err.code !== 'EEXIST') {
-    throw err;
-  }
-});
 
 const DEFAULT_EXCLUSIONS = ['**/.*', '**/*.d.ts'];
 


### PR DESCRIPTION
## Summary
- normalize compiler-host paths with `normalizeToAbsolutePath(..., baseDir)`
- gate only `readDirectory` for `node_modules` paths outside the analyzed `baseDir`
- keep `node_modules` lookups under `baseDir` allowed
- keep TypeScript default library location lookups allowed in the guard
- remove `cleanRootNodeModules()` from ruling IT setup (`RulingTest`)
- simplify compiler-host tests to assert skip behavior in `readDirectory` only

## Validation
- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/jsts/tests/program/compilerHost.test.ts`
- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/jsts/tests/program/*.test.ts`