### PR TITLE
JS-1589 Apply monorepo grouping rule to maven updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,8 +26,8 @@
       "matchDepNames": ["/^org\\.sonarsource\\.javascript:/"]
     },
     {
-      "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
-      "matchManagers": ["npm"],
+      "description": "Group npm and maven updates per source repository (monorepo), fallback to per dependency",
+      "matchManagers": ["npm", "maven"],
       "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
       "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
     },


### PR DESCRIPTION
## Summary
- apply the existing monorepo/fallback grouping rule to both 
pm and maven
- stop inheriting the single global Maven grouping behavior from the shared preset

## Why
Align Maven behavior with the npm strategy so updates are grouped by suite/monorepo when possible, and otherwise split per dependency.