### PR TITLE
BUILD-10835 Replace sonar-m-docker with warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -776,7 +776,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_without_node_alpine:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: QA without Node on Alpine SQ:LATEST_RELEASE
     needs: [setup, get_build_number, build]
     if: github.event_name == 'schedule'
@@ -883,7 +883,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_fast_without_node_alpine:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Fast QA without Node on Alpine SQ:LATEST_RELEASE
     needs: [setup, get_build_number, build]
     if: github.event_name == 'schedule'

--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   get_build_number:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Get build number
     permissions:
       id-token: write
@@ -33,7 +33,7 @@ jobs:
 
   build_and_publish:
     name: Build and publish Docker image
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     needs: get_build_number
     permissions:
       id-token: write

--- a/.github/workflows/docker-a3s.yml
+++ b/.github/workflows/docker-a3s.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   get_build_number:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Get build number
     permissions:
       id-token: write
@@ -35,7 +35,7 @@ jobs:
 
   build_and_publish:
     name: Build and publish Docker image
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     needs: get_build_number
     environment: ${{ inputs.environment == 'Prod' && 'Prod' || 'Dev5' }}
     permissions:

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -18,7 +18,7 @@ jobs:
   dogfood_merge:
     # Run if triggered by push to dogfood/*, or if Build workflow succeeded on master
     if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Update dogfood branch
     permissions:
       id-token: write # required for SonarSource/vault-action-wrapper


### PR DESCRIPTION
BUILD-10835

## Purpose

Switch every workflow that used the `sonar-m-docker` label to `warp-custom-ubuntu-24-04`, per the platform move to WarpBuild general-purpose Ubuntu runners (Docker is available natively on that image).

## Changes

| Workflow | Updates |
|----------|---------|
| `.github/workflows/dogfood.yml` | 1 job |
| `.github/workflows/docker-a3s.yml` | 2 jobs |
| `.github/workflows/docker-a3s-repox.yml` | 2 jobs |
| `.github/workflows/build.yml` | `plugin_qa_without_node_alpine`, `plugin_qa_fast_without_node_alpine` |

## Behavioral notes

- No change to `sonar-m` or other self-hosted labels.
- Jobs that rely on Docker on the host should behave like on `sonar-m-docker`; validate Docker-based steps on the first WarpBuild runs if anything assumes the old image layout.

## Breaking changes

None intended; runner label swap only.