### PR TITLE
JS-1685 [codex] Fix S6759 readonly props inherited from Readonly base

### DIFF
--- a/packages/analysis/src/jsts/rules/S6759/rule.ts
+++ b/packages/analysis/src/jsts/rules/S6759/rule.ts
@@ -173,6 +173,51 @@ function isReadOnly(props: Node, services: RequiredParserServices) {
 
   /* All properties must be read-only */
   return properties.every(property =>
-    isPropertyReadonlyInType(type, property.getEscapedName(), checker),
+    isPropertyReadonlyIncludingBaseTypes(type, property, checker),
   );
+}
+
+function isPropertyReadonlyIncludingBaseTypes(
+  type: ts.Type,
+  property: ts.Symbol,
+  checker: ts.TypeChecker,
+  seen = new Set<ts.Type>(),
+): boolean {
+  const name = property.getEscapedName();
+  if (isPropertyReadonlyInType(type, name, checker)) {
+    return true;
+  }
+
+  // Inherited properties can be exposed as transient symbols whose declarations
+  // no longer carry readonly modifiers from mapped base types like Readonly<T>.
+  if (!(property.flags & ts.SymbolFlags.Transient)) {
+    return false;
+  }
+
+  if (!(type.flags & ts.TypeFlags.Object) || seen.has(type)) {
+    return false;
+  }
+  seen.add(type);
+
+  const objectType = type as ts.ObjectType;
+  if (!(objectType.objectFlags & ts.ObjectFlags.ClassOrInterface)) {
+    return false;
+  }
+
+  const baseTypes = checker.getBaseTypes(objectType as ts.InterfaceType);
+  return (
+    baseTypes?.some(baseType => {
+      const baseProperty = getPropertyFromType(baseType, name);
+      return (
+        baseProperty !== undefined &&
+        isPropertyReadonlyIncludingBaseTypes(baseType, baseProperty, checker, seen)
+      );
+    }) ?? false
+  );
+}
+
+function getPropertyFromType(type: ts.Type, name: ts.__String) {
+  return String(name).startsWith('__')
+    ? type.getProperties().find(property => property.getEscapedName() === name)
+    : type.getProperty(String(name));
 }

--- a/packages/analysis/src/jsts/rules/S6759/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6759/unit.test.ts
@@ -141,6 +141,24 @@ function DerivedComponent(props: DerivedProps) {
 }
           `,
         },
+        {
+          // Community: interface extending a Readonly-wrapped alias should preserve readonly props
+          code: `
+type PropsWithClassName<Props extends Record<string, unknown> = {}> = Readonly<
+  Props & {
+    className?: string;
+  }
+>;
+
+interface ContentRendererProps extends PropsWithClassName {
+  readonly chatId: string;
+}
+
+function ErrorRenderer({ chatId }: ContentRendererProps) {
+  return <div>{chatId}</div>;
+}
+          `,
+        },
       ],
       invalid: [
         {


### PR DESCRIPTION
## What changed
- added an `S6759` regression test for props interfaces extending a `Readonly<...>` alias
- updated the rule to recover readonly information from inherited mapped base types when `ts-api-utils` loses it on transient symbols

## Why
`S6759` incorrectly raised on props that were already effectively readonly when an interface inherited members from a `Readonly<...>` alias.

## Root cause
The rule relied on `ts-api-utils.isPropertyReadonlyInType(...)`. That helper handles direct mapped `Readonly<T>` types, but for inherited interface members it can see only a transient property symbol whose declaration no longer carries the mapped readonly modifier. As a result, inherited props such as `className` were treated as mutable even though the base type came from `Readonly<...>`.

## Impact
This removes a false positive for TypeScript React components using readonly utility types through interface inheritance, without changing the behavior for explicit mutable overrides.

## Validation
- `npm run bbf`
- `git submodule update --init --recursive`
- `npm run ruling`
- `node --import tsx --test --test-reporter=spec packages/analysis/src/jsts/rules/S6759/unit.test.ts packages/analysis/src/jsts/rules/S6759/cb.test.ts`
