### PR TITLE
JS-1494 Fix S6418 legacy decimal parameter crash and add scanner smoke tests

### DIFF
--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -28,7 +28,8 @@ export const fields = [
     {
       field: 'randomnessSensibility',
       description: 'Minimum shannon entropy threshold of the secret',
-      default: '5.0',
+      default: 5,
+      customDefault: '5.0',
       customForConfiguration: Number,
     },
   ],

--- a/packages/jsts/src/rules/S6418/config.ts
+++ b/packages/jsts/src/rules/S6418/config.ts
@@ -28,7 +28,8 @@ export const fields = [
     {
       field: 'randomnessSensibility',
       description: 'Minimum shannon entropy threshold of the secret',
-      default: 5,
+      default: '5.0',
+      customForConfiguration: Number,
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/jsts/src/rules/helpers/configs.ts
+++ b/packages/jsts/src/rules/helpers/configs.ts
@@ -24,6 +24,7 @@ type ESLintConfigurationDefaultProperty = {
  * Necessary for the property to show up in the SonarQube interface.
  * @param description will explain to the user what the property configures
  * @param displayName only necessary if the name of the property is different from the `field` name
+ * @param customDefault only necessary if different default in SQ different than in JS/TS
  * @param items only necessary if type is 'array'
  * @param fieldType only necessary if you need to override the default fieldType in SQ
  * @param customForConfiguration replacement content how to pass this variable to the Configuration object
@@ -31,6 +32,7 @@ type ESLintConfigurationDefaultProperty = {
 export type ESLintConfigurationSQProperty = ESLintConfigurationDefaultProperty & {
   description: string;
   displayName?: string;
+  customDefault?: Default;
   items?: {
     type: 'string' | 'integer';
   };

--- a/packages/jsts/src/rules/helpers/generate-meta.ts
+++ b/packages/jsts/src/rules/helpers/generate-meta.ts
@@ -17,7 +17,6 @@
 import type { Rule } from 'eslint';
 import type { RulesMeta } from '@eslint/core';
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
-import { applyTransformations } from './configs.js';
 import type { ESLintConfiguration } from './configs.js';
 import merge from 'lodash.merge';
 
@@ -62,13 +61,6 @@ export function generateMeta(sonarMeta: SonarMeta, ruleMeta?: RulesMeta): RulesM
   // If rules contains default options, we will augment them with our defaults.
   if (ruleMeta?.defaultOptions) {
     metadata.defaultOptions = merge(ruleMeta.defaultOptions, sonarMeta.meta.defaultOptions);
-  }
-
-  if (metadata.defaultOptions && sonarMeta.fields) {
-    metadata.defaultOptions = applyTransformations(
-      sonarMeta.fields,
-      metadata.defaultOptions as unknown[],
-    ) as Rule.RuleMetaData['defaultOptions'];
   }
 
   // RSPEC metadata can include fixable also for rules with suggestions, because RSPEC doesn't differentiate between fix

--- a/packages/jsts/src/rules/helpers/generate-meta.ts
+++ b/packages/jsts/src/rules/helpers/generate-meta.ts
@@ -17,6 +17,7 @@
 import type { Rule } from 'eslint';
 import type { RulesMeta } from '@eslint/core';
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
+import { applyTransformations } from './configs.js';
 import type { ESLintConfiguration } from './configs.js';
 import merge from 'lodash.merge';
 
@@ -61,6 +62,13 @@ export function generateMeta(sonarMeta: SonarMeta, ruleMeta?: RulesMeta): RulesM
   // If rules contains default options, we will augment them with our defaults.
   if (ruleMeta?.defaultOptions) {
     metadata.defaultOptions = merge(ruleMeta.defaultOptions, sonarMeta.meta.defaultOptions);
+  }
+
+  if (metadata.defaultOptions && sonarMeta.fields) {
+    metadata.defaultOptions = applyTransformations(
+      sonarMeta.fields,
+      metadata.defaultOptions as unknown[],
+    ) as Rule.RuleMetaData['defaultOptions'];
   }
 
   // RSPEC metadata can include fixable also for rules with suggestions, because RSPEC doesn't differentiate between fix

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsChecksTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsChecksTest.java
@@ -127,8 +127,17 @@ class JsTsChecksTest {
   }
 
   @Test
-  void should_initialize_all_builtin_checks_with_legacy_rule_properties() {
-    JsTsChecks checks = new JsTsChecks(buildCheckFactoryWithParameters(legacyParameters()));
+  void should_initialize_all_builtin_checks_with_s6418_decimal_rule_property_value() {
+    JsTsChecks checks = new JsTsChecks(
+      buildCheckFactoryWithParameters(
+        Map.of(
+          RuleKey.of(CheckList.JS_REPOSITORY_KEY, "S6418"),
+          Map.of("randomnessSensibility", "5.0"),
+          RuleKey.of(CheckList.TS_REPOSITORY_KEY, "S6418"),
+          Map.of("randomnessSensibility", "5.0")
+        )
+      )
+    );
     assertThat(checks.all()).hasSize(expectedBuiltinRuleCount());
   }
 
@@ -228,15 +237,6 @@ class JsTsChecksTest {
       ruleOverrides.forEach(activeRule::setParam);
       builder.addRule(activeRule.build());
     }
-  }
-
-  private static Map<RuleKey, Map<String, String>> legacyParameters() {
-    return Map.of(
-      RuleKey.of(CheckList.JS_REPOSITORY_KEY, "S6418"),
-      Map.of("randomnessSensibility", "5.0"),
-      RuleKey.of(CheckList.TS_REPOSITORY_KEY, "S6418"),
-      Map.of("randomnessSensibility", "5.0")
-    );
   }
 
   private static int expectedBuiltinRuleCount() {

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsChecksTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/JsTsChecksTest.java
@@ -24,10 +24,15 @@ import static org.sonar.plugins.javascript.api.Language.TYPESCRIPT;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.rule.CheckFactory;
+import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
+import org.sonar.api.batch.rule.internal.NewActiveRule;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
 import org.sonar.javascript.checks.CheckList;
 import org.sonar.javascript.checks.MainFileCheck;
 import org.sonar.plugins.javascript.api.CustomRuleRepository;
@@ -116,6 +121,18 @@ class JsTsChecksTest {
   }
 
   @Test
+  void should_initialize_all_builtin_checks_with_default_rule_properties() {
+    JsTsChecks checks = new JsTsChecks(buildCheckFactoryWithParameters(Map.of()));
+    assertThat(checks.all()).hasSize(expectedBuiltinRuleCount());
+  }
+
+  @Test
+  void should_initialize_all_builtin_checks_with_legacy_rule_properties() {
+    JsTsChecks checks = new JsTsChecks(buildCheckFactoryWithParameters(legacyParameters()));
+    assertThat(checks.all()).hasSize(expectedBuiltinRuleCount());
+  }
+
+  @Test
   void test_equals() {
     var js1 = new JsTsChecks.LanguageAndRepository(JAVASCRIPT, "javascript");
     var js2 = new JsTsChecks.LanguageAndRepository(JAVASCRIPT, "javascript");
@@ -165,4 +182,64 @@ class JsTsChecksTest {
   @JavaScriptRule
   @Rule(key = "customcheck")
   public static class CustomTsCheck extends MainFileCheck {}
+
+  private static CheckFactory buildCheckFactoryWithParameters(
+    Map<RuleKey, Map<String, String>> parameterOverrides
+  ) {
+    ActiveRulesBuilder builder = new ActiveRulesBuilder();
+    addActiveRules(
+      builder,
+      CheckList.JS_REPOSITORY_KEY,
+      CheckList.getJavaScriptChecks(),
+      parameterOverrides
+    );
+    addActiveRules(
+      builder,
+      CheckList.TS_REPOSITORY_KEY,
+      CheckList.getTypeScriptChecks(),
+      parameterOverrides
+    );
+    return new CheckFactory(builder.build());
+  }
+
+  private static void addActiveRules(
+    ActiveRulesBuilder builder,
+    String repositoryKey,
+    List<Class<? extends EslintHook>> checkClasses,
+    Map<RuleKey, Map<String, String>> parameterOverrides
+  ) {
+    for (var checkClass : checkClasses) {
+      Rule rule = checkClass.getAnnotation(Rule.class);
+      if (rule == null) {
+        continue;
+      }
+      RuleKey ruleKey = RuleKey.of(repositoryKey, rule.key());
+      NewActiveRule.Builder activeRule = new NewActiveRule.Builder().setRuleKey(ruleKey);
+      Map<String, String> ruleOverrides = parameterOverrides.getOrDefault(ruleKey, Map.of());
+      for (var field : checkClass.getDeclaredFields()) {
+        RuleProperty ruleProperty = field.getAnnotation(RuleProperty.class);
+        if (ruleProperty != null) {
+          if (ruleOverrides.containsKey(ruleProperty.key())) {
+            continue;
+          }
+          activeRule.setParam(ruleProperty.key(), ruleProperty.defaultValue());
+        }
+      }
+      ruleOverrides.forEach(activeRule::setParam);
+      builder.addRule(activeRule.build());
+    }
+  }
+
+  private static Map<RuleKey, Map<String, String>> legacyParameters() {
+    return Map.of(
+      RuleKey.of(CheckList.JS_REPOSITORY_KEY, "S6418"),
+      Map.of("randomnessSensibility", "5.0"),
+      RuleKey.of(CheckList.TS_REPOSITORY_KEY, "S6418"),
+      Map.of("randomnessSensibility", "5.0")
+    );
+  }
+
+  private static int expectedBuiltinRuleCount() {
+    return CheckList.getJavaScriptChecks().size() + CheckList.getTypeScriptChecks().size();
+  }
 }

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -150,8 +150,12 @@ function generateBody(
       return;
     }
 
+    const getSQDefault = () => {
+      return property.customDefault ?? property.default;
+    };
+
     const getJavaType = () => {
-      const defaultValue = property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
           return 'int';
@@ -165,7 +169,7 @@ function generateBody(
     };
 
     const getDefaultValueString = () => {
-      const defaultValue = property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':
@@ -180,7 +184,7 @@ function generateBody(
     };
 
     const getDefaultValue = () => {
-      const defaultValue = property.default;
+      const defaultValue = getSQDefault();
       switch (typeof defaultValue) {
         case 'number':
         case 'boolean':


### PR DESCRIPTION
## Summary
- fix S6418 scanner-side parameter shape to accept persisted legacy value `randomnessSensibility="5.0"` without crashing
- add scanner smoke coverage in `JsTsChecksTest` for all built-in JS/TS checks with reflected `@RuleProperty` defaults
- add legacy-parameter smoke coverage (including S6418 `5.0`) to catch upgrade regressions

## Validation
- `npx tsx --test packages/jsts/src/rules/S6418/unit.test.ts`
- `npx tsx --test packages/grpc/tests/server.test.ts --test-name-pattern "S6418"`
- `mvn -pl sonar-plugin/sonar-javascript-plugin -am -Dtest=JsTsChecksTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Regression proof
- with temporary pre-fix S6418 config (`default: 5`, no conversion), `should_initialize_all_builtin_checks_with_legacy_rule_properties` fails with `NumberFormatException: For input string: "5.0"`
- after restoring the fix, the same test command passes
