### PR TITLE
Revert "JS-1193 Escape backslashes in generated Java rule classes (#6629)"

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -449,14 +449,15 @@ export const fields = [
 
 #### Field Properties
 
-| Property      | Required              | Purpose                                                                     |
-| ------------- | --------------------- | --------------------------------------------------------------------------- |
-| `field`       | Yes                   | ESLint/schema key name                                                      |
-| `default`     | Yes                   | Default value; also determines type (`number`, `string`, `boolean`, arrays) |
-| `description` | **For SQ visibility** | Makes the option visible in SonarQube UI                                    |
-| `displayName` | No                    | SonarQube key if different from `field`                                     |
-| `items`       | For arrays            | `{ type: 'string' }` or `{ type: 'integer' }`                               |
-| `fieldType`   | No                    | Override SQ field type (e.g., `'TEXT'`)                                     |
+| Property        | Required              | Purpose                                                                     |
+| --------------- | --------------------- | --------------------------------------------------------------------------- |
+| `field`         | Yes                   | ESLint/schema key name                                                      |
+| `default`       | Yes                   | Default value; also determines type (`number`, `string`, `boolean`, arrays) |
+| `description`   | **For SQ visibility** | Makes the option visible in SonarQube UI                                    |
+| `displayName`   | No                    | SonarQube key if different from `field`                                     |
+| `items`         | For arrays            | `{ type: 'string' }` or `{ type: 'integer' }`                               |
+| `customDefault` | No                    | Different default for SQ than JS/TS                                         |
+| `fieldType`     | No                    | Override SQ field type (e.g., `'TEXT'`)                                     |
 
 ### Making Options Visible in SonarQube
 

--- a/packages/grpc/src/transformers/rule-configurations/jsts.ts
+++ b/packages/grpc/src/transformers/rule-configurations/jsts.ts
@@ -53,6 +53,7 @@ type FieldDef = {
   field: string;
   displayName?: string;
   default: unknown;
+  customDefault?: unknown;
   customForConfiguration?: (value: unknown) => unknown;
 };
 
@@ -119,6 +120,16 @@ function parseParamValue(value: string, defaultValue: unknown) {
   return value;
 }
 
+function getParseTarget(fieldDef: {
+  default: unknown;
+  customDefault?: unknown;
+  customForConfiguration?: (value: unknown) => unknown;
+}) {
+  return fieldDef.customForConfiguration && fieldDef.customDefault !== undefined
+    ? fieldDef.customDefault
+    : fieldDef.default;
+}
+
 /**
  * Build an object configuration from an array of field definitions.
  *
@@ -165,7 +176,7 @@ function buildObjectConfiguration(fieldDefs: FieldDef[], paramsLookup: Map<strin
     const paramValue = paramsLookup.get(sqKey);
 
     if (paramValue !== undefined) {
-      paramsObj[fieldDef.field] = parseParamValue(paramValue, fieldDef.default);
+      paramsObj[fieldDef.field] = parseParamValue(paramValue, getParseTarget(fieldDef));
     }
   }
 
@@ -219,6 +230,7 @@ function buildPrimitiveConfiguration(
   element: {
     default: unknown;
     displayName?: string;
+    customDefault?: unknown;
     customForConfiguration?: (value: unknown) => unknown;
   },
   paramsLookup: Map<string, string>,
@@ -230,7 +242,7 @@ function buildPrimitiveConfiguration(
   if (sqKey) {
     const paramValue = paramsLookup.get(sqKey);
     if (paramValue !== undefined) {
-      return parseParamValue(paramValue, element.default);
+      return parseParamValue(paramValue, getParseTarget(element));
     }
   } else if (params.length > 0 && index === 0) {
     // Fallback for Type B primitives without displayName.

--- a/packages/grpc/tests/server.test.ts
+++ b/packages/grpc/tests/server.test.ts
@@ -594,8 +594,8 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle rule with customForConfiguration (S1441 — quotes)', async () => {
-    // S1441 has default: 'single' and customForConfiguration handling SQ values 'true'/'false'.
+  it('should handle rule with customForConfiguration and customDefault (S1441 — quotes)', async () => {
+    // S1441 has customDefault: true and customForConfiguration: `value ? "single" : "double"`
     // When SQ sends singleQuotes='true', it should be transformed to 'single' for ESLint
     const content = 'const x = "hello";\n';
 
@@ -633,9 +633,9 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle number field in object config (S6418 — hard-coded secrets)', async () => {
-    // S6418 config.ts has randomnessSensibility with numeric default: 5.
-    // The gRPC path should parse 'randomnessSensibility' as number.
+  it('should handle customDefault with number field in object config (S6418 — hard-coded secrets)', async () => {
+    // S6418 config.ts has randomnessSensibility with default: 5 (number) and customDefault: '5.0' (string for Java).
+    // The gRPC path should parse 'randomnessSensibility' as a number (from default: 5).
     // Also tests that 'secretWords' string param is passed correctly.
     // Needs a high-entropy string to exceed the sensibility threshold.
     const content =
@@ -678,8 +678,9 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle escaped regex string defaults (S139 — trailing comments)', async () => {
-    // S139 (line-comment-position) config.ts has ignorePattern default: '^\\s*[^\\s]+$'.
+  it('should handle customDefault with escaped regex string (S139 — trailing comments)', async () => {
+    // S139 (line-comment-position) config.ts has ignorePattern with default: '^\\s*[^\\s]+$'
+    // and customDefault: '^\\\\s*[^\\\\s]+$' (double-escaped for Java).
     // The SQ key is 'pattern' (displayName).
 
     // Multi-word trailing comment doesn't match default ignorePattern → should trigger
@@ -719,30 +720,9 @@ describe('gRPC server', () => {
     expect(responseNoTrigger.issues?.length).toBe(0);
   });
 
-  it('should handle escaped regex defaults with optional $ prefix (S101 — class names)', async () => {
-    // S101 default format is '^\\$?[A-Z][a-zA-Z0-9]*$' and should allow optional '$'.
-    // This verifies the default from Java is correctly unescaped on the JS side.
-    const content = 'interface $ZodCheckDef {}\ninterface my_interface {}\n';
-
-    const request: analyzer.IAnalyzeRequest = {
-      analysisId: generateAnalysisId(),
-      contextIds: {},
-      sourceFiles: [{ relativePath: '/project/src/interface-name.ts', content }],
-      activeRules: [
-        {
-          ruleKey: { repo: 'javascript', rule: 'S101' },
-          params: [],
-        },
-      ],
-    };
-
-    const response = await client.analyze(request);
-    expect(response.issues?.length).toBe(1);
-    expect(response.issues?.[0].rule?.rule).toBe('S101');
-  });
-
-  it('should handle escaped regex defaults in arrays (S7718 — catch error name)', async () => {
-    // S7718 config.ts has ignore field default as an array of regexes.
+  it('should handle customDefault with array of escaped regexes (S7718 — catch error name)', async () => {
+    // S7718 config.ts has ignore field with default: array of regexes and
+    // customDefault: same array with double-escaped regexes (for Java).
     // The gRPC path should split comma-separated values into an array.
     const content = 'try { foo(); } catch (myVar) { throw myVar; }\n';
 

--- a/packages/jsts/src/rules/S101/config.ts
+++ b/packages/jsts/src/rules/S101/config.ts
@@ -24,6 +24,7 @@ export const fields = [
       field: 'format',
       description: 'Regular expression used to check the class names against.',
       default: String.raw`^\$?[A-Z][a-zA-Z0-9]*$`,
+      customDefault: String.raw`^\\$?[A-Z][a-zA-Z0-9]*$`,
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S134/config.ts
+++ b/packages/jsts/src/rules/S134/config.ts
@@ -22,7 +22,7 @@ export const fields = [
   [
     {
       field: 'maximumNestingLevel',
-      description: 'Maximum allowed "if/for/while/switch/try" statements nesting depth',
+      description: String.raw`Maximum allowed \"if/for/while/switch/try\" statements nesting depth`,
       default: 3,
     },
   ],

--- a/packages/jsts/src/rules/S139/config.ts
+++ b/packages/jsts/src/rules/S139/config.ts
@@ -24,6 +24,7 @@ export const fields = [
       field: 'ignorePattern',
       description: 'Pattern (JavaScript syntax) for text of trailing comments that are allowed.',
       default: String.raw`^\s*[^\s]+$`,
+      customDefault: `^\\\\s*[^\\\\s]+$`,
       displayName: 'pattern',
     },
   ],

--- a/packages/jsts/src/rules/S1441/config.ts
+++ b/packages/jsts/src/rules/S1441/config.ts
@@ -22,9 +22,9 @@ export const fields = [
   {
     description: 'Set to true to require single quotes, false for double quotes.',
     default: 'single',
+    customDefault: true,
     displayName: 'singleQuotes',
-    customForConfiguration: (value: unknown) =>
-      value === false || value === 'false' || value === 'double' ? 'double' : 'single',
+    customForConfiguration: (value: unknown) => (value ? 'single' : 'double'),
   },
   [
     {

--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -29,6 +29,8 @@ export const fields = [
       field: 'randomnessSensibility',
       description: 'Minimum shannon entropy threshold of the secret',
       default: 5,
+      customDefault: '5.0',
+      customForConfiguration: Number,
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/S7718/config.ts
+++ b/packages/jsts/src/rules/S7718/config.ts
@@ -33,6 +33,15 @@ export const fields = [
         '^[cC][aA][uU][sS][eE]$',
         '^[rR][eE][aA][sS][oO][nN]$',
       ],
+      customDefault: [
+        '^(e|ex)$',
+        '[eE][xX][cC][eE][pP][tT][iI][oO][nN]$',
+        '[eE][rR][rR]$',
+        '^_',
+        String.raw`^\\w\\$\\d+$`,
+        '^[cC][aA][uU][sS][eE]$',
+        '^[rR][eE][aA][sS][oO][nN]$',
+      ],
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/helpers/configs.ts
+++ b/packages/jsts/src/rules/helpers/configs.ts
@@ -24,6 +24,7 @@ type ESLintConfigurationDefaultProperty = {
  * Necessary for the property to show up in the SonarQube interface.
  * @param description will explain to the user what the property configures
  * @param displayName only necessary if the name of the property is different from the `field` name
+ * @param customDefault only necessary if different default in SQ different than in JS/TS
  * @param items only necessary if type is 'array'
  * @param fieldType only necessary if you need to override the default fieldType in SQ
  * @param customForConfiguration replacement content how to pass this variable to the Configuration object
@@ -31,6 +32,7 @@ type ESLintConfigurationDefaultProperty = {
 export type ESLintConfigurationSQProperty = ESLintConfigurationDefaultProperty & {
   description: string;
   displayName?: string;
+  customDefault?: Default;
   items?: {
     type: 'string' | 'integer';
   };
@@ -154,8 +156,8 @@ export function applyTransformations(
       // fieldDefinition is a single property: { default, customForConfiguration, ... }
       // mergedConfigEntry is a scalar value (string, number, boolean)
       //
-      // Example — S1441 fieldDefinition = { default: 'single', customForConfiguration: (v) => ... }
-      // mergedConfigEntry = 'true' (string from SQ)
+      // Example — S1441 fieldDefinition = { default: 'single', customDefault: true, customForConfiguration: (v) => v ? 'single' : 'double' }
+      // mergedConfigEntry = true (boolean from SQ)
       // After transform: 'single' (string expected by ESLint quotes rule)
       return fieldDefinition.customForConfiguration(mergedConfigEntry);
     }

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -150,8 +150,12 @@ function generateBody(
       return;
     }
 
+    const getSQDefault = () => {
+      return property.customDefault ?? property.default;
+    };
+
     const getJavaType = () => {
-      const defaultValue = property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
           return 'int';
@@ -165,31 +169,31 @@ function generateBody(
     };
 
     const getDefaultValueString = () => {
-      const defaultValue = property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':
           return `"" + ${defaultValue}`;
         case 'string':
-          return `"${escapeJavaString(defaultValue)}"`;
+          return `"${defaultValue}"`;
         case 'object': {
           assert(Array.isArray(defaultValue));
-          return `"${escapeJavaString(defaultValue.join(','))}"`;
+          return `"${defaultValue.join(',')}"`;
         }
       }
     };
 
     const getDefaultValue = () => {
-      const defaultValue = property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':
           return `${defaultValue.toString()}`;
         case 'string':
-          return `"${escapeJavaString(defaultValue)}"`;
+          return `"${defaultValue}"`;
         case 'object':
           assert(Array.isArray(defaultValue));
-          return `"${escapeJavaString(defaultValue.join(','))}"`;
+          return `"${defaultValue.join(',')}"`;
       }
     };
 
@@ -197,7 +201,7 @@ function generateBody(
     const defaultValue = getDefaultValueString();
     imports.add('import org.sonar.check.RuleProperty;');
     result.push(
-      `@RuleProperty(key="${escapeJavaString(property.displayName ?? defaultFieldName)}", description = "${escapeJavaString(property.description)}", defaultValue = ${defaultValue}, type="${escapeJavaString(property.fieldType || '')}")`,
+      `@RuleProperty(key="${property.displayName ?? defaultFieldName}", description = "${property.description}", defaultValue = ${defaultValue}, type="${property.fieldType || ''}")`,
     );
     result.push(`${getJavaType()} ${defaultFieldName} = ${getDefaultValue()};`);
     hasSQProperties = true;


### PR DESCRIPTION
## Summary
- revert commit `77bd9b75cb` from PR #6629
- keep compatibility with current generator behavior by restoring escaped quotes in `S134` config

## Verification
- `mvnd install`
