### PR TITLE
JS-1688 extend dependencies cache with versions

### DIFF
--- a/packages/analysis/src/jsts/linter/filters/rule-filter.ts
+++ b/packages/analysis/src/jsts/linter/filters/rule-filter.ts
@@ -18,7 +18,7 @@ import type { RuleConfig } from '../config/rule-config.js';
 import type { FileType } from '../../../contracts/file.js';
 import type { JsTsLanguage } from '../../../common/configuration.js';
 import type { AnalysisMode } from '../../analysis/analysis.js';
-import type { ModuleType } from '../../rules/helpers/dependency-manifests/dependencies.js';
+import type { ModuleType } from '../../rules/helpers/dependency-manifests/resolvers/types.js';
 import type { Minimatch } from 'minimatch';
 
 export interface RuleFilterContext {

--- a/packages/analysis/src/jsts/linter/linter.ts
+++ b/packages/analysis/src/jsts/linter/linter.ts
@@ -271,7 +271,9 @@ export class Linter {
        * The wrapper's linting configuration includes multiple ESLint
        * configurations: one per fileType/language/analysisMode combination.
        */
-      const dependencies = getDependencies(dirnamePath(normalizedFilePath), Linter.baseDir);
+      const dependencies = new Set(
+        getDependencies(dirnamePath(normalizedFilePath), Linter.baseDir).keys(),
+      );
       const context: RuleFilterContext = {
         extensionName: extname(normalizePath(filePath)),
         fileType,

--- a/packages/analysis/src/jsts/rules/S4328/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4328/rule.ts
@@ -23,8 +23,8 @@ import ts from 'typescript';
 import { generateMeta } from '../helpers/generate-meta.js';
 import type { FromSchema } from 'json-schema-to-ts';
 import * as meta from './generated-meta.js';
-import type { Minimatch } from 'minimatch';
 import { getDependenciesSanitizePaths } from '../helpers/dependency-manifests/dependencies.js';
+import type { DependenciesList } from '../helpers/dependency-manifests/resolvers/types.js';
 
 const messages = {
   removeOrAddDependency: 'Either remove this import or add it as a dependency.',
@@ -88,7 +88,7 @@ export const rule: Rule.RuleModule = {
 function raiseOnImplicitImport(
   module: estree.Literal,
   loc: estree.SourceLocation,
-  dependencies: Set<string | Minimatch>,
+  dependencies: DependenciesList,
   filename: string,
   host: ts.ModuleResolutionHost | undefined,
   options: ts.CompilerOptions | undefined,
@@ -121,7 +121,7 @@ function raiseOnImplicitImport(
     return;
   }
 
-  for (const dependency of dependencies) {
+  for (const dependency of dependencies.keys()) {
     if (typeof dependency === 'string') {
       if (dependency === packageName) {
         return;

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/all-in-parent-dirs.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/all-in-parent-dirs.ts
@@ -115,9 +115,9 @@ export const getDependencyManifests = (
  */
 function logDuplicateDependenciesInManifests(manifests: DependencyManifest[]): void {
   const dependencyDefinitions = new Map<string, DependencyDefinition>();
-  for (const manifest of manifests) {
+  for (const { dependencies, type: manifestType } of manifests) {
     const dependenciesByNameInManifest = new Map<string, string | undefined>();
-    for (const [name, version] of manifest.getDependencies()) {
+    for (const [name, version] of dependencies) {
       if (typeof name !== 'string' || dependenciesByNameInManifest.has(name)) {
         continue;
       }
@@ -127,15 +127,12 @@ function logDuplicateDependenciesInManifests(manifests: DependencyManifest[]): v
       const firstDefinition = dependencyDefinitions.get(dependencyName);
       if (firstDefinition) {
         logDuplicateDependencyDefinition(dependencyName, firstDefinition, {
-          manifestType: manifest.type,
+          manifestType,
           version,
         });
         continue;
       }
-      dependencyDefinitions.set(dependencyName, {
-        manifestType: manifest.type,
-        version,
-      });
+      dependencyDefinitions.set(dependencyName, { manifestType, version });
     }
   }
 }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/all-in-parent-dirs.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/all-in-parent-dirs.ts
@@ -27,7 +27,6 @@ import {
 import { PACKAGE_JSON } from './index.js';
 import { patternInParentsCache } from '../find-up/all-in-parent-dirs.js';
 import type { Rule } from 'eslint';
-import { getDependenciesFromManifest } from './parse.js';
 import { type DependencyManifest, type ManifestResolver } from './resolvers/types.js';
 import { denoManifestResolver } from './resolvers/deno.js';
 import { npmManifestResolver } from './resolvers/npm.js';
@@ -118,14 +117,11 @@ function logDuplicateDependenciesInManifests(manifests: DependencyManifest[]): v
   const dependencyDefinitions = new Map<string, DependencyDefinition>();
   for (const manifest of manifests) {
     const dependenciesByNameInManifest = new Map<string, string | undefined>();
-    for (const dependency of getDependenciesFromManifest(manifest)) {
-      if (
-        typeof dependency.name !== 'string' ||
-        dependenciesByNameInManifest.has(dependency.name)
-      ) {
+    for (const [name, version] of manifest.getDependencies()) {
+      if (typeof name !== 'string' || dependenciesByNameInManifest.has(name)) {
         continue;
       }
-      dependenciesByNameInManifest.set(dependency.name, dependency.version);
+      dependenciesByNameInManifest.set(name, version);
     }
     for (const [dependencyName, version] of dependenciesByNameInManifest) {
       const firstDefinition = dependencyDefinitions.get(dependencyName);

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/all-in-parent-dirs.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/all-in-parent-dirs.ts
@@ -118,7 +118,7 @@ function logDuplicateDependenciesInManifests(manifests: DependencyManifest[]): v
   for (const { dependencies, type: manifestType } of manifests) {
     const dependenciesByNameInManifest = new Map<string, string | undefined>();
     for (const [name, version] of dependencies) {
-      if (typeof name !== 'string' || dependenciesByNameInManifest.has(name)) {
+      if (typeof name !== 'string') {
         continue;
       }
       dependenciesByNameInManifest.set(name, version);

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -82,7 +82,7 @@ export const moduleTypeCache = new ComputedCache(
  *
  * @param dir dirname of the context.filename
  * @param topDir working dir, will search up to that root
- * @returns Set with the dependency names
+ * @returns Map of dependency names to their version strings
  */
 export function getDependencies(
   dir: NormalizedAbsolutePath,

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -104,10 +104,7 @@ export function getDependencies(
  * take precedence. Otherwise, package.json#type from the closest manifest only
  * is used. If that closest manifest exists but omits "type", default to CommonJS.
  */
-export function getModuleType(
-  filePath: NormalizedAbsolutePath,
-  topDir: NormalizedAbsolutePath,
-): ModuleType | undefined {
+export function getModuleType(filePath: NormalizedAbsolutePath, topDir: NormalizedAbsolutePath) {
   const extensionSignal = MODULE_TYPE_BY_EXTENSION[extname(filePath).toLowerCase()];
   if (extensionSignal) {
     return extensionSignal;

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -16,7 +16,6 @@
  */
 import type { Rule } from 'eslint';
 import { ComputedCache } from '../cache.js';
-import type { Minimatch } from 'minimatch';
 import fs from 'node:fs';
 import { extname } from 'node:path/posix';
 import { minVersion } from 'semver';
@@ -27,11 +26,11 @@ import {
   dirnamePath,
   stripBOM,
 } from '../files.js';
-import { getDependenciesFromManifest } from './parse.js';
 import { getClosestDependencyManifestDir } from './closest.js';
-import { getDependencyManifests } from './all-in-parent-dirs.js';
+import { getDependencyManifests, getPackageJsonManifests } from './all-in-parent-dirs.js';
+import { DependenciesList, type ModuleType } from './resolvers/types.js';
 
-export type ModuleType = 'module' | 'commonjs';
+export type { ModuleType } from './resolvers/types.js';
 
 const MODULE_TYPE_BY_EXTENSION: Readonly<Record<string, ModuleType>> = {
   '.mjs': 'module',
@@ -46,22 +45,20 @@ const MODULE_TYPE_BY_EXTENSION: Readonly<Record<string, ModuleType>> = {
 export const dependenciesCache = new ComputedCache(
   (dir: NormalizedAbsolutePath, topDir?: NormalizedAbsolutePath) => {
     const closestDependencyManifestDir = getClosestDependencyManifestDir(dir, topDir);
-    const result = new Set<string | Minimatch>();
+    const result: DependenciesList = new Map();
 
     if (!closestDependencyManifestDir) {
       return result;
     }
 
     for (const manifest of getDependencyManifests(closestDependencyManifestDir, topDir, fs)) {
-      const manifestDependencies = getDependenciesFromManifest(manifest);
-      for (const dependency of manifestDependencies) {
-        result.add(dependency.name);
-        if (dependency.alias) {
-          // Also add the alias as a dependency, so it can be resolved in rules, for instance S4328
-          result.add(dependency.alias);
+      for (const [name, version] of manifest.getDependencies()) {
+        if (!result.has(name)) {
+          result.set(name, version);
         }
       }
     }
+
     return result;
   },
 );
@@ -76,19 +73,7 @@ export const moduleTypeCache = new ComputedCache(
       return undefined;
     }
     const [firstManifest] = getDependencyManifests(closestDependencyManifestDirName, topDir, fs);
-    switch (firstManifest?.type) {
-      case 'npm':
-        if (firstManifest.manifest.type === 'module') {
-          return 'module';
-        }
-        // Default to CommonJS if "type" field is missing
-        return 'commonjs';
-      case 'deno':
-        // Deno treats all modules as ESM
-        return 'module';
-      default:
-        return undefined;
-    }
+    return firstManifest?.getModuleType();
   },
 );
 
@@ -102,12 +87,12 @@ export const moduleTypeCache = new ComputedCache(
 export function getDependencies(
   dir: NormalizedAbsolutePath,
   topDir: NormalizedAbsolutePath,
-): Set<string | Minimatch> {
+): DependenciesList {
   const closestDependencyManifestDir = getClosestDependencyManifestDir(dir, topDir);
   if (closestDependencyManifestDir) {
     return dependenciesCache.get(closestDependencyManifestDir, topDir);
   }
-  return new Set();
+  return new Map();
 }
 
 /**
@@ -117,7 +102,10 @@ export function getDependencies(
  * take precedence. Otherwise, package.json#type from the closest manifest only
  * is used. If that closest manifest exists but omits "type", default to CommonJS.
  */
-export function getModuleType(filePath: NormalizedAbsolutePath, topDir: NormalizedAbsolutePath) {
+export function getModuleType(
+  filePath: NormalizedAbsolutePath,
+  topDir: NormalizedAbsolutePath,
+): ModuleType | undefined {
   const extensionSignal = MODULE_TYPE_BY_EXTENSION[extname(filePath).toLowerCase()];
   if (extensionSignal) {
     return extensionSignal;
@@ -125,7 +113,7 @@ export function getModuleType(filePath: NormalizedAbsolutePath, topDir: Normaliz
   return moduleTypeCache.get(dirnamePath(filePath), topDir);
 }
 
-export function getDependenciesSanitizePaths(context: Rule.RuleContext): Set<string | Minimatch> {
+export function getDependenciesSanitizePaths(context: Rule.RuleContext): DependenciesList {
   return getDependencies(
     dirnamePath(normalizeToAbsolutePath(context.filename)),
     normalizeToAbsolutePath(context.cwd),
@@ -140,25 +128,13 @@ export function getDependenciesSanitizePaths(context: Rule.RuleContext): Set<str
  */
 export function getReactVersion(context: Rule.RuleContext): string | null {
   const dir = dirnamePath(normalizeToAbsolutePath(context.filename));
-  for (const dependencyManifest of getDependencyManifests(
-    dir,
-    normalizeToAbsolutePath(context.cwd),
-    fs,
-  )) {
-    if (dependencyManifest.type !== 'npm') {
-      continue;
-    }
-    const packageJson = dependencyManifest.manifest;
-    const reactVersion = packageJson.dependencies?.react ?? packageJson.devDependencies?.react;
-    if (reactVersion) {
-      const parsed = parseReactVersion(reactVersion);
-      if (parsed) {
-        return parsed;
-      }
-      // Continue searching in parent package.json files if parsing fails
-    }
+  const dependencies = getDependencies(dir, normalizeToAbsolutePath(context.cwd));
+  const reactVersion = dependencies.get('react');
+
+  if (!reactVersion) {
+    return null;
   }
-  return null;
+  return parseReactVersion(reactVersion);
 }
 
 /**
@@ -205,21 +181,29 @@ function getVersionSignalFromManifests(
   dependencyName: string,
   fallbackSignal?: (packageJson: PackageJson) => string | null,
 ): string | null {
-  const packageJson = getDependencyManifests(baseDir, baseDir, fs).find(
-    manifest => manifest.type === 'npm',
-  )?.manifest;
-  if (!packageJson) {
-    return null;
-  }
+  const dependenciesList = getDependencies(
+    normalizeToAbsolutePath(baseDir),
+    normalizeToAbsolutePath(baseDir),
+  );
 
-  const dependencyVersion = getDependencyVersionSignal(packageJson, dependencyName);
+  // TODO: REVIEW TYPE STRIPPING
+  const DEFINITELY_TYPED = '@types/';
+  const lookupKey = dependencyName.startsWith(DEFINITELY_TYPED)
+    ? dependencyName.substring(DEFINITELY_TYPED.length)
+    : dependencyName;
+  const dependencyVersion = dependenciesList.get(lookupKey) ?? null;
   if (isValidDependencySignal(dependencyVersion)) {
     return dependencyVersion;
   }
 
-  const fallbackVersion = fallbackSignal?.(packageJson);
-  if (fallbackVersion !== null && fallbackVersion !== undefined) {
-    return fallbackVersion;
+  if (fallbackSignal) {
+    const packageJson = getPackageJsonManifests(baseDir, baseDir, fs)[0];
+    if (packageJson) {
+      const fallbackVersion = fallbackSignal(packageJson);
+      if (fallbackVersion !== null && fallbackVersion !== undefined) {
+        return fallbackVersion;
+      }
+    }
   }
 
   return null;

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -49,8 +49,12 @@ export const dependenciesCache = new ComputedCache(
       return result;
     }
 
-    for (const manifest of getDependencyManifests(closestDependencyManifestDir, topDir, fs)) {
-      for (const [name, version] of manifest.getDependencies()) {
+    for (const { dependencies } of getDependencyManifests(
+      closestDependencyManifestDir,
+      topDir,
+      fs,
+    )) {
+      for (const [name, version] of dependencies) {
         if (!result.has(name)) {
           result.set(name, version);
         }
@@ -71,7 +75,7 @@ export const moduleTypeCache = new ComputedCache(
       return undefined;
     }
     const [firstManifest] = getDependencyManifests(closestDependencyManifestDirName, topDir, fs);
-    return firstManifest?.getModuleType();
+    return firstManifest?.moduleType;
   },
 );
 
@@ -193,7 +197,7 @@ function getVersionSignalFromManifests(
     if (manifest.type !== 'npm') {
       continue;
     }
-    const version = manifest.getDependencies().get(lookupKey) ?? null;
+    const version = manifest.dependencies.get(lookupKey) ?? null;
     if (isValidDependencySignal(version)) {
       return version;
     }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -28,7 +28,7 @@ import {
 } from '../files.js';
 import { getClosestDependencyManifestDir } from './closest.js';
 import { getDependencyManifests, getPackageJsonManifests } from './all-in-parent-dirs.js';
-import { DependenciesList, type ModuleType } from './resolvers/types.js';
+import { DEFINITELY_TYPED, DependenciesList, type ModuleType } from './resolvers/types.js';
 
 export type { ModuleType } from './resolvers/types.js';
 
@@ -183,7 +183,6 @@ function getVersionSignalFromManifests(
 ): string | null {
   // Only look at npm manifests: Deno `npm:` imports are download aliases and don't carry
   // meaningful version signals for the project's actual npm dependency resolution.
-  const DEFINITELY_TYPED = '@types/';
   const lookupKey = dependencyName.startsWith(DEFINITELY_TYPED)
     ? dependencyName.substring(DEFINITELY_TYPED.length)
     : dependencyName;

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -28,9 +28,7 @@ import {
 } from '../files.js';
 import { getClosestDependencyManifestDir } from './closest.js';
 import { getDependencyManifests, getPackageJsonManifests } from './all-in-parent-dirs.js';
-import { DEFINITELY_TYPED, DependenciesList, type ModuleType } from './resolvers/types.js';
-
-export type { ModuleType } from './resolvers/types.js';
+import { DEFINITELY_TYPED, type DependenciesList, type ModuleType } from './resolvers/types.js';
 
 const MODULE_TYPE_BY_EXTENSION: Readonly<Record<string, ModuleType>> = {
   '.mjs': 'module',

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -132,7 +132,7 @@ export function getReactVersion(context: Rule.RuleContext): string | null {
   const dir = dirnamePath(normalizeToAbsolutePath(context.filename));
   const dependencies = getDependencies(dir, normalizeToAbsolutePath(context.cwd));
   const reactVersion = dependencies.get('react');
-
+  // Deno npm: imports reflect the actual runtime version and are intentionally included here, unlike the TypeScript/Node.js version signals
   if (!reactVersion) {
     return null;
   }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -181,19 +181,25 @@ function getVersionSignalFromManifests(
   dependencyName: string,
   fallbackSignal?: (packageJson: PackageJson) => string | null,
 ): string | null {
-  const dependenciesList = getDependencies(
-    normalizeToAbsolutePath(baseDir),
-    normalizeToAbsolutePath(baseDir),
-  );
-
-  // TODO: REVIEW TYPE STRIPPING
+  // Only look at npm manifests: Deno `npm:` imports are download aliases and don't carry
+  // meaningful version signals for the project's actual npm dependency resolution.
   const DEFINITELY_TYPED = '@types/';
   const lookupKey = dependencyName.startsWith(DEFINITELY_TYPED)
     ? dependencyName.substring(DEFINITELY_TYPED.length)
     : dependencyName;
-  const dependencyVersion = dependenciesList.get(lookupKey) ?? null;
-  if (isValidDependencySignal(dependencyVersion)) {
-    return dependencyVersion;
+
+  for (const manifest of getDependencyManifests(
+    normalizeToAbsolutePath(baseDir),
+    normalizeToAbsolutePath(baseDir),
+    fs,
+  )) {
+    if (manifest.type !== 'npm') {
+      continue;
+    }
+    const version = manifest.getDependencies().get(lookupKey) ?? null;
+    if (isValidDependencySignal(version)) {
+      return version;
+    }
   }
 
   if (fallbackSignal) {

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
@@ -16,7 +16,7 @@
  */
 import { Minimatch } from 'minimatch';
 import type { PackageJson } from 'type-fest';
-import { DEFINITELY_TYPED, DependenciesList } from './resolvers/types.js';
+import { DEFINITELY_TYPED, type DependenciesList } from './resolvers/types.js';
 
 export function addDependencies(
   result: DependenciesList,
@@ -64,7 +64,6 @@ export function addDependency(
     );
   }
   if (alias) {
-    // TODO: REVIEW ALIAS ACCESS IN RULES
     // Also add the alias as a dependency, so it can be resolved in rules, for instance S4328
     result.set(alias, version);
   }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
@@ -16,9 +16,7 @@
  */
 import { Minimatch } from 'minimatch';
 import type { PackageJson } from 'type-fest';
-import { DependenciesList } from './resolvers/types.js';
-
-const DefinitelyTyped = '@types/';
+import { DEFINITELY_TYPED, DependenciesList } from './resolvers/types.js';
 
 export function addDependencies(
   result: DependenciesList,
@@ -59,8 +57,8 @@ export function addDependency(
     result.set(new Minimatch(dependency, { nocase: true, matchBase: true }), version);
   } else {
     result.set(
-      dependency.startsWith(DefinitelyTyped)
-        ? dependency.substring(DefinitelyTyped.length)
+      dependency.startsWith(DEFINITELY_TYPED)
+        ? dependency.substring(DEFINITELY_TYPED.length)
         : dependency,
       version,
     );

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
@@ -20,12 +20,6 @@ import { DependenciesList } from './resolvers/types.js';
 
 const DefinitelyTyped = '@types/';
 
-export type Dependency = {
-  name: string | Minimatch;
-  version?: string;
-  alias?: string;
-};
-
 export function addDependencies(
   result: DependenciesList,
   dependencies: PackageJson.Dependency,

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
@@ -16,77 +16,18 @@
  */
 import { Minimatch } from 'minimatch';
 import type { PackageJson } from 'type-fest';
-import { type DependencyManifest, type DenoManifest } from './resolvers/types.js';
+import { DependenciesList } from './resolvers/types.js';
 
 const DefinitelyTyped = '@types/';
 
-type Dependency = {
+export type Dependency = {
   name: string | Minimatch;
   version?: string;
   alias?: string;
 };
 
-export function getDependenciesFromPackageJson(content: PackageJson) {
-  const result = new Set<Dependency>();
-  if (content.name) {
-    addDependencies(result, { [content.name]: '*' });
-  }
-  if (content.dependencies !== undefined) {
-    addDependencies(result, content.dependencies);
-  }
-  if (content.devDependencies !== undefined) {
-    addDependencies(result, content.devDependencies);
-  }
-  if (content.peerDependencies !== undefined) {
-    addDependencies(result, content.peerDependencies);
-  }
-  if (content.optionalDependencies !== undefined) {
-    addDependencies(result, content.optionalDependencies);
-  }
-  if (content._moduleAliases !== undefined) {
-    // see https://www.npmjs.com/package/module-alias
-    addDependencies(result, content._moduleAliases as PackageJson.Dependency);
-  }
-  if (Array.isArray(content.workspaces)) {
-    addDependenciesArray(result, content.workspaces);
-  } else if (content.workspaces?.packages) {
-    addDependenciesArray(result, content.workspaces?.packages);
-  }
-  return result;
-}
-
-function getDependenciesFromDenoManifest(manifest: DenoManifest): Set<Dependency> {
-  const dependencies = new Set<Dependency>();
-
-  if (manifest.imports && typeof manifest.imports === 'object') {
-    for (const [alias, target] of Object.entries(manifest.imports)) {
-      if (typeof target !== 'string') {
-        continue;
-      }
-
-      const parsedSpecifier = parseImportMapSpecifier(target);
-      if (parsedSpecifier) {
-        addDependency(dependencies, {
-          dependency: parsedSpecifier.packageName,
-          isGlob: false,
-          version: parsedSpecifier.version,
-          alias,
-        });
-      }
-    }
-  }
-
-  if (Array.isArray(manifest.workspace)) {
-    addDependenciesArray(dependencies, manifest.workspace);
-  } else if (manifest.workspace?.members) {
-    addDependenciesArray(dependencies, manifest.workspace.members);
-  }
-
-  return dependencies;
-}
-
-function addDependencies(
-  result: Set<Dependency>,
+export function addDependencies(
+  result: DependenciesList,
   dependencies: PackageJson.Dependency,
   isGlob = false,
 ) {
@@ -103,15 +44,6 @@ type ImportMapSpecifier = {
   packageName: string;
   version?: string;
 };
-
-export function getDependenciesFromManifest(manifest: DependencyManifest): Set<Dependency> {
-  switch (manifest.type) {
-    case 'npm':
-      return getDependenciesFromPackageJson(manifest.manifest);
-    case 'deno':
-      return getDependenciesFromDenoManifest(manifest.manifest);
-  }
-}
 
 // Captures `npm:` payload as: package name (scoped or unscoped), optional version, optional ignored subpath.
 // Examples:
@@ -141,7 +73,11 @@ export function parseImportMapSpecifier(value: string): ImportMapSpecifier | und
   };
 }
 
-function addDependenciesArray(result: Set<Dependency>, dependencies: string[], isGlob = true) {
+export function addDependenciesArray(
+  result: DependenciesList,
+  dependencies: string[],
+  isGlob = true,
+) {
   for (const name of dependencies) {
     addDependency(result, { dependency: name, isGlob });
   }
@@ -154,23 +90,23 @@ type AddDependencyParameters = {
   alias?: string;
 };
 
-function addDependency(
-  result: Set<Dependency>,
+export function addDependency(
+  result: DependenciesList,
   { dependency, isGlob, version, alias }: AddDependencyParameters,
 ) {
   if (isGlob) {
-    result.add({
-      name: new Minimatch(dependency, { nocase: true, matchBase: true }),
-      version,
-      alias,
-    });
+    result.set(new Minimatch(dependency, { nocase: true, matchBase: true }), version);
   } else {
-    result.add({
-      name: dependency.startsWith(DefinitelyTyped)
+    result.set(
+      dependency.startsWith(DefinitelyTyped)
         ? dependency.substring(DefinitelyTyped.length)
         : dependency,
       version,
-      alias,
-    });
+    );
+  }
+  if (alias) {
+    // TODO: REVIEW ALIAS ACCESS IN RULES
+    // Also add the alias as a dependency, so it can be resolved in rules, for instance S4328
+    result.set(alias, version);
   }
 }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parse.ts
@@ -40,39 +40,6 @@ export function addDependencies(
   }
 }
 
-type ImportMapSpecifier = {
-  packageName: string;
-  version?: string;
-};
-
-// Captures `npm:` payload as: package name (scoped or unscoped), optional version, optional ignored subpath.
-// Examples:
-// npm:cowsay@^1.6.0
-// npm:@scopename/mypackage@~11.1.0
-const DENO_NPM_IMPORT_PATTERN = /^(@[^/]*\/[^/@]*|[^/@]+)(?:@([^/]*))?(?:\/.*)?$/;
-
-/**
- * Parses an import map URL Specifier matching Deno npm format:
- * npm:<package>[@<version>][/<path>]
- */
-export function parseImportMapSpecifier(value: string): ImportMapSpecifier | undefined {
-  // currently only handle npm: specifiers since rules are focused on NPM dependencies
-  if (!value.startsWith('npm:')) {
-    return undefined;
-  }
-
-  const match = DENO_NPM_IMPORT_PATTERN.exec(value.slice('npm:'.length));
-  if (!match) {
-    return undefined;
-  }
-
-  const [, packageName, version] = match;
-  return {
-    packageName,
-    version: version || undefined,
-  };
-}
-
 export function addDependenciesArray(
   result: DependenciesList,
   dependencies: string[],

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
@@ -15,10 +15,16 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import ts from 'typescript';
-import { type ManifestResolver, type DependencyManifest, type DenoManifest } from './types.js';
+import {
+  type ManifestResolver,
+  type DependencyManifest,
+  type DenoManifest,
+  DependenciesList,
+} from './types.js';
 import { type File, stripBOM } from '../../files.js';
 import { DENO_JSON, DENO_JSONC } from '../index.js';
 import { getManifestFileInDir } from './helpers.js';
+import { addDependenciesArray, addDependency, parseImportMapSpecifier } from '../parse.js';
 
 export const denoManifestResolver: ManifestResolver = {
   resolve(dir, topDir, fileSystem): DependencyManifest[] {
@@ -26,13 +32,47 @@ export const denoManifestResolver: ManifestResolver = {
     const denoJson = getManifestFileInDir(DENO_JSON, dir, topDir, fileSystem);
     const denoJsonc = getManifestFileInDir(DENO_JSONC, dir, topDir, fileSystem);
     if (denoJsonc && denoJson === undefined) {
-      return [{ type: 'deno', manifest: parseDenoManifest(denoJsonc) ?? {} }];
+      return [
+        { type: 'deno', getDependencies: wrapGetDependencies(parseDenoManifest(denoJsonc) ?? {}) },
+      ];
     } else if (denoJson) {
-      return [{ type: 'deno', manifest: parseDenoManifest(denoJson) ?? {} }];
+      return [
+        { type: 'deno', getDependencies: wrapGetDependencies(parseDenoManifest(denoJson) ?? {}) },
+      ];
     }
     return [];
   },
 };
+
+function wrapGetDependencies(manifest: DenoManifest): () => DependenciesList {
+  const dependencies: DependenciesList = new Map();
+
+  if (manifest.imports && typeof manifest.imports === 'object') {
+    for (const [alias, target] of Object.entries(manifest.imports)) {
+      if (typeof target !== 'string') {
+        continue;
+      }
+
+      const parsedSpecifier = parseImportMapSpecifier(target);
+      if (parsedSpecifier) {
+        addDependency(dependencies, {
+          dependency: parsedSpecifier.packageName,
+          isGlob: false,
+          version: parsedSpecifier.version,
+          alias,
+        });
+      }
+    }
+  }
+
+  if (Array.isArray(manifest.workspace)) {
+    addDependenciesArray(dependencies, manifest.workspace);
+  } else if (manifest.workspace?.members) {
+    addDependenciesArray(dependencies, manifest.workspace.members);
+  }
+
+  return () => dependencies;
+}
 
 function parseDenoManifest(file: File): DenoManifest | undefined {
   try {

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import ts from 'typescript';
-import {
-  type DenoManifest,
+import type {
+  DenoManifest,
   DependenciesList,
-  type DependencyManifest,
-  type ManifestResolver,
-  type ModuleType,
+  DependencyManifest,
+  ManifestResolver,
+  ModuleType,
 } from './types.js';
 import { type File, stripBOM } from '../../files.js';
 import { DENO_JSON, DENO_JSONC } from '../index.js';
@@ -44,8 +44,8 @@ export const denoManifestResolver: ManifestResolver = {
       return [
         {
           type: 'deno',
-          getDependencies: buildDependencies(parseDenoManifest(effectiveDenoJson) ?? {}),
-          getModuleType: () => denoModuleType,
+          dependencies: buildDependencies(parseDenoManifest(effectiveDenoJson) ?? {}),
+          moduleType: denoModuleType,
         },
       ];
     }
@@ -53,7 +53,7 @@ export const denoManifestResolver: ManifestResolver = {
   },
 };
 
-function buildDependencies(manifest: DenoManifest): () => DependenciesList {
+function buildDependencies(manifest: DenoManifest): DependenciesList {
   const dependencies: DependenciesList = new Map();
 
   if (manifest.imports && typeof manifest.imports === 'object') {
@@ -80,7 +80,7 @@ function buildDependencies(manifest: DenoManifest): () => DependenciesList {
     addDependenciesArray(dependencies, manifest.workspace.members);
   }
 
-  return () => dependencies;
+  return dependencies;
 }
 
 function parseDenoManifest(file: File): DenoManifest | undefined {

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
@@ -38,19 +38,13 @@ export const denoManifestResolver: ManifestResolver = {
     const denoJson = getManifestFileInDir(DENO_JSON, dir, topDir, fileSystem);
     const denoJsonc = getManifestFileInDir(DENO_JSONC, dir, topDir, fileSystem);
     const denoModuleType: ModuleType = 'module';
-    if (denoJsonc && denoJson === undefined) {
+    const effectiveDenoJson = denoJson ?? denoJsonc;
+
+    if (effectiveDenoJson) {
       return [
         {
           type: 'deno',
-          getDependencies: buildDependencies(parseDenoManifest(denoJsonc) ?? {}),
-          getModuleType: () => denoModuleType,
-        },
-      ];
-    } else if (denoJson) {
-      return [
-        {
-          type: 'deno',
-          getDependencies: buildDependencies(parseDenoManifest(denoJson) ?? {}),
+          getDependencies: buildDependencies(parseDenoManifest(effectiveDenoJson) ?? {}),
           getModuleType: () => denoModuleType,
         },
       ];

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
@@ -16,15 +16,20 @@
  */
 import ts from 'typescript';
 import {
-  type ManifestResolver,
-  type DependencyManifest,
   type DenoManifest,
   DependenciesList,
+  type DependencyManifest,
+  type ManifestResolver,
 } from './types.js';
 import { type File, stripBOM } from '../../files.js';
 import { DENO_JSON, DENO_JSONC } from '../index.js';
 import { getManifestFileInDir } from './helpers.js';
-import { addDependenciesArray, addDependency, parseImportMapSpecifier } from '../parse.js';
+import { addDependenciesArray, addDependency } from '../parse.js';
+
+type ImportMapSpecifier = {
+  packageName: string;
+  version?: string;
+};
 
 export const denoManifestResolver: ManifestResolver = {
   resolve(dir, topDir, fileSystem): DependencyManifest[] {
@@ -88,4 +93,32 @@ function parseDenoManifest(file: File): DenoManifest | undefined {
     console.debug(`Error parsing deno manifest ${file.path}: ${error}`);
     return;
   }
+}
+
+// Captures `npm:` payload as: package name (scoped or unscoped), optional version, optional ignored subpath.
+// Examples:
+// npm:cowsay@^1.6.0
+// npm:@scopename/mypackage@~11.1.0
+const DENO_NPM_IMPORT_PATTERN = /^(@[^/]*\/[^/@]*|[^/@]+)(?:@([^/]*))?(?:\/.*)?$/;
+
+/**
+ * Parses an import map URL Specifier matching Deno npm format:
+ * npm:<package>[@<version>][/<path>]
+ */
+export function parseImportMapSpecifier(value: string): ImportMapSpecifier | undefined {
+  // currently only handle npm: specifiers since rules are focused on NPM dependencies
+  if (!value.startsWith('npm:')) {
+    return undefined;
+  }
+
+  const match = DENO_NPM_IMPORT_PATTERN.exec(value.slice('npm:'.length));
+  if (!match) {
+    return undefined;
+  }
+
+  const [, packageName, version] = match;
+  return {
+    packageName,
+    version: version || undefined,
+  };
 }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
@@ -38,18 +38,18 @@ export const denoManifestResolver: ManifestResolver = {
     const denoJsonc = getManifestFileInDir(DENO_JSONC, dir, topDir, fileSystem);
     if (denoJsonc && denoJson === undefined) {
       return [
-        { type: 'deno', getDependencies: wrapGetDependencies(parseDenoManifest(denoJsonc) ?? {}) },
+        { type: 'deno', getDependencies: buildDependencies(parseDenoManifest(denoJsonc) ?? {}) },
       ];
     } else if (denoJson) {
       return [
-        { type: 'deno', getDependencies: wrapGetDependencies(parseDenoManifest(denoJson) ?? {}) },
+        { type: 'deno', getDependencies: buildDependencies(parseDenoManifest(denoJson) ?? {}) },
       ];
     }
     return [];
   },
 };
 
-function wrapGetDependencies(manifest: DenoManifest): () => DependenciesList {
+function buildDependencies(manifest: DenoManifest): () => DependenciesList {
   const dependencies: DependenciesList = new Map();
 
   if (manifest.imports && typeof manifest.imports === 'object') {
@@ -105,7 +105,7 @@ const DENO_NPM_IMPORT_PATTERN = /^(@[^/]*\/[^/@]*|[^/@]+)(?:@([^/]*))?(?:\/.*)?$
  * Parses an import map URL Specifier matching Deno npm format:
  * npm:<package>[@<version>][/<path>]
  */
-export function parseImportMapSpecifier(value: string): ImportMapSpecifier | undefined {
+function parseImportMapSpecifier(value: string): ImportMapSpecifier | undefined {
   // currently only handle npm: specifiers since rules are focused on NPM dependencies
   if (!value.startsWith('npm:')) {
     return undefined;

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
@@ -20,6 +20,7 @@ import {
   DependenciesList,
   type DependencyManifest,
   type ManifestResolver,
+  type ModuleType,
 } from './types.js';
 import { type File, stripBOM } from '../../files.js';
 import { DENO_JSON, DENO_JSONC } from '../index.js';
@@ -36,13 +37,22 @@ export const denoManifestResolver: ManifestResolver = {
     // if both `deno.json` and `deno.jsonc` are present, prefer `deno.json` and ignore `deno.jsonc`
     const denoJson = getManifestFileInDir(DENO_JSON, dir, topDir, fileSystem);
     const denoJsonc = getManifestFileInDir(DENO_JSONC, dir, topDir, fileSystem);
+    const denoModuleType: ModuleType = 'module';
     if (denoJsonc && denoJson === undefined) {
       return [
-        { type: 'deno', getDependencies: buildDependencies(parseDenoManifest(denoJsonc) ?? {}) },
+        {
+          type: 'deno',
+          getDependencies: buildDependencies(parseDenoManifest(denoJsonc) ?? {}),
+          getModuleType: () => denoModuleType,
+        },
       ];
     } else if (denoJson) {
       return [
-        { type: 'deno', getDependencies: buildDependencies(parseDenoManifest(denoJson) ?? {}) },
+        {
+          type: 'deno',
+          getDependencies: buildDependencies(parseDenoManifest(denoJson) ?? {}),
+          getModuleType: () => denoModuleType,
+        },
       ];
     }
     return [];

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
@@ -16,11 +16,13 @@
  */
 import type { PackageJson } from 'type-fest';
 import yaml from 'yaml';
-import { type ManifestResolver, type DependencyManifest } from './types.js';
+import { type ManifestResolver, type DependencyManifest, DependenciesList } from './types.js';
 import { type File, stripBOM } from '../../files.js';
 import { PACKAGE_JSON, PNPM_WORKSPACE_YAML } from '../index.js';
 import { closestPatternCache } from '../../find-up/closest.js';
 import { getManifestFileInDir } from './helpers.js';
+import { Minimatch } from 'minimatch';
+import { addDependencies, addDependenciesArray } from '../parse.js';
 
 type PnpmWorkspace = {
   packages?: string[];
@@ -47,9 +49,46 @@ export const npmManifestResolver: ManifestResolver = {
       manifest = injectWorkspacePackages(manifest, parsedPnpmWorkspace);
       manifest = resolveCatalogReferences(manifest, parsedPnpmWorkspace);
     }
-    return [{ type: 'npm', manifest }];
+    return [{ type: 'npm', getDependencies: wrapGetDependencies(manifest) }];
   },
 };
+
+function wrapGetDependencies(
+  packageJson: PackageJson,
+): () => Map<string | Minimatch, string | undefined> {
+  const result: DependenciesList = new Map();
+  const fieldsToVisit = [
+    'name',
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+    '_moduleAliases',
+    'workspaces',
+  ] as const;
+
+  fieldsToVisit.forEach(field => {
+    if (!packageJson[field]) {
+      return;
+    }
+    if (field === 'name') {
+      addDependencies(result, { [packageJson[field]]: '*' });
+      return;
+    }
+    if (field === 'workspaces') {
+      addDependenciesArray(
+        result,
+        Array.isArray(packageJson[field])
+          ? packageJson[field]
+          : (packageJson[field]?.packages ?? []),
+      );
+      return;
+    }
+    addDependencies(result, packageJson[field] as PackageJson.Dependency);
+  });
+
+  return () => result;
+}
 
 function parsePackageJson(file: File): PackageJson | undefined {
   try {

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
@@ -16,7 +16,12 @@
  */
 import type { PackageJson } from 'type-fest';
 import yaml from 'yaml';
-import { type ManifestResolver, type DependencyManifest, DependenciesList } from './types.js';
+import {
+  type ManifestResolver,
+  type DependencyManifest,
+  type ModuleType,
+  DependenciesList,
+} from './types.js';
 import { type File, stripBOM } from '../../files.js';
 import { PACKAGE_JSON, PNPM_WORKSPACE_YAML } from '../index.js';
 import { closestPatternCache } from '../../find-up/closest.js';
@@ -48,7 +53,14 @@ export const npmManifestResolver: ManifestResolver = {
       manifest = injectWorkspacePackages(manifest, parsedPnpmWorkspace);
       manifest = resolveCatalogReferences(manifest, parsedPnpmWorkspace);
     }
-    return [{ type: 'npm', getDependencies: buildDependencies(manifest) }];
+    const moduleType: ModuleType = manifest.type === 'module' ? 'module' : 'commonjs';
+    return [
+      {
+        type: 'npm',
+        getDependencies: buildDependencies(manifest),
+        getModuleType: () => moduleType,
+      },
+    ];
   },
 };
 

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
@@ -21,7 +21,6 @@ import { type File, stripBOM } from '../../files.js';
 import { PACKAGE_JSON, PNPM_WORKSPACE_YAML } from '../index.js';
 import { closestPatternCache } from '../../find-up/closest.js';
 import { getManifestFileInDir } from './helpers.js';
-import { Minimatch } from 'minimatch';
 import { addDependencies, addDependenciesArray } from '../parse.js';
 
 type PnpmWorkspace = {
@@ -53,10 +52,8 @@ export const npmManifestResolver: ManifestResolver = {
   },
 };
 
-function wrapGetDependencies(
-  packageJson: PackageJson,
-): () => Map<string | Minimatch, string | undefined> {
-  const result: DependenciesList = new Map();
+function wrapGetDependencies(packageJson: PackageJson): () => DependenciesList {
+  const dependencies: DependenciesList = new Map();
   const fieldsToVisit = [
     'name',
     'dependencies',
@@ -72,22 +69,22 @@ function wrapGetDependencies(
       return;
     }
     if (field === 'name') {
-      addDependencies(result, { [packageJson[field]]: '*' });
+      addDependencies(dependencies, { [packageJson[field]]: '*' });
       return;
     }
     if (field === 'workspaces') {
       addDependenciesArray(
-        result,
+        dependencies,
         Array.isArray(packageJson[field])
           ? packageJson[field]
           : (packageJson[field]?.packages ?? []),
       );
       return;
     }
-    addDependencies(result, packageJson[field] as PackageJson.Dependency);
+    addDependencies(dependencies, packageJson[field] as PackageJson.Dependency);
   });
 
-  return () => result;
+  return () => dependencies;
 }
 
 function parsePackageJson(file: File): PackageJson | undefined {

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
@@ -16,10 +16,10 @@
  */
 import type { PackageJson } from 'type-fest';
 import yaml from 'yaml';
-import {
-  type ManifestResolver,
-  type DependencyManifest,
-  type ModuleType,
+import type {
+  ManifestResolver,
+  DependencyManifest,
+  ModuleType,
   DependenciesList,
 } from './types.js';
 import { type File, stripBOM } from '../../files.js';

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
@@ -58,7 +58,7 @@ export const npmManifestResolver: ManifestResolver = {
       {
         type: 'npm',
         dependencies: buildDependencies(manifest),
-        moduleType: moduleType,
+        moduleType,
       },
     ];
   },

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
@@ -48,11 +48,11 @@ export const npmManifestResolver: ManifestResolver = {
       manifest = injectWorkspacePackages(manifest, parsedPnpmWorkspace);
       manifest = resolveCatalogReferences(manifest, parsedPnpmWorkspace);
     }
-    return [{ type: 'npm', getDependencies: wrapGetDependencies(manifest) }];
+    return [{ type: 'npm', getDependencies: buildDependencies(manifest) }];
   },
 };
 
-function wrapGetDependencies(packageJson: PackageJson): () => DependenciesList {
+function buildDependencies(packageJson: PackageJson): () => DependenciesList {
   const dependencies: DependenciesList = new Map();
   const fieldsToVisit = [
     'name',
@@ -64,13 +64,13 @@ function wrapGetDependencies(packageJson: PackageJson): () => DependenciesList {
     'workspaces',
   ] as const;
 
-  fieldsToVisit.forEach(field => {
+  for (const field of fieldsToVisit) {
     if (!packageJson[field]) {
-      return;
+      continue;
     }
     if (field === 'name') {
       addDependencies(dependencies, { [packageJson[field]]: '*' });
-      return;
+      continue;
     }
     if (field === 'workspaces') {
       addDependenciesArray(
@@ -79,10 +79,10 @@ function wrapGetDependencies(packageJson: PackageJson): () => DependenciesList {
           ? packageJson[field]
           : (packageJson[field]?.packages ?? []),
       );
-      return;
+      continue;
     }
     addDependencies(dependencies, packageJson[field] as PackageJson.Dependency);
-  });
+  }
 
   return () => dependencies;
 }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm.ts
@@ -57,14 +57,14 @@ export const npmManifestResolver: ManifestResolver = {
     return [
       {
         type: 'npm',
-        getDependencies: buildDependencies(manifest),
-        getModuleType: () => moduleType,
+        dependencies: buildDependencies(manifest),
+        moduleType: moduleType,
       },
     ];
   },
 };
 
-function buildDependencies(packageJson: PackageJson): () => DependenciesList {
+function buildDependencies(packageJson: PackageJson): DependenciesList {
   const dependencies: DependenciesList = new Map();
   const fieldsToVisit = [
     'name',
@@ -96,7 +96,7 @@ function buildDependencies(packageJson: PackageJson): () => DependenciesList {
     addDependencies(dependencies, packageJson[field] as PackageJson.Dependency);
   }
 
-  return () => dependencies;
+  return dependencies;
 }
 
 function parsePackageJson(file: File): PackageJson | undefined {

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
@@ -14,21 +14,24 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import type { PackageJson } from 'type-fest';
+import { Minimatch } from 'minimatch';
 import type { NormalizedAbsolutePath } from '../../files.js';
 import type { Filesystem } from '../../find-up/find-minimatch.js';
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
 type ImportMap = Record<string, unknown>;
 
+export type DependenciesList = Map<string | Minimatch, string | undefined>;
+
 export type DenoManifest = {
   imports?: ImportMap;
   workspace?: string[] | { members?: string[] };
 };
 
-export type DependencyManifest =
-  | { type: 'npm'; manifest: PackageJson }
-  | { type: 'deno'; manifest: DenoManifest };
+export interface DependencyManifest {
+  readonly type: 'npm' | 'deno';
+  getDependencies: () => Map<string | Minimatch, string | undefined>;
+}
 
 /**
  * Strategy interface for resolving dependency manifests of a specific type from a single

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
@@ -23,6 +23,8 @@ type ImportMap = Record<string, unknown>;
 
 export type DependenciesList = Map<string | Minimatch, string | undefined>;
 
+export type ModuleType = 'module' | 'commonjs';
+
 export type DenoManifest = {
   imports?: ImportMap;
   workspace?: string[] | { members?: string[] };
@@ -31,6 +33,7 @@ export type DenoManifest = {
 export interface DependencyManifest {
   readonly type: 'npm' | 'deno';
   getDependencies: () => DependenciesList;
+  getModuleType: () => ModuleType | undefined;
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
@@ -25,6 +25,8 @@ export type DependenciesList = Map<string | Minimatch, string | undefined>;
 
 export type ModuleType = 'module' | 'commonjs';
 
+export const DEFINITELY_TYPED = '@types/';
+
 export type DenoManifest = {
   imports?: ImportMap;
   workspace?: string[] | { members?: string[] };

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
@@ -34,8 +34,8 @@ export type DenoManifest = {
 
 export interface DependencyManifest {
   readonly type: 'npm' | 'deno';
-  getDependencies: () => DependenciesList;
-  getModuleType: () => ModuleType | undefined;
+  readonly dependencies: DependenciesList;
+  readonly moduleType: ModuleType | undefined;
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/types.ts
@@ -30,7 +30,7 @@ export type DenoManifest = {
 
 export interface DependencyManifest {
   readonly type: 'npm' | 'deno';
-  getDependencies: () => Map<string | Minimatch, string | undefined>;
+  getDependencies: () => DependenciesList;
 }
 
 /**

--- a/packages/analysis/src/telemetry.ts
+++ b/packages/analysis/src/telemetry.ts
@@ -17,7 +17,7 @@
 import { minVersion } from 'semver';
 import ts from 'typescript';
 import { getTypeScriptSignalsFromPackageJsonFiles } from './jsts/rules/helpers/dependency-manifests/dependencies.js';
-import type { ModuleType } from './jsts/rules/helpers/dependency-manifests/dependencies.js';
+import type { ModuleType } from './jsts/rules/helpers/dependency-manifests/resolvers/types.js';
 import { dependencyManifestStore } from './file-stores/index.js';
 
 const NOT_DETECTED = 'not-detected';

--- a/packages/analysis/tests/dependency-manifests.test.ts
+++ b/packages/analysis/tests/dependency-manifests.test.ts
@@ -128,7 +128,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].getDependencies()).toEqual(
+    expect(manifests[0].dependencies).toEqual(
       new Map([
         ['react', '^19.1.1'],
         ['react-dom', '^19.1.1'],
@@ -151,7 +151,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(currentDirectory, topDirectory);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm', 'npm']);
-    expect(manifests[0].getDependencies()).toEqual(
+    expect(manifests[0].dependencies).toEqual(
       new Map([
         ['react', '^19.1.1'],
         ['react-dom', '^19.1.1'],
@@ -167,7 +167,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].getDependencies()).toEqual(
+    expect(manifests[0].dependencies).toEqual(
       new Map<string | Minimatch, string | undefined>([
         ['react', '^19.0.0'],
         ['root', '*'],
@@ -184,7 +184,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].getDependencies()).toEqual(
+    expect(manifests[0].dependencies).toEqual(
       new Map<string | Minimatch, string | undefined>([
         ['react', '^19.1.1'],
         [new Minimatch('packages/*', { nocase: true, matchBase: true }), undefined],
@@ -201,7 +201,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].getDependencies()).toEqual(
+    expect(manifests[0].dependencies).toEqual(
       new Map([[new Minimatch('existing/*', { nocase: true, matchBase: true }), undefined]]),
     );
   });
@@ -217,7 +217,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].getDependencies()).toEqual(new Map([['react', 'catalog:']]));
+    expect(manifests[0].dependencies).toEqual(new Map([['react', 'catalog:']]));
     expect(consoleLogMock.calls[0].arguments[0]).toEqual(
       'Dependency "react" could not be resolved for catalog "default"',
     );
@@ -248,7 +248,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['deno']);
-    expect(manifests[0].getDependencies()).toEqual(
+    expect(manifests[0].dependencies).toEqual(
       new Map([
         ['reactAlias', '^19.1.0'],
         ['react', '^19.1.0'],
@@ -277,7 +277,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['deno', 'npm']);
-    expect(manifests[0].getDependencies()).toEqual(
+    expect(manifests[0].dependencies).toEqual(
       new Map([
         ['deno-only', '1.2.3'],
         ['react', '^19.0.0'],

--- a/packages/analysis/tests/dependency-manifests.test.ts
+++ b/packages/analysis/tests/dependency-manifests.test.ts
@@ -36,6 +36,7 @@ import {
   PACKAGE_JSON,
 } from '../src/jsts/rules/helpers/dependency-manifests/index.js';
 import { patternInParentsCache } from '../src/jsts/rules/helpers/find-up/all-in-parent-dirs.js';
+import { Minimatch } from 'minimatch';
 
 const closestPackageJsonCache = closestPatternCache.get(PACKAGE_JSON);
 const packageJsonsInParentsCache = patternInParentsCache.get(PACKAGE_JSON);
@@ -100,11 +101,21 @@ describe('files', () => {
     const subDir = normalizeToAbsolutePath(join(baseDir, 'src'));
     const nestedSubDir = normalizeToAbsolutePath(join(subDir, 'nested'));
 
-    expect(getDependencies(subDir, baseDir)).toEqual(new Set(['test-module', 'pkg1', 'pkg2']));
+    expect(getDependencies(subDir, baseDir)).toEqual(
+      new Map([
+        ['test-module', '*'],
+        ['pkg1', '1.0.7'],
+        ['pkg2', '2.0.0'],
+      ]),
+    );
     expect(dependenciesCache.size).toEqual(1);
 
     expect(getDependencies(nestedSubDir, baseDir)).toEqual(
-      new Set(['test-module', 'pkg1', 'pkg2']),
+      new Map([
+        ['test-module', '*'],
+        ['pkg1', '1.0.7'],
+        ['pkg2', '2.0.0'],
+      ]),
     );
     expect(dependenciesCache.size).toEqual(1);
     expect(dependenciesCache.has(baseDir)).toEqual(true);
@@ -117,19 +128,15 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].manifest).toMatchObject({
-      dependencies: {
-        react: '^19.1.1',
-        'react-dom': '^19.1.1',
-        vue: '^3.5.0',
-      },
-      peerDependencies: {
-        typescript: '^5.8.0',
-      },
-      optionalDependencies: {
-        rollup: '^4.40.0',
-      },
-    });
+    expect(manifests[0].getDependencies()).toEqual(
+      new Map([
+        ['react', '^19.1.1'],
+        ['react-dom', '^19.1.1'],
+        ['vue', '^3.5.0'],
+        ['typescript', '^5.8.0'],
+        ['rollup', '^4.40.0'],
+      ]),
+    );
   });
 
   it('should resolve pnpm catalog references from pnpm-workspace.yaml for lower-level-directory package.json', async () => {
@@ -144,15 +151,13 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(currentDirectory, topDirectory);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm', 'npm']);
-    expect(manifests[0].manifest).toMatchObject({
-      dependencies: {
-        react: '^19.1.1',
-        'react-dom': '^19.1.1',
-      },
-      devDependencies: {
-        vue: '^3.5.0',
-      },
-    });
+    expect(manifests[0].getDependencies()).toEqual(
+      new Map([
+        ['react', '^19.1.1'],
+        ['react-dom', '^19.1.1'],
+        ['vue', '^3.5.0'],
+      ]),
+    );
   });
 
   it('should inject pnpm workspace packages into manifest workspaces', async () => {
@@ -162,10 +167,14 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].manifest).toMatchObject({
-      workspaces: ['packages/*', 'apps/*'],
-      dependencies: { react: '^19.0.0' },
-    });
+    expect(manifests[0].getDependencies()).toEqual(
+      new Map<string | Minimatch, string | undefined>([
+        ['react', '^19.0.0'],
+        ['root', '*'],
+        [new Minimatch('packages/*', { nocase: true, matchBase: true }), undefined],
+        [new Minimatch('apps/*', { nocase: true, matchBase: true }), undefined],
+      ]),
+    );
   });
 
   it('should inject workspace packages alongside catalog reference resolution', async () => {
@@ -175,23 +184,12 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].manifest).toMatchObject({
-      workspaces: ['packages/*'],
-      dependencies: { react: '^19.1.1' },
-    });
-  });
-
-  it('should not set workspaces when pnpm-workspace.yaml has no packages field', async () => {
-    const baseDir = normalizeToAbsolutePath(join(fixtures, 'pnpm-workspace-catalog'));
-    const configuration = createConfiguration({ baseDir });
-    await initFileStores(configuration);
-
-    const manifests = getDependencyManifests(baseDir, baseDir);
-    const [manifest] = manifests;
-    expect(manifest.type).toEqual('npm');
-    if (manifest.type === 'npm') {
-      expect(manifest.manifest.workspaces).toBeUndefined();
-    }
+    expect(manifests[0].getDependencies()).toEqual(
+      new Map<string | Minimatch, string | undefined>([
+        ['react', '^19.1.1'],
+        [new Minimatch('packages/*', { nocase: true, matchBase: true }), undefined],
+      ]),
+    );
   });
 
   it('should not overwrite existing workspaces when pnpm-workspace.yaml also defines packages', async () => {
@@ -203,13 +201,9 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].manifest).toMatchObject({
-      workspaces: ['existing/*'],
-    });
-    const [manifest] = manifests;
-    if (manifest.type === 'npm') {
-      expect(manifest.manifest.workspaces).not.toContain('new-packages/*');
-    }
+    expect(manifests[0].getDependencies()).toEqual(
+      new Map([[new Minimatch('existing/*', { nocase: true, matchBase: true }), undefined]]),
+    );
   });
 
   it('should not resolve the dependency when pnpm catalog references are not found', async ({
@@ -223,11 +217,7 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['npm']);
-    expect(manifests[0].manifest).toMatchObject({
-      dependencies: {
-        react: 'catalog:',
-      },
-    });
+    expect(manifests[0].getDependencies()).toEqual(new Map([['react', 'catalog:']]));
     expect(consoleLogMock.calls[0].arguments[0]).toEqual(
       'Dependency "react" could not be resolved for catalog "default"',
     );
@@ -242,7 +232,13 @@ describe('files', () => {
     expect(closestDenoJsonCache.has(baseDir)).toEqual(true);
     expect(denoJsoncsInParentsCache.has(baseDir)).toEqual(true);
     expect(closestDenoJsoncCache.has(baseDir)).toEqual(true);
-    expect(getDependencies(baseDir, baseDir)).toEqual(new Set(['react', '@scope/pkg', 'pkgAlias']));
+    expect(getDependencies(baseDir, baseDir)).toEqual(
+      new Map([
+        ['react', '^19.1.0'],
+        ['@scope/pkg', '~2.0.0'],
+        ['pkgAlias', '~2.0.0'],
+      ]),
+    );
   });
 
   it('should parse deno.jsonc with comments and trailing commas', async () => {
@@ -252,11 +248,12 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['deno']);
-    expect(manifests[0].manifest).toMatchObject({
-      imports: {
-        reactAlias: 'npm:react@^19.1.0',
-      },
-    });
+    expect(manifests[0].getDependencies()).toEqual(
+      new Map([
+        ['reactAlias', '^19.1.0'],
+        ['react', '^19.1.0'],
+      ]),
+    );
   });
 
   it('should include package.json dependencies when deno.json is present in the same directory', async () => {
@@ -265,7 +262,11 @@ describe('files', () => {
     await initFileStores(configuration);
 
     expect(getDependencies(baseDir, baseDir)).toEqual(
-      new Set(['deno-only', 'react', 'package-only']),
+      new Map([
+        ['deno-only', '1.2.3'],
+        ['react', '^19.0.0'],
+        ['package-only', '1.0.0'],
+      ]),
     );
   });
 
@@ -276,12 +277,12 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['deno', 'npm']);
-    expect(manifests[0].manifest).toMatchObject({
-      imports: {
-        'deno-only': 'npm:deno-only@1.2.3',
-        react: 'npm:react@^19.0.0',
-      },
-    });
+    expect(manifests[0].getDependencies()).toEqual(
+      new Map([
+        ['deno-only', '1.2.3'],
+        ['react', '^19.0.0'],
+      ]),
+    );
   });
 
   it('should include react when package.json and deno.json define it at the same level', async () => {
@@ -291,7 +292,12 @@ describe('files', () => {
 
     const manifests = getDependencyManifests(baseDir, baseDir);
     expect(manifests.map(manifest => manifest.type)).toEqual(['deno', 'npm']);
-    expect(getDependencies(baseDir, baseDir)).toEqual(new Set(['react', 'reactAlias']));
+    expect(getDependencies(baseDir, baseDir)).toEqual(
+      new Map([
+        ['react', '^19.1.0'],
+        ['reactAlias', '^19.1.0'],
+      ]),
+    );
   });
 
   it('should log when a dependency is defined in multiple manifests', async ({ mock }) => {
@@ -301,7 +307,12 @@ describe('files', () => {
     const configuration = createConfiguration({ baseDir });
     await initFileStores(configuration);
 
-    expect(getDependencies(baseDir, baseDir)).toEqual(new Set(['react', 'reactAlias']));
+    expect(getDependencies(baseDir, baseDir)).toEqual(
+      new Map([
+        ['react', '^19.1.0'],
+        ['reactAlias', '^19.1.0'],
+      ]),
+    );
     expect(
       consoleLogMock.calls
         .map(call => call.arguments[0])
@@ -325,7 +336,11 @@ describe('files', () => {
     const subDir = normalizeToAbsolutePath(join(baseDir, 'subdir'));
 
     expect(getDependencies(subDir, baseDir)).toEqual(
-      new Set(['child-only', 'shared', 'parent-only']),
+      new Map([
+        ['child-only', '1.0.0'],
+        ['shared', '2.0.0'],
+        ['parent-only', '1.0.0'],
+      ]),
     );
     expect(
       consoleLogMock.calls
@@ -410,7 +425,7 @@ describe('files', () => {
     const configuration = createConfiguration({ baseDir });
     await initFileStores(configuration);
     const filePath = join(baseDir, 'deno.jsonc');
-    expect(getDependencies(baseDir, baseDir)).toEqual(new Set());
+    expect(getDependencies(baseDir, baseDir)).toEqual(new Map());
     expect(
       consoleLogMock.calls
         .map(call => call.arguments[0])

--- a/packages/analysis/tests/jsts/rules/helpers/dependency-manifests.test.ts
+++ b/packages/analysis/tests/jsts/rules/helpers/dependency-manifests.test.ts
@@ -14,55 +14,39 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { describe, it } from 'node:test';
 import path from 'node:path';
-import { stripBOM } from '../../../../src/jsts/rules/helpers/files.js';
-import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
 import { expect } from 'expect';
-import {
-  getDependenciesFromManifest,
-  getDependenciesFromPackageJson,
-  parseImportMapSpecifier,
-} from '../../../../src/jsts/rules/helpers/dependency-manifests/parse.js';
+import { normalizeToAbsolutePath } from '../../../../src/jsts/rules/helpers/files.js';
+import { getDependencyManifests } from '../../../../src/jsts/rules/helpers/dependency-manifests/all-in-parent-dirs.js';
+import { parseImportMapSpecifier } from '../../../../src/jsts/rules/helpers/dependency-manifests/resolvers/deno.js';
 
 describe('package-json', () => {
   it('should handle arrays in package-jsons dependency versions', async () => {
-    const filePath = path.join(import.meta.dirname, 'fixtures', 'package.json');
-    const fileContent = JSON.parse(stripBOM(await readFile(filePath, 'utf8')));
-    const dependencies = getDependenciesFromPackageJson(fileContent);
-    expect(dependencies).toEqual(
-      new Set([
-        {
-          name: 'foo',
-          version: 'file:bar',
-        },
-      ]),
-    );
+    const currentDirectory = normalizeToAbsolutePath(path.join(import.meta.dirname, 'fixtures'));
+    const manifests = getDependencyManifests(currentDirectory, currentDirectory);
+    const npmManifest = manifests.find(({ type }) => type === 'npm');
+    expect(npmManifest?.type).toBe('npm');
+    expect(npmManifest?.getDependencies()).toEqual(new Map([['foo', 'file:bar']]));
   });
 
   it('should extract npm package dependencies from deno.json imports', () => {
-    const dependencies = getDependenciesFromManifest({
-      type: 'deno',
-      manifest: {
-        imports: {
-          reactAlias: 'npm:react@^19.1.0',
-          utils: 'jsr:@std/assert@^1.0.0',
-          lodashFp: 'npm:lodash@^4.17.21/fp',
-          remote: 'https://deno.land/x/case/mod.ts',
-          scopedAlias: 'npm:@scope/package@~2.0.0',
-          noVersion: 'npm:chalk',
-          invalidVersion: 'npm:koa@not-a-semver',
-        },
-      },
-    });
-
-    expect(dependencies).toEqual(
-      new Set([
-        { name: 'react', version: '^19.1.0', alias: 'reactAlias' },
-        { name: 'lodash', version: '^4.17.21', alias: 'lodashFp' },
-        { name: '@scope/package', version: '~2.0.0', alias: 'scopedAlias' },
-        { name: 'chalk', version: undefined, alias: 'noVersion' },
-        { name: 'koa', version: 'not-a-semver', alias: 'invalidVersion' },
+    const currentDirectory = normalizeToAbsolutePath(path.join(import.meta.dirname, 'fixtures'));
+    const manifests = getDependencyManifests(currentDirectory, currentDirectory);
+    const denoManifest = manifests.find(({ type }) => type === 'deno');
+    expect(denoManifest?.type).toBe('deno');
+    expect(denoManifest?.getDependencies()).toEqual(
+      new Map([
+        ['react', '^19.1.0'],
+        ['reactAlias', '^19.1.0'],
+        ['lodash', '^4.17.21'],
+        ['lodashFp', '^4.17.21'],
+        ['@scope/package', '~2.0.0'],
+        ['scopedAlias', '~2.0.0'],
+        ['chalk', undefined],
+        ['noVersion', undefined],
+        ['koa', 'not-a-semver'],
+        ['invalidVersion', 'not-a-semver'],
       ]),
     );
   });
@@ -123,7 +107,6 @@ describe('parseImportMapSpecifier', () => {
       version: undefined,
     });
   });
-
   it('should return package without version when version is empty before path', () => {
     expect(parseImportMapSpecifier('npm:react@/jsx-runtime')).toEqual({
       packageName: 'react',

--- a/packages/analysis/tests/jsts/rules/helpers/dependency-manifests.test.ts
+++ b/packages/analysis/tests/jsts/rules/helpers/dependency-manifests.test.ts
@@ -19,7 +19,6 @@ import { describe, it } from 'node:test';
 import { expect } from 'expect';
 import { normalizeToAbsolutePath } from '../../../../src/jsts/rules/helpers/files.js';
 import { getDependencyManifests } from '../../../../src/jsts/rules/helpers/dependency-manifests/all-in-parent-dirs.js';
-import { parseImportMapSpecifier } from '../../../../src/jsts/rules/helpers/dependency-manifests/resolvers/deno.js';
 
 describe('package-json', () => {
   it('should handle arrays in package-jsons dependency versions', async () => {
@@ -47,70 +46,14 @@ describe('package-json', () => {
         ['noVersion', undefined],
         ['koa', 'not-a-semver'],
         ['invalidVersion', 'not-a-semver'],
+        ['@scope/subpkg', '1.0.0'],
+        ['scopedSubpathAlias', '1.0.0'],
+        ['@scope/noversion', undefined],
+        ['scopedNoVersionAlias', undefined],
+        ['cowsay', undefined],
+        ['emptyVersionAlias', undefined],
+        // 'invalidScoped' ("npm:@scope") is filtered out — not added to the map
       ]),
     );
-  });
-});
-
-describe('parseImportMapSpecifier', () => {
-  it('should parse unscoped package without version', () => {
-    expect(parseImportMapSpecifier('npm:chalk')).toEqual({
-      packageName: 'chalk',
-      version: undefined,
-    });
-  });
-
-  it('should parse unscoped package with version and subpath', () => {
-    expect(parseImportMapSpecifier('npm:lodash@^4.17.21/fp')).toEqual({
-      packageName: 'lodash',
-      version: '^4.17.21',
-    });
-  });
-
-  it('should parse scoped package with version and subpath', () => {
-    expect(parseImportMapSpecifier('npm:@scope/package@~2.0.0/feature')).toEqual({
-      packageName: '@scope/package',
-      version: '~2.0.0',
-    });
-  });
-
-  it('should parse scoped package with subpath and no version', () => {
-    expect(parseImportMapSpecifier('npm:@scope/package/utils')).toEqual({
-      packageName: '@scope/package',
-      version: undefined,
-    });
-  });
-
-  it('should return undefined for missing scheme separator', () => {
-    expect(parseImportMapSpecifier('react@19')).toBeUndefined();
-  });
-
-  it('should return undefined for empty specifier', () => {
-    expect(parseImportMapSpecifier('npm:')).toBeUndefined();
-  });
-
-  it('should return undefined for non-npm package specifiers', () => {
-    expect(parseImportMapSpecifier('jsr:@std/assert@^1.0.0')).toBeUndefined();
-  });
-
-  it('should return undefined for URL targets', () => {
-    expect(parseImportMapSpecifier('https://deno.land/x/case/mod.ts')).toBeUndefined();
-  });
-
-  it('should return undefined for invalid scoped package format', () => {
-    expect(parseImportMapSpecifier('npm:@scope')).toBeUndefined();
-  });
-
-  it('should return package without version when version is empty', () => {
-    expect(parseImportMapSpecifier('npm:react@')).toEqual({
-      packageName: 'react',
-      version: undefined,
-    });
-  });
-  it('should return package without version when version is empty before path', () => {
-    expect(parseImportMapSpecifier('npm:react@/jsx-runtime')).toEqual({
-      packageName: 'react',
-      version: undefined,
-    });
   });
 });

--- a/packages/analysis/tests/jsts/rules/helpers/dependency-manifests.test.ts
+++ b/packages/analysis/tests/jsts/rules/helpers/dependency-manifests.test.ts
@@ -26,7 +26,7 @@ describe('package-json', () => {
     const manifests = getDependencyManifests(currentDirectory, currentDirectory);
     const npmManifest = manifests.find(({ type }) => type === 'npm');
     expect(npmManifest?.type).toBe('npm');
-    expect(npmManifest?.getDependencies()).toEqual(new Map([['foo', 'file:bar']]));
+    expect(npmManifest?.dependencies).toEqual(new Map([['foo', 'file:bar']]));
   });
 
   it('should extract npm package dependencies from deno.json imports', () => {
@@ -34,7 +34,7 @@ describe('package-json', () => {
     const manifests = getDependencyManifests(currentDirectory, currentDirectory);
     const denoManifest = manifests.find(({ type }) => type === 'deno');
     expect(denoManifest?.type).toBe('deno');
-    expect(denoManifest?.getDependencies()).toEqual(
+    expect(denoManifest?.dependencies).toEqual(
       new Map([
         ['react', '^19.1.0'],
         ['reactAlias', '^19.1.0'],

--- a/packages/analysis/tests/jsts/rules/helpers/fixtures/deno.json
+++ b/packages/analysis/tests/jsts/rules/helpers/fixtures/deno.json
@@ -6,6 +6,10 @@
     "remote": "https://deno.land/x/case/mod.ts",
     "scopedAlias": "npm:@scope/package@~2.0.0",
     "noVersion": "npm:chalk",
-    "invalidVersion": "npm:koa@not-a-semver"
+    "invalidVersion": "npm:koa@not-a-semver",
+    "scopedSubpathAlias": "npm:@scope/subpkg@1.0.0/utils",
+    "scopedNoVersionAlias": "npm:@scope/noversion/feature",
+    "emptyVersionAlias": "npm:cowsay@",
+    "invalidScoped": "npm:@scope"
   }
 }

--- a/packages/analysis/tests/jsts/rules/helpers/fixtures/deno.json
+++ b/packages/analysis/tests/jsts/rules/helpers/fixtures/deno.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "reactAlias": "npm:react@^19.1.0",
+    "utils": "jsr:@std/assert@^1.0.0",
+    "lodashFp": "npm:lodash@^4.17.21/fp",
+    "remote": "https://deno.land/x/case/mod.ts",
+    "scopedAlias": "npm:@scope/package@~2.0.0",
+    "noVersion": "npm:chalk",
+    "invalidVersion": "npm:koa@not-a-semver"
+  }
+}


### PR DESCRIPTION
Part of the context awareness epic. Relates to Jira task 1688.
