### PR TITLE
JS-1704 Update the Node test harness to match the Java harness

### DIFF
--- a/its/ruling/src/test/expected/vitest/typescript-S5914.json
+++ b/its/ruling/src/test/expected/vitest/typescript-S5914.json
@@ -44,12 +44,6 @@
 "vitest:test/cli/fixtures/custom-pool/tests/custom-run.threads.spec.ts": [
 4
 ],
-"vitest:test/cli/fixtures/dotted-files/.cache/projects/test/should-run.test.ts": [
-4
-],
-"vitest:test/cli/fixtures/fails/.dot-folder/dot-test.test.ts": [
-4
-],
 "vitest:test/cli/fixtures/fails/hook-timeout.test.ts": [
 8
 ],

--- a/packages/ruling/testProject.ts
+++ b/packages/ruling/testProject.ts
@@ -71,6 +71,7 @@ export async function testProject(projectName: string) {
   const actualPath = join(actualBase, name);
 
   const baseDir = normalizeToAbsolutePath(join(sourcesPath, folder ?? join('projects', name)));
+  const defaultTestExclusions = testDir ? DEFAULT_EXCLUSIONS : undefined;
 
   const configuration = createConfiguration({
     baseDir,
@@ -78,6 +79,7 @@ export async function testProject(projectName: string) {
     canAccessFileSystem: true,
     skipNodeModuleLookupOutsideBaseDir: true,
     tests: testDir ? [testDir] : undefined,
+    testExclusions: defaultTestExclusions,
     exclusions: exclusions ? DEFAULT_EXCLUSIONS.concat(exclusions.split(',')) : DEFAULT_EXCLUSIONS,
   });
 


### PR DESCRIPTION
## Summary

This fixes the `Ruling Test` failure left on `master` after #6935 merged.

The vitest expected ruling output contained two issues from hidden files under `test/`:

- `test/cli/fixtures/dotted-files/.cache/projects/test/should-run.test.ts`
- `test/cli/fixtures/fails/.dot-folder/dot-test.test.ts`

On the Java/scanner side, those files are not analyzed. On the Node ruling side, they were still analyzed because the default exclusions (`**/.*`, `**/*.d.ts`) were only applied to main files, not to test files. That left the two ruling implementations out of sync and made `Ruling Test` fail on `master`.

This change aligns the Node ruling harness with the Java/scanner behavior by applying the default exclusions to test files as well, then removes the two stale vitest entries from the expected ruling output.

## Why this is needed

- fixes the current `Ruling Test` failure on `master`
- keeps Java and Node ruling behavior consistent for ruling
- avoids keeping incorrect vitest expectations in the repo
- does not change the rule behavior itself; this is a ruling-harness consistency fix
