### PR TITLE
JS-581 Use @sonar/scan npm package for SonarQube analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -539,12 +539,17 @@ jobs:
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
-        run: |
+          SONAR_PROJECT_KEY: org.sonarsource.javascript:javascript
+          SONAR_ORGANIZATION: ''
+        run: &run_sonarqube_analysis |
           SONAR_ARGS="-Dsonar.host.url=$SONAR_HOST_URL"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.token=$SONAR_TOKEN"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.projectKey=org.sonarsource.javascript:javascript"
+          SONAR_ARGS="$SONAR_ARGS -Dsonar.projectKey=$SONAR_PROJECT_KEY"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.projectVersion=${{ steps.config-maven.outputs.project-version }}"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.scm.revision=${{ github.sha }}"
+          if [ -n "$SONAR_ORGANIZATION" ]; then
+            SONAR_ARGS="$SONAR_ARGS -Dsonar.organization=$SONAR_ORGANIZATION"
+          fi
           SONAR_ARGS="$SONAR_ARGS -Dsonar.java.libraries=$HOME/.m2/repository/**/*.jar"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.java.test.binaries=sonar-plugin/*/target/test-classes"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.java.test.libraries=$HOME/.m2/repository/**/*.jar"
@@ -594,28 +599,9 @@ jobs:
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
-        run: |
-          SONAR_ARGS="-Dsonar.host.url=$SONAR_HOST_URL"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.token=$SONAR_TOKEN"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.projectKey=SonarSource_SonarJS"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.projectVersion=${{ steps.config-maven.outputs.project-version }}"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.scm.revision=${{ github.sha }}"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.organization=sonarsource"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.libraries=$HOME/.m2/repository/**/*.jar"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.test.binaries=sonar-plugin/*/target/test-classes"
-          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.test.libraries=$HOME/.m2/repository/**/*.jar"
-          SONAR_ARGS="$SONAR_ARGS -Dcommercial"
-
-          # Add branch/PR information
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            SONAR_ARGS="$SONAR_ARGS -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}"
-            SONAR_ARGS="$SONAR_ARGS -Dsonar.pullrequest.branch=${{ github.head_ref }}"
-            SONAR_ARGS="$SONAR_ARGS -Dsonar.pullrequest.base=${{ github.base_ref }}"
-          else
-            SONAR_ARGS="$SONAR_ARGS -Dsonar.branch.name=${{ github.ref_name }}"
-          fi
-
-          npx @sonar/scan $SONAR_ARGS
+          SONAR_PROJECT_KEY: SonarSource_SonarJS
+          SONAR_ORGANIZATION: sonarsource
+        run: *run_sonarqube_analysis
 
   plugin_qa_with_node:
     runs-on: sonar-m-public

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -554,6 +554,7 @@ jobs:
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
+          NODE_OPTIONS: --use-system-ca
         run: |
           SONAR_ARGS="-Dsonar.host.url=$SONAR_HOST_URL"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.token=$SONAR_TOKEN"
@@ -605,6 +606,7 @@ jobs:
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
+          NODE_OPTIONS: --use-system-ca
         run: |
           SONAR_ARGS="-Dsonar.host.url=$SONAR_HOST_URL"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.token=$SONAR_TOKEN"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -539,7 +539,6 @@ jobs:
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
-          NODE_OPTIONS: --use-system-ca
         run: |
           SONAR_ARGS="-Dsonar.host.url=$SONAR_HOST_URL"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.token=$SONAR_TOKEN"
@@ -595,7 +594,6 @@ jobs:
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
-          NODE_OPTIONS: --use-system-ca
         run: |
           SONAR_ARGS="-Dsonar.host.url=$SONAR_HOST_URL"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.token=$SONAR_TOKEN"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -550,6 +550,10 @@ jobs:
           secrets: |
             development/kv/data/next url | SONAR_URL;
             development/kv/data/next token | SONAR_TOKEN;
+      - name: Install SonarQube npm scanner
+        env:
+          NODE_OPTIONS: --use-system-ca
+        run: npm install -g @sonar/scan
       - name: Run SonarQube analysis on Next
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
@@ -572,7 +576,7 @@ jobs:
             SONAR_ARGS="$SONAR_ARGS -Dsonar.branch.name=${{ github.ref_name }}"
           fi
 
-          npx @sonar/scan $SONAR_ARGS
+          sonar-scanner $SONAR_ARGS
 
   analyze_shadows:
     runs-on: sonar-m-public
@@ -602,6 +606,10 @@ jobs:
           secrets: |
             development/kv/data/${{ matrix.sonar-platform }} url | SONAR_URL;
             development/kv/data/${{ matrix.sonar-platform }} token | SONAR_TOKEN;
+      - name: Install SonarQube npm scanner
+        env:
+          NODE_OPTIONS: --use-system-ca
+        run: npm install -g @sonar/scan
       - name: Run SonarQube analysis on ${{ matrix.platform }}
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
@@ -625,7 +633,7 @@ jobs:
             SONAR_ARGS="$SONAR_ARGS -Dsonar.branch.name=${{ github.ref_name }}"
           fi
 
-          npx @sonar/scan $SONAR_ARGS
+          sonar-scanner $SONAR_ARGS
 
   plugin_qa_with_node:
     runs-on: sonar-m-public

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -546,6 +546,9 @@ jobs:
           SONAR_ARGS="$SONAR_ARGS -Dsonar.projectKey=org.sonarsource.javascript:javascript"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.projectVersion=${{ steps.config-maven.outputs.project-version }}"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.scm.revision=${{ github.sha }}"
+          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.libraries=$HOME/.m2/repository/**/*.jar"
+          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.test.binaries=sonar-plugin/*/target/test-classes"
+          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.test.libraries=$HOME/.m2/repository/**/*.jar"
           SONAR_ARGS="$SONAR_ARGS -Dcommercial"
 
           # Add branch/PR information
@@ -600,6 +603,9 @@ jobs:
           SONAR_ARGS="$SONAR_ARGS -Dsonar.projectVersion=${{ steps.config-maven.outputs.project-version }}"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.scm.revision=${{ github.sha }}"
           SONAR_ARGS="$SONAR_ARGS -Dsonar.organization=sonarsource"
+          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.libraries=$HOME/.m2/repository/**/*.jar"
+          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.test.binaries=sonar-plugin/*/target/test-classes"
+          SONAR_ARGS="$SONAR_ARGS -Dsonar.java.test.libraries=$HOME/.m2/repository/**/*.jar"
           SONAR_ARGS="$SONAR_ARGS -Dcommercial"
 
           # Add branch/PR information

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,16 +284,9 @@ jobs:
     steps:
       - *checkout
       - *mise
-      - id: secrets
-        name: Access vault secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/artifactory/token/${{ github.repository_owner }}-${{ github.event.repository.name }}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-      - name: Configure npm registry
-        run: |
-          npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
-          npm config set registry https://repox.jfrog.io/artifactory/api/npm/npm/
+      - &config_npm
+        name: Configure npm registry
+        uses: SonarSource/ci-github-actions/config-npm@v1
       - *npm_cache
       - *download_rspec_rule_data
       - *rspec_secrets
@@ -320,16 +313,7 @@ jobs:
     steps:
       - *checkout
       - *mise
-      - id: secrets
-        name: Access vault secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/artifactory/token/${{ github.repository_owner }}-${{ github.event.repository.name }}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-      - name: Configure npm registry
-        run: |
-          npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
-          npm config set registry https://repox.jfrog.io/artifactory/api/npm/npm/
+      - *config_npm
       - *npm_cache
       - *download_rspec_rule_data
       - *rspec_secrets
@@ -550,10 +534,7 @@ jobs:
           secrets: |
             development/kv/data/next url | SONAR_URL;
             development/kv/data/next token | SONAR_TOKEN;
-      - name: Install SonarQube npm scanner
-        env:
-          NODE_OPTIONS: --use-system-ca
-        run: npm install -g @sonar/scan
+      - *config_npm
       - name: Run SonarQube analysis on Next
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
@@ -576,7 +557,7 @@ jobs:
             SONAR_ARGS="$SONAR_ARGS -Dsonar.branch.name=${{ github.ref_name }}"
           fi
 
-          sonar-scanner $SONAR_ARGS
+          npx @sonar/scan $SONAR_ARGS
 
   analyze_shadows:
     runs-on: sonar-m-public
@@ -606,10 +587,7 @@ jobs:
           secrets: |
             development/kv/data/${{ matrix.sonar-platform }} url | SONAR_URL;
             development/kv/data/${{ matrix.sonar-platform }} token | SONAR_TOKEN;
-      - name: Install SonarQube npm scanner
-        env:
-          NODE_OPTIONS: --use-system-ca
-        run: npm install -g @sonar/scan
+      - *config_npm
       - name: Run SonarQube analysis on ${{ matrix.platform }}
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_URL }}
@@ -633,7 +611,7 @@ jobs:
             SONAR_ARGS="$SONAR_ARGS -Dsonar.branch.name=${{ github.ref_name }}"
           fi
 
-          sonar-scanner $SONAR_ARGS
+          npx @sonar/scan $SONAR_ARGS
 
   plugin_qa_with_node:
     runs-on: sonar-m-public

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -571,7 +571,7 @@ jobs:
             SONAR_ARGS="$SONAR_ARGS -Dsonar.branch.name=${{ github.ref_name }}"
           fi
 
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.1.0.4751:sonar $SONAR_ARGS
+          npx @sonar/scan $SONAR_ARGS
 
   analyze_shadows:
     runs-on: sonar-m-public
@@ -623,7 +623,7 @@ jobs:
             SONAR_ARGS="$SONAR_ARGS -Dsonar.branch.name=${{ github.ref_name }}"
           fi
 
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.1.0.4751:sonar $SONAR_ARGS
+          npx @sonar/scan $SONAR_ARGS
 
   plugin_qa_with_node:
     runs-on: sonar-m-public
@@ -1089,7 +1089,6 @@ jobs:
 
           🤖 Generated with GitHub Actions"
           fi
-
           get_open_fix_pr_url() {
             gh pr list \
               --head "$FIX_BRANCH" \

--- a/its/plugin/fast-tests/pom.xml
+++ b/its/plugin/fast-tests/pom.xml
@@ -14,8 +14,6 @@
 
   <properties>
     <surefire.argLine>-server</surefire.argLine>
-    <sonar.sources/>
-    <sonar.tests>src/test</sonar.tests>
   </properties>
 
   <dependencies>

--- a/its/plugin/plugins/eslint-custom-rules-plugin-legacy/pom.xml
+++ b/its/plugin/plugins/eslint-custom-rules-plugin-legacy/pom.xml
@@ -67,10 +67,4 @@
     </plugins>
   </build>
 
-  <properties>
-    <!-- sonar scanner properties -->
-    <sonar.sources>src/main</sonar.sources>
-    <sonar.tests/>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
-  </properties>
 </project>

--- a/its/plugin/plugins/eslint-custom-rules-plugin/pom.xml
+++ b/its/plugin/plugins/eslint-custom-rules-plugin/pom.xml
@@ -67,10 +67,4 @@
     </plugins>
   </build>
 
-  <properties>
-    <!-- sonar scanner properties -->
-    <sonar.sources>src/main</sonar.sources>
-    <sonar.tests/>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
-  </properties>
 </project>

--- a/its/plugin/sonarlint-tests/pom.xml
+++ b/its/plugin/sonarlint-tests/pom.xml
@@ -13,9 +13,6 @@
 
   <properties>
     <surefire.argLine>-server</surefire.argLine>
-    <!-- sonar scanner properties -->
-    <sonar.sources/>
-    <sonar.tests>src/test</sonar.tests>
   </properties>
 
   <!--

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -13,8 +13,6 @@
 
   <properties>
     <surefire.argLine>-server</surefire.argLine>
-    <sonar.sources/>
-    <sonar.tests>src/test</sonar.tests>
   </properties>
 
   <dependencies>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -59,10 +59,5 @@
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
     <skipTests>true</skipTests>
-    <!-- sonar scanner properties -->
-    <sonar.sources>src/main</sonar.sources>
-    <sonar.tests>src/test</sonar.tests>
-    <sonar.javascript.lcov.reportPaths/>
-    <sonar.typescript.tsconfigPath/>
   </properties>
 </project>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -19,8 +19,6 @@
 
   <properties>
     <surefire.argLine>-server -Xmx512m</surefire.argLine>
-    <sonar.sources/>
-    <sonar.tests>src/test</sonar.tests>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
     <sonar.version>26.4.0.121862</sonar.version>
     <sonar.api.version>13.5.0.4319</sonar.api.version>
     <sonar-orchestrator.version>6.1.0.3962</sonar-orchestrator.version>
-    <sonar.sca.exclusions>its/**,packages/**/*.fixture.*,packages/**/fixtures/**/*</sonar.sca.exclusions>
     <gson.version>2.13.2</gson.version>
     <analyzer-commons.version>2.22.0.4796</analyzer-commons.version>
     <sslr.version>1.25.1.3886</sslr.version>
@@ -86,19 +85,6 @@
     <version.surefire.plugin>3.1.2</version.surefire.plugin>
     <!-- FIXME fix javadoc errors -->
     <doclint>none</doclint>
-
-    <!-- sonar analysis -->
-    <sonar.sources>packages/</sonar.sources>
-    <sonar.exclusions>packages/**/*.test.ts,packages/**/*.fixture.*,packages/**/fixtures/**/*,packages/**/fixtures-*/**/*,packages/grpc/src/proto/*,packages/analysis/src/jsts/parsers/estree.js,packages/analysis/src/jsts/parsers/estree.d.ts,packages/analysis/src/jsts/rules/**/generated-meta.ts,packages/analysis/src/jsts/rules/metas.ts,packages/analysis/src/jsts/rules/plugin-rules.ts,packages/analysis/src/jsts/rules/rules.ts</sonar.exclusions>
-    <sonar.tests>packages/</sonar.tests>
-    <sonar.test.inclusions>packages/**/*.test.ts</sonar.test.inclusions>
-    <sonar.javascript.lcov.reportPaths>coverage/js/lcov.info</sonar.javascript.lcov.reportPaths>
-    <sonar.testExecutionReportPaths>coverage/js/test-report.xml</sonar.testExecutionReportPaths>
-    <sonar.typescript.tsconfigPath>
-      ${project.basedir}/packages/tsconfig.app.json,${project.basedir}/packages/tsconfig.test.json
-    </sonar.typescript.tsconfigPath>
-    <sonar.cpd.exclusions>sonar-plugin/javascript-checks/src/main/resources/**/*.html</sonar.cpd.exclusions>
-    <sonar.coverage.exclusions>packages/ruling/**/*,packages/*/tests/**/*,resources/org/sonar/l10n/javascript/rules/javascript/**,packages/analysis/src/jsts/rules/**/generated-meta.ts,packages/analysis/src/jsts/rules/metas.ts,packages/analysis/src/jsts/rules/plugin-rules.ts,packages/analysis/src/jsts/rules/rules.ts</sonar.coverage.exclusions>
   </properties>
 
   <dependencyManagement>

--- a/sonar-plugin/api/pom.xml
+++ b/sonar-plugin/api/pom.xml
@@ -12,10 +12,6 @@
 
   <name>SonarQube JavaScript :: API</name>
 
-  <properties>
-    <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>

--- a/sonar-plugin/bridge/pom.xml
+++ b/sonar-plugin/bridge/pom.xml
@@ -11,7 +11,6 @@
   <name>SonarQube JavaScript :: Bridge</name>
   <properties>
     <protobuf.version>4.34.1</protobuf.version>
-    <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
   <dependencies>
     <dependency>

--- a/sonar-plugin/css/pom.xml
+++ b/sonar-plugin/css/pom.xml
@@ -12,10 +12,6 @@
 
   <name>SonarQube JavaScript :: CSS</name>
 
-  <properties>
-    <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/sonar-plugin/javascript-checks/pom.xml
+++ b/sonar-plugin/javascript-checks/pom.xml
@@ -12,12 +12,6 @@
 
   <name>SonarQube JavaScript :: Checks</name>
 
-  <properties>
-    <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    <sonar.exclusions>src/main/java/org/sonar/javascript/checks/AllChecks.java,src/main/java/org/sonar/javascript/checks/S*.java</sonar.exclusions>
-    <sonar.coverage.exclusions>src/main/java/org/sonar/javascript/checks/AllChecks.java,src/main/java/org/sonar/javascript/checks/S*.java</sonar.coverage.exclusions>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/sonar-plugin/pom.xml
+++ b/sonar-plugin/pom.xml
@@ -13,16 +13,6 @@
 
   <name>SonarQube JavaScript</name>
 
-  <properties>
-    <!-- sonar scanner properties -->
-    <sonar.sources>src/main</sonar.sources>
-    <sonar.tests>src/test</sonar.tests>
-    <sonar.javascript.lcov.reportPaths/>
-    <sonar.typescript.tsconfigPath/>
-    <sonar.test.exclusions>tests/**/fixtures/**/*,tests/**/rules/comment-based/**/*</sonar.test.exclusions>
-  </properties>
-
-
   <modules>
     <module>api</module>
     <module>javascript-checks</module>

--- a/sonar-plugin/sonar-javascript-plugin/pom.xml
+++ b/sonar-plugin/sonar-javascript-plugin/pom.xml
@@ -27,7 +27,6 @@
   <properties>
     <artifactoryToken/>
     <nodejs.runtime.version>24.11.0.70</nodejs.runtime.version>
-    <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>

--- a/sonar-plugin/standalone/pom.xml
+++ b/sonar-plugin/standalone/pom.xml
@@ -12,10 +12,6 @@
 
   <name>SonarQube JavaScript :: Standalone</name>
 
-  <properties>
-    <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-  </properties>
-
     <dependencies>
       <dependency>
         <groupId>${project.groupId}</groupId>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,44 @@
+# SonarQube analysis configuration
+# Dynamic properties (projectKey, token, host.url, etc.) are passed via CLI args in CI
+
+sonar.sources=packages/,sonar-plugin/
+sonar.exclusions=\
+  packages/**/*.test.ts,\
+  packages/**/*.fixture.*,\
+  packages/**/fixtures/**/*,\
+  packages/**/fixtures-*/**/*,\
+  packages/grpc/src/proto/*,\
+  packages/analysis/src/jsts/parsers/estree.js,\
+  packages/analysis/src/jsts/parsers/estree.d.ts,\
+  packages/analysis/src/jsts/rules/**/generated-meta.ts,\
+  packages/analysis/src/jsts/rules/metas.ts,\
+  packages/analysis/src/jsts/rules/plugin-rules.ts,\
+  packages/analysis/src/jsts/rules/rules.ts,\
+  sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/AllChecks.java,\
+  sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/S*.java
+
+sonar.tests=packages/,sonar-plugin/
+sonar.test.inclusions=packages/**/*.test.ts,sonar-plugin/*/src/test/**/*
+sonar.test.exclusions=tests/**/fixtures/**/*,tests/**/rules/comment-based/**/*
+
+sonar.javascript.lcov.reportPaths=coverage/js/lcov.info
+sonar.testExecutionReportPaths=coverage/js/test-report.xml
+sonar.typescript.tsconfigPath=packages/tsconfig.app.json,packages/tsconfig.test.json
+
+sonar.cpd.exclusions=sonar-plugin/javascript-checks/src/main/resources/**/*.html
+sonar.coverage.exclusions=\
+  packages/ruling/**/*,\
+  packages/*/tests/**/*,\
+  resources/org/sonar/l10n/javascript/rules/javascript/**,\
+  packages/analysis/src/jsts/rules/**/generated-meta.ts,\
+  packages/analysis/src/jsts/rules/metas.ts,\
+  packages/analysis/src/jsts/rules/plugin-rules.ts,\
+  packages/analysis/src/jsts/rules/rules.ts,\
+  sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/AllChecks.java,\
+  sonar-plugin/javascript-checks/src/main/java/org/sonar/javascript/checks/S*.java
+
+sonar.sca.exclusions=its/**,packages/**/*.fixture.*,packages/**/fixtures/**/*
+
+# Java analysis (previously auto-detected by Maven multi-module scanner)
+sonar.java.binaries=sonar-plugin/*/target/classes
+sonar.coverage.jacoco.xmlReportPaths=sonar-plugin/*/target/site/jacoco/jacoco.xml


### PR DESCRIPTION
## Summary
- Replace `sonar-maven-plugin` with `npx @sonar/scan` in both `analyze_primary` and `analyze_shadows` CI jobs
- Consolidate all sonar scanner properties from 14 pom.xml files into a single `sonar-project.properties`
- Add explicit `sonar.java.binaries` and `sonar.coverage.jacoco.xmlReportPaths` (previously auto-detected by Maven)

## Test plan
- [x] Verify `analyze_primary` job passes on this PR (SonarQube NEXT)
- [ ] Compare analysis results (file count, issues, coverage) with a recent master run
- [ ] After merge, verify nightly `analyze_shadows` succeeds on SonarCloud EU and SonarQube US

🤖 Generated with [Claude Code](https://claude.com/claude-code)