### PR TITLE
Disable grouping by default in Renovate (keep npm monorepo grouping)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,11 @@
       "matchDepNames": ["/^org\\.sonarsource\\.javascript:/"]
     },
     {
+      "description": "Don't group maven updates",
+      "matchManagers": ["maven"],
+      "groupName": null
+    },
+    {
       "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
       "matchManagers": ["npm"],
       "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,8 +26,8 @@
       "matchDepNames": ["/^org\\.sonarsource\\.javascript:/"]
     },
     {
-      "description": "Don't group maven updates",
-      "matchManagers": ["maven"],
+      "description": "Don't group updates by default",
+      "matchPackageNames": ["*"],
       "groupName": null
     },
     {
@@ -38,9 +38,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "pinDigests": false,
-      "groupName": "all github actions",
-      "groupSlug": "all-github-actions"
+      "pinDigests": false
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Summary
- add an explicit Renovate override to disable grouping for maven updates
- keep npm monorepo grouping unchanged

## Why
The shared preset groups Maven dependencies by default. This override ensures Maven updates are always split (one PR/update stream per dependency) instead of grouped.