### PR TITLE
JS-1736 Clarify /tests skill guidance for false-positive fixes

### DIFF
--- a/.claude/skills/tests/SKILL.md
+++ b/.claude/skills/tests/SKILL.md
@@ -126,8 +126,8 @@ When `meta.ts` contains `implementation = 'decorated'`, add an upstream sentinel
        const ruleTester = new DefaultParserRuleTester();
        ruleTester.run('{ESLINT_ID}', upstreamRule, {
          valid: [],
-          { code: `...`, errors: 1, output: `...` }, // include output if the upstream rule has autofix; omit if the rule is not fixable
-          // one entry per distinct FP pattern
+         invalid: [
+           { code: `...`, errors: 1, output: `...` }, // include output if the upstream rule has autofix; omit if the rule is not fixable
            // one entry per distinct FP pattern
          ],
        });

--- a/.claude/skills/tests/SKILL.md
+++ b/.claude/skills/tests/SKILL.md
@@ -63,6 +63,30 @@ problematicCode();
 
 When fixing false positives, add test cases to the `valid` array - the false positive is code that should be treated as valid.
 
+### Converting FP Reproducers to Failing Tests (TDD Style)
+
+FP reproducers are entries in the `invalid` array for code that raises a false positive. They may have a comment inside the entry object documenting why it is an FP:
+
+```typescript
+invalid: [
+  {
+    // FP: rule incorrectly flags this pattern because...
+    code: `const x = foo();`,
+    errors: 1,
+  },
+]
+```
+
+To convert a reproducer to a failing test, move the entry from `invalid` to `valid`, remove the `errors` field, and remove any autofix expectations such as `output` or `suggestions`. Keep fields like `filename` and `options` if they are still needed for the test setup:
+
+```typescript
+// Before (reproducer — test passes because the issue IS raised and expected):
+invalid: [{ code: `const x = foo();`, filename: 'fixture.ts', errors: 1, output: `foo()` }]
+
+// After (failing test — test fails because the issue IS raised but valid is asserted):
+valid: [{ code: `const x = foo();`, filename: 'fixture.ts' }]
+```
+
 ## Isolating Failing Test Cases
 
 When tests fail and you need to identify which specific test case is causing the failure:
@@ -80,3 +104,44 @@ This isolation technique helps identify exactly which test cases are failing whe
 ## Ruling Tests
 
 Ruling tests (integration tests against real-world code) are in the separate SonarJS-Ruling repository.
+
+## Upstream Sentinel Tests (Decorator Rules)
+
+When `meta.ts` contains `implementation = 'decorated'`, add an upstream sentinel `describe` block **before** the main `describe` block in the test file.
+
+1. Read `decorator.ts` to identify each distinct FP pattern being suppressed (conditions that trigger an early `return` instead of calling `context.report`)
+2. Read `meta.ts` to find the `eslintId` (the upstream ESLint rule name)
+3. Read `index.ts` to find the exact import pattern already in use:
+   - ESLint core rules: `import { getESLintCoreRule } from '../external/core.js'` then `getESLintCoreRule('{ESLINT_ID}')`
+   - Plugin rules: `import { rules } from '../external/{PLUGIN}.js'` then `rules['{ESLINT_ID}']`
+4. Add the same import to the test file and obtain a reference to the upstream rule the same way
+   - Never import directly from `eslint-plugin-*` packages or `eslint/use-at-your-own-risk` — always use the `external/` shims
+5. Add a comment above the sentinel block explaining its purpose, then the block itself:
+   ```typescript
+   // Sentinel: verify that the upstream ESLint rule still raises on the patterns our decorator fixes.
+   // If this test starts failing (i.e., the upstream rule no longer reports these patterns),
+   // it signals that the decorator can be safely removed.
+   describe('S{RULE_ID} upstream sentinel', () => {
+     it('upstream {ESLINT_ID} raises on {FP pattern description} that decorator suppresses', () => {
+       const ruleTester = new DefaultParserRuleTester();
+       ruleTester.run('{ESLINT_ID}', upstreamRule, {
+         valid: [],
+         invalid: [
+           { code: `...`, errors: 1 }, // {pattern description} — suppressed by decorator, raised by upstream
+           // one entry per distinct FP pattern
+         ],
+       });
+     });
+   });
+   ```
+6. Do NOT modify the tests for the decorated rule (imported from `./index.js`) — they remain exactly as written
+
+---
+
+## Move test cases from invalid to valid when removing them — do not silently delete
+
+**What**: Removing a test case from the `invalid` array (because the fix now suppresses it) without adding it to the `valid` array.
+
+**Why**: The case is now valid — the rule no longer raises an issue on it — but the test suite contains no evidence of this. Future readers cannot tell whether the omission is intentional or an oversight, and a regression that re-introduces the false positive would go undetected.
+
+**How**: When a previously-invalid test case becomes valid because of the fix, always move it to the `valid` array rather than deleting it. If the case was for a chained or compound expression where multiple assignments are involved (and all are now suppressed), add a comment explaining why all assignments are suppressed.

--- a/.claude/skills/tests/SKILL.md
+++ b/.claude/skills/tests/SKILL.md
@@ -126,8 +126,8 @@ When `meta.ts` contains `implementation = 'decorated'`, add an upstream sentinel
        const ruleTester = new DefaultParserRuleTester();
        ruleTester.run('{ESLINT_ID}', upstreamRule, {
          valid: [],
-         invalid: [
-           { code: `...`, errors: 1 }, // {pattern description} — suppressed by decorator, raised by upstream
+          { code: `...`, errors: 1, output: `...` }, // include output if the upstream rule has autofix; omit if the rule is not fixable
+          // one entry per distinct FP pattern
            // one entry per distinct FP pattern
          ],
        });


### PR DESCRIPTION
## Summary

This updates the `/tests` skill for SonarJS to better reflect how false-positive fixes are represented in rule tests.

- add guidance for converting existing FP reproducers from `invalid` to failing `valid` cases
- clarify that autofix expectations such as `output` and `suggestions` should be removed during that conversion while keeping setup fields like `filename` and `options` when needed
- add decorator upstream sentinel guidance and explicit guidance to move suppressed cases from `invalid` to `valid` instead of deleting them

## Why

The SonarJS skill and the mirrored Nigel guidance had drifted.
SonarJS already had the richer explanation for `errors` objects used in quickfix assertions, while Nigel had accumulated useful guidance for FP reproducers and decorator sentinels.
This change merges those pieces so the SonarJS-side skill is the more complete reference again.

## Validation

- `git diff --check`
- no automated SonarJS test currently validates `.claude/skills/tests/SKILL.md`
