### PR TITLE
JS-1653 Preserve file-level analyzer errors without aborting analysis

### DIFF
--- a/packages/grpc/src/analyze-project-server-grpc.ts
+++ b/packages/grpc/src/analyze-project-server-grpc.ts
@@ -1,0 +1,131 @@
+﻿/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import * as grpc from '@grpc/grpc-js';
+import type { RequestResult } from './analyze-project-request.js';
+import { sonarjs as analyzeProjectProto } from './proto/analyze-project.js';
+
+const ANALYZE_PROJECT_SERVICE_NAME = 'sonarjs.analyzeproject.v1.AnalyzeProjectService';
+
+export const GRPC_SERVER_OPTIONS: grpc.ServerOptions = {
+  'grpc.max_receive_message_length': -1,
+  'grpc.max_send_message_length': -1,
+};
+
+export type AnalyzeProjectRequest = analyzeProjectProto.analyzeproject.v1.IAnalyzeProjectRequest;
+export type AnalyzeProjectStreamResponse =
+  analyzeProjectProto.analyzeproject.v1.IAnalyzeProjectStreamResponse;
+export type AnalyzeProjectUnaryResponse =
+  analyzeProjectProto.analyzeproject.v1.IAnalyzeProjectUnaryResponse;
+export type CancelAnalysisRequest = analyzeProjectProto.analyzeproject.v1.ICancelAnalysisRequest;
+export type CancelAnalysisResponse = analyzeProjectProto.analyzeproject.v1.ICancelAnalysisResponse;
+export type LeaseRequest = analyzeProjectProto.analyzeproject.v1.ILeaseRequest;
+export type LeaseResponse = analyzeProjectProto.analyzeproject.v1.ILeaseResponse;
+
+export function createAnalyzeProjectServiceDefinition(): grpc.ServiceDefinition {
+  return {
+    AnalyzeProject: {
+      path: `/${ANALYZE_PROJECT_SERVICE_NAME}/AnalyzeProject`,
+      requestStream: false,
+      responseStream: true,
+      requestSerialize: (value: AnalyzeProjectRequest) =>
+        Buffer.from(
+          analyzeProjectProto.analyzeproject.v1.AnalyzeProjectRequest.encode(value).finish(),
+        ),
+      requestDeserialize: (buffer: Buffer) =>
+        analyzeProjectProto.analyzeproject.v1.AnalyzeProjectRequest.decode(buffer),
+      responseSerialize: (value: AnalyzeProjectStreamResponse) =>
+        Buffer.from(
+          analyzeProjectProto.analyzeproject.v1.AnalyzeProjectStreamResponse.encode(value).finish(),
+        ),
+      responseDeserialize: (buffer: Buffer) =>
+        analyzeProjectProto.analyzeproject.v1.AnalyzeProjectStreamResponse.decode(buffer),
+    },
+    AnalyzeProjectUnary: {
+      path: `/${ANALYZE_PROJECT_SERVICE_NAME}/AnalyzeProjectUnary`,
+      requestStream: false,
+      responseStream: false,
+      requestSerialize: (value: AnalyzeProjectRequest) =>
+        Buffer.from(
+          analyzeProjectProto.analyzeproject.v1.AnalyzeProjectRequest.encode(value).finish(),
+        ),
+      requestDeserialize: (buffer: Buffer) =>
+        analyzeProjectProto.analyzeproject.v1.AnalyzeProjectRequest.decode(buffer),
+      responseSerialize: (value: AnalyzeProjectUnaryResponse) =>
+        Buffer.from(
+          analyzeProjectProto.analyzeproject.v1.AnalyzeProjectUnaryResponse.encode(value).finish(),
+        ),
+      responseDeserialize: (buffer: Buffer) =>
+        analyzeProjectProto.analyzeproject.v1.AnalyzeProjectUnaryResponse.decode(buffer),
+    },
+    CancelAnalysis: {
+      path: `/${ANALYZE_PROJECT_SERVICE_NAME}/CancelAnalysis`,
+      requestStream: false,
+      responseStream: false,
+      requestSerialize: (value: CancelAnalysisRequest) =>
+        Buffer.from(
+          analyzeProjectProto.analyzeproject.v1.CancelAnalysisRequest.encode(value).finish(),
+        ),
+      requestDeserialize: (buffer: Buffer) =>
+        analyzeProjectProto.analyzeproject.v1.CancelAnalysisRequest.decode(buffer),
+      responseSerialize: (value: CancelAnalysisResponse) =>
+        Buffer.from(
+          analyzeProjectProto.analyzeproject.v1.CancelAnalysisResponse.encode(value).finish(),
+        ),
+      responseDeserialize: (buffer: Buffer) =>
+        analyzeProjectProto.analyzeproject.v1.CancelAnalysisResponse.decode(buffer),
+    },
+    Lease: {
+      path: `/${ANALYZE_PROJECT_SERVICE_NAME}/Lease`,
+      requestStream: true,
+      responseStream: true,
+      requestSerialize: (value: LeaseRequest) =>
+        Buffer.from(analyzeProjectProto.analyzeproject.v1.LeaseRequest.encode(value).finish()),
+      requestDeserialize: (buffer: Buffer) =>
+        analyzeProjectProto.analyzeproject.v1.LeaseRequest.decode(buffer),
+      responseSerialize: (value: LeaseResponse) =>
+        Buffer.from(analyzeProjectProto.analyzeproject.v1.LeaseResponse.encode(value).finish()),
+      responseDeserialize: (buffer: Buffer) =>
+        analyzeProjectProto.analyzeproject.v1.LeaseResponse.decode(buffer),
+    },
+  };
+}
+
+export function toGrpcError(message: string, code = grpc.status.INTERNAL): grpc.ServiceError {
+  const error = new Error(message) as grpc.ServiceError;
+  error.name = 'AnalyzeProjectServiceError';
+  error.code = code;
+  error.details = message;
+  error.metadata = new grpc.Metadata();
+  return error;
+}
+
+export function failStreamingCall(
+  call:
+    | grpc.ServerWritableStream<AnalyzeProjectRequest, AnalyzeProjectStreamResponse>
+    | grpc.ServerDuplexStream<LeaseRequest, LeaseResponse>,
+  error: grpc.ServiceError,
+) {
+  call.emit('error', error);
+}
+
+export function toGrpcErrorFromFailure(result: Extract<RequestResult, { type: 'failure' }>) {
+  return toGrpcError(
+    result.error.message,
+    result.reason === 'invalid_request' ? grpc.status.INVALID_ARGUMENT : grpc.status.INTERNAL,
+  );
+}

--- a/packages/grpc/src/analyze-project-server-lifecycle.ts
+++ b/packages/grpc/src/analyze-project-server-lifecycle.ts
@@ -1,0 +1,295 @@
+﻿/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import * as grpc from '@grpc/grpc-js';
+import type { Worker } from 'node:worker_threads';
+import { debug } from '../../shared/src/helpers/logging.js';
+import { handleAnalyzeProjectRequest, type WorkerData } from './analyze-project-handle-request.js';
+import { logMemoryError } from './analyze-project-memory.js';
+import type {
+  AnalyzeProjectIncrementalEvent,
+  AnalyzeProjectResponse,
+  AnalyzeProjectRuntimeRequest,
+  RequestResult,
+} from './analyze-project-request.js';
+import type {
+  AnalyzeProjectWorkerInMessage,
+  AnalyzeProjectWorkerOutMessage,
+} from './analyze-project-worker/messages.js';
+
+const WORKER_RESPONSE_TIMEOUT_MS = 15_000;
+
+export type HandleRequestInCurrentThread = (
+  request: AnalyzeProjectRuntimeRequest,
+  incrementalResultsChannel?: (result: AnalyzeProjectIncrementalEvent) => void,
+) => Promise<RequestResult<AnalyzeProjectResponse | void>>;
+
+export type AnalyzeProjectServerState = {
+  analysisInProgress: boolean;
+  leaseCall: grpc.ServerDuplexStream<any, any> | null;
+  nextWorkerRequestId: number;
+  shuttingDown: boolean;
+  startupShutdownTimeout: NodeJS.Timeout | null;
+};
+
+export type AnalyzeProjectServerLifecycle = {
+  scheduleStartupShutdownTimeout: () => void;
+  clearStartupShutdownTimeout: () => void;
+  requestCancel: () => Promise<boolean>;
+  shutdown: (reason: string) => Promise<void>;
+};
+
+type AnalyzeProjectServerDependencies = {
+  handleRequestInCurrentThread: HandleRequestInCurrentThread;
+  newWorkerRequestId: () => string;
+  resolveClosed: () => void;
+  server: grpc.Server;
+  state: AnalyzeProjectServerState;
+  timeout: number;
+  unregisterGarbageCollectionObserver: () => void;
+  worker?: Worker;
+};
+
+export type AnalyzeProjectImplementationDependencies = {
+  handleRequestInCurrentThread: HandleRequestInCurrentThread;
+  lifecycle: AnalyzeProjectServerLifecycle;
+  newWorkerRequestId: () => string;
+  state: AnalyzeProjectServerState;
+  worker?: Worker;
+};
+
+export async function waitForWorkerCompletion(
+  worker: Worker,
+  expectedType: AnalyzeProjectWorkerOutMessage['type'],
+  expectedRequestId: string,
+  trigger: () => void,
+  timeoutMs?: number,
+): Promise<AnalyzeProjectWorkerOutMessage> {
+  return new Promise((resolve, reject) => {
+    const timeout =
+      timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            cleanup();
+            reject(new Error(`Timed out waiting for worker message '${expectedType}'`));
+          }, timeoutMs);
+
+    const onMessage = (message: AnalyzeProjectWorkerOutMessage) => {
+      if (message.type !== expectedType || message.requestId !== expectedRequestId) {
+        return;
+      }
+      cleanup();
+      resolve(message);
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onExit = (code: number) => {
+      cleanup();
+      reject(new Error(`Worker exited with code ${code}`));
+    };
+
+    const cleanup = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      worker.off('message', onMessage);
+      worker.off('error', onError);
+      worker.off('exit', onExit);
+    };
+
+    worker.on('message', onMessage);
+    worker.on('error', onError);
+    worker.on('exit', onExit);
+    trigger();
+  });
+}
+
+export function createServerState(): AnalyzeProjectServerState {
+  return {
+    analysisInProgress: false,
+    leaseCall: null,
+    nextWorkerRequestId: 0,
+    shuttingDown: false,
+    startupShutdownTimeout: null,
+  };
+}
+
+export function createHandleRequestInCurrentThread(
+  workerData: WorkerData,
+): HandleRequestInCurrentThread {
+  return (request, incrementalResultsChannel) =>
+    handleAnalyzeProjectRequest(request, workerData, incrementalResultsChannel);
+}
+
+export function getNextWorkerRequestId(state: AnalyzeProjectServerState): string {
+  state.nextWorkerRequestId += 1;
+  return String(state.nextWorkerRequestId);
+}
+
+function clearStartupShutdownTimeout(state: AnalyzeProjectServerState) {
+  if (state.startupShutdownTimeout) {
+    clearTimeout(state.startupShutdownTimeout);
+    state.startupShutdownTimeout = null;
+  }
+}
+
+async function cancelAnalysisOnShutdown(
+  handleRequestInCurrentThread: HandleRequestInCurrentThread,
+  newWorkerRequestId: () => string,
+  state: AnalyzeProjectServerState,
+  worker?: Worker,
+) {
+  if (!state.analysisInProgress) {
+    return;
+  }
+
+  if (worker) {
+    try {
+      worker.postMessage({
+        type: 'cancel',
+        requestId: newWorkerRequestId(),
+      } satisfies AnalyzeProjectWorkerInMessage);
+    } catch (e) {
+      debug(`Failed to post cancel to worker: ${e}`);
+    }
+    return;
+  }
+
+  try {
+    await handleRequestInCurrentThread({ type: 'on-cancel-analysis' });
+  } catch (e) {
+    debug(`Failed to cancel in-process analysis: ${e}`);
+  }
+}
+
+async function closeWorker(worker?: Worker) {
+  if (!worker) {
+    return;
+  }
+
+  try {
+    worker.postMessage({ type: 'close' } satisfies AnalyzeProjectWorkerInMessage);
+  } catch (e) {
+    debug(`Failed to post close to worker: ${e}`);
+  }
+
+  try {
+    await worker.terminate();
+  } catch (e) {
+    debug(`Failed to terminate worker: ${e}`);
+  }
+}
+
+export function createLifecycle({
+  handleRequestInCurrentThread,
+  newWorkerRequestId,
+  resolveClosed,
+  server,
+  state,
+  timeout,
+  unregisterGarbageCollectionObserver,
+  worker,
+}: AnalyzeProjectServerDependencies): AnalyzeProjectServerLifecycle {
+  const requestCancel = async () => {
+    if (!worker) {
+      const result = await handleRequestInCurrentThread({ type: 'on-cancel-analysis' });
+      return result.type === 'success';
+    }
+
+    const requestId = newWorkerRequestId();
+    const completion = await waitForWorkerCompletion(
+      worker,
+      'cancel-complete',
+      requestId,
+      () =>
+        worker.postMessage({ type: 'cancel', requestId } satisfies AnalyzeProjectWorkerInMessage),
+      WORKER_RESPONSE_TIMEOUT_MS,
+    );
+    return completion.type === 'cancel-complete' && completion.result.type === 'success';
+  };
+
+  const closeLeaseCall = () => {
+    if (!state.leaseCall) {
+      return;
+    }
+    const currentLeaseCall = state.leaseCall;
+    state.leaseCall = null;
+    try {
+      currentLeaseCall.end();
+    } catch (e) {
+      debug(`Failed to end lease stream: ${e}`);
+    }
+  };
+
+  const shutdown = async (reason: string) => {
+    if (state.shuttingDown) {
+      return;
+    }
+    state.shuttingDown = true;
+    debug(`Shutting down gRPC analyze-project server: ${reason}`);
+    clearStartupShutdownTimeout(state);
+    closeLeaseCall();
+    unregisterGarbageCollectionObserver();
+    await cancelAnalysisOnShutdown(handleRequestInCurrentThread, newWorkerRequestId, state, worker);
+    await closeWorker(worker);
+
+    server.forceShutdown();
+    resolveClosed();
+  };
+
+  const scheduleStartupShutdownTimeout = () => {
+    if (timeout <= 0) {
+      return;
+    }
+    clearStartupShutdownTimeout(state);
+    state.startupShutdownTimeout = setTimeout(() => {
+      void shutdown('lease acquisition timeout');
+    }, timeout);
+  };
+
+  return {
+    scheduleStartupShutdownTimeout,
+    clearStartupShutdownTimeout: () => clearStartupShutdownTimeout(state),
+    requestCancel,
+    shutdown,
+  };
+}
+
+export function attachWorkerLifecycleHandlers(
+  worker: Worker | undefined,
+  lifecycle: AnalyzeProjectServerLifecycle,
+  state: AnalyzeProjectServerState,
+) {
+  if (!worker) {
+    return;
+  }
+
+  worker.on('error', error => {
+    logMemoryError(error);
+    void lifecycle.shutdown('worker error');
+  });
+  worker.on('exit', code => {
+    debug(`The worker thread exited with code ${code}`);
+    if (!state.shuttingDown) {
+      void lifecycle.shutdown('worker exit');
+    }
+  });
+}

--- a/packages/grpc/src/analyze-project-server-lifecycle.ts
+++ b/packages/grpc/src/analyze-project-server-lifecycle.ts
@@ -19,6 +19,7 @@ import * as grpc from '@grpc/grpc-js';
 import type { Worker } from 'node:worker_threads';
 import { debug } from '../../shared/src/helpers/logging.js';
 import { handleAnalyzeProjectRequest, type WorkerData } from './analyze-project-handle-request.js';
+import type { LeaseRequest, LeaseResponse } from './analyze-project-server-grpc.js';
 import { logMemoryError } from './analyze-project-memory.js';
 import type {
   AnalyzeProjectIncrementalEvent,
@@ -40,7 +41,7 @@ export type HandleRequestInCurrentThread = (
 
 export type AnalyzeProjectServerState = {
   analysisInProgress: boolean;
-  leaseCall: grpc.ServerDuplexStream<any, any> | null;
+  leaseCall: grpc.ServerDuplexStream<LeaseRequest, LeaseResponse> | null;
   nextWorkerRequestId: number;
   shuttingDown: boolean;
   startupShutdownTimeout: NodeJS.Timeout | null;

--- a/packages/grpc/src/analyze-project-server.ts
+++ b/packages/grpc/src/analyze-project-server.ts
@@ -17,383 +17,48 @@
 
 import * as grpc from '@grpc/grpc-js';
 import type { Worker } from 'node:worker_threads';
-import { sonarjs as analyzeProjectProto } from './proto/analyze-project.js';
 import { debug, info } from '../../shared/src/helpers/logging.js';
-import { handleAnalyzeProjectRequest, type WorkerData } from './analyze-project-handle-request.js';
 import type {
   AnalyzeProjectWorkerInMessage,
   AnalyzeProjectWorkerOutMessage,
 } from './analyze-project-worker/messages.js';
 import {
   logMemoryConfiguration,
-  logMemoryError,
   registerGarbageCollectionObserver,
 } from './analyze-project-memory.js';
-import type {
-  AnalyzeProjectIncrementalEvent,
-  AnalyzeProjectResponse,
-  AnalyzeProjectRuntimeRequest,
-  RequestResult,
-} from './analyze-project-request.js';
 import {
   toAnalyzeProjectStreamResponse,
   toAnalyzeProjectUnaryResponse,
 } from './analyze-project-convert.js';
-
-const ANALYZE_PROJECT_SERVICE_NAME = 'sonarjs.analyzeproject.v1.AnalyzeProjectService';
-const WORKER_RESPONSE_TIMEOUT_MS = 15_000;
-const GRPC_SERVER_OPTIONS: grpc.ServerOptions = {
-  'grpc.max_receive_message_length': -1,
-  'grpc.max_send_message_length': -1,
-};
-
-type AnalyzeProjectRequest = analyzeProjectProto.analyzeproject.v1.IAnalyzeProjectRequest;
-type AnalyzeProjectStreamResponse =
-  analyzeProjectProto.analyzeproject.v1.IAnalyzeProjectStreamResponse;
-type AnalyzeProjectUnaryResponse =
-  analyzeProjectProto.analyzeproject.v1.IAnalyzeProjectUnaryResponse;
-type CancelAnalysisRequest = analyzeProjectProto.analyzeproject.v1.ICancelAnalysisRequest;
-type CancelAnalysisResponse = analyzeProjectProto.analyzeproject.v1.ICancelAnalysisResponse;
-type LeaseRequest = analyzeProjectProto.analyzeproject.v1.ILeaseRequest;
-type LeaseResponse = analyzeProjectProto.analyzeproject.v1.ILeaseResponse;
+import {
+  createAnalyzeProjectServiceDefinition,
+  failStreamingCall,
+  GRPC_SERVER_OPTIONS,
+  toGrpcError,
+  toGrpcErrorFromFailure,
+  type AnalyzeProjectRequest,
+  type AnalyzeProjectStreamResponse,
+  type AnalyzeProjectUnaryResponse,
+  type CancelAnalysisRequest,
+  type CancelAnalysisResponse,
+  type LeaseRequest,
+  type LeaseResponse,
+} from './analyze-project-server-grpc.js';
+import {
+  attachWorkerLifecycleHandlers,
+  createHandleRequestInCurrentThread,
+  createLifecycle,
+  createServerState,
+  getNextWorkerRequestId,
+  waitForWorkerCompletion,
+  type AnalyzeProjectImplementationDependencies,
+} from './analyze-project-server-lifecycle.js';
 type UnaryCompleteMessage = Extract<AnalyzeProjectWorkerOutMessage, { type: 'unary-complete' }>;
 
 type AnalyzeProjectServerResult = {
   server: grpc.Server;
   serverClosed: Promise<void>;
 };
-
-type HandleRequestInCurrentThread = (
-  request: AnalyzeProjectRuntimeRequest,
-  incrementalResultsChannel?: (result: AnalyzeProjectIncrementalEvent) => void,
-) => Promise<RequestResult<AnalyzeProjectResponse | void>>;
-
-type AnalyzeProjectServerState = {
-  analysisInProgress: boolean;
-  leaseCall: grpc.ServerDuplexStream<LeaseRequest, LeaseResponse> | null;
-  nextWorkerRequestId: number;
-  shuttingDown: boolean;
-  startupShutdownTimeout: NodeJS.Timeout | null;
-};
-
-type AnalyzeProjectServerLifecycle = {
-  scheduleStartupShutdownTimeout: () => void;
-  clearStartupShutdownTimeout: () => void;
-  requestCancel: () => Promise<boolean>;
-  shutdown: (reason: string) => Promise<void>;
-};
-
-type AnalyzeProjectServerDependencies = {
-  handleRequestInCurrentThread: HandleRequestInCurrentThread;
-  newWorkerRequestId: () => string;
-  resolveClosed: () => void;
-  server: grpc.Server;
-  state: AnalyzeProjectServerState;
-  timeout: number;
-  unregisterGarbageCollectionObserver: () => void;
-  worker?: Worker;
-};
-
-type AnalyzeProjectImplementationDependencies = {
-  handleRequestInCurrentThread: HandleRequestInCurrentThread;
-  lifecycle: AnalyzeProjectServerLifecycle;
-  newWorkerRequestId: () => string;
-  state: AnalyzeProjectServerState;
-  worker?: Worker;
-};
-
-function createAnalyzeProjectServiceDefinition(): grpc.ServiceDefinition {
-  return {
-    AnalyzeProject: {
-      path: `/${ANALYZE_PROJECT_SERVICE_NAME}/AnalyzeProject`,
-      requestStream: false,
-      responseStream: true,
-      requestSerialize: (value: AnalyzeProjectRequest) =>
-        Buffer.from(
-          analyzeProjectProto.analyzeproject.v1.AnalyzeProjectRequest.encode(value).finish(),
-        ),
-      requestDeserialize: (buffer: Buffer) =>
-        analyzeProjectProto.analyzeproject.v1.AnalyzeProjectRequest.decode(buffer),
-      responseSerialize: (value: AnalyzeProjectStreamResponse) =>
-        Buffer.from(
-          analyzeProjectProto.analyzeproject.v1.AnalyzeProjectStreamResponse.encode(value).finish(),
-        ),
-      responseDeserialize: (buffer: Buffer) =>
-        analyzeProjectProto.analyzeproject.v1.AnalyzeProjectStreamResponse.decode(buffer),
-    },
-    AnalyzeProjectUnary: {
-      path: `/${ANALYZE_PROJECT_SERVICE_NAME}/AnalyzeProjectUnary`,
-      requestStream: false,
-      responseStream: false,
-      requestSerialize: (value: AnalyzeProjectRequest) =>
-        Buffer.from(
-          analyzeProjectProto.analyzeproject.v1.AnalyzeProjectRequest.encode(value).finish(),
-        ),
-      requestDeserialize: (buffer: Buffer) =>
-        analyzeProjectProto.analyzeproject.v1.AnalyzeProjectRequest.decode(buffer),
-      responseSerialize: (value: AnalyzeProjectUnaryResponse) =>
-        Buffer.from(
-          analyzeProjectProto.analyzeproject.v1.AnalyzeProjectUnaryResponse.encode(value).finish(),
-        ),
-      responseDeserialize: (buffer: Buffer) =>
-        analyzeProjectProto.analyzeproject.v1.AnalyzeProjectUnaryResponse.decode(buffer),
-    },
-    CancelAnalysis: {
-      path: `/${ANALYZE_PROJECT_SERVICE_NAME}/CancelAnalysis`,
-      requestStream: false,
-      responseStream: false,
-      requestSerialize: (value: CancelAnalysisRequest) =>
-        Buffer.from(
-          analyzeProjectProto.analyzeproject.v1.CancelAnalysisRequest.encode(value).finish(),
-        ),
-      requestDeserialize: (buffer: Buffer) =>
-        analyzeProjectProto.analyzeproject.v1.CancelAnalysisRequest.decode(buffer),
-      responseSerialize: (value: CancelAnalysisResponse) =>
-        Buffer.from(
-          analyzeProjectProto.analyzeproject.v1.CancelAnalysisResponse.encode(value).finish(),
-        ),
-      responseDeserialize: (buffer: Buffer) =>
-        analyzeProjectProto.analyzeproject.v1.CancelAnalysisResponse.decode(buffer),
-    },
-    Lease: {
-      path: `/${ANALYZE_PROJECT_SERVICE_NAME}/Lease`,
-      requestStream: true,
-      responseStream: true,
-      requestSerialize: (value: LeaseRequest) =>
-        Buffer.from(analyzeProjectProto.analyzeproject.v1.LeaseRequest.encode(value).finish()),
-      requestDeserialize: (buffer: Buffer) =>
-        analyzeProjectProto.analyzeproject.v1.LeaseRequest.decode(buffer),
-      responseSerialize: (value: LeaseResponse) =>
-        Buffer.from(analyzeProjectProto.analyzeproject.v1.LeaseResponse.encode(value).finish()),
-      responseDeserialize: (buffer: Buffer) =>
-        analyzeProjectProto.analyzeproject.v1.LeaseResponse.decode(buffer),
-    },
-  };
-}
-
-function toGrpcError(message: string, code = grpc.status.INTERNAL): grpc.ServiceError {
-  const error = new Error(message) as grpc.ServiceError;
-  error.name = 'AnalyzeProjectServiceError';
-  error.code = code;
-  error.details = message;
-  error.metadata = new grpc.Metadata();
-  return error;
-}
-
-function failStreamingCall(
-  call:
-    | grpc.ServerWritableStream<AnalyzeProjectRequest, AnalyzeProjectStreamResponse>
-    | grpc.ServerDuplexStream<LeaseRequest, LeaseResponse>,
-  error: grpc.ServiceError,
-) {
-  call.emit('error', error);
-}
-
-function toGrpcErrorFromFailure(result: Extract<RequestResult, { type: 'failure' }>) {
-  return toGrpcError(
-    result.error.message,
-    result.reason === 'invalid_request' ? grpc.status.INVALID_ARGUMENT : grpc.status.INTERNAL,
-  );
-}
-
-async function waitForWorkerCompletion(
-  worker: Worker,
-  expectedType: AnalyzeProjectWorkerOutMessage['type'],
-  expectedRequestId: string,
-  trigger: () => void,
-  timeoutMs?: number,
-): Promise<AnalyzeProjectWorkerOutMessage> {
-  return new Promise((resolve, reject) => {
-    const timeout =
-      timeoutMs === undefined
-        ? undefined
-        : setTimeout(() => {
-            cleanup();
-            reject(new Error(`Timed out waiting for worker message '${expectedType}'`));
-          }, timeoutMs);
-
-    const onMessage = (message: AnalyzeProjectWorkerOutMessage) => {
-      if (message.type !== expectedType || message.requestId !== expectedRequestId) {
-        return;
-      }
-      cleanup();
-      resolve(message);
-    };
-
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-
-    const onExit = (code: number) => {
-      cleanup();
-      reject(new Error(`Worker exited with code ${code}`));
-    };
-
-    const cleanup = () => {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-      worker.off('message', onMessage);
-      worker.off('error', onError);
-      worker.off('exit', onExit);
-    };
-
-    worker.on('message', onMessage);
-    worker.on('error', onError);
-    worker.on('exit', onExit);
-    trigger();
-  });
-}
-
-function createServerState(): AnalyzeProjectServerState {
-  return {
-    analysisInProgress: false,
-    leaseCall: null,
-    nextWorkerRequestId: 0,
-    shuttingDown: false,
-    startupShutdownTimeout: null,
-  };
-}
-
-function createHandleRequestInCurrentThread(workerData: WorkerData): HandleRequestInCurrentThread {
-  return (request, incrementalResultsChannel) =>
-    handleAnalyzeProjectRequest(request, workerData, incrementalResultsChannel);
-}
-
-function getNextWorkerRequestId(state: AnalyzeProjectServerState): string {
-  state.nextWorkerRequestId += 1;
-  return String(state.nextWorkerRequestId);
-}
-
-function clearStartupShutdownTimeout(state: AnalyzeProjectServerState) {
-  if (state.startupShutdownTimeout) {
-    clearTimeout(state.startupShutdownTimeout);
-    state.startupShutdownTimeout = null;
-  }
-}
-
-async function cancelAnalysisOnShutdown(
-  handleRequestInCurrentThread: HandleRequestInCurrentThread,
-  newWorkerRequestId: () => string,
-  state: AnalyzeProjectServerState,
-  worker?: Worker,
-) {
-  if (!state.analysisInProgress) {
-    return;
-  }
-
-  if (worker) {
-    try {
-      worker.postMessage({
-        type: 'cancel',
-        requestId: newWorkerRequestId(),
-      } satisfies AnalyzeProjectWorkerInMessage);
-    } catch (e) {
-      debug(`Failed to post cancel to worker: ${e}`);
-    }
-    return;
-  }
-
-  try {
-    await handleRequestInCurrentThread({ type: 'on-cancel-analysis' });
-  } catch (e) {
-    debug(`Failed to cancel in-process analysis: ${e}`);
-  }
-}
-
-async function closeWorker(worker?: Worker) {
-  if (!worker) {
-    return;
-  }
-
-  try {
-    worker.postMessage({ type: 'close' } satisfies AnalyzeProjectWorkerInMessage);
-  } catch (e) {
-    debug(`Failed to post close to worker: ${e}`);
-  }
-
-  try {
-    await worker.terminate();
-  } catch (e) {
-    debug(`Failed to terminate worker: ${e}`);
-  }
-}
-
-function createLifecycle({
-  handleRequestInCurrentThread,
-  newWorkerRequestId,
-  resolveClosed,
-  server,
-  state,
-  timeout,
-  unregisterGarbageCollectionObserver,
-  worker,
-}: AnalyzeProjectServerDependencies): AnalyzeProjectServerLifecycle {
-  const requestCancel = async () => {
-    if (!worker) {
-      const result = await handleRequestInCurrentThread({ type: 'on-cancel-analysis' });
-      return result.type === 'success';
-    }
-
-    const requestId = newWorkerRequestId();
-    const completion = await waitForWorkerCompletion(
-      worker,
-      'cancel-complete',
-      requestId,
-      () =>
-        worker.postMessage({ type: 'cancel', requestId } satisfies AnalyzeProjectWorkerInMessage),
-      WORKER_RESPONSE_TIMEOUT_MS,
-    );
-    return completion.type === 'cancel-complete' && completion.result.type === 'success';
-  };
-
-  const closeLeaseCall = () => {
-    if (!state.leaseCall) {
-      return;
-    }
-    const currentLeaseCall = state.leaseCall;
-    state.leaseCall = null;
-    try {
-      currentLeaseCall.end();
-    } catch (e) {
-      debug(`Failed to end lease stream: ${e}`);
-    }
-  };
-
-  const shutdown = async (reason: string) => {
-    if (state.shuttingDown) {
-      return;
-    }
-    state.shuttingDown = true;
-    debug(`Shutting down gRPC analyze-project server: ${reason}`);
-    clearStartupShutdownTimeout(state);
-    closeLeaseCall();
-    unregisterGarbageCollectionObserver();
-    await cancelAnalysisOnShutdown(handleRequestInCurrentThread, newWorkerRequestId, state, worker);
-    await closeWorker(worker);
-
-    server.forceShutdown();
-    resolveClosed();
-  };
-
-  const scheduleStartupShutdownTimeout = () => {
-    if (timeout <= 0) {
-      return;
-    }
-    clearStartupShutdownTimeout(state);
-    state.startupShutdownTimeout = setTimeout(() => {
-      void shutdown('lease acquisition timeout');
-    }, timeout);
-  };
-
-  return {
-    scheduleStartupShutdownTimeout,
-    clearStartupShutdownTimeout: () => clearStartupShutdownTimeout(state),
-    requestCancel,
-    shutdown,
-  };
-}
 
 function createAnalyzeProjectStreamHandler({
   handleRequestInCurrentThread,
@@ -674,27 +339,6 @@ function createAnalyzeProjectImplementation(
   };
 }
 
-function attachWorkerLifecycleHandlers(
-  worker: Worker | undefined,
-  lifecycle: AnalyzeProjectServerLifecycle,
-  state: AnalyzeProjectServerState,
-) {
-  if (!worker) {
-    return;
-  }
-
-  worker.on('error', error => {
-    logMemoryError(error);
-    void lifecycle.shutdown('worker error');
-  });
-  worker.on('exit', code => {
-    debug(`The worker thread exited with code ${code}`);
-    if (!state.shuttingDown) {
-      void lifecycle.shutdown('worker exit');
-    }
-  });
-}
-
 export const analyzeProjectServerInternals = {
   createAnalyzeProjectStreamHandler,
   createLifecycle,
@@ -709,7 +353,7 @@ export async function startAnalyzeProjectServer(
   timeout = 0,
 ): Promise<AnalyzeProjectServerResult> {
   await logMemoryConfiguration();
-  const workerData: WorkerData = { debugMemory };
+  const workerData = { debugMemory };
   const unregisterGarbageCollectionObserver = debugMemory
     ? registerGarbageCollectionObserver()
     : () => {};

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -87,8 +87,7 @@ public class BridgeServerImpl implements BridgeServer {
   public static final String NODE_TIMEOUT_PROPERTY = "sonar.javascript.node.timeout";
   public static final String SONARJS_EXISTING_NODE_PROCESS_PORT =
     "SONARJS_EXISTING_NODE_PROCESS_PORT";
-  private static final String STARTUP_PORT_LOG_PREFIX =
-    "gRPC analyze-project server listening on ";
+  private static final String STARTUP_PORT_LOG_PREFIX = "gRPC analyze-project server listening on ";
   private static final int STARTUP_PORT_WAIT_POLL_INTERVAL_MS = 100;
   private static final String ANALYSIS_CANCELLED_MESSAGE =
     "Analysis interrupted because the SensorContext is in cancelled state";
@@ -292,11 +291,6 @@ public class BridgeServerImpl implements BridgeServer {
     }
   }
 
-  private NodeCommand initNodeCommand(BridgeServerConfig serverConfig, File scriptFile)
-    throws IOException {
-    return initNodeCommand(serverConfig, scriptFile, new LogOutputConsumer());
-  }
-
   private NodeCommand initNodeCommand(
     BridgeServerConfig serverConfig,
     File scriptFile,
@@ -387,7 +381,9 @@ public class BridgeServerImpl implements BridgeServer {
     // The Node startup log has a fixed format; parsing the trailing port keeps IPv6 support
     // without relying on a broad regular expression over arbitrary process output.
     int separatorIndex = message.lastIndexOf(':');
-    if (separatorIndex < STARTUP_PORT_LOG_PREFIX.length() || separatorIndex == message.length() - 1) {
+    if (
+      separatorIndex < STARTUP_PORT_LOG_PREFIX.length() || separatorIndex == message.length() - 1
+    ) {
       return null;
     }
 

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
@@ -127,9 +127,7 @@ public class AnalysisProcessor {
     this.file = file;
 
     LOG.error("Failed to analyze file [{}]: {}", file, message);
-    if (context.failFast() && !CssLanguage.KEY.equals(file.language())) {
-      throw new IllegalStateException("Failed to analyze file " + file);
-    }
+    failFastOnNonCssAnalysisError(context, CssLanguage.KEY.equals(file.language()));
 
     context.getSensorContext().newAnalysisError().onFile(file).message(message).save();
   }
@@ -151,11 +149,10 @@ public class AnalysisProcessor {
       LOG.error("Failed to analyze file [{}] from TypeScript: {}", file, message);
     } else {
       LOG.error("Failed to analyze file [{}]: {}", file, message);
-      if (
-        context.failFast() && parsingError.getLanguage() != AnalysisLanguage.ANALYSIS_LANGUAGE_CSS
-      ) {
-        throw new IllegalStateException("Failed to analyze file " + file);
-      }
+      failFastOnNonCssAnalysisError(
+        context,
+        parsingError.getLanguage() == AnalysisLanguage.ANALYSIS_LANGUAGE_CSS
+      );
     }
 
     var parsingErrorRuleKey = parsingErrorRuleKey(parsingError);
@@ -201,6 +198,12 @@ public class AnalysisProcessor {
       newAnalysisError.at(file.newPointer(1, 0));
     }
     newAnalysisError.message(message).save();
+  }
+
+  private void failFastOnNonCssAnalysisError(JsTsContext<?> context, boolean isCss) {
+    if (context.failFast() && !isCss) {
+      throw new IllegalStateException("Failed to analyze file " + file);
+    }
   }
 
   @Nullable

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
@@ -123,6 +123,17 @@ public class AnalysisProcessor {
     return issues;
   }
 
+  void processFileError(JsTsContext<?> context, InputFile file, String message) {
+    this.file = file;
+
+    LOG.error("Failed to analyze file [{}]: {}", file, message);
+    if (context.failFast() && !CssLanguage.KEY.equals(file.language())) {
+      throw new IllegalStateException("Failed to analyze file " + file);
+    }
+
+    context.getSensorContext().newAnalysisError().onFile(file).message(message).save();
+  }
+
   void processCacheAnalysis(JsTsContext<?> context, InputFile file, CacheAnalysis cacheAnalysis) {
     this.file = file;
 

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensor.java
@@ -354,25 +354,20 @@ public class WebSensor implements Sensor {
       var filePath = fileResultMessage.getFilePath();
       var response = fileResultMessage.getResult();
       try {
-        if (response.hasError() && !response.getError().isBlank()) {
-          throw new IllegalStateException(
-            "Failed to analyze file " + filePath + ": " + response.getError()
-          );
-        }
         var file = fileToInputFile.get(filePath);
         if (file == null) {
           LOG.warn("Skipping analysis result for unknown file path: {}", filePath);
           return;
         }
-        var issues = analysisProcessor.processResponse(context, checks, file, response);
-        var dedupedIssues = ExternalIssueRepository.deduplicateIssues(
-          externalIssues.get(filePath),
-          issues
-        );
-        if (!dedupedIssues.isEmpty()) {
-          ExternalIssueRepository.saveESLintIssues(context.getSensorContext(), dedupedIssues);
+        if (response.hasError() && !response.getError().isBlank()) {
+          // The HTTP transport used to drop per-file runtime errors after logging them in Node.js.
+          // Keep the project analysis running, but surface the failure explicitly on the file.
+          analysisProcessor.processFileError(context, file, response.getError());
+          saveExternalIssues(filePath, List.of());
+          return;
         }
-        externalIssues.remove(filePath);
+        var issues = analysisProcessor.processResponse(context, checks, file, response);
+        saveExternalIssues(filePath, issues);
         // Only cache JS/TS file results -- non-JS/TS files (CSS, HTML, YAML) skip caching.
         var cacheStrategy = fileToCacheStrategy.get(filePath);
         Node responseAst = responseAst(response);
@@ -385,6 +380,20 @@ public class WebSensor implements Sensor {
           new IllegalStateException("Failed to decode analysis AST for " + filePath, e)
         );
       }
+    }
+
+    private void saveExternalIssues(
+      String filePath,
+      List<org.sonar.plugins.javascript.analyzeproject.grpc.Issue> issues
+    ) {
+      var dedupedIssues = ExternalIssueRepository.deduplicateIssues(
+        externalIssues.get(filePath),
+        issues
+      );
+      if (!dedupedIssues.isEmpty()) {
+        ExternalIssueRepository.saveESLintIssues(context.getSensorContext(), dedupedIssues);
+      }
+      externalIssues.remove(filePath);
     }
 
     private void handleMeta(ProjectAnalysisMeta meta) {

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
@@ -767,6 +767,74 @@ class WebSensorTest {
   }
 
   @Test
+  void should_record_file_error_without_failing_analysis() {
+    var expectedResponse = createProjectResponse(
+      new HashMap<>() {
+        {
+          put(inputFile.absolutePath(), createErrorResponse("Runtime error message"));
+        }
+      }
+    );
+
+    executeSensorMockingResponse(expectedResponse);
+
+    assertThat(context.allIssues()).isEmpty();
+    assertThat(context.allAnalysisErrors()).hasSize(1);
+    assertThat(logTester.logs(Level.ERROR)).contains(
+      "Failed to analyze file [dir/file.ts]: Runtime error message"
+    );
+  }
+
+  @Test
+  void should_keep_external_issues_when_file_analysis_returns_error() throws Exception {
+    baseDir = Paths.get("src/test/resources/de-duplicate-issues");
+    context = createSensorContext(baseDir);
+    context.settings().setProperty(JavaScriptPlugin.ESLINT_REPORT_PATHS, "eslint-report.json");
+
+    inputFile = createInputFile(
+      context,
+      "file.js",
+      StandardCharsets.ISO_8859_1,
+      baseDir,
+      "function addOne(i) {\n    if (i != NaN) {\n        return i ++\n    } else {\n      return\n    }\n};"
+    );
+
+    var expectedResponse = createProjectResponse(
+      new HashMap<>() {
+        {
+          put(inputFile.absolutePath(), createErrorResponse("Runtime error message"));
+        }
+      }
+    );
+
+    executeSensorMockingResponse(expectedResponse);
+
+    assertThat(context.allIssues()).isEmpty();
+    assertThat(context.allExternalIssues()).hasSize(3);
+    assertThat(context.allAnalysisErrors()).hasSize(1);
+  }
+
+  @Test
+  void should_fail_fast_with_file_error() {
+    MapSettings settings = new MapSettings().setProperty("sonar.internal.analysis.failFast", true);
+    context.setSettings(settings);
+    var expectedResponse = createProjectResponse(
+      new HashMap<>() {
+        {
+          put(inputFile.absolutePath(), createErrorResponse("Runtime error message"));
+        }
+      }
+    );
+
+    assertThatThrownBy(() -> executeSensorMockingResponse(expectedResponse))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Analysis of JS/TS files failed");
+    assertThat(logTester.logs(Level.ERROR)).contains(
+      "Failed to analyze file [dir/file.ts]: Runtime error message"
+    );
+  }
+
+  @Test
   void should_fail_fast_with_parsing_error_without_line() {
     MapSettings settings = new MapSettings().setProperty("sonar.internal.analysis.failFast", true);
     context.setSettings(settings);
@@ -1604,6 +1672,10 @@ class WebSensorTest {
       .setMetrics(Metrics.getDefaultInstance())
       .addAllIssues(issues)
       .build();
+  }
+
+  private ProjectAnalysisFileResult createErrorResponse(String message) {
+    return ProjectAnalysisFileResult.newBuilder().setError(message).build();
   }
 
   private ProjectAnalysisFileResult createResponse() {


### PR DESCRIPTION
## Summary
- preserve the pre-gRPC behavior for per-file analyzer runtime errors returned inside a successful project response
- record those file failures as Sonar analysis errors instead of aborting the whole analysis
- keep imported external issues for files whose internal analysis failed

## Validation
- mvn --% -pl sonar-plugin/sonar-javascript-plugin -am -Dtest=WebSensorTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test
