### PR TITLE
JS-1691 Move releasability condition to job level

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1319,16 +1319,16 @@ jobs:
     name: Releasability
     needs:
       - promote
+    if: >-
+      github.ref_name == github.event.repository.default_branch ||
+      startsWith(github.ref_name, 'branch-') ||
+      startsWith(github.ref_name, 'dogfood-')
     permissions:
       id-token: write
       statuses: write
       contents: read
     steps:
       - uses: SonarSource/gh-action_releasability/releasability-status@v3
-        if: >-
-          github.ref_name == github.event.repository.default_branch ||
-          startsWith(github.ref_name, 'branch-') ||
-          startsWith(github.ref_name, 'dogfood-')
         with:
           optional_checks: "Jira"
         env:


### PR DESCRIPTION
## Summary
- move the `releasability` branch guard from the step to the job in `build.yml`
- keep the existing SonarJS branch predicate unchanged
- avoid allocating a runner when the releasability job would be skipped

## Testing
- `git diff --check`