### PR TITLE
JS-1651 Recognize test.prop and it.prop from @fast-check/vitest in S2187

### DIFF
--- a/packages/analysis/src/jsts/rules/S2187/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2187/rule.ts
@@ -78,6 +78,9 @@ const APIs = new Set([
   'it.runIf',
   'test.for',
   'it.for',
+  // @fast-check/vitest (property-based testing)
+  'test.prop',
+  'it.prop',
   // eslint rule tester
   'ruleTester.run',
 ]);

--- a/packages/analysis/src/jsts/rules/S2187/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2187/unit.test.ts
@@ -79,6 +79,22 @@ describe('S2187', () => {
         },
         {
           code: `
+        /* a test file using 'test.prop' from @fast-check/vitest */
+        test.prop([fc.string(), fc.string(), fc.string()])('should detect substrings', (a, b, c) => {
+            expect((a + b + c).includes(b)).toBe(true)
+        });`,
+          filename: 'foo.test.js',
+        },
+        {
+          code: `
+        /* a test file using 'it.prop' from @fast-check/vitest */
+        it.prop([fc.nat()])('should be positive', (n) => {
+            expect(n).toBeGreaterThanOrEqual(0)
+        });`,
+          filename: 'foo.test.js',
+        },
+        {
+          code: `
         const ruleTester = new NoTypeCheckingRuleTester();
         ruleTester.run('Sections of code should not be commented out', rule, {
           valid: [


### PR DESCRIPTION
This PR cherry-picks 943f5168acef27ffac862ae7d9973cc8a2b60d71 from #6849 so CI can run from a branch in this repository.

Original contribution by @pavel-kalmykov.