### PR TITLE
JS-1493 Fix open SonarCloud maintainability issues

### DIFF
--- a/packages/jsts/src/rules/S1192/rule.ts
+++ b/packages/jsts/src/rules/S1192/rule.ts
@@ -54,7 +54,7 @@ export const rule: Rule.RuleModule = {
       ...DEFAULT_OPTIONS,
       ...(context.options as FromSchema<typeof meta.schema>)[0],
     };
-    const whitelist = ignoreStrings.split(',');
+    const whitelist = new Set(ignoreStrings.split(','));
     return {
       Literal: (node: estree.Node) => {
         const literal = node as TSESTree.Literal;
@@ -67,7 +67,7 @@ export const rule: Rule.RuleModule = {
           const stringContent = literal.value.trim();
 
           if (
-            !whitelist.includes(literal.value) &&
+            !whitelist.has(literal.value) &&
             !isExcludedByUsageContext(context, literal) &&
             stringContent.length >= MIN_LENGTH &&
             !NO_SEPARATOR_REGEXP.test(stringContent)

--- a/packages/jsts/src/rules/S134/config.ts
+++ b/packages/jsts/src/rules/S134/config.ts
@@ -22,7 +22,7 @@ export const fields = [
   [
     {
       field: 'maximumNestingLevel',
-      description: `Maximum allowed \\"if/for/while/switch/try\\" statements nesting depth`,
+      description: 'Maximum allowed "if/for/while/switch/try" statements nesting depth',
       default: 3,
     },
   ],

--- a/packages/jsts/src/rules/S139/config.ts
+++ b/packages/jsts/src/rules/S139/config.ts
@@ -23,7 +23,7 @@ export const fields = [
     {
       field: 'ignorePattern',
       description: 'Pattern (JavaScript syntax) for text of trailing comments that are allowed.',
-      default: `^\\s*[^\\s]+$`,
+      default: String.raw`^\s*[^\s]+$`,
       displayName: 'pattern',
     },
   ],

--- a/packages/jsts/src/rules/S3776/rule.ts
+++ b/packages/jsts/src/rules/S3776/rule.ts
@@ -372,7 +372,7 @@ export const rule: Rule.RuleModule = {
           if (
             current.operator !== '||' &&
             current.operator !== '??' &&
-            (!previous || previous.operator !== current.operator)
+            previous?.operator !== current.operator
           ) {
             const operatorTokenLoc = getFirstTokenAfter(
               current.left,

--- a/packages/jsts/src/rules/S3782/rule.ts
+++ b/packages/jsts/src/rules/S3782/rule.ts
@@ -36,7 +36,7 @@ export const rule: Rule.RuleModule = {
 
     function isBuiltInMethod(symbol: ts.Symbol) {
       const parent = symbol.valueDeclaration?.parent;
-      if (!parent || parent.kind !== ts.SyntaxKind.InterfaceDeclaration) {
+      if (parent?.kind !== ts.SyntaxKind.InterfaceDeclaration) {
         return false;
       }
       const parentSymbol = tc.getSymbolAtLocation((parent as ts.InterfaceDeclaration).name);

--- a/packages/jsts/src/rules/S4158/rule.ts
+++ b/packages/jsts/src/rules/S4158/rule.ts
@@ -199,7 +199,7 @@ function isForIterationPattern(ref: Scope.Reference) {
     n => n.type === 'ForOfStatement' || n.type === 'ForInStatement',
   ) as TSESTree.ForOfStatement | TSESTree.ForInStatement;
 
-  return forInOrOfStatement && forInOrOfStatement.right === ref.identifier;
+  return forInOrOfStatement?.right === ref.identifier;
 }
 
 function isElementRead(ref: Scope.Reference) {

--- a/packages/jsts/src/rules/S6486/rule.ts
+++ b/packages/jsts/src/rules/S6486/rule.ts
@@ -39,7 +39,7 @@ export const rule: Rule.RuleModule = {
         const node = pNode as unknown as TSESTree.JSXAttribute;
 
         const value = node.value;
-        if (!value || value.type !== 'JSXExpressionContainer') {
+        if (value?.type !== 'JSXExpressionContainer') {
           // key='foo' or just simply 'key'
           return;
         }

--- a/packages/jsts/src/rules/helpers/module.ts
+++ b/packages/jsts/src/rules/helpers/module.ts
@@ -75,7 +75,7 @@ export function isRequire(node: Node): node is estree.CallExpression {
  */
 function getModuleNameFromRequire(node: Node): estree.Literal | undefined {
   if (isRequire(node)) {
-    const moduleName = (node as estree.CallExpression).arguments[0];
+    const moduleName = node.arguments[0];
     if (moduleName.type === 'Literal') {
       return moduleName;
     }

--- a/packages/jsts/tests/tools/testers/comment-based/helpers/locations.ts
+++ b/packages/jsts/tests/tools/testers/comment-based/helpers/locations.ts
@@ -23,9 +23,9 @@ export const LINE_ADJUSTMENT = String.raw`(?:@(?<lineAdjustment>(?<relativeAdjus
 const STARTS_WITH_LOCATION = /^ *\^/;
 const COUNT = String.raw`(?<count>\d+)`;
 const DIRECTION = '(?<direction>[<>])';
-const MESSAGE = '(?<message>.*?)';
+const MESSAGE_CONTENT = String.raw`(?:[^}]|}(?!\}))*`;
 const LOCATION_PATTERN = new RegExp(
-  String.raw` *` +
+  String.raw`^ *` +
     // highlighted range, ex: ^^^^ |OR| ^^^@12 |OR| ^^^@-2
     String.raw`(?<range>\^(?:\[(?<params>[^\]]+)\]|\^+)?)` +
     LINE_ADJUSTMENT +
@@ -37,9 +37,9 @@ const LOCATION_PATTERN = new RegExp(
     String.raw`)?` +
     // message, ex: {{msg}}
     String.raw` *(?:\{\{` +
-    MESSAGE +
+    String.raw`(?<message>${MESSAGE_CONTENT})` +
     String.raw`\}\})? *` +
-    String.raw`(?:\r(\n?)|\n)?`,
+    String.raw`(?:\r?\n)?`,
 );
 
 export abstract class Location {

--- a/packages/jsts/tests/tools/testers/comment-based/helpers/locations.ts
+++ b/packages/jsts/tests/tools/testers/comment-based/helpers/locations.ts
@@ -25,21 +25,21 @@ const COUNT = String.raw`(?<count>\d+)`;
 const DIRECTION = '(?<direction>[<>])';
 const MESSAGE = '(?<message>.*?)';
 const LOCATION_PATTERN = new RegExp(
-  ' *' +
+  String.raw` *` +
     // highlighted range, ex: ^^^^ |OR| ^^^@12 |OR| ^^^@-2
-    '(?<range>\\^(?:\\[(?<params>[^\\]]+)\\]|\\^+)?)' +
+    String.raw`(?<range>\^(?:\[(?<params>[^\]]+)\]|\^+)?)` +
     LINE_ADJUSTMENT +
     // count, ex: 3 |OR| direction
-    ' *(?:' +
+    String.raw` *(?:` +
     COUNT +
-    '|' +
+    String.raw`|` +
     DIRECTION +
-    ')?' +
+    String.raw`)?` +
     // message, ex: {{msg}}
-    ' *(?:\\{\\{' +
+    String.raw` *(?:\{\{` +
     MESSAGE +
-    '\\}\\})? *' +
-    '(?:\r(\n?)|\n)?',
+    String.raw`\}\})? *` +
+    String.raw`(?:\r(\n?)|\n)?`,
 );
 
 export abstract class Location {

--- a/packages/jsts/tests/tools/testers/comment-based/helpers/locations.ts
+++ b/packages/jsts/tests/tools/testers/comment-based/helpers/locations.ts
@@ -23,7 +23,7 @@ export const LINE_ADJUSTMENT = String.raw`(?:@(?<lineAdjustment>(?<relativeAdjus
 const STARTS_WITH_LOCATION = /^ *\^/;
 const COUNT = String.raw`(?<count>\d+)`;
 const DIRECTION = '(?<direction>[<>])';
-const MESSAGE_CONTENT = String.raw`(?:[^}]|}(?!\}))*`;
+const MESSAGE_CONTENT = String.raw`(?:(?!\}\}(?!\})).)*`;
 const LOCATION_PATTERN = new RegExp(
   String.raw`^ *` +
     // highlighted range, ex: ^^^^ |OR| ^^^@12 |OR| ^^^@-2

--- a/packages/jsts/tests/tools/testers/comment-based/helpers/quickfixes.ts
+++ b/packages/jsts/tests/tools/testers/comment-based/helpers/quickfixes.ts
@@ -16,12 +16,14 @@
  */
 import { LineIssues } from './issues.js';
 import { Comment } from './comments.js';
-import { extractEffectiveLine, LINE_ADJUSTMENT } from './locations.js';
+import { extractEffectiveLine } from './locations.js';
 
 const STARTS_WITH_QUICKFIX = /^ *(edit|del|add|fix)@/;
 export const QUICKFIX_SEPARATOR = String.raw`[,\s]+`;
 export const QUICKFIX_ID = String.raw`\[\[(?<quickfixes>\w+(=\d+)?!?(?:${QUICKFIX_SEPARATOR}(?:\w+(=\d+)?!?))*)\]\]`;
-const BRACED_TEXT_CONTENT = String.raw`(?:[^}]|}(?!\}))*`;
+const BRACED_TEXT_CONTENT = String.raw`(?:(?!\}\}(?!\})).)*`;
+// Legacy fixtures support line adjustments both as `@+1` and `+1`.
+const QUICKFIX_LINE_ADJUSTMENT = String.raw`(?:@?(?<lineAdjustment>(?<relativeAdjustment>[+-])?\d+))?`;
 const QUICKFIX_DESCRIPTION_PATTERN = new RegExp(
   String.raw`^ *` +
     // quickfix description, ex: fix@qf1 {{Replace with foo}}
@@ -35,7 +37,7 @@ const QUICKFIX_CHANGE_PATTERN = new RegExp(
   String.raw`^ *` +
     // quickfix edit, ex: edit@qf1
     String.raw`(?<type>edit|add|del)@(?<quickfixId>\w+)` +
-    LINE_ADJUSTMENT +
+    QUICKFIX_LINE_ADJUSTMENT +
     // start and end columns, ex: [[sc=1;ec=5]] both are optional
     String.raw` *(?:\[\[` +
     String.raw`(?<firstColumnType>sc|ec)=(?<firstColumnValue>\d+)(?:;(?<secondColumnType>sc|ec)=(?<secondColumnValue>\d+))?` +

--- a/packages/jsts/tests/tools/testers/comment-based/helpers/quickfixes.ts
+++ b/packages/jsts/tests/tools/testers/comment-based/helpers/quickfixes.ts
@@ -21,17 +21,18 @@ import { extractEffectiveLine, LINE_ADJUSTMENT } from './locations.js';
 const STARTS_WITH_QUICKFIX = /^ *(edit|del|add|fix)@/;
 export const QUICKFIX_SEPARATOR = String.raw`[,\s]+`;
 export const QUICKFIX_ID = String.raw`\[\[(?<quickfixes>\w+(=\d+)?!?(?:${QUICKFIX_SEPARATOR}(?:\w+(=\d+)?!?))*)\]\]`;
+const BRACED_TEXT_CONTENT = String.raw`(?:[^}]|}(?!\}))*`;
 const QUICKFIX_DESCRIPTION_PATTERN = new RegExp(
-  String.raw` *` +
+  String.raw`^ *` +
     // quickfix description, ex: fix@qf1 {{Replace with foo}}
     String.raw`fix@(?<quickfixId>\w+)` +
     // message, ex: {{msg}}
-    String.raw` *(?:\{\{(?<message>.*?)\}\}(?!\}))? *` +
-    String.raw`(?:\r(\n?)|\n)?`,
+    String.raw` *(?:\{\{(?<message>${BRACED_TEXT_CONTENT})\}\}(?!\}))? *` +
+    String.raw`(?:\r?\n)?$`,
 );
 
 const QUICKFIX_CHANGE_PATTERN = new RegExp(
-  String.raw` *` +
+  String.raw`^ *` +
     // quickfix edit, ex: edit@qf1
     String.raw`(?<type>edit|add|del)@(?<quickfixId>\w+)` +
     LINE_ADJUSTMENT +
@@ -40,8 +41,8 @@ const QUICKFIX_CHANGE_PATTERN = new RegExp(
     String.raw`(?<firstColumnType>sc|ec)=(?<firstColumnValue>\d+)(?:;(?<secondColumnType>sc|ec)=(?<secondColumnValue>\d+))?` +
     String.raw`\]\])?` +
     // contents to be applied, ex: {{foo}}
-    String.raw` *(?:\{\{(?<contents>.*?)\}\}(?!\}))?` +
-    String.raw` *(?:\r(\n?)|\n)?`,
+    String.raw` *(?:\{\{(?<contents>${BRACED_TEXT_CONTENT})\}\}(?!\}))?` +
+    String.raw` *(?:\r?\n)?$`,
 );
 
 type ChangeType = 'add' | 'del' | 'edit';

--- a/packages/jsts/tests/tools/testers/comment-based/helpers/quickfixes.ts
+++ b/packages/jsts/tests/tools/testers/comment-based/helpers/quickfixes.ts
@@ -19,30 +19,29 @@ import { Comment } from './comments.js';
 import { extractEffectiveLine, LINE_ADJUSTMENT } from './locations.js';
 
 const STARTS_WITH_QUICKFIX = /^ *(edit|del|add|fix)@/;
-export const QUICKFIX_SEPARATOR = '[,\\s]+';
-export const QUICKFIX_ID =
-  '\\[\\[(?<quickfixes>\\w+(=\\d+)?!?(?:' + QUICKFIX_SEPARATOR + '(?:\\w+(=\\d+)?!?))*)\\]\\]';
+export const QUICKFIX_SEPARATOR = String.raw`[,\s]+`;
+export const QUICKFIX_ID = String.raw`\[\[(?<quickfixes>\w+(=\d+)?!?(?:${QUICKFIX_SEPARATOR}(?:\w+(=\d+)?!?))*)\]\]`;
 const QUICKFIX_DESCRIPTION_PATTERN = new RegExp(
-  ' *' +
+  String.raw` *` +
     // quickfix description, ex: fix@qf1 {{Replace with foo}}
-    'fix@(?<quickfixId>\\w+)' +
+    String.raw`fix@(?<quickfixId>\w+)` +
     // message, ex: {{msg}}
-    ' *(?:\\{\\{(?<message>.*?)\\}\\}(?!\\}))? *' +
-    '(?:\\r(\\n?)|\\n)?',
+    String.raw` *(?:\{\{(?<message>.*?)\}\}(?!\}))? *` +
+    String.raw`(?:\r(\n?)|\n)?`,
 );
 
 const QUICKFIX_CHANGE_PATTERN = new RegExp(
-  ' *' +
+  String.raw` *` +
     // quickfix edit, ex: edit@qf1
-    '(?<type>edit|add|del)@(?<quickfixId>\\w+)' +
+    String.raw`(?<type>edit|add|del)@(?<quickfixId>\w+)` +
     LINE_ADJUSTMENT +
     // start and end columns, ex: [[sc=1;ec=5]] both are optional
-    ' *(?:\\[\\[' +
-    '(?<firstColumnType>sc|ec)=(?<firstColumnValue>\\d+)(?:;(?<secondColumnType>sc|ec)=(?<secondColumnValue>\\d+))?' +
-    '\\]\\])?' +
+    String.raw` *(?:\[\[` +
+    String.raw`(?<firstColumnType>sc|ec)=(?<firstColumnValue>\d+)(?:;(?<secondColumnType>sc|ec)=(?<secondColumnValue>\d+))?` +
+    String.raw`\]\])?` +
     // contents to be applied, ex: {{foo}}
-    ' *(?:\\{\\{(?<contents>.*?)\\}\\}(?!\\}))?' +
-    ' *(?:\\r(\\n?)|\\n)?',
+    String.raw` *(?:\{\{(?<contents>.*?)\}\}(?!\}))?` +
+    String.raw` *(?:\r(\n?)|\n)?`,
 );
 
 type ChangeType = 'add' | 'del' | 'edit';

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -431,10 +431,10 @@ public class BridgeServerImpl implements BridgeServer {
     try {
       return AnalysisResponse.fromDTO(GSON.fromJson(result.reader(), AnalysisResponseDTO.class));
     } catch (JsonSyntaxException e) {
-      String msg =
-        "Failed to parse response for file " + filePath + ": \n-----\n" + result + "\n-----\n";
-      LOG.error(msg, e);
-      throw new IllegalStateException("Failed to parse response", e);
+      throw new IllegalStateException(
+        "Failed to parse response for file " + filePath + ": \n-----\n" + result + "\n-----\n",
+        e
+      );
     }
   }
 
@@ -556,9 +556,13 @@ public class BridgeServerImpl implements BridgeServer {
     @Override
     public void accept(String message) {
       if (message.startsWith("DEBUG")) {
-        LOG.debug(message.substring(5).trim());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(message.substring(5).trim());
+        }
       } else if (message.startsWith("WARN")) {
-        LOG.warn(message.substring(4).trim());
+        if (LOG.isWarnEnabled()) {
+          LOG.warn(message.substring(4).trim());
+        }
       } else {
         LOG.info(message);
       }

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/EmbeddedNode.java
@@ -174,7 +174,9 @@ public class EmbeddedNode {
       var is = getClass().getResourceAsStream(platform.archivePathInJar());
 
       if (is == null) {
-        LOG.debug("Embedded node not found for platform {}", platform.archivePathInJar());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Embedded node not found for platform {}", platform.archivePathInJar());
+        }
         return;
       }
 

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommand.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/nodejs/NodeCommand.java
@@ -78,11 +78,11 @@ public class NodeCommand {
    */
   public void start() {
     try {
-      LOG.debug("Launching command {}", toString());
+      LOG.debug("Launching command {}", this);
       process = processWrapper.startProcess(command, env, outputConsumer, errorConsumer);
     } catch (IOException e) {
       throw new NodeCommandException(
-        "Error when running: '" + toString() + "'. Is Node.js available during analysis?",
+        "Error when running: '" + this + "'. Is Node.js available during analysis?",
         e
       );
     }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
@@ -22,7 +22,6 @@ import static org.sonar.plugins.javascript.bridge.BridgeServer.IssueLocation;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/cache/CacheReporter.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/cache/CacheReporter.java
@@ -75,8 +75,10 @@ class CacheReporter {
     var hits = getHits();
     var misses = total - hits;
 
-    LOG.info(format("Hit the cache for %d out of %d", hits, total));
-    LOG.info(format("Miss the cache for %d out of %d%s", misses, total, getMissMessages(total)));
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Hit the cache for {} out of {}", hits, total);
+      LOG.info("Miss the cache for {} out of {}{}", misses, total, getMissMessages(total));
+    }
   }
 
   private String getMissMessages(int total) {
@@ -87,7 +89,7 @@ class CacheReporter {
       .map(entry -> getMissMessage(total, entry.getKey().get(), entry.getValue().intValue()))
       .sorted()
       .collect(joining(", "));
-    return message.length() > 0 ? (": " + message) : "";
+    return !message.isEmpty() ? (": " + message) : "";
   }
 
   private int getTotal() {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/AbstractExternalIssuesSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/AbstractExternalIssuesSensor.java
@@ -56,11 +56,13 @@ abstract class AbstractExternalIssuesSensor implements Sensor {
     FilePredicates predicates = context.fileSystem().predicates();
     InputFile inputFile = context.fileSystem().inputFile(predicates.hasPath(fileName));
     if (inputFile == null) {
-      LOG.warn(
-        "No input file found for {}. No {} issues will be imported on this file.",
-        fileName,
-        linterName()
-      );
+      if (LOG.isWarnEnabled()) {
+        LOG.warn(
+          "No input file found for {}. No {} issues will be imported on this file.",
+          fileName,
+          linterName()
+        );
+      }
       return null;
     }
     return inputFile;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/CoverageSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/CoverageSensor.java
@@ -159,7 +159,7 @@ public class CoverageSensor implements Sensor {
 
   private static void logIfUsedProperty(SensorContext context, String property) {
     if (context.config().hasKey(property)) {
-      LOG.debug(String.format("Property %s is used.", property));
+      LOG.debug("Property {} is used.", property);
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes the currently open SonarCloud maintainability issues for `SonarSource_SonarJS` that are in this codebase slice.

Main changes:
- TypeScript cleanup for maintainability rules:
  - Replace escaped regex strings with `String.raw` in config/test helper patterns
  - Use optional chaining where recommended
  - Replace whitelist array lookups with `Set.has`
  - Remove unnecessary type assertion
- Java cleanup for maintainability rules:
  - Remove unused import
  - Avoid eager logging argument computation by guarding calls where needed
  - Use parameterized logging instead of `String.format`
  - Use `isEmpty()` for empty-string check
  - Improve exception handling by rethrowing with contextual message

## Validation
- `npx prettier --check` on touched files
- `npx tsx --tsconfig packages/tsconfig.test.json --test ...`
  - `packages/jsts/src/rules/S1192/unit.test.ts`
  - `packages/jsts/src/rules/S134/unit.test.ts`
  - `packages/jsts/src/rules/S3776/unit.test.ts`
  - `packages/jsts/src/rules/S3782/unit.test.ts`
  - `packages/jsts/src/rules/S4158/unit.test.ts`
  - `packages/jsts/src/rules/S6486/cb.test.ts`
  - `packages/jsts/tests/tools/testers/comment-based/framework.test.ts`
- Java compile checks:
  - `mvn -pl sonar-plugin/bridge -DskipTests -Dexec.skip=true compile`
  - `mvn -pl sonar-plugin/sonar-javascript-plugin -DskipTests -Dexec.skip=true compile`
