### PR TITLE
JS-1714 Automatically update rule counts in README.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,23 +333,26 @@ jobs:
       - *npm_cache
       - *download_rspec_rule_data
       - *rspec_secrets
-      - name: Regenerate ESLint README
+      - name: Regenerate README files
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.rspec-secrets.outputs.vault).RSPEC_GITHUB_TOKEN }}
         run: |
           git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
           npm install --no-save builtin-modules@3.3.0
           npm run eslint-plugin:compile
+          npm run count-rules
       - name: Open or update README refresh PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          commit-message: Update eslint-plugin-sonarjs README
-          title: Update eslint-plugin-sonarjs README
-          body: Automated refresh of `packages/analysis/src/jsts/rules/README.md`.
+          commit-message: Update generated README files
+          title: Update generated README files
+          body: Automated refresh of `packages/analysis/src/jsts/rules/README.md` and rule counts in `README.md`.
           branch: bot/update-eslint-rules-readme
           base: master
-          add-paths: packages/analysis/src/jsts/rules/README.md
+          add-paths: |
+            README.md
+            packages/analysis/src/jsts/rules/README.md
           delete-branch: true
 
   test_eslint_plugin:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,7 +312,7 @@ jobs:
     runs-on: github-ubuntu-latest-s
     needs: [setup, populate_npm_cache, sync_rspec]
     name: ESLint README Freshness
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,7 +312,7 @@ jobs:
     runs-on: github-ubuntu-latest-s
     needs: [setup, populate_npm_cache, sync_rspec]
     name: ESLint README Freshness
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule'
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Part of [JS-1714](https://sonarsource.atlassian.net/browse/JS-1714)
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

This updates the nightly README refresh job so it also runs `npm run count-rules` after regenerating the ESLint plugin docs. As a result, the automated PR now updates both `packages/analysis/src/jsts/rules/README.md` and the rule counts in the main `README.md`, keeping the top-level features section in sync when new rules are added.

[JS-1714]: https://sonarsource.atlassian.net/browse/JS-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ