### PR TITLE
JS-1579 Group npm Renovate PRs by monorepo instead of one global npm PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,12 @@
       "matchDepNames": ["/^org\\.sonarsource\\.javascript:/"]
     },
     {
+      "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
+      "matchManagers": ["npm"],
+      "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
+      "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
+    },
+    {
       "matchManagers": ["github-actions"],
       "pinDigests": false,
       "groupName": "all github actions",


### PR DESCRIPTION
## Problem
Recent Renovate runs created broad PRs such as:
- #6785 (enovate/npm-dependencies)
- #6786 (enovate/major-npm-dependencies)

This happens because the shared preset groups all npm updates under 
pm dependencies.

## Change
Add one generic npm package rule in .github/renovate.json:
- group by sourceRepo when available (monorepo behavior)
- fallback to depName when sourceRepo is missing

This keeps configuration generic (no per-monorepo hardcoded list) while avoiding one massive npm PR.

## Expected behavior
- @typescript-eslint/* updates are grouped together
- Babel packages are grouped together
- unrelated npm packages no longer collapse into a single global npm PR
