### PR TITLE
Recognize test.prop and it.prop from @fast-check/vitest in `S2187`

### DIFF
--- a/packages/analysis/src/jsts/rules/S2187/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2187/rule.ts
@@ -78,6 +78,9 @@ const APIs = new Set([
   'it.runIf',
   'test.for',
   'it.for',
+  // @fast-check/vitest (property-based testing)
+  'test.prop',
+  'it.prop',
   // eslint rule tester
   'ruleTester.run',
 ]);

--- a/packages/analysis/src/jsts/rules/S2187/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2187/unit.test.ts
@@ -79,6 +79,22 @@ describe('S2187', () => {
         },
         {
           code: `
+        /* a test file using 'test.prop' from @fast-check/vitest */
+        test.prop([fc.string(), fc.string(), fc.string()])('should detect substrings', (a, b, c) => {
+            expect((a + b + c).includes(b)).toBe(true)
+        });`,
+          filename: 'foo.test.js',
+        },
+        {
+          code: `
+        /* a test file using 'it.prop' from @fast-check/vitest */
+        it.prop([fc.nat()])('should be positive', (n) => {
+            expect(n).toBeGreaterThanOrEqual(0)
+        });`,
+          filename: 'foo.test.js',
+        },
+        {
+          code: `
         const ruleTester = new NoTypeCheckingRuleTester();
         ruleTester.run('Sections of code should not be commented out', rule, {
           valid: [


### PR DESCRIPTION
`S2187` flags test files that use `test.prop` from [`@fast-check/vitest`](https://github.com/dubzzz/fast-check/tree/main/packages/vitest) as empty. The rule knows about `test.each`, `test.only`, `test.for`, etc., but not `test.prop`.

```ts
import { test, fc } from '@fast-check/vitest';

// S2187 reports: "Add some tests to this file or delete it."
test.prop([fc.string(), fc.string(), fc.string()])('should detect substrings', (a, b, c) => {
  expect((a + b + c).includes(b)).toBe(true);
});
```

This PR adds `test.prop` and `it.prop` to the `APIs` set in the `S2187` rule. They follow the same curried-call pattern as `test.each`, so just adding the names to the set is enough. Two test cases added to `unit.test.ts`.

References:
- [`@fast-check/vitest` on GitHub](https://github.com/dubzzz/fast-check/tree/main/packages/vitest)
- [Property-based testing with Vitest tutorial](https://fast-check.dev/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-vitest/)