### PR TITLE
JS-1718 Fix GitHub Actions deprecation warnings

### DIFF
--- a/.github/workflows/LabelEslintPlugin.yml
+++ b/.github/workflows/LabelEslintPlugin.yml
@@ -6,10 +6,13 @@ on:
     paths:
       - 'packages/analysis/src/jsts/rules/**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   add_eslint_plugin_label:
     name: Add eslint-plugin label to Jira
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     types: [closed]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
       pull-requests: read
@@ -23,6 +26,6 @@ jobs:
             development/kv/data/jira token | JIRA_TOKEN;
       - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -26,6 +26,6 @@ jobs:
             development/kv/data/jira token | JIRA_TOKEN;
       - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     types: ["opened"]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     types: ["review_requested"]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: sonar-xs
     permissions:
       id-token: write
-      pull-requests: read
     # For external PR, ticket should be moved manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
@@ -24,10 +23,11 @@ jobs:
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
       - uses: sonarsource/gh-action-lt-backlog/SubmitReview@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -4,12 +4,16 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
+      pull-requests: read
     # For external PR, ticket should be moved manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
@@ -20,11 +24,10 @@ jobs:
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
-            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
       - uses: sonarsource/gh-action-lt-backlog/SubmitReview@v2
         with:
-          github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,16 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Nightly for analysis, IRIS, and ESLint README freshness
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   setup:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Setup - Prepare Node.js versions and test hashes
     permissions: &read_permissions
       id-token: write
@@ -73,7 +76,7 @@ jobs:
           echo "Cache month: $MONTH"
 
   get_build_number:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Get build number
     needs: setup
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -85,7 +88,7 @@ jobs:
         uses: SonarSource/ci-github-actions/get-build-number@master
 
   populate_npm_cache:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Populate NPM cache for Linux
     needs: setup
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -138,7 +141,7 @@ jobs:
     steps: *populate_npm_cache_steps
 
   sync_rspec:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: Sync RSPEC metadata
     needs: [setup, populate_npm_cache]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -185,7 +188,7 @@ jobs:
           retention-days: 1
 
   build:
-    runs-on: sonar-l-public
+    runs-on: sonar-l
     name: Build SonarJS on Linux
     needs: [setup, get_build_number, populate_npm_cache, sync_rspec]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -333,26 +336,23 @@ jobs:
       - *npm_cache
       - *download_rspec_rule_data
       - *rspec_secrets
-      - name: Regenerate README files
+      - name: Regenerate ESLint README
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.rspec-secrets.outputs.vault).RSPEC_GITHUB_TOKEN }}
         run: |
           git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
           npm install --no-save builtin-modules@3.3.0
           npm run eslint-plugin:compile
-          npm run count-rules
       - name: Open or update README refresh PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          commit-message: Update generated README files
-          title: Update generated README files
-          body: Automated refresh of `packages/analysis/src/jsts/rules/README.md` and rule counts in `README.md`.
+          commit-message: Update eslint-plugin-sonarjs README
+          title: Update eslint-plugin-sonarjs README
+          body: Automated refresh of `packages/analysis/src/jsts/rules/README.md`.
           branch: bot/update-eslint-rules-readme
           base: master
-          add-paths: |
-            README.md
-            packages/analysis/src/jsts/rules/README.md
+          add-paths: packages/analysis/src/jsts/rules/README.md
           delete-branch: true
 
   test_eslint_plugin:
@@ -390,7 +390,7 @@ jobs:
           npm run test
 
   knip:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Knip
     needs: [setup, populate_npm_cache, sync_rspec]
     permissions: *read_permissions
@@ -408,7 +408,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.rspec-secrets.outputs.vault).RSPEC_GITHUB_TOKEN }}
 
   test_js:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: Unit tests JavaScript/TypeScript
     needs: [setup, populate_npm_cache, sync_rspec]
     permissions: *read_permissions
@@ -514,7 +514,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.rspec-secrets.outputs.vault || '{}').RSPEC_GITHUB_TOKEN }}
 
   analyze_primary:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: Analyze in SonarQube NEXT
     needs: [setup, test_js, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -578,7 +578,7 @@ jobs:
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.1.0.4751:sonar $SONAR_ARGS
 
   analyze_shadows:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: Analyze in ${{ matrix.platform }}
     needs: [setup, test_js, build]
     permissions: *read_permissions
@@ -630,7 +630,7 @@ jobs:
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.1.0.4751:sonar $SONAR_ARGS
 
   plugin_qa_with_node:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: QA with Node ${{ matrix.node-version }} on Ubuntu
     needs: [setup, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -675,7 +675,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_fast_with_node:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: Fast QA with Node ${{ matrix.node-version }} on Ubuntu
     needs: [setup, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -701,7 +701,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_without_node:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: QA without Node on Ubuntu SQ:LATEST_RELEASE
     needs: [setup, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -748,7 +748,7 @@ jobs:
 
   # DEV tests run only on nightly schedule to avoid constant downloads
   plugin_qa_without_node_dev:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: QA without Node on Ubuntu SQ:DEV
     needs: [setup, build]
     if: github.event_name == 'schedule'
@@ -829,7 +829,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_fast_without_node:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: Fast QA without Node on Ubuntu SQ:LATEST_RELEASE
     needs: [setup, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -856,7 +856,7 @@ jobs:
 
   # DEV tests run only on nightly schedule to avoid constant downloads
   plugin_qa_fast_without_node_dev:
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: Fast QA without Node on Ubuntu SQ:DEV
     needs: [setup, build]
     if: github.event_name == 'schedule'
@@ -1012,7 +1012,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   js_ts_ruling:
-    runs-on: sonar-xl-public
+    runs-on: sonar-xl
     name: JS/TS Ruling
     needs: [setup, populate_npm_cache, sync_rspec]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -1231,7 +1231,7 @@ jobs:
           fi
 
   ruling:
-    runs-on: sonar-xl-public
+    runs-on: sonar-xl
     name: Ruling Test
     needs: [setup, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -1249,9 +1249,7 @@ jobs:
       - name: Run Ruling Tests
         run: |
           cd its/ruling
-          # Cap ruling parallelism explicitly: using all CPUs on sonar-xl-public can
-          # overwhelm the shared SonarQube/Node workload and make the runner drop.
-          mvn test -Dtest=RulingTest -DskipTests=false -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -Djunit.jupiter.execution.parallel.config.strategy=fixed -Djunit.jupiter.execution.parallel.config.fixed.parallelism=8 -B -e -V
+          mvn test -Dtest=RulingTest -DskipTests=false -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -Djunit.jupiter.execution.parallel.config.dynamic.factor=1 -B -e -V
         env:
           SONARSOURCE_QA: true
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
@@ -1264,7 +1262,7 @@ jobs:
 
   # IRIS tasks (nightly only)
   run_iris:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: IRIS SQ NEXT -> ${{ matrix.shadow-name }}
     needs: [analyze_primary, analyze_shadows]
     if: github.event_name == 'schedule'
@@ -1287,7 +1285,7 @@ jobs:
           shadow1_platform: ${{ matrix.shadow-platform }}
 
   promote:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     needs:
       - build
       - build_win
@@ -1318,20 +1316,20 @@ jobs:
           promote-pull-request: true
 
   releasability:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Releasability
     needs:
       - promote
-    if: >-
-      github.ref_name == github.event.repository.default_branch ||
-      startsWith(github.ref_name, 'branch-') ||
-      startsWith(github.ref_name, 'dogfood-')
     permissions:
       id-token: write
       statuses: write
       contents: read
     steps:
       - uses: SonarSource/gh-action_releasability/releasability-status@v3
+        if: >-
+          github.ref_name == github.event.repository.default_branch ||
+          startsWith(github.ref_name, 'branch-') ||
+          startsWith(github.ref_name, 'dogfood-')
         with:
           optional_checks: "Jira"
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,23 +336,26 @@ jobs:
       - *npm_cache
       - *download_rspec_rule_data
       - *rspec_secrets
-      - name: Regenerate ESLint README
+      - name: Regenerate README files
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.rspec-secrets.outputs.vault).RSPEC_GITHUB_TOKEN }}
         run: |
           git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
           npm install --no-save builtin-modules@3.3.0
           npm run eslint-plugin:compile
+          npm run count-rules
       - name: Open or update README refresh PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          commit-message: Update eslint-plugin-sonarjs README
-          title: Update eslint-plugin-sonarjs README
-          body: Automated refresh of `packages/analysis/src/jsts/rules/README.md`.
+          commit-message: Update generated README files
+          title: Update generated README files
+          body: Automated refresh of `packages/analysis/src/jsts/rules/README.md` and rule counts in `README.md`.
           branch: bot/update-eslint-rules-readme
           base: master
-          add-paths: packages/analysis/src/jsts/rules/README.md
+          add-paths: |
+            README.md
+            packages/analysis/src/jsts/rules/README.md
           delete-branch: true
 
   test_eslint_plugin:
@@ -1249,7 +1252,9 @@ jobs:
       - name: Run Ruling Tests
         run: |
           cd its/ruling
-          mvn test -Dtest=RulingTest -DskipTests=false -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -Djunit.jupiter.execution.parallel.config.dynamic.factor=1 -B -e -V
+          # Cap ruling parallelism explicitly: using all CPUs on sonar-xl can
+          # overwhelm the shared SonarQube/Node workload and make the runner drop.
+          mvn test -Dtest=RulingTest -DskipTests=false -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -Djunit.jupiter.execution.parallel.config.strategy=fixed -Djunit.jupiter.execution.parallel.config.fixed.parallelism=8 -B -e -V
         env:
           SONARSOURCE_QA: true
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
@@ -1320,16 +1325,16 @@ jobs:
     name: Releasability
     needs:
       - promote
+    if: >-
+      github.ref_name == github.event.repository.default_branch ||
+      startsWith(github.ref_name, 'branch-') ||
+      startsWith(github.ref_name, 'dogfood-')
     permissions:
       id-token: write
       statuses: write
       contents: read
     steps:
       - uses: SonarSource/gh-action_releasability/releasability-status@v3
-        if: >-
-          github.ref_name == github.event.repository.default_branch ||
-          startsWith(github.ref_name, 'branch-') ||
-          startsWith(github.ref_name, 'dogfood-')
         with:
           optional_checks: "Jira"
         env:

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -13,9 +13,12 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   bump-version:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -10,6 +10,7 @@ on:
         default: master
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   DOCKER_REPOX_BUILDS_REGISTRY: repox-sonarsource-docker-builds.jfrog.io
   DOCKER_IMAGE: "a3s/analysis/javascript"
 

--- a/.github/workflows/docker-a3s.yml
+++ b/.github/workflows/docker-a3s.yml
@@ -17,6 +17,9 @@ on:
           - Prod
         default: Dev
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   get_build_number:
     runs-on: sonar-m-docker

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - 'dogfood/*'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   dogfood_merge:
     # Run if triggered by push to dogfood/*, or if Build workflow succeeded on master

--- a/.github/workflows/release_eslint_plugin.yml
+++ b/.github/workflows/release_eslint_plugin.yml
@@ -9,11 +9,14 @@ on:
         description: 'Version (semver)'
         required: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   publish:
     permissions:
       id-token: write # required for GitHub OIDC and SonarSource/vault-action-wrapper
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     environment: release
     env:
       RELEASE_TAG: ${{ github.event.inputs.release_version }}

--- a/.github/workflows/update-eslint-plugin-changelog.yml
+++ b/.github/workflows/update-eslint-plugin-changelog.yml
@@ -13,9 +13,12 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   update-changelog:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- replace deprecated `sonar-*-public` runner labels with `sonar-*`
- opt affected workflows into the Node 24 JavaScript action runtime with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`
- clean up two backlog workflow token expressions while touching those files

## Context
This addresses the warnings reported in GitHub Actions run 25419706578:
- deprecated self-hosted runner labels such as `sonar-xs-public`
- JavaScript actions still advertising the Node 20 runtime

## Validation
- `git diff --check -- .github/workflows`
- repo scan confirms there are no remaining `sonar-*-public` workflow labels