### PR TITLE
JS-1728 Resolve root Bun catalogs in package.json

### DIFF
--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/package-json.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/package-json.ts
@@ -40,30 +40,27 @@ export const packageJsonManifestResolver: ManifestResolver = {
       return [];
     }
     let parsedPackageJson = parsePackageJson(packageJson) ?? {};
+    const pnpmWorkspaceFile = closestPatternCache
+      .get(PNPM_WORKSPACE_YAML, fileSystem)
+      .get(topDir)
+      .get(dir);
+    const parsedPnpmWorkspace = pnpmWorkspaceFile
+      ? parsePnpmWorkspace(pnpmWorkspaceFile)
+      : undefined;
 
-    let catalogSource: CatalogSource | undefined = undefined;
-    const closestParent = findClosestParentPackageJsonWithCatalogs(dir, topDir, fileSystem);
+    if (parsedPnpmWorkspace) {
+      parsedPackageJson = injectWorkspacePackages(parsedPackageJson, parsedPnpmWorkspace);
+    }
 
-    if (closestParent) {
-      // If the closest parent package.json has catalogs defined, we use it as the catalog source for resolving catalog references.
-      const workspaces = Array.isArray(closestParent.workspaces)
-        ? undefined
-        : closestParent.workspaces;
-      catalogSource = {
-        catalog: workspaces?.catalog ?? closestParent.catalog,
-        catalogs: workspaces?.catalogs ?? closestParent.catalogs,
-      };
-    } else {
-      // No parent package.json with catalogs found, we check if there's a pnpm workspace file that we can use as a catalog source.
-      const pnpmWorkspaceFile = closestPatternCache
-        .get(PNPM_WORKSPACE_YAML, fileSystem)
-        .get(topDir)
-        .get(dir);
-      const parsedPnpmWorkspace = pnpmWorkspaceFile
-        ? parsePnpmWorkspace(pnpmWorkspaceFile)
-        : undefined;
-      if (parsedPnpmWorkspace) {
-        parsedPackageJson = injectWorkspacePackages(parsedPackageJson, parsedPnpmWorkspace);
+    // Bun allows catalogs to be defined in the current root package.json.
+    let catalogSource = getCatalogSource(parsedPackageJson);
+    if (!catalogSource) {
+      const closestParent = findClosestParentPackageJsonWithCatalogs(dir, topDir, fileSystem);
+      if (closestParent) {
+        // If the closest parent package.json has catalogs defined, we use it as the catalog source for resolving catalog references.
+        catalogSource = getCatalogSource(closestParent);
+      } else if (parsedPnpmWorkspace) {
+        // No package.json with catalogs found, we check if there's a pnpm workspace file that we can use as a catalog source.
         catalogSource = parsedPnpmWorkspace;
       }
     }
@@ -218,4 +215,15 @@ function hasCatalogs(packageJson: ExtendedPackageJson): boolean {
     return !!(workspaces.catalog || workspaces.catalogs);
   }
   return false;
+}
+
+function getCatalogSource(packageJson: ExtendedPackageJson): CatalogSource | undefined {
+  if (!hasCatalogs(packageJson)) {
+    return undefined;
+  }
+  const workspaces = Array.isArray(packageJson.workspaces) ? undefined : packageJson.workspaces;
+  return {
+    catalog: workspaces?.catalog ?? packageJson.catalog,
+    catalogs: workspaces?.catalogs ?? packageJson.catalogs,
+  };
 }

--- a/packages/analysis/tests/dependency-manifests.test.ts
+++ b/packages/analysis/tests/dependency-manifests.test.ts
@@ -323,6 +323,23 @@ describe('files', () => {
     });
   }
 
+  it('should resolve bun catalog default references for the root package.json consuming its own catalog', async () => {
+    const baseDir = normalizeToAbsolutePath(join(fixtures, 'bun-workspace-default-root-catalog'));
+    const configuration = createConfiguration({ baseDir });
+    await initFileStores(configuration);
+
+    const manifests = getDependencyManifests(baseDir, baseDir);
+    expect(manifests.map(manifest => manifest.type)).toEqual(['package-json']);
+    expect(manifests[0].dependencies).toEqual(
+      new Map<string | Minimatch, string | undefined>([
+        ['my-monorepo', '*'],
+        ['react', '^18.0.0'],
+        ['react-dom', '^19.0.0'],
+        [new Minimatch('packages/*', { nocase: true, matchBase: true }), undefined],
+      ]),
+    );
+  });
+
   for (const fixture of ['bun-workspace-named-catalog', 'bun-workspace-named-root-catalog']) {
     it(`should resolve bun catalog named references (${fixture})`, async () => {
       const baseDir = normalizeToAbsolutePath(join(fixtures, fixture));
@@ -344,6 +361,26 @@ describe('files', () => {
       );
     });
   }
+
+  it('should resolve bun catalog named references for the root package.json consuming its own catalogs', async () => {
+    const baseDir = normalizeToAbsolutePath(join(fixtures, 'bun-workspace-named-root-catalog'));
+    const configuration = createConfiguration({ baseDir });
+    await initFileStores(configuration);
+
+    const manifests = getDependencyManifests(baseDir, baseDir);
+    expect(manifests.map(manifest => manifest.type)).toEqual(['package-json']);
+    expect(manifests[0].dependencies).toEqual(
+      new Map<string | Minimatch, string | undefined>([
+        ['my-monorepo', '*'],
+        ['react', '^18.0.0'],
+        ['react-dom', '^19.0.0'],
+        ['jest', '30.0.0'],
+        ['testing-library', '14.0.0'],
+        ['webpack', '5.0.0'],
+        [new Minimatch('packages/*', { nocase: true, matchBase: true }), undefined],
+      ]),
+    );
+  });
 
   it('should not resolve bun named catalog references when catalog is missing', async ({
     mock,

--- a/packages/analysis/tests/fixtures-package-jsons/bun-workspace-default-root-catalog/package.json
+++ b/packages/analysis/tests/fixtures-package-jsons/bun-workspace-default-root-catalog/package.json
@@ -3,6 +3,10 @@
   "workspaces": {
     "packages": ["packages/*"]
   },
+  "dependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "catalog": {
     "react": "^18.0.0",
     "react-dom": "^19.0.0"

--- a/packages/analysis/tests/fixtures-package-jsons/bun-workspace-named-root-catalog/package.json
+++ b/packages/analysis/tests/fixtures-package-jsons/bun-workspace-named-root-catalog/package.json
@@ -3,6 +3,15 @@
   "workspaces": {
     "packages": ["packages/*"]
   },
+  "dependencies": {
+    "react": "catalog:ui",
+    "react-dom": "catalog:ui"
+  },
+  "devDependencies": {
+    "jest": "catalog:testing",
+    "testing-library": "catalog:testing",
+    "webpack": "catalog:build"
+  },
   "catalogs": {
     "build": {
       "webpack": "5.0.0"


### PR DESCRIPTION
## Summary

Use the current `package.json` as a Bun catalog source before falling back to parent `package.json` files or `pnpm-workspace.yaml`.

This fixes the case where the workspace root defines Bun catalogs and also consumes its own `catalog:` dependencies.

## Testing

- `npm ci`
- `npx tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec --test-reporter-destination=stdout packages/analysis/tests/dependency-manifests.test.ts`
- `npm run bbf`