### PR TITLE
JS-1679 [codex] Update ruling documentation paths

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -73,8 +73,8 @@ The "Ruling Test" is an integration test which launches the analysis of a large 
 npm run ruling
 ```
 
-You can copy the files with the actual issues located at `packages/ruling/actual/`
-into the directory with the expected issues `its/ruling/src/test/resources/expected/`.
+The generated issues are written under `packages/ruling/actual/<project>/`.
+The expected issues are stored under `its/ruling/src/test/expected/<project>/`.
 
 From the project root, run: `npm run ruling-sync`
 

--- a/tools/ruling-debug-script.sh
+++ b/tools/ruling-debug-script.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-default_actual_dir="packages/ruling/actual/jsts"
+default_actual_dir="packages/ruling/actual"
 
-expected_dir="its/ruling/src/test/expected/jsts"
+expected_dir="its/ruling/src/test/expected"
 actual_dir="${1:-$default_actual_dir}"
 
 # Differing files


### PR DESCRIPTION
## Summary
- update the JS/TS ruling documentation to point at the current generated and expected issue directories
- align `tools/ruling-debug-script.sh` with the current JS/TS ruling directory layout

## Why
The documentation still referenced the old expected-issues path, and the helper diff script still defaulted to the old `jsts` subdirectories.

## Validation
- `git diff --check`
- `bash -n tools/ruling-debug-script.sh`
- verified the documented paths against `packages/ruling/testProject.ts` and `tools/ruling-sync.js`
