### PR TITLE
JS-1525 Fix FP S7785 : Suppress zod catch warnings

### DIFF
--- a/packages/analysis/src/jsts/rules/S7785/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7785/decorator.ts
@@ -17,27 +17,131 @@
 // https://sonarsource.github.io/rspec/#/rspec/S7785/javascript
 
 import type { Rule } from 'eslint';
+import type estree from 'estree';
+import { interceptReport } from '../helpers/decorators/interceptor.js';
 import { generateMeta } from '../helpers/generate-meta.js';
-import { isESModule } from '../helpers/module.js';
+import { getImportDeclarations, isESModule } from '../helpers/module.js';
+import { isRequiredParserServices } from '../helpers/parser-services.js';
+import { isThenable } from '../helpers/type.js';
 import * as meta from './generated-meta.js';
 
 /**
- * Decorates the unicorn/prefer-top-level-await rule to skip CommonJS files.
- *
- * Top-level await is only available in ES modules, not CommonJS.
- * Flagging CJS files for not using top-level await is a false positive
- * since they can't use it anyway.
+ * Packages whose fluent APIs use `.then()`/`.catch()`/`.finally()` as synchronous
+ * schema/configuration methods — not as Promise prototype methods.
+ */
+const ALLOWED_NON_PROMISE_PACKAGES = new Set(['zod']);
+const PROMISE_PROTOTYPE_METHODS = new Set(['then', 'catch', 'finally']);
+
+/**
+ * Decorates the unicorn/prefer-top-level-await rule to:
+ * 1. Skip CommonJS files (top-level await is not available in CJS).
+ * 2. Suppress false positives where `.then()`/`.catch()`/`.finally()` is called on
+ *    a non-Promise object (e.g. Zod schema objects), using two-mode detection:
+ *    - Mode 1 (type checker available): structural PromiseLike/Promise type check.
+ *    - Mode 2 (fallback): import-source allowlist heuristic.
  */
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
+  const intercepted = interceptReport(rule, suppressNonPromiseChains);
   return {
-    ...rule,
+    ...intercepted,
     meta: generateMeta(meta, rule.meta),
-
     create(context: Rule.RuleContext) {
       if (!isESModule(context)) {
         return {};
       }
-      return rule.create(context);
+      return intercepted.create(context);
     },
   };
+}
+
+/**
+ * Intercepts `'promise'` reports and suppresses them when the receiver of the
+ * chained call is not a Promise/PromiseLike type.
+ *
+ * Non-`'promise'` reports (`'iife'`, `'identifier'`) are passed through unchanged.
+ */
+function suppressNonPromiseChains(
+  context: Rule.RuleContext,
+  reportDescriptor: Rule.ReportDescriptor,
+): void {
+  // Only intercept 'promise' reports
+  if (!('messageId' in reportDescriptor) || reportDescriptor.messageId !== 'promise') {
+    context.report(reportDescriptor);
+    return;
+  }
+
+  // The unicorn rule reports the property Identifier (e.g. the `catch` node in `foo.catch(…)`)
+  if (!('node' in reportDescriptor)) {
+    context.report(reportDescriptor);
+    return;
+  }
+
+  const methodNode = reportDescriptor.node as Rule.Node;
+  if (methodNode.type !== 'Identifier') {
+    context.report(reportDescriptor);
+    return;
+  }
+
+  const methodName = methodNode.name;
+  const parent = methodNode.parent;
+
+  // parent must be a MemberExpression whose .property is the reported Identifier
+  if (parent.type !== 'MemberExpression') {
+    context.report(reportDescriptor);
+    return;
+  }
+
+  const receiver = parent.object;
+  const services = context.sourceCode.parserServices;
+  if (isRequiredParserServices(services)) {
+    // Mode 1: type checker available — check that the receiver is thenable
+    if (isThenable(receiver, services) && PROMISE_PROTOTYPE_METHODS.has(methodName)) {
+      context.report(reportDescriptor);
+    }
+
+    return;
+  }
+
+  // Mode 2: fallback — import-source allowlist heuristic
+  if (!isFromAllowedPackage(receiver, context)) {
+    context.report(reportDescriptor);
+  }
+}
+
+/**
+ * Returns true when the chain root is an identifier imported from a package on
+ * the allowlist. In that case, the chain is almost certainly not a Promise chain.
+ *
+ * e.g. import { z } from 'zod';
+ * z.number().catch(0)
+ */
+function isFromAllowedPackage(receiver: estree.Node, context: Rule.RuleContext): boolean {
+  let root: estree.Node = receiver;
+
+  while (true) {
+    if (root.type === 'CallExpression' && root.callee.type === 'MemberExpression') {
+      root = root.callee.object;
+    } else if (root.type === 'MemberExpression') {
+      root = root.object;
+    } else {
+      break;
+    }
+  }
+
+  if (root.type !== 'Identifier') {
+    return false;
+  }
+
+  const rootName = root.name;
+  const imports = getImportDeclarations(context);
+
+  for (const declaration of imports) {
+    for (const specifier of declaration.specifiers) {
+      if (specifier.local.name === rootName && typeof declaration.source.value === 'string') {
+        return ALLOWED_NON_PROMISE_PACKAGES.has(declaration.source.value);
+      }
+    }
+  }
+
+  return false;
 }

--- a/packages/analysis/src/jsts/rules/S7785/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7785/decorator.ts
@@ -21,24 +21,21 @@ import type estree from 'estree';
 import { interceptReport } from '../helpers/decorators/interceptor.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getImportDeclarations, isESModule } from '../helpers/module.js';
-import { isRequiredParserServices } from '../helpers/parser-services.js';
-import { isThenable } from '../helpers/type.js';
 import * as meta from './generated-meta.js';
 
 /**
- * Packages whose fluent APIs use `.then()`/`.catch()`/`.finally()` as synchronous
- * schema/configuration methods — not as Promise prototype methods.
+ * Packages whose fluent APIs use `.catch()`/`.finally()` as synchronous
+ * schema/configuration methods — not as Promise prototype methods
  */
 const ALLOWED_NON_PROMISE_PACKAGES = new Set(['zod']);
-const PROMISE_PROTOTYPE_METHODS = new Set(['then', 'catch', 'finally']);
 
 /**
- * Decorates the unicorn/prefer-top-level-await rule to:
- * 1. Skip CommonJS files (top-level await is not available in CJS).
- * 2. Suppress false positives where `.then()`/`.catch()`/`.finally()` is called on
- *    a non-Promise object (e.g. Zod schema objects), using two-mode detection:
- *    - Mode 1 (type checker available): structural PromiseLike/Promise type check.
- *    - Mode 2 (fallback): import-source allowlist heuristic.
+ * Decorates the unicorn/prefer-top-level-await rule to skip CommonJS files.
+ *
+ * Top-level await is only available in ES modules, not CommonJS.
+ * Flagging CJS files for not using top-level await is a false positive
+ * since they can't use it anyway.
+ * Suppress promise-like warnings for modules with non-PromiseLike APIs defining custom catch/finally methods
  */
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
   const intercepted = interceptReport(rule, suppressNonPromiseChains);
@@ -56,9 +53,7 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
 
 /**
  * Intercepts `'promise'` reports and suppresses them when the receiver of the
- * chained call is not a Promise/PromiseLike type.
- *
- * Non-`'promise'` reports (`'iife'`, `'identifier'`) are passed through unchanged.
+ * chained call comes from an `allowed` module.
  */
 function suppressNonPromiseChains(
   context: Rule.RuleContext,
@@ -82,7 +77,6 @@ function suppressNonPromiseChains(
     return;
   }
 
-  const methodName = methodNode.name;
   const parent = methodNode.parent;
 
   // parent must be a MemberExpression whose .property is the reported Identifier
@@ -92,30 +86,20 @@ function suppressNonPromiseChains(
   }
 
   const receiver = parent.object;
-  const services = context.sourceCode.parserServices;
-  if (isRequiredParserServices(services)) {
-    // Mode 1: type checker available — check that the receiver is thenable
-    if (isThenable(receiver, services) && PROMISE_PROTOTYPE_METHODS.has(methodName)) {
-      context.report(reportDescriptor);
-    }
 
-    return;
-  }
-
-  // Mode 2: fallback — import-source allowlist heuristic
-  if (!isFromAllowedPackage(receiver, context)) {
+  if (!isNonPromiseChainRoot(receiver, context)) {
     context.report(reportDescriptor);
   }
 }
 
 /**
  * Returns true when the chain root is an identifier imported from a package on
- * the allowlist. In that case, the chain is almost certainly not a Promise chain.
+ * the allowlist. In that case, the chain is almost certainly not a Promise chain nad t
  *
  * e.g. import { z } from 'zod';
  * z.number().catch(0)
  */
-function isFromAllowedPackage(receiver: estree.Node, context: Rule.RuleContext): boolean {
+function isNonPromiseChainRoot(receiver: estree.Node, context: Rule.RuleContext): boolean {
   let root: estree.Node = receiver;
 
   while (true) {

--- a/packages/analysis/src/jsts/rules/S7785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7785/unit.test.ts
@@ -15,10 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import {
-  NoTypeCheckingRuleTester,
-  RuleTester,
-} from '../../../../tests/jsts/tools/testers/rule-tester.js';
+import { NoTypeCheckingRuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S7785', () => {
@@ -112,102 +109,6 @@ describe('S7785', () => {
             getPromise().catch(err => console.error(err));
           `,
           errors: [{ messageId: 'promise' }],
-        },
-      ],
-    });
-  });
-
-  it('should not report non-Promise .catch() chains on non-thenable types (with type checker)', () => {
-    // False positive: with type information, the receiver of .catch() is a ZodOptional
-    // (or similar Zod type) which does not implement PromiseLike, so the report is suppressed.
-    const ruleTester = new RuleTester();
-    ruleTester.run('S7785', rule, {
-      valid: [
-        {
-          // Zod schema .catch() — ZodOptional has no `then` property
-          code: `
-            import { z } from 'zod';
-            const schema = z.string().optional().catch('');
-          `,
-        },
-        {
-          // Zod schema .catch() with undefined default — from the real-world FP
-          code: `
-            import { z } from 'zod';
-            const schema = z.coerce.number().optional().catch(undefined);
-          `,
-        },
-        {
-          // Actual top-level await is valid
-          code: `
-            const result = await fetch('https://example.com');
-          `,
-        },
-        {
-          // Custom class with .catch() but no .then() — not a Promise, must not be flagged
-          code: `
-            class Catchable { catch(fn: (e: unknown) => void) { return this; } }
-            new Catchable().catch(() => {});
-          `,
-        },
-        {
-          // Custom class with .finally() but no .then() — not a Promise, must not be flagged
-          code: `
-            class Finalizable { finally(fn: () => void) { return this; } }
-            new Finalizable().finally(() => {});
-          `,
-        },
-        {
-          // Custom class with both .catch() and .finally() but no .then() — still not a Promise
-          code: `
-            class Resource {
-              catch(fn: (e: unknown) => void) { return this; }
-              finally(fn: () => void) { return this; }
-            }
-            new Resource().catch(() => {}).finally(() => {});
-          `,
-        },
-      ],
-      invalid: [
-        {
-          // Real promise chain — fetch() returns a Promise which has both `then` and `catch`
-          code: `
-            fetch('https://example.com').catch(err => console.error(err));
-          `,
-          errors: [{ messageId: 'promise' }],
-        },
-        {
-          // Promise.resolve().then() — PromiseLike must still be flagged
-          code: `
-            Promise.resolve(42).then(v => console.log(v));
-          `,
-          errors: [{ messageId: 'promise' }],
-        },
-        {
-          // Custom thenable (has callable .then()) — IS PromiseLike, calling .then() must be flagged
-          code: `
-            class Thenable { then(onfulfilled: (value: unknown) => void) { return this; } }
-            new Thenable().then(v => console.log(v));
-          `,
-          errors: [{ messageId: 'promise' }],
-        },
-        {
-          // Custom class with both .then() and .catch() — IS Promise-like, calling .catch() must be flagged
-          code: `
-            class PromiseLike {
-              then(resolve: (value: unknown) => void) { return this; }
-              catch(reject: (error: unknown) => void) { return this; }
-            }
-            new PromiseLike().catch(err => console.error(err));
-          `,
-          errors: [{ messageId: 'promise' }],
-        },
-        {
-          // IIFE must still be flagged regardless
-          code: `
-            (async () => { await fetch('https://example.com'); })();
-          `,
-          errors: [{ messageId: 'iife' }],
         },
       ],
     });

--- a/packages/analysis/src/jsts/rules/S7785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7785/unit.test.ts
@@ -15,7 +15,10 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
-import { NoTypeCheckingRuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
+import {
+  NoTypeCheckingRuleTester,
+  RuleTester,
+} from '../../../../tests/jsts/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
 
 describe('S7785', () => {
@@ -42,6 +45,168 @@ describe('S7785', () => {
       invalid: [
         {
           code: `(async () => { await fetch('https://example.com'); })();`,
+          errors: [{ messageId: 'iife' }],
+        },
+      ],
+    });
+  });
+
+  it('should not report non-Promise .catch() chains from allowlisted packages (no type checker)', () => {
+    // False positive: Zod's .catch() is a synchronous schema transformation method,
+    // not Promise.prototype.catch. Suppress via import-source allowlist.
+    const ruleTester = new NoTypeCheckingRuleTester();
+    ruleTester.run('S7785', rule, {
+      valid: [
+        {
+          // Zod schema with .catch() as default value fallback
+          code: `
+            import { z } from 'zod';
+            const schema = z.string().optional().catch('');
+          `,
+        },
+        {
+          // Zod schema with chained .catch() on number
+          code: `
+            import { z } from 'zod';
+            const schema = z.coerce.number().optional().catch(0);
+          `,
+        },
+        {
+          // Zod schema with .catch() on boolean
+          code: `
+            import { z } from 'zod';
+            const schema = z.boolean().optional().catch(false);
+          `,
+        },
+        {
+          // Zod namespace import with .catch()
+          code: `
+            import * as z from 'zod';
+            const schema = z.string().catch('default');
+          `,
+        },
+        {
+          // Multiple Zod fields in z.object(), all with .catch()
+          code: `
+            import { z } from 'zod';
+            const QueryParams = z.object({
+              org_id: z.string().optional().catch(''),
+              callback_port: z.coerce.number().optional().catch(undefined),
+              is_admin_login: z.boolean().optional().catch(false),
+            });
+          `,
+        },
+      ],
+      invalid: [
+        {
+          // Real promise chain from fetch() must still be flagged
+          code: `
+            fetch('https://example.com').catch(err => console.error(err));
+          `,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // Non-zod import must still be flagged
+          code: `
+            import { getPromise } from 'some-library';
+            getPromise().catch(err => console.error(err));
+          `,
+          errors: [{ messageId: 'promise' }],
+        },
+      ],
+    });
+  });
+
+  it('should not report non-Promise .catch() chains on non-thenable types (with type checker)', () => {
+    // False positive: with type information, the receiver of .catch() is a ZodOptional
+    // (or similar Zod type) which does not implement PromiseLike, so the report is suppressed.
+    const ruleTester = new RuleTester();
+    ruleTester.run('S7785', rule, {
+      valid: [
+        {
+          // Zod schema .catch() — ZodOptional has no `then` property
+          code: `
+            import { z } from 'zod';
+            const schema = z.string().optional().catch('');
+          `,
+        },
+        {
+          // Zod schema .catch() with undefined default — from the real-world FP
+          code: `
+            import { z } from 'zod';
+            const schema = z.coerce.number().optional().catch(undefined);
+          `,
+        },
+        {
+          // Actual top-level await is valid
+          code: `
+            const result = await fetch('https://example.com');
+          `,
+        },
+        {
+          // Custom class with .catch() but no .then() — not a Promise, must not be flagged
+          code: `
+            class Catchable { catch(fn: (e: unknown) => void) { return this; } }
+            new Catchable().catch(() => {});
+          `,
+        },
+        {
+          // Custom class with .finally() but no .then() — not a Promise, must not be flagged
+          code: `
+            class Finalizable { finally(fn: () => void) { return this; } }
+            new Finalizable().finally(() => {});
+          `,
+        },
+        {
+          // Custom class with both .catch() and .finally() but no .then() — still not a Promise
+          code: `
+            class Resource {
+              catch(fn: (e: unknown) => void) { return this; }
+              finally(fn: () => void) { return this; }
+            }
+            new Resource().catch(() => {}).finally(() => {});
+          `,
+        },
+      ],
+      invalid: [
+        {
+          // Real promise chain — fetch() returns a Promise which has both `then` and `catch`
+          code: `
+            fetch('https://example.com').catch(err => console.error(err));
+          `,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // Promise.resolve().then() — PromiseLike must still be flagged
+          code: `
+            Promise.resolve(42).then(v => console.log(v));
+          `,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // Custom thenable (has callable .then()) — IS PromiseLike, calling .then() must be flagged
+          code: `
+            class Thenable { then(onfulfilled: (value: unknown) => void) { return this; } }
+            new Thenable().then(v => console.log(v));
+          `,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // Custom class with both .then() and .catch() — IS Promise-like, calling .catch() must be flagged
+          code: `
+            class PromiseLike {
+              then(resolve: (value: unknown) => void) { return this; }
+              catch(reject: (error: unknown) => void) { return this; }
+            }
+            new PromiseLike().catch(err => console.error(err));
+          `,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // IIFE must still be flagged regardless
+          code: `
+            (async () => { await fetch('https://example.com'); })();
+          `,
           errors: [{ messageId: 'iife' }],
         },
       ],


### PR DESCRIPTION
Part of JS-1525

Suppresses warnings suggesting top-level await if the chain root is imported from an allowlisted package (zod).

Zod (and other packages to be identified) defines a custom interface with a  synchronous`catch` method that does not behave like a Promise. The underlying unicorn rule simply checks for `catch`/`then`/`finally` calls by name, triggering a false positive.

Fix: Walk up the call chain to reach the root identifier, if the root comes from an identified module (zod for now), then we can assume that the warning can be suppressed.
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
