### PR TITLE
JS-1719 Fix releasability job skip on non-schedule builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1326,9 +1326,13 @@ jobs:
     needs:
       - promote
     if: >-
-      github.ref_name == github.event.repository.default_branch ||
-      startsWith(github.ref_name, 'branch-') ||
-      startsWith(github.ref_name, 'dogfood-')
+      !failure() && !cancelled() &&
+      needs.promote.result == 'success' &&
+      (
+        github.ref_name == github.event.repository.default_branch ||
+        startsWith(github.ref_name, 'branch-') ||
+        startsWith(github.ref_name, 'dogfood-')
+      )
     permissions:
       id-token: write
       statuses: write


### PR DESCRIPTION
## Summary

This updates the `Releasability` job condition so it can still run on `master` and release branches when unrelated upstream jobs are intentionally skipped.

- keep the branch filter for `master`, `branch-*`, and `dogfood-*`
- allow the job to continue when nightly-only ancestors are skipped
- still require `promote` itself to succeed before running releasability

## Verification

- `git diff --check`
- parsed `.github/workflows/build.yml` with `yaml.safe_load(...)`
