### PR TITLE
JS-1726 NO-JIRA Add hs-template project to the ruling tests

### DIFF
--- a/its/ruling/src/test/expected/hs-template/typescript-S105.json
+++ b/its/ruling/src/test/expected/hs-template/typescript-S105.json
@@ -1,0 +1,5 @@
+{
+"hs-template:apps/admin/src/components/legacy-component.tsx": [
+9
+]
+}

--- a/its/ruling/src/test/expected/hs-template/typescript-S106.json
+++ b/its/ruling/src/test/expected/hs-template/typescript-S106.json
@@ -1,0 +1,5 @@
+{
+"hs-template:apps/admin/src/components/legacy-component.tsx": [
+50
+]
+}

--- a/its/ruling/src/test/expected/hs-template/typescript-S1441.json
+++ b/its/ruling/src/test/expected/hs-template/typescript-S1441.json
@@ -1,0 +1,8 @@
+{
+"hs-template:apps/admin/src/components/legacy-component.tsx": [
+2,
+4,
+6,
+50
+]
+}

--- a/its/ruling/src/test/expected/hs-template/typescript-S1444.json
+++ b/its/ruling/src/test/expected/hs-template/typescript-S1444.json
@@ -1,0 +1,5 @@
+{
+"hs-template:apps/admin/src/components/legacy-component.tsx": [
+23
+]
+}

--- a/its/ruling/src/test/expected/hs-template/typescript-S1537.json
+++ b/its/ruling/src/test/expected/hs-template/typescript-S1537.json
@@ -1,0 +1,6 @@
+{
+"hs-template:apps/admin/src/components/legacy-component.tsx": [
+25,
+48
+]
+}

--- a/its/ruling/src/test/expected/hs-template/typescript-S6791.json
+++ b/its/ruling/src/test/expected/hs-template/typescript-S6791.json
@@ -1,0 +1,7 @@
+{
+"hs-template:apps/admin/src/components/legacy-component.tsx": [
+34,
+39,
+46
+]
+}

--- a/its/ruling/src/test/expected/hs-template/typescript-S6957.json
+++ b/its/ruling/src/test/expected/hs-template/typescript-S6957.json
@@ -1,0 +1,16 @@
+{
+"hs-template:apps/admin/src/components/legacy-component.tsx": [
+2,
+4,
+4,
+4,
+6,
+34,
+39,
+46,
+65,
+69,
+73,
+80
+]
+}

--- a/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
@@ -95,6 +95,7 @@ class RulingTest {
       project("ecmascript6-today"),
       project("expressionist.js"),
       project("Ghost"),
+      project("hs-template"),
       project("http"),
       project("reddit-mobile"),
       project("redux"),

--- a/packages/ruling/projects.json
+++ b/packages/ruling/projects.json
@@ -95,6 +95,11 @@
     "exclusions": null
   },
   {
+    "name": "hs-template",
+    "testDir": null,
+    "exclusions": null
+  },
+  {
     "name": "http",
     "testDir": null,
     "exclusions": null

--- a/packages/ruling/projects/hs-template.ruling.test.ts
+++ b/packages/ruling/projects/hs-template.ruling.test.ts
@@ -1,0 +1,25 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { projectName, testProject, ok } from '../testProject.js';
+import { describe, it } from 'node:test';
+
+describe('Ruling', () => {
+  const name = projectName(import.meta.filename);
+  it(name, { timeout: 10 * 60 * 1000 }, async () => {
+    ok(await testProject(name));
+  });
+});


### PR DESCRIPTION
This MR updates the git submodule `jsts-test-sources` to latest master and includes the hs-template project to the list of projects on which the ruling tests are performed.