### PR TITLE
JS-1682 Fix S6324 false negatives in printable ranges

### DIFF
--- a/packages/analysis/src/jsts/rules/S6324/rule.ts
+++ b/packages/analysis/src/jsts/rules/S6324/rule.ts
@@ -40,15 +40,17 @@ function isCharacterClassRangeBoundary(character: AST.Character): boolean {
 }
 
 /**
- * Control characters inside character classes that contain ranges indicate intentional
- * character set construction (e.g., [\x00-\x08\x0b\x0c] for YAML/CSS non-printables).
+ * Standalone control characters are exempt only when the character class contains
+ * a range that starts in the control-character block (e.g., [\x00-\x08\x0b\x0c]).
  */
-function isInCharacterClassWithRanges(character: AST.Character): boolean {
+function isInCharacterClassWithControlCharRange(character: AST.Character): boolean {
   const parent = character.parent;
   if (parent.type !== 'CharacterClass') {
     return false;
   }
-  return parent.elements.some(element => element.type === 'CharacterClassRange');
+  return parent.elements.some(
+    element => element.type === 'CharacterClassRange' && element.min.value <= MAX_CONTROL_CHAR_CODE,
+  );
 }
 
 /**
@@ -117,7 +119,7 @@ export const rule: Rule.RuleModule = createRegExpRule(context => {
           raw.startsWith(String.raw`\u`)) &&
         !EXCEPTIONS.has(raw) &&
         !isCharacterClassRangeBoundary(character) &&
-        !isInCharacterClassWithRanges(character) &&
+        !isInCharacterClassWithControlCharRange(character) &&
         !isAnsiSequenceStart(character) &&
         !isOscTerminator(character)
       ) {

--- a/packages/analysis/src/jsts/rules/S6324/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6324/unit.test.ts
@@ -221,6 +221,31 @@ describe('S6324', () => {
           errors: 2,
         },
         {
+          // Standalone control char should still be flagged when the only range is printable.
+          code: String.raw`/[\x01a-z]/`,
+          errors: 1,
+        },
+        {
+          // Multiple standalone control chars should still be flagged when mixed with a printable range.
+          code: String.raw`/[\x02\x03A-Z]/`,
+          errors: 2,
+        },
+        {
+          // Printable digit ranges must not exempt standalone control chars.
+          code: String.raw`/[0-9\x01]/`,
+          errors: 1,
+        },
+        {
+          // Existing VT/FF standalone cases stay noncompliant even when mixed with printable ranges.
+          code: String.raw`/[\x0b\x0ca-z]/`,
+          errors: 2,
+        },
+        {
+          // Interpreted control chars should also be reported when the only range is printable.
+          code: '/[\u0001A-Z]/',
+          errors: 1,
+        },
+        {
           // Standalone NULL byte replacement (like saxparser.js)
           code: String.raw`str.replace(/\u0000/g, '')`,
           errors: 1,


### PR DESCRIPTION
## Summary
- restrict the S6324 character-class exemption to ranges that start in the control-character block
- add regression tests for standalone control characters mixed with printable ranges like `a-z`, `A-Z`, and `0-9`
- preserve the existing compliant YAML, Jest, and asciify-style patterns already covered by the S6324 suite

## Root cause
`isInCharacterClassWithRanges` treated any character class containing any `CharacterClassRange` as intentional character-set construction. That incorrectly exempted standalone control characters when the only range in the class was printable.

## Impact
S6324 now reports standalone control characters again when they are mixed with printable ranges, while still allowing intentional control-character range patterns.

## Validation
- `npx tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec --test-reporter-destination stdout packages/analysis/src/jsts/rules/S6324/unit.test.ts`
- `npx prettier --check packages/analysis/src/jsts/rules/S6324/rule.ts packages/analysis/src/jsts/rules/S6324/unit.test.ts`
