### PR TITLE
BUILD-10993 Evaluate warp-custom-docker-m runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -722,16 +722,14 @@ jobs:
         shell: bash
         run: |
           node --version
-          NODE_PATH=$(which node)
-          sudo mv "$NODE_PATH" "${NODE_PATH}.disabled"
 
-          # Verify node is no longer accessible
-          if which node 2>/dev/null; then
-            echo "ERROR: node is still accessible!"
-            exit 1
-          else
-            echo "SUCCESS: node is no longer accessible"
-          fi
+          function node() {
+            echo "node is disabled"
+            exit 0
+          }
+          export -f node
+
+          node
       - *orchestrator_cache
       - name: Run Plugin QA without Node
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -773,7 +773,7 @@ jobs:
     runs-on: warp-custom-docker-m
     name: QA without Node on Alpine SQ:LATEST_RELEASE
     needs: [setup, get_build_number, build]
-    if: github.event_name == 'schedule'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     container:
       image: alpine/java:22-jdk@sha256:f1537f450ab5c45a07a3323cbbdc2e4388d70b01940cf2acecea67faa3b36229
     permissions: *read_permissions
@@ -880,7 +880,7 @@ jobs:
     runs-on: warp-custom-docker-m
     name: Fast QA without Node on Alpine SQ:LATEST_RELEASE
     needs: [setup, get_build_number, build]
-    if: github.event_name == 'schedule'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     container:
       image: alpine/java:22-jdk@sha256:f1537f450ab5c45a07a3323cbbdc2e4388d70b01940cf2acecea67faa3b36229
     permissions: *read_permissions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,16 +111,14 @@ jobs:
             java = "21.0"
             maven = "3.9"
             node = "24.11.0"
-      - if: steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
-        uses: SonarSource/ci-github-actions/config-npm@v1
-      - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      - if: steps.cache.outputs.cache-hit != 'true'
         id: secrets
         name: Access vault secrets
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/artifactory/token/${{ github.repository_owner }}-${{ github.event.repository.name }}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-      - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      - if: steps.cache.outputs.cache-hit != 'true'
         name: Configure npm registry
         run: |
           npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
@@ -724,14 +722,16 @@ jobs:
         shell: bash
         run: |
           node --version
+          NODE_PATH=$(which node)
+          sudo mv "$NODE_PATH" "${NODE_PATH}.disabled"
 
-          function node() {
-            echo "node is disabled"
-            exit 0
-          }
-          export -f node
-
-          node
+          # Verify node is no longer accessible
+          if which node 2>/dev/null; then
+            echo "ERROR: node is still accessible!"
+            exit 1
+          else
+            echo "SUCCESS: node is no longer accessible"
+          fi
       - *orchestrator_cache
       - name: Run Plugin QA without Node
         run: |
@@ -770,7 +770,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_without_node_alpine:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-docker-m
     name: QA without Node on Alpine SQ:LATEST_RELEASE
     needs: [setup, get_build_number, build]
     if: github.event_name == 'schedule'
@@ -877,7 +877,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_fast_without_node_alpine:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-docker-m
     name: Fast QA without Node on Alpine SQ:LATEST_RELEASE
     needs: [setup, get_build_number, build]
     if: github.event_name == 'schedule'

--- a/packages/grpc/src/analyze-project-memory.ts
+++ b/packages/grpc/src/analyze-project-memory.ts
@@ -27,35 +27,13 @@ export async function logMemoryConfiguration() {
   const osMem = Math.floor(os.totalmem() / MB);
   const heapSize = getHeapSize();
   const dockerMemLimit = await readDockerMemoryLimit();
-  const { infoMessage, warningMessage } = getMemoryConfigurationMessages(
-    osMem,
-    heapSize,
-    dockerMemLimit,
-  );
-  info(infoMessage);
-  if (warningMessage) {
-    warn(warningMessage);
+  const dockerMem = dockerMemLimit ? `, Docker (${dockerMemLimit} MB),` : ',';
+  info(`Memory configuration: OS (${osMem} MB)${dockerMem} Node.js (${heapSize} MB).`);
+  if (heapSize > osMem) {
+    warn(
+      `Node.js heap size limit ${heapSize} is higher than available memory ${osMem}. Check your configuration of sonar.javascript.node.maxspace`,
+    );
   }
-}
-
-export function getMemoryConfigurationMessages(
-  osMem: number,
-  heapSize: number,
-  dockerMemLimit?: number,
-) {
-  const dockerMem = dockerMemLimit === undefined ? ',' : `, Docker (${dockerMemLimit} MB),`;
-  const availableMem = getAvailableMemory(osMem, dockerMemLimit);
-  return {
-    infoMessage: `Memory configuration: OS (${osMem} MB)${dockerMem} Node.js (${heapSize} MB).`,
-    warningMessage:
-      heapSize > availableMem
-        ? `Node.js heap size limit ${heapSize} is higher than available memory ${availableMem}. Check your configuration of sonar.javascript.node.maxspace`
-        : undefined,
-  };
-}
-
-export function getAvailableMemory(osMem: number, dockerMemLimit?: number) {
-  return dockerMemLimit === undefined ? osMem : Math.min(osMem, dockerMemLimit);
 }
 
 async function readDockerMemoryLimit() {

--- a/packages/grpc/src/analyze-project-memory.ts
+++ b/packages/grpc/src/analyze-project-memory.ts
@@ -27,13 +27,35 @@ export async function logMemoryConfiguration() {
   const osMem = Math.floor(os.totalmem() / MB);
   const heapSize = getHeapSize();
   const dockerMemLimit = await readDockerMemoryLimit();
-  const dockerMem = dockerMemLimit ? `, Docker (${dockerMemLimit} MB),` : ',';
-  info(`Memory configuration: OS (${osMem} MB)${dockerMem} Node.js (${heapSize} MB).`);
-  if (heapSize > osMem) {
-    warn(
-      `Node.js heap size limit ${heapSize} is higher than available memory ${osMem}. Check your configuration of sonar.javascript.node.maxspace`,
-    );
+  const { infoMessage, warningMessage } = getMemoryConfigurationMessages(
+    osMem,
+    heapSize,
+    dockerMemLimit,
+  );
+  info(infoMessage);
+  if (warningMessage) {
+    warn(warningMessage);
   }
+}
+
+export function getMemoryConfigurationMessages(
+  osMem: number,
+  heapSize: number,
+  dockerMemLimit?: number,
+) {
+  const dockerMem = dockerMemLimit === undefined ? ',' : `, Docker (${dockerMemLimit} MB),`;
+  const availableMem = getAvailableMemory(osMem, dockerMemLimit);
+  return {
+    infoMessage: `Memory configuration: OS (${osMem} MB)${dockerMem} Node.js (${heapSize} MB).`,
+    warningMessage:
+      heapSize > availableMem
+        ? `Node.js heap size limit ${heapSize} is higher than available memory ${availableMem}. Check your configuration of sonar.javascript.node.maxspace`
+        : undefined,
+  };
+}
+
+export function getAvailableMemory(osMem: number, dockerMemLimit?: number) {
+  return dockerMemLimit === undefined ? osMem : Math.min(osMem, dockerMemLimit);
 }
 
 async function readDockerMemoryLimit() {

--- a/packages/grpc/tests/analyze-project-memory.test.ts
+++ b/packages/grpc/tests/analyze-project-memory.test.ts
@@ -14,34 +14,9 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
+import { logMemoryError } from '../src/analyze-project-memory.js';
 import { describe, it, type Mock } from 'node:test';
 import { expect } from 'expect';
-import {
-  getAvailableMemory,
-  getMemoryConfigurationMessages,
-  logMemoryError,
-} from '../src/analyze-project-memory.js';
-
-describe('memory configuration', () => {
-  it('should prefer docker memory limit when it is lower than host memory', () => {
-    expect(getAvailableMemory(507675, 32768)).toEqual(32768);
-  });
-
-  it('should warn when node heap is higher than effective available memory', () => {
-    expect(getMemoryConfigurationMessages(507675, 500192, 32768)).toEqual({
-      infoMessage: 'Memory configuration: OS (507675 MB), Docker (32768 MB), Node.js (500192 MB).',
-      warningMessage:
-        'Node.js heap size limit 500192 is higher than available memory 32768. Check your configuration of sonar.javascript.node.maxspace',
-    });
-  });
-
-  it('should not warn when node heap fits in available memory', () => {
-    expect(getMemoryConfigurationMessages(8192, 4096)).toEqual({
-      infoMessage: 'Memory configuration: OS (8192 MB), Node.js (4096 MB).',
-      warningMessage: undefined,
-    });
-  });
-});
 
 describe('logMemoryError', () => {
   it('should log out-of-memory troubleshooting guide', ({ mock }) => {

--- a/packages/grpc/tests/analyze-project-memory.test.ts
+++ b/packages/grpc/tests/analyze-project-memory.test.ts
@@ -14,9 +14,34 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { logMemoryError } from '../src/analyze-project-memory.js';
+import {
+  getAvailableMemory,
+  getMemoryConfigurationMessages,
+  logMemoryError,
+} from '../src/analyze-project-memory.js';
 import { describe, it, type Mock } from 'node:test';
 import { expect } from 'expect';
+
+describe('memory configuration', () => {
+  it('should prefer docker memory limit when it is lower than host memory', () => {
+    expect(getAvailableMemory(507675, 32768)).toEqual(32768);
+  });
+
+  it('should warn when node heap is higher than effective available memory', () => {
+    expect(getMemoryConfigurationMessages(507675, 500192, 32768)).toEqual({
+      infoMessage: 'Memory configuration: OS (507675 MB), Docker (32768 MB), Node.js (500192 MB).',
+      warningMessage:
+        'Node.js heap size limit 500192 is higher than available memory 32768. Check your configuration of sonar.javascript.node.maxspace',
+    });
+  });
+
+  it('should not warn when node heap fits in available memory', () => {
+    expect(getMemoryConfigurationMessages(8192, 4096)).toEqual({
+      infoMessage: 'Memory configuration: OS (8192 MB), Node.js (4096 MB).',
+      warningMessage: undefined,
+    });
+  });
+});
 
 describe('logMemoryError', () => {
   it('should log out-of-memory troubleshooting guide', ({ mock }) => {


### PR DESCRIPTION
## Summary
- Evaluate `warp-custom-docker-m` runner as replacement for `sonar-m-docker` on Alpine Docker QA jobs
- Reverted workarounds from the original migration to test out-of-the-box compatibility:
  - Removed `config-npm` action (restored vault-based npm config for all OSes)
  - Restored `sudo mv` node disabling (instead of function override)
  - Reverted `memory.ts` / `memory.test.ts` docker memory detection changes

## Changed jobs
| Job | Old runner | New runner |
|-----|-----------|------------|
| QA without Node on Alpine | `sonar-m-docker` | `warp-custom-docker-m` |
| Fast QA without Node on Alpine | `sonar-m-docker` | `warp-custom-docker-m` |