### PR TITLE
JS-1499 Harden parser options and propagate ES/module signals (fixes JS-674)

### DIFF
--- a/.claude/skills/peach-check/INSTRUCTIONS.md
+++ b/.claude/skills/peach-check/INSTRUCTIONS.md
@@ -1,0 +1,426 @@
+# Peach Main Analysis Check
+
+Canonical instructions for the `peach-check` skill live in this file.
+
+Use this skill when the user asks to check the latest Peach run, triage Peach Main Analysis
+failures, or decide whether Peach blocks a SonarJS release.
+
+## Overview
+
+- Repository under analysis: `SonarSource/peachee-js`
+- Workflow file: `main-analysis.yml`
+- Branch: `js-ts-css-html`
+- Classification guide: `docs/peach-main-analysis.md`
+- Canonical issue-history helper: `.claude/skills/peach-check/peach-issue-history.js`
+
+This skill fetches the target run, collects failed jobs, runs an analysis-consistency check across
+successful project scans to verify that the current Peach state is materially consistent with
+recent history, classifies the findings with the guide, and prints a summary focused on SonarJS
+ownership.
+
+## Prerequisites
+
+- Run from the SonarJS repository.
+- Verify GitHub auth first with `gh auth status`.
+- Ensure the current GitHub identity can access `SonarSource/peachee-js`.
+- Ensure `PEACH_KEY` and `PEACHEE_ROOT` are set, and that `PEACHEE_ROOT` points to a local
+  `peachee-js` checkout.
+- Parallelize independent job triage work when the runtime permits it, but do not chain shell commands.
+
+## Command Discipline
+
+- Never chain commands with `&&`, `;`, or `|`.
+- Keep each shell command standalone so permission prompts and failures stay attributable.
+- Parallel execution is fine when calls are independent.
+- Put labels in prose, not in shell wrappers such as `echo "===" && ...`.
+
+## Invocation
+
+`/peach-check [run-id]`
+
+- Without `run-id`: analyze the latest completed run.
+- With `run-id`: analyze that specific run.
+
+## Workflow
+
+### 1. Resolve the run
+
+If a run id was provided, use it directly.
+
+Otherwise fetch the latest completed run of `main-analysis.yml` on `js-ts-css-html`:
+
+```bash
+gh run list \
+  --repo SonarSource/peachee-js \
+  --workflow main-analysis.yml \
+  --branch js-ts-css-html \
+  --limit 5 \
+  --json databaseId,conclusion,createdAt,status \
+  --jq '[.[] | select(.status == "completed")] | first | {databaseId, conclusion, createdAt}'
+```
+
+Record:
+
+- `RUN_ID`
+- run timestamp
+- overall conclusion
+
+If the chosen run has `conclusion == "cancelled"`, stop and report that the run is incomplete and
+not usable for release triage. Recommend a rerun and do not classify jobs from that run.
+
+### 2. Collect project jobs
+
+Use the helper script to fetch the Peach run jobs and materialize the working sets consumed by the
+rest of the workflow:
+
+```bash
+node .claude/skills/peach-check/peach-run-jobs.js RUN_ID target
+```
+
+The script calls `gh api "repos/SonarSource/peachee-js/actions/runs/RUN_ID/jobs?per_page=100"`
+from Node.js, falls back to explicit `?page=N` fetches if the paginated response comes back short,
+and writes these files:
+
+- `target/jobs-merged.json`
+- `target/analyzed-jobs.json`
+- `target/exclusion-counts.json`
+- `target/failed-jobs.json`
+- `target/project-jobs.json`
+
+`target/jobs-merged.json` includes `expected_total`, `total_jobs`, `failed_jobs`, and
+`counts_match`. If the script still cannot reconcile `expected_total` with `total_jobs` after the
+explicit page fallback, it exits non-zero. Stop there and report the mismatch instead of
+classifying partial data.
+
+`target/analyzed-jobs.json` excludes workflow-only jobs such as `prepare-project-matrix` and
+`diff-validation-aggregated`.
+
+`target/exclusion-counts.json` records:
+
+- `excluded_workflow_jobs`
+- `excluded_project_jobs`
+
+If you intentionally exclude any real project scans beyond those two workflow jobs, replace
+`excluded_project_jobs: 0` with the count from that additional exclusion filter and mention why.
+
+For excluded jobs:
+
+- do not count them as analyzed failures
+- do not classify them
+- do not emit them as findings
+- mention them at most once as excluded-by-design context
+- record `excluded_workflow_jobs` for excluded non-project workflow jobs such as
+  `prepare-project-matrix` and `diff-validation-aggregated`
+- record `excluded_project_jobs` separately so the summary makes it explicit how many actual
+  project scans were excluded; this is normally `0` unless you intentionally exclude a real project scan
+
+Use `target/failed-jobs.json` for failure triage and `target/project-jobs.json` for the
+analysis-consistency check.
+
+For each remaining failed job, record:
+
+- job id
+- job name
+- completion time
+- job URL
+- `failing_step_name`
+- `owning_phase` as `pre-scan`, `analyze`, or `post-scan`
+
+If job metadata is incomplete, fetch the job directly:
+
+```bash
+gh api "repos/SonarSource/peachee-js/actions/jobs/JOB_ID"
+```
+
+When multiple steps are failed, use the earliest failed step that actually ran as the owner.
+Treat later cleanup or report failures as downstream noise unless they are the only failed steps.
+
+If the failing step name contains `Diff Val` or `diff-val`, classify the job immediately as
+`IGNORE`. These monitoring failures are not SonarJS release blockers.
+
+### 3. Run the analysis-consistency check
+
+Before any early-safe exit, use the canonical repo-local helper script to verify that each
+successful project both:
+
+- produced a fresh Peach analysis during this run window
+- looks materially consistent with recent history, so a green GitHub job does not hide a
+  suspicious downward shift in the analyzed state
+
+The helper uses recent SonarQube history as the baseline:
+
+```bash
+node .claude/skills/peach-check/peach-issue-history.js \
+  target/project-jobs.json \
+  "${PEACHEE_ROOT}" \
+  target/peach-issue-history.json
+```
+
+The helper script reads:
+
+- `PEACH_KEY` for Peach authentication
+- `PEACH_ISSUE_DROP_THRESHOLD_PCT` with default `5`
+- `PEACH_ISSUE_DROP_MIN_ABS` with default `20`
+- `PEACH_ISSUE_HISTORY_CONCURRENCY` with default `8`
+
+Do not call `mc peach issue-history` from this skill anymore.
+
+Interpret the helper statuses like this:
+
+- `OK` → the project has a fresh analysis in the run window and its current metric is materially
+  consistent with the recent baseline
+- `DROP` → record one `NEEDS-MANUAL-REVIEW` finding per flagged project; describe it as a
+  suspicious downward variation versus recent history
+- `INSUFFICIENT_HISTORY` → mention only in the summary; there is not enough baseline to judge
+  consistency, but this alone does not block a `SAFE` verdict
+- `STALE` → treat as `NEEDS-MANUAL-REVIEW`; describe it as "no fresh Peach analysis observed
+  during this run window", not just `STALE`
+- `UNRESOLVED_PROJECT` for excluded workflow jobs such as `prepare-project-matrix` → ignore it
+- other `UNRESOLVED_PROJECT` rows → treat as `NEEDS-MANUAL-REVIEW`; describe them as "could not
+  match successful job to Peach project", so the consistency check is incomplete
+- `ERROR` → treat as `NEEDS-MANUAL-REVIEW`; describe it as "analysis-consistency check failed for
+  this project"
+
+Use this query to isolate the history rows that block the clean early exit:
+
+```bash
+jq '
+  [.rows[] | select(
+    .status != "OK" and
+    .status != "INSUFFICIENT_HISTORY" and
+    (
+      .status != "UNRESOLVED_PROJECT" or
+      (
+        .source_job_name != "prepare-project-matrix" and
+        .source_job_name != "diff-validation-aggregated"
+      )
+    )
+  )]
+' target/peach-issue-history.json
+```
+
+Each `DROP` finding should include:
+
+- SonarQube project key
+- latest analysis date
+- current metric value
+- baseline value
+- absolute drop
+- percentage drop
+
+Treat `threshold-abs` as a small-project noise floor, not an alternative trigger. Flag `DROP`
+only when the measured drop clears both gates:
+
+- `drop_abs >= threshold-abs`
+- `drop_pct >= threshold_pct`
+
+Equivalent single-condition restatement after converting the percentage gate into absolute units:
+
+- `drop_abs >= max(threshold-abs, baseline * threshold_pct / 100)`
+
+That `max(...)` form is the same two-gate rule above, not an OR trigger.
+
+### 4. Early exit if no failures and the analysis state looks consistent
+
+This is the normal green path. If `target/failed-jobs.json` reports `0` failed jobs and the
+problematic-history query above returns `[]`, stop here: Sections 5 through 9 do not apply.
+Report the run as safe, include the exclusion counts plus the consistency summary, and stop.
+
+If any project is `DROP`, `STALE`, non-excluded `UNRESOLVED_PROJECT`, or `ERROR`, do not call the
+run safe even if the GitHub workflow has no failed project jobs.
+
+If one or more failed jobs remain after exclusions, continue to Section 5.
+
+### 5. Read the classification guide
+
+Read `docs/peach-main-analysis.md` once before classifying the jobs that made it past the early
+exit. Use the guide's flowchart and failure categories as the source of truth.
+
+### 6. Watch for mass failure
+
+If at least 80% of analyzed jobs failed after exclusions, treat it as a probable shared root cause.
+Do not fully triage every job first.
+
+Instead:
+
+1. Sample five representative jobs across the run.
+2. Run Phase 2 classification on those samples.
+3. If any sampled job is `CRITICAL`, the mass verdict is `CRITICAL`.
+4. Otherwise apply the shared verdict to the whole event.
+5. In the summary, note the mass event and cite only the sampled jobs as evidence.
+
+Mass-failure verdict rules, in this order:
+
+- `CRITICAL` if the shared stack trace originates in `org.sonar.plugins.javascript`
+- `IGNORE` if the shared error is a Peach infrastructure failure with no SonarJS involvement
+- `NEEDS-MANUAL-REVIEW` otherwise
+
+### 7. Triage logs in phases
+
+Only download logs for jobs that still need log-based classification.
+
+If any failed jobs remain after the early-exit check, create the output directory:
+
+```bash
+mkdir -p target/peach-logs
+```
+
+#### Phase 1 — Download log and filter failure signals
+
+Download the log to disk:
+
+```bash
+gh api "repos/SonarSource/peachee-js/actions/jobs/JOB_ID/logs" > target/peach-logs/JOB_ID.log
+```
+
+Then filter for high-signal markers:
+
+```bash
+sed --sandbox -n '
+/\[36;1m/b
+/Process completed with exit code/p
+/EXECUTION FAILURE/p
+/OutOfMemoryError/p
+/502 Bad Gateway/p
+/503 Service Unavailable/p
+/Diff Val/p
+/diff-val/p
+/Fail to download plugin \[javascript\]/p
+/api\/v2\/analysis\/engine/p
+/Artifact has expired/p
+/All 3 attempts failed/p
+/ERR_PNPM/p
+/ERESOLVE/p
+/ETARGET/p
+/notarget/p
+/Invalid value of sonar/p
+/does not exist for/p
+/SocketTimeoutException/p
+/ReportPublisher\.upload/p
+' target/peach-logs/JOB_ID.log
+```
+
+Important rules:
+
+- Do not trust the first `Process completed with exit code ...` line by default.
+- Nested commands can emit intermediate failures that the workflow later survives.
+- Trust step metadata first, then use the final failing log section to determine ownership.
+- If Phase 1 shows scanner exit code 3 with `EXECUTION FAILURE`, continue to Phase 2. Phase 1
+  alone cannot rule SonarJS in or out.
+
+Many jobs can be classified immediately from Phase 1:
+
+- project misconfiguration
+- dependency install failure
+- Peach unavailable
+- artifact expired
+- clone or checkout failures
+- other pre-scan network failures
+
+If checkout shows repository access loss, call that out explicitly instead of leaving it as a
+generic auth failure.
+
+#### Phase 2 — Sensor and stack trace filter
+
+Run this only for jobs where Phase 1 showed scanner failure or the owning phase is ambiguous:
+
+```bash
+sed --sandbox -n '
+/\[36;1m/b
+/Sensor /p
+/EXECUTION FAILURE/p
+/Node\.js process running out of memory/p
+/sonar\.javascript\.node\.maxspace/p
+/sonar\.javascript\.node\.debugMemory/p
+/OutOfMemoryError/p
+/ReportPublisher\.upload/p
+/api\/ce\/submit/p
+/SocketTimeoutException/p
+/Process completed with exit code/p
+/org\.sonar\.plugins\.javascript/p
+' target/peach-logs/JOB_ID.log
+```
+
+Apply the last-sensor-wins rule from the guide:
+
+- the last sensor that started before the error owns the crash
+- if JavaScript analysis finished and a later non-SonarJS sensor failed, do not blame SonarJS
+- if the last active sensor is a SonarJS sensor and the log shows SonarJS frames or explicit
+  Node heap exhaustion, classify it as `CRITICAL`
+- if `ReportPublisher.upload` or `/api/ce/submit` fails after JS analysis completed, classify it
+  as `post-scan` and `IGNORE` for SonarJS ownership
+
+#### Phase 3 — Full log
+
+If the failure is still ambiguous, read the full saved log and classify manually.
+
+### 8. Classify each job
+
+Classify each failed job as one of:
+
+- `CRITICAL`
+- `IGNORE`
+- `NEEDS-MANUAL-REVIEW`
+
+Prefer direct classification from logs. Use parallel subagents only when a job remains ambiguous
+after Phase 2 and the runtime allows delegation.
+
+If a subagent returns no structured assessment, record:
+
+- verdict: `NEEDS-MANUAL-REVIEW`
+- evidence: `Agent returned no output`
+
+### 9. Check for clustered failures
+
+If two or more jobs share the same category, check whether they failed within a five-minute
+window. Use timestamps from log lines rather than `completedAt` from the paginated jobs API,
+because `completedAt` may be `null`.
+
+If clustered, add a note that the jobs likely came from a single infrastructure event.
+
+### 10. Print summary
+
+Group findings by shared cause, not one row per job.
+Translate raw helper statuses such as `STALE` into plain language in the findings; reserve the raw
+status names for the compact summary counts.
+
+Do not emit `prepare-project-matrix` or `diff-validation-aggregated` as findings. Add a single
+exclusion line that names the excluded workflow jobs and prints both exclusion counts, for example
+`Excluded by design: prepare-project-matrix, diff-validation-aggregated (workflow jobs excluded: 2, project jobs excluded: 0)`.
+
+Use this structure:
+
+```text
+## Peach Main Analysis — Run RUN_ID (DATE)
+
+Excluded by design: prepare-project-matrix, diff-validation-aggregated (workflow jobs excluded: WORKFLOW_EXCLUDED, project jobs excluded: PROJECT_EXCLUDED)
+
+### IGNORE — Peach report upload timeout
+- closure-library — `ReportPublisher.upload` to `/api/ce/submit` timed out after JS analysis completed
+- nx — `ReportPublisher.upload` to `/api/ce/submit` timed out after JS analysis completed
+
+### NEEDS-MANUAL-REVIEW — Suspicious issue count drop
+- js:FreeCodeCamp — `violations` dropped from median baseline 4150 to 3821 (-7.9%, -329)
+
+### Summary
+- CRITICAL: N jobs
+- NEEDS-MANUAL-REVIEW: N items
+- IGNORE: N jobs
+- Analysis-consistency check: OK=N, DROP=N, INSUFFICIENT_HISTORY=N, STALE=N, UNRESOLVED_PROJECT=N, ERROR=N
+
+Release recommendation: SAFE | NOT SAFE | REVIEW NEEDED
+```
+
+Release recommendation rules:
+
+- `SAFE` when there are zero `CRITICAL` and zero `NEEDS-MANUAL-REVIEW` items
+- `NOT SAFE` when there is one or more `CRITICAL` jobs
+- `REVIEW NEEDED` when there are zero `CRITICAL` but one or more `NEEDS-MANUAL-REVIEW` items
+
+If every failed job is either Diff Val monitoring or another `IGNORE` category, the run is still
+`SAFE` only when the analysis-consistency check is also clean.
+
+### 11. Update docs when needed
+
+If you identify a new failure pattern during the session, update
+`docs/peach-main-analysis.md` so the guide stays current for future runs.

--- a/.claude/skills/peach-check/peach-issue-history.js
+++ b/.claude/skills/peach-check/peach-issue-history.js
@@ -1,0 +1,698 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync as nodeExecFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_METRIC = 'violations';
+const DEFAULT_BASELINE_WINDOW = 5;
+const DEFAULT_THRESHOLD_PCT = 5;
+const DEFAULT_THRESHOLD_ABS = 20;
+const DEFAULT_CONCURRENCY = 8;
+const DEFAULT_HISTORY_PAGE_SIZE = 100;
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const RETRYABLE_STATUS_CODES = new Set([429, 502, 503]);
+const WORKFLOW_ONLY_JOBS = new Set(['prepare-project-matrix', 'diff-validation-aggregated']);
+
+export async function runIssueHistory(options, runtime = {}) {
+  const readFileSync = runtime.readFileSync ?? fs.readFileSync;
+  const writeFileSync = runtime.writeFileSync ?? fs.writeFileSync;
+  const existsSync = runtime.existsSync ?? fs.existsSync;
+  const execFileSync = runtime.execFileSync ?? defaultExecFileSync;
+  const apiToken = options.apiToken ?? process.env.PEACH_KEY;
+
+  if (!apiToken) {
+    throw new Error('PEACH_KEY is required');
+  }
+
+  const metric = DEFAULT_METRIC;
+  const baselineWindow = options.baselineWindow ?? readNumberEnv('PEACH_ISSUE_BASELINE_WINDOW', DEFAULT_BASELINE_WINDOW);
+  const thresholdPct = options.thresholdPct ?? readNumberEnv('PEACH_ISSUE_DROP_THRESHOLD_PCT', DEFAULT_THRESHOLD_PCT);
+  const thresholdAbs = options.thresholdAbs ?? readNumberEnv('PEACH_ISSUE_DROP_MIN_ABS', DEFAULT_THRESHOLD_ABS);
+  const concurrency = options.concurrency ?? readIntegerEnv('PEACH_ISSUE_HISTORY_CONCURRENCY', DEFAULT_CONCURRENCY);
+
+  const jobsJsonData = readJobsJsonData(options.jobsJsonPath, readFileSync);
+  const projectSources = new Map();
+  const unresolvedRows = collectProjectsFromJobsJson(jobsJsonData, options.peacheeRoot, {
+    projectSources,
+    readFileSync,
+    existsSync,
+    execFileSync,
+    metric,
+    baselineWindow,
+  });
+  const freshnessWindow = resolveFreshnessWindow(jobsJsonData);
+
+  const rows = await mapWithConcurrencyLimit(
+    Array.from(projectSources.entries()),
+    concurrency,
+    async ([projectKey, sourceJobName]) =>
+      evaluateProjectHistory(
+        {
+          apiToken,
+          projectKey,
+          sourceJobName,
+          metric,
+          baselineWindow,
+          thresholdPct,
+          thresholdAbs,
+          freshnessWindow,
+        },
+        runtime,
+      ),
+  );
+
+  const combinedRows = [...rows, ...unresolvedRows].sort((left, right) =>
+    getRowIdentifier(left).localeCompare(getRowIdentifier(right)),
+  );
+  const report = {
+    metric,
+    baseline_kind: 'median',
+    baseline_window: baselineWindow,
+    threshold_pct: thresholdPct,
+    threshold_abs: thresholdAbs,
+    concurrency,
+    analysis_after: freshnessWindow.analysisAfter,
+    analysis_before: freshnessWindow.analysisBefore,
+    rows: combinedRows.map(toJsonRow),
+    summary: summarizeRows(combinedRows),
+  };
+
+  writeFileSync(options.outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf-8');
+  return report;
+}
+
+function readJobsJsonData(jobsJsonPath, readFileSync) {
+  const payload = JSON.parse(readFileSync(jobsJsonPath, 'utf-8'));
+  const jobs = extractJobs(payload);
+  const firstJob = jobs.find(job => readStringField(job.raw, ['headSha', 'head_sha']));
+
+  return {
+    jobs,
+    metadata: {
+      headSha:
+        readStringField(payload, ['headSha', 'head_sha']) ??
+        (firstJob ? readStringField(firstJob.raw, ['headSha', 'head_sha']) : undefined),
+      createdAt: readStringField(payload, ['createdAt', 'created_at']),
+      startedAt: readStringField(payload, ['startedAt', 'started_at']),
+      updatedAt: readStringField(payload, ['updatedAt', 'updated_at']),
+    },
+  };
+}
+
+function extractJobs(payload) {
+  if (Array.isArray(payload)) {
+    return payload.flatMap(extractJobs);
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  if (Array.isArray(payload.jobs)) {
+    return payload.jobs.flatMap(extractJobs);
+  }
+
+  const name = readStringField(payload, ['name']);
+  if (!name) {
+    return [];
+  }
+
+  return [
+    {
+      raw: payload,
+      name,
+      conclusion: readStringField(payload, ['conclusion']),
+      startedAt: readStringField(payload, ['startedAt', 'started_at']),
+      completedAt: readStringField(payload, ['completedAt', 'completed_at']),
+    },
+  ];
+}
+
+function collectProjectsFromJobsJson(jobsJsonData, peacheeRoot, options) {
+  const unresolvedRows = new Map();
+  const headSha = jobsJsonData.metadata.headSha;
+
+  if (headSha) {
+    ensureCommitAvailable(peacheeRoot, headSha, options.execFileSync);
+  }
+
+  for (const job of jobsJsonData.jobs) {
+    if (WORKFLOW_ONLY_JOBS.has(job.name) || job.conclusion !== 'success') {
+      continue;
+    }
+
+    const propertiesContent = readProjectPropertiesForJob(peacheeRoot, job.name, headSha, {
+      readFileSync: options.readFileSync,
+      existsSync: options.existsSync,
+      execFileSync: options.execFileSync,
+    });
+
+    if (!propertiesContent) {
+      unresolvedRows.set(
+        job.name,
+        createUnresolvedRow(
+          job.name,
+          headSha ? `Missing sonar-project.properties at ${headSha}` : 'Missing sonar-project.properties',
+          options.metric,
+          options.baselineWindow,
+        ),
+      );
+      continue;
+    }
+
+    const projectKey = extractProjectKeyFromProperties(propertiesContent);
+    if (!projectKey) {
+      unresolvedRows.set(
+        job.name,
+        createUnresolvedRow(job.name, 'Missing sonar.projectKey', options.metric, options.baselineWindow),
+      );
+      continue;
+    }
+
+    if (!options.projectSources.has(projectKey) || options.projectSources.get(projectKey) === undefined) {
+      options.projectSources.set(projectKey, job.name);
+    }
+  }
+
+  return Array.from(unresolvedRows.values());
+}
+
+function resolveFreshnessWindow(jobsJsonData) {
+  const referenceTimestamp = firstDefinedNumber(
+    parseTimestamp(jobsJsonData.metadata.updatedAt),
+    latestTimestamp(jobsJsonData.jobs.map(job => job.completedAt)),
+    parseTimestamp(jobsJsonData.metadata.startedAt),
+    latestTimestamp(jobsJsonData.jobs.map(job => job.startedAt)),
+    parseTimestamp(jobsJsonData.metadata.createdAt),
+  );
+
+  if (referenceTimestamp === undefined) {
+    return {};
+  }
+
+  const previousDayStart = new Date(referenceTimestamp);
+  previousDayStart.setUTCHours(0, 0, 0, 0);
+  previousDayStart.setUTCDate(previousDayStart.getUTCDate() - 1);
+
+  return {
+    analysisAfter: formatIsoTimestamp(previousDayStart.getTime()),
+    analysisBefore: formatIsoTimestamp(referenceTimestamp),
+  };
+}
+
+function ensureCommitAvailable(peacheeRoot, headSha, execFileSync) {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', '--quiet', `${headSha}^{commit}`], {
+      cwd: peacheeRoot,
+      encoding: 'utf-8',
+    });
+  } catch {
+    throw new Error(`jobs-json headSha ${headSha} is not available in ${peacheeRoot}`);
+  }
+}
+
+function readProjectPropertiesForJob(peacheeRoot, jobName, headSha, runtime) {
+  const relativePath = path.posix.join(jobName, 'sonar-project.properties');
+
+  if (headSha) {
+    try {
+      return runtime.execFileSync('git', ['show', `${headSha}:${relativePath}`], {
+        cwd: peacheeRoot,
+        encoding: 'utf-8',
+      });
+    } catch {
+      return undefined;
+    }
+  }
+
+  const propertiesPath = path.join(peacheeRoot, jobName, 'sonar-project.properties');
+  if (!runtime.existsSync(propertiesPath)) {
+    return undefined;
+  }
+
+  return runtime.readFileSync(propertiesPath, 'utf-8');
+}
+
+function extractProjectKeyFromProperties(content) {
+  const match = /^\s*sonar\.projectKey\s*=\s*(.+)\s*$/m.exec(content);
+  return match?.[1]?.trim();
+}
+
+async function evaluateProjectHistory(options, runtime) {
+  try {
+    const history = await fetchMeasureHistoryWithRetry(
+      options.projectKey,
+      options.metric,
+      options.apiToken,
+      options.baselineWindow + 1,
+      runtime,
+    );
+    const sortedHistory = toDatedHistory(history);
+
+    if (sortedHistory.length === 0) {
+      return createErrorRow(options, 'No measure history found');
+    }
+
+    const parsedWindow = parseFreshnessWindow(options.freshnessWindow);
+    const currentIndex = findCurrentHistoryIndex(sortedHistory, parsedWindow);
+
+    if (currentIndex === -1) {
+      const latest = sortedHistory[sortedHistory.length - 1];
+      const previousValues = sortedHistory.slice(0, -1).map(entry => entry.value);
+      const historyTruncated = previousValues.length > 0 && previousValues.length < options.baselineWindow;
+
+      return {
+        status: 'STALE',
+        projectKey: options.projectKey,
+        sourceJobName: options.sourceJobName,
+        metric: options.metric,
+        analysisDate: latest.date,
+        currentValue: latest.value,
+        baselineKind: 'median',
+        baselineWindow: options.baselineWindow,
+        historyPoints: sortedHistory.length,
+        historyTruncated,
+        message: 'Latest analysis is outside the freshness window',
+      };
+    }
+
+    const current = sortedHistory[currentIndex];
+    const previousValues = sortedHistory.slice(0, currentIndex).map(entry => entry.value);
+    const baselineSample = previousValues.slice(-options.baselineWindow);
+    const baselineValue = baselineSample.length > 0 ? computeMedian(baselineSample) : undefined;
+    const historyTruncated = previousValues.length > 0 && previousValues.length < options.baselineWindow;
+
+    if (previousValues.length < options.baselineWindow) {
+      return {
+        status: 'INSUFFICIENT_HISTORY',
+        projectKey: options.projectKey,
+        sourceJobName: options.sourceJobName,
+        metric: options.metric,
+        analysisDate: current.date,
+        currentValue: current.value,
+        baselineValue,
+        baselineKind: 'median',
+        baselineWindow: options.baselineWindow,
+        historyPoints: currentIndex + 1,
+        historyTruncated,
+      };
+    }
+
+    const dropAbs = (baselineValue ?? 0) - current.value;
+    const dropPct = baselineValue && baselineValue > 0 ? (dropAbs / baselineValue) * 100 : 0;
+    const clearsPctThreshold = dropPct >= options.thresholdPct;
+    const clearsAbsNoiseFloor = dropAbs >= options.thresholdAbs;
+    // The absolute threshold is a noise floor, not an alternative trigger.
+    const status =
+      (baselineValue ?? 0) > 0 && clearsPctThreshold && clearsAbsNoiseFloor ? 'DROP' : 'OK';
+
+    return {
+      status,
+      projectKey: options.projectKey,
+      sourceJobName: options.sourceJobName,
+      metric: options.metric,
+      analysisDate: current.date,
+      currentValue: current.value,
+      baselineValue,
+      baselineKind: 'median',
+      baselineWindow: options.baselineWindow,
+      historyPoints: currentIndex + 1,
+      historyTruncated: false,
+      dropAbs,
+      dropPct,
+    };
+  } catch (error) {
+    return createErrorRow(options, error instanceof Error ? error.message : String(error));
+  }
+}
+
+async function fetchMeasureHistoryWithRetry(projectKey, metric, apiToken, requiredHistoryPoints, runtime) {
+  const fetchMeasureHistory = runtime.fetchMeasureHistory ?? defaultFetchMeasureHistory;
+  const sleep = runtime.sleep ?? (ms => new Promise(resolve => setTimeout(resolve, ms)));
+  const random = runtime.random ?? Math.random;
+
+  for (let attempt = 0; attempt < DEFAULT_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      return await fetchMeasureHistory(projectKey, metric, apiToken, requiredHistoryPoints);
+    } catch (error) {
+      const statusCode = getStatusCode(error);
+      const isRetryable = statusCode !== undefined && RETRYABLE_STATUS_CODES.has(statusCode);
+      if (!isRetryable || attempt === DEFAULT_RETRY_ATTEMPTS - 1) {
+        throw error;
+      }
+
+      const delayMs = 100 * 2 ** attempt + Math.floor(random() * 50);
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error(`Failed to fetch measure history for ${projectKey}`);
+}
+
+async function defaultFetchMeasureHistory(projectKey, metric, apiToken, requiredHistoryPoints = DEFAULT_BASELINE_WINDOW + 1) {
+  const pageSize = Math.max(DEFAULT_HISTORY_PAGE_SIZE, requiredHistoryPoints);
+  const firstPage = await fetchMeasureHistoryPage(projectKey, metric, apiToken, 1, pageSize);
+
+  if (firstPage.total <= firstPage.history.length) {
+    return firstPage.history;
+  }
+
+  const lastPageIndex = Math.ceil(firstPage.total / pageSize);
+  const history = [...firstPage.history];
+
+  // Freshness-window matching can target an older analysis when newer scans exist, so the
+  // caller needs the full ordered series rather than only the tail pages.
+  // Any later-page failure bubbles to fetchMeasureHistoryWithRetry(), which retries the
+  // full pagination pass so every page gets identical retry handling.
+  for (let pageIndex = 2; pageIndex <= lastPageIndex; pageIndex += 1) {
+    const page = await fetchMeasureHistoryPage(projectKey, metric, apiToken, pageIndex, pageSize);
+    history.push(...page.history);
+  }
+
+  return history;
+}
+
+async function fetchMeasureHistoryPage(projectKey, metric, apiToken, pageIndex, pageSize) {
+  const params = new URLSearchParams({
+    component: projectKey,
+    metrics: metric,
+    p: String(pageIndex),
+    ps: String(pageSize),
+  });
+  const response = await fetchPeachJson(`/api/measures/search_history?${params.toString()}`, apiToken);
+  const measure = response.measures?.find(entry => entry.metric === metric) ?? response.measures?.[0];
+
+  return {
+    total: response.paging?.total ?? measure?.history?.length ?? 0,
+    history: (measure?.history ?? [])
+      .map(entry => ({
+        date: entry.date ?? '',
+        value: Number(entry.value),
+      }))
+      .filter(entry => entry.date.length > 0 && Number.isFinite(entry.value)),
+  };
+}
+
+async function fetchPeachJson(pathname, apiToken) {
+  const response = await fetch(`https://peach.sonarsource.com${pathname}`, {
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${apiToken}:`).toString('base64')}`,
+      Accept: 'application/json',
+    },
+    redirect: 'manual',
+  });
+
+  if (response.status === 301 || response.status === 302) {
+    throw createRequestError(`Redirect to: ${response.headers.get('location')}. Authentication may have failed.`, response.status);
+  }
+
+  if (response.status === 401) {
+    throw createRequestError('Authentication failed. Check your PEACH_KEY token.', response.status);
+  }
+
+  if (response.status === 403) {
+    throw createRequestError('Access denied. You may not have permission to access this resource.', response.status);
+  }
+
+  if (response.status >= 400) {
+    throw createRequestError(`API request failed with status ${response.status}: ${await response.text()}`, response.status);
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    throw createRequestError('Failed to parse JSON response from Peach.');
+  }
+}
+
+function createRequestError(message, statusCode) {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  return error;
+}
+
+function toDatedHistory(history) {
+  return history
+    .flatMap(entry => {
+      const timestamp = parseTimestamp(entry.date);
+      return timestamp === undefined ? [] : [{ ...entry, timestamp }];
+    })
+    .sort((left, right) => left.timestamp - right.timestamp);
+}
+
+function parseFreshnessWindow(window) {
+  const analysisAfterTimestamp = parseTimestamp(window.analysisAfter);
+  const analysisBeforeTimestamp = parseTimestamp(window.analysisBefore);
+
+  if (
+    analysisAfterTimestamp !== undefined &&
+    analysisBeforeTimestamp !== undefined &&
+    analysisAfterTimestamp > analysisBeforeTimestamp
+  ) {
+    throw new Error('analysisAfter must be earlier than or equal to analysisBefore');
+  }
+
+  return {
+    analysisAfterTimestamp,
+    analysisBeforeTimestamp,
+  };
+}
+
+function findCurrentHistoryIndex(history, window) {
+  if (window.analysisAfterTimestamp === undefined && window.analysisBeforeTimestamp === undefined) {
+    return history.length - 1;
+  }
+
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const point = history[index];
+    if (
+      (window.analysisAfterTimestamp === undefined || point.timestamp >= window.analysisAfterTimestamp) &&
+      (window.analysisBeforeTimestamp === undefined || point.timestamp <= window.analysisBeforeTimestamp)
+    ) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function computeMedian(values) {
+  const sortedValues = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sortedValues.length / 2);
+
+  if (sortedValues.length % 2 === 1) {
+    return sortedValues[middle];
+  }
+
+  return (sortedValues[middle - 1] + sortedValues[middle]) / 2;
+}
+
+async function mapWithConcurrencyLimit(items, limit, mapper) {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+
+      if (currentIndex >= items.length) {
+        return;
+      }
+
+      results[currentIndex] = await mapper(items[currentIndex]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+function createUnresolvedRow(sourceJobName, message, metric, baselineWindow) {
+  return {
+    status: 'UNRESOLVED_PROJECT',
+    sourceJobName,
+    metric,
+    baselineKind: 'median',
+    baselineWindow,
+    historyPoints: 0,
+    historyTruncated: false,
+    message,
+  };
+}
+
+function createErrorRow(options, message) {
+  return {
+    status: 'ERROR',
+    projectKey: options.projectKey,
+    sourceJobName: options.sourceJobName,
+    metric: options.metric,
+    baselineKind: 'median',
+    baselineWindow: options.baselineWindow,
+    historyPoints: 0,
+    historyTruncated: false,
+    message,
+  };
+}
+
+function summarizeRows(rows) {
+  return rows.reduce((summary, row) => {
+    summary[row.status] = (summary[row.status] ?? 0) + 1;
+    return summary;
+  }, {});
+}
+
+function toJsonRow(row) {
+  return {
+    project_key: row.projectKey,
+    metric: row.metric,
+    analysis_date: row.analysisDate,
+    current_value: row.currentValue,
+    baseline_value: row.baselineValue,
+    baseline_kind: row.baselineKind,
+    baseline_window: row.baselineWindow,
+    history_points: row.historyPoints,
+    history_truncated: row.historyTruncated,
+    drop_abs: row.dropAbs,
+    drop_pct: row.dropPct,
+    status: row.status,
+    source_job_name: row.sourceJobName,
+    message: row.message,
+  };
+}
+
+function getRowIdentifier(row) {
+  return row.projectKey ?? row.sourceJobName ?? '';
+}
+
+function readStringField(value, keys) {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    if (typeof value[key] === 'string') {
+      return value[key];
+    }
+  }
+
+  return undefined;
+}
+
+function parseTimestamp(value) {
+  if (!value) {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
+function latestTimestamp(values) {
+  return values.reduce((latest, value) => {
+    const timestamp = parseTimestamp(value);
+    if (timestamp === undefined) {
+      return latest;
+    }
+
+    return latest === undefined || timestamp > latest ? timestamp : latest;
+  }, undefined);
+}
+
+function formatIsoTimestamp(timestamp) {
+  return new Date(timestamp).toISOString().replace('.000Z', 'Z');
+}
+
+function firstDefinedNumber(...values) {
+  return values.find(value => value !== undefined);
+}
+
+function getStatusCode(error) {
+  if (error && typeof error === 'object' && 'statusCode' in error && typeof error.statusCode === 'number') {
+    return error.statusCode;
+  }
+
+  return undefined;
+}
+
+function readNumberEnv(name, fallback) {
+  const rawValue = process.env[name];
+  if (rawValue === undefined || rawValue === '') {
+    return fallback;
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  return parsed;
+}
+
+function readIntegerEnv(name, fallback) {
+  const rawValue = process.env[name];
+  if (rawValue === undefined || rawValue === '') {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function defaultExecFileSync(command, args, options = {}) {
+  return nodeExecFileSync(command, args, {
+    cwd: options.cwd,
+    encoding: options.encoding ?? 'utf-8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+export async function main(argv = process.argv.slice(2), runtime = {}) {
+  if (argv.length !== 3) {
+    throw new Error(
+      'Usage: node .claude/skills/peach-check/peach-issue-history.js <project-jobs.json> <peachee-root> <output.json>',
+    );
+  }
+
+  const [jobsJsonPath, peacheeRoot, outputPath] = argv;
+  await runIssueHistory(
+    {
+      jobsJsonPath,
+      peacheeRoot,
+      outputPath,
+    },
+    runtime,
+  );
+}
+
+const entrypoint = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === entrypoint) {
+  main().catch(error => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/.claude/skills/peach-check/peach-issue-history.test.js
+++ b/.claude/skills/peach-check/peach-issue-history.test.js
@@ -1,0 +1,655 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runIssueHistory } from './peach-issue-history.js';
+
+function createGitExecFileSyncStub(headSha, files) {
+  return (command, args) => {
+    assert.equal(command, 'git');
+
+    if (args[0] === 'rev-parse') {
+      assert.equal(args[3], `${headSha}^{commit}`);
+      return `${headSha}\n`;
+    }
+
+    if (args[0] === 'show') {
+      const filePath = args[1].slice(`${headSha}:`.length);
+      const content = files[filePath];
+      if (content === undefined) {
+        throw new Error(`missing file: ${filePath}`);
+      }
+      return content;
+    }
+
+    throw new Error(`unexpected git invocation: ${args.join(' ')}`);
+  };
+}
+
+function createFetchResponse(payload) {
+  return {
+    status: 200,
+    headers: {
+      get: () => null,
+    },
+    json: async () => payload,
+  };
+}
+
+function createErrorFetchResponse(status, body = 'temporary failure') {
+  return {
+    status,
+    headers: {
+      get: () => null,
+    },
+    text: async () => body,
+  };
+}
+
+async function runSingleProjectIssueHistory({
+  baselineValues,
+  currentValue,
+  headSha,
+  projectKey,
+  projectName,
+  thresholdPct = 5,
+  thresholdAbs = 20,
+}) {
+  const output = {};
+
+  await runIssueHistory(
+    {
+      jobsJsonPath: '/tmp/project-jobs.json',
+      peacheeRoot: '/tmp/peachee-js',
+      outputPath: '/tmp/peach-issue-history.json',
+      apiToken: 'test-token',
+      thresholdPct,
+      thresholdAbs,
+    },
+    {
+      readFileSync: filePath => {
+        assert.equal(filePath, '/tmp/project-jobs.json');
+        return JSON.stringify({
+          total_jobs: 1,
+          jobs: [
+            {
+              name: projectName,
+              conclusion: 'success',
+              head_sha: headSha,
+              started_at: '2026-05-01T08:10:46Z',
+              completed_at: '2026-05-01T08:16:08Z',
+            },
+          ],
+        });
+      },
+      writeFileSync: (filePath, content) => {
+        output[filePath] = content;
+      },
+      existsSync: filePath => {
+        assert.equal(filePath, `/tmp/peachee-js/${projectName}/sonar-project.properties`);
+        return true;
+      },
+      execFileSync: createGitExecFileSyncStub(headSha, {
+        [`${projectName}/sonar-project.properties`]: `sonar.projectKey=${projectKey}\n`,
+      }),
+      fetchMeasureHistory: async requestedProjectKey => {
+        assert.equal(requestedProjectKey, projectKey);
+        return [
+          ...baselineValues.map((value, index) => ({
+            date: `2026-04-${String(index + 26).padStart(2, '0')}T03:10:35Z`,
+            value,
+          })),
+          { date: '2026-05-01T08:15:00Z', value: currentValue },
+        ];
+      },
+      sleep: async () => {},
+      random: () => 0,
+    },
+  );
+
+  return JSON.parse(output['/tmp/peach-issue-history.json']);
+}
+
+test('runIssueHistory uses snake_case job metadata and ignores later stale zeroes', async () => {
+  const headSha = '2222222222222222222222222222222222222222';
+  const output = {};
+
+  await runIssueHistory(
+    {
+      jobsJsonPath: '/tmp/project-jobs.json',
+      peacheeRoot: '/tmp/peachee-js',
+      outputPath: '/tmp/peach-issue-history.json',
+      apiToken: 'test-token',
+    },
+    {
+      readFileSync: (filePath) => {
+        assert.equal(filePath, '/tmp/project-jobs.json');
+        return JSON.stringify({
+          total_jobs: 1,
+          jobs: [
+            {
+              name: 'ant-design',
+              conclusion: 'success',
+              head_sha: headSha,
+              started_at: '2026-05-01T08:10:46Z',
+              completed_at: '2026-05-01T08:16:08Z',
+            },
+          ],
+        });
+      },
+      writeFileSync: (filePath, content) => {
+        output[filePath] = content;
+      },
+      existsSync: (filePath) => {
+        assert.equal(filePath, '/tmp/peachee-js/ant-design/sonar-project.properties');
+        return true;
+      },
+      execFileSync: createGitExecFileSyncStub(headSha, {
+        'ant-design/sonar-project.properties': 'sonar.projectKey=js:CommittedProject\n',
+      }),
+      fetchMeasureHistory: async (projectKey) => {
+        assert.equal(projectKey, 'js:CommittedProject');
+        return [
+          { date: '2026-04-26T03:10:35Z', value: 25000 },
+          { date: '2026-04-27T03:10:35Z', value: 25020 },
+          { date: '2026-04-28T03:10:35Z', value: 25040 },
+          { date: '2026-04-29T03:10:35Z', value: 25060 },
+          { date: '2026-04-30T03:10:35Z', value: 25080 },
+          { date: '2026-05-01T08:15:00Z', value: 24940 },
+          { date: '2026-05-02T03:10:35Z', value: 0 },
+        ];
+      },
+      sleep: async () => {},
+      random: () => 0,
+    },
+  );
+
+  const report = JSON.parse(output['/tmp/peach-issue-history.json']);
+  assert.equal(report.analysis_after, '2026-04-30T00:00:00Z');
+  assert.equal(report.analysis_before, '2026-05-01T08:16:08Z');
+  assert.deepEqual(report.summary, { OK: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.project_key, 'js:CommittedProject');
+  assert.equal(row.status, 'OK');
+  assert.equal(row.analysis_date, '2026-05-01T08:15:00Z');
+  assert.equal(row.current_value, 24940);
+  assert.equal(row.baseline_value, 25040);
+});
+
+test('runIssueHistory keeps high-percentage drops OK below the absolute noise floor', async () => {
+  const report = await runSingleProjectIssueHistory({
+    baselineValues: [10, 10, 10, 10, 10],
+    currentValue: 9,
+    headSha: '4444444444444444444444444444444444444444',
+    projectKey: 'js:SmallProject',
+    projectName: 'small-project',
+    thresholdPct: 5,
+    thresholdAbs: 2,
+  });
+
+  assert.deepEqual(report.summary, { OK: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.status, 'OK');
+  assert.equal(row.baseline_value, 10);
+  assert.equal(row.current_value, 9);
+  assert.equal(row.drop_abs, 1);
+  assert.equal(row.drop_pct, 10);
+});
+
+test('runIssueHistory keeps drops OK when only the absolute threshold is exceeded', async () => {
+  const report = await runSingleProjectIssueHistory({
+    baselineValues: [100, 100, 100, 100, 100],
+    currentValue: 79,
+    headSha: '6666666666666666666666666666666666666666',
+    projectKey: 'js:LargeProject',
+    projectName: 'large-project',
+    thresholdPct: 25,
+    thresholdAbs: 20,
+  });
+
+  assert.deepEqual(report.summary, { OK: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.status, 'OK');
+  assert.equal(row.baseline_value, 100);
+  assert.equal(row.current_value, 79);
+  assert.equal(row.drop_abs, 21);
+  assert.equal(row.drop_pct, 21);
+});
+
+test('runIssueHistory marks DROP when both drop thresholds are exceeded', async () => {
+  const report = await runSingleProjectIssueHistory({
+    baselineValues: [10, 10, 10, 10, 10],
+    currentValue: 7,
+    headSha: '5555555555555555555555555555555555555555',
+    projectKey: 'js:DropProject',
+    projectName: 'drop-project',
+    thresholdPct: 5,
+    thresholdAbs: 2,
+  });
+
+  assert.deepEqual(report.summary, { DROP: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.status, 'DROP');
+  assert.equal(row.baseline_value, 10);
+  assert.equal(row.current_value, 7);
+  assert.equal(row.drop_abs, 3);
+  assert.equal(row.drop_pct, 30);
+});
+
+test('runIssueHistory reads the newest history page for long-lived projects', async t => {
+  const headSha = '3333333333333333333333333333333333333333';
+  const output = {};
+  const requestedPages = [];
+  const originalFetch = globalThis.fetch;
+  const historyStart = Date.UTC(2025, 11, 26, 3, 0, 0);
+  const history = Array.from({ length: 131 }, (_, index) => ({
+    date: new Date(historyStart + index * 24 * 60 * 60 * 1000).toISOString(),
+    value: '1000',
+  }));
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async url => {
+    const parsedUrl = new URL(url);
+    assert.equal(parsedUrl.hostname, 'peach.sonarsource.com');
+    assert.equal(parsedUrl.pathname, '/api/measures/search_history');
+    assert.equal(parsedUrl.searchParams.get('component'), 'js:LongLivedProject');
+    assert.equal(parsedUrl.searchParams.get('metrics'), 'violations');
+
+    const pageIndex = Number(parsedUrl.searchParams.get('p') ?? '1');
+    const pageSize = Number(parsedUrl.searchParams.get('ps') ?? '100');
+    const start = (pageIndex - 1) * pageSize;
+    requestedPages.push(pageIndex);
+
+    return createFetchResponse({
+      paging: {
+        pageIndex,
+        pageSize,
+        total: history.length,
+      },
+      measures: [
+        {
+          metric: 'violations',
+          history: history.slice(start, start + pageSize),
+        },
+      ],
+    });
+  };
+
+  await runIssueHistory(
+    {
+      jobsJsonPath: '/tmp/project-jobs.json',
+      peacheeRoot: '/tmp/peachee-js',
+      outputPath: '/tmp/peach-issue-history.json',
+      apiToken: 'test-token',
+    },
+    {
+      readFileSync: filePath => {
+        assert.equal(filePath, '/tmp/project-jobs.json');
+        return JSON.stringify({
+          total_jobs: 1,
+          jobs: [
+            {
+              name: 'long-lived-project',
+              conclusion: 'success',
+              head_sha: headSha,
+              started_at: '2026-05-05T03:10:46Z',
+              completed_at: '2026-05-05T03:16:08Z',
+            },
+          ],
+        });
+      },
+      writeFileSync: (filePath, content) => {
+        output[filePath] = content;
+      },
+      existsSync: filePath => {
+        assert.equal(filePath, '/tmp/peachee-js/long-lived-project/sonar-project.properties');
+        return true;
+      },
+      execFileSync: createGitExecFileSyncStub(headSha, {
+        'long-lived-project/sonar-project.properties': 'sonar.projectKey=js:LongLivedProject\n',
+      }),
+      sleep: async () => {},
+      random: () => 0,
+    },
+  );
+
+  assert.deepEqual(requestedPages, [1, 2]);
+
+  const report = JSON.parse(output['/tmp/peach-issue-history.json']);
+  assert.deepEqual(report.summary, { OK: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.project_key, 'js:LongLivedProject');
+  assert.equal(row.status, 'OK');
+  assert.equal(row.analysis_date, '2026-05-05T03:00:00.000Z');
+  assert.equal(row.current_value, 1000);
+  assert.equal(row.baseline_value, 1000);
+});
+
+test('runIssueHistory computes the baseline across three history pages', async t => {
+  const headSha = '7777777777777777777777777777777777777777';
+  const output = {};
+  const requestedPages = [];
+  const originalFetch = globalThis.fetch;
+  const endTimestamp = Date.UTC(2026, 4, 5, 3, 0, 0);
+  const history = Array.from({ length: 203 }, (_, index) => ({
+    date: new Date(endTimestamp - (202 - index) * 24 * 60 * 60 * 1000).toISOString(),
+    value: String(index + 1),
+  }));
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async url => {
+    const parsedUrl = new URL(url);
+    assert.equal(parsedUrl.hostname, 'peach.sonarsource.com');
+    assert.equal(parsedUrl.pathname, '/api/measures/search_history');
+    assert.equal(parsedUrl.searchParams.get('component'), 'js:ThreePageProject');
+    assert.equal(parsedUrl.searchParams.get('metrics'), 'violations');
+
+    const pageIndex = Number(parsedUrl.searchParams.get('p') ?? '1');
+    const pageSize = Number(parsedUrl.searchParams.get('ps') ?? '100');
+    const start = (pageIndex - 1) * pageSize;
+    requestedPages.push(pageIndex);
+
+    return createFetchResponse({
+      paging: {
+        pageIndex,
+        pageSize,
+        total: history.length,
+      },
+      measures: [
+        {
+          metric: 'violations',
+          history: history.slice(start, start + pageSize),
+        },
+      ],
+    });
+  };
+
+  await runIssueHistory(
+    {
+      jobsJsonPath: '/tmp/project-jobs.json',
+      peacheeRoot: '/tmp/peachee-js',
+      outputPath: '/tmp/peach-issue-history.json',
+      apiToken: 'test-token',
+    },
+    {
+      readFileSync: filePath => {
+        assert.equal(filePath, '/tmp/project-jobs.json');
+        return JSON.stringify({
+          total_jobs: 1,
+          jobs: [
+            {
+              name: 'three-page-project',
+              conclusion: 'success',
+              head_sha: headSha,
+              started_at: '2026-05-05T03:10:46Z',
+              completed_at: '2026-05-05T03:16:08Z',
+            },
+          ],
+        });
+      },
+      writeFileSync: (filePath, content) => {
+        output[filePath] = content;
+      },
+      existsSync: filePath => {
+        assert.equal(filePath, '/tmp/peachee-js/three-page-project/sonar-project.properties');
+        return true;
+      },
+      execFileSync: createGitExecFileSyncStub(headSha, {
+        'three-page-project/sonar-project.properties': 'sonar.projectKey=js:ThreePageProject\n',
+      }),
+      sleep: async () => {},
+      random: () => 0,
+    },
+  );
+
+  assert.deepEqual(requestedPages, [1, 2, 3]);
+
+  const report = JSON.parse(output['/tmp/peach-issue-history.json']);
+  assert.deepEqual(report.summary, { OK: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.project_key, 'js:ThreePageProject');
+  assert.equal(row.status, 'OK');
+  assert.equal(row.analysis_date, '2026-05-05T03:00:00.000Z');
+  assert.equal(row.current_value, 203);
+  assert.equal(row.baseline_value, 200);
+});
+
+test('runIssueHistory keeps enough three-page history when later analyses are outside the freshness window', async t => {
+  const headSha = '9999999999999999999999999999999999999999';
+  const output = {};
+  const requestedPages = [];
+  const originalFetch = globalThis.fetch;
+  const endTimestamp = Date.UTC(2026, 4, 5, 3, 0, 0);
+  const history = Array.from({ length: 203 }, (_, index) => ({
+    date: new Date(endTimestamp - (202 - index) * 24 * 60 * 60 * 1000).toISOString(),
+    value: String(index + 1),
+  }));
+  const currentEntry = history[102];
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async url => {
+    const parsedUrl = new URL(url);
+    assert.equal(parsedUrl.hostname, 'peach.sonarsource.com');
+    assert.equal(parsedUrl.pathname, '/api/measures/search_history');
+    assert.equal(parsedUrl.searchParams.get('component'), 'js:ThreePageProject');
+    assert.equal(parsedUrl.searchParams.get('metrics'), 'violations');
+
+    const pageIndex = Number(parsedUrl.searchParams.get('p') ?? '1');
+    const pageSize = Number(parsedUrl.searchParams.get('ps') ?? '100');
+    const start = (pageIndex - 1) * pageSize;
+    requestedPages.push(pageIndex);
+
+    return createFetchResponse({
+      paging: {
+        pageIndex,
+        pageSize,
+        total: history.length,
+      },
+      measures: [
+        {
+          metric: 'violations',
+          history: history.slice(start, start + pageSize),
+        },
+      ],
+    });
+  };
+
+  await runIssueHistory(
+    {
+      jobsJsonPath: '/tmp/project-jobs.json',
+      peacheeRoot: '/tmp/peachee-js',
+      outputPath: '/tmp/peach-issue-history.json',
+      apiToken: 'test-token',
+    },
+    {
+      readFileSync: filePath => {
+        assert.equal(filePath, '/tmp/project-jobs.json');
+        return JSON.stringify({
+          total_jobs: 1,
+          jobs: [
+            {
+              name: 'three-page-project',
+              conclusion: 'success',
+              head_sha: headSha,
+              started_at: currentEntry.date,
+              completed_at: new Date(Date.parse(currentEntry.date) + 10 * 60 * 1000).toISOString(),
+            },
+          ],
+        });
+      },
+      writeFileSync: (filePath, content) => {
+        output[filePath] = content;
+      },
+      existsSync: filePath => {
+        assert.equal(filePath, '/tmp/peachee-js/three-page-project/sonar-project.properties');
+        return true;
+      },
+      execFileSync: createGitExecFileSyncStub(headSha, {
+        'three-page-project/sonar-project.properties': 'sonar.projectKey=js:ThreePageProject\n',
+      }),
+      sleep: async () => {},
+      random: () => 0,
+    },
+  );
+
+  assert.deepEqual(requestedPages, [1, 2, 3]);
+
+  const report = JSON.parse(output['/tmp/peach-issue-history.json']);
+  assert.deepEqual(report.summary, { OK: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.project_key, 'js:ThreePageProject');
+  assert.equal(row.status, 'OK');
+  assert.equal(row.analysis_date, currentEntry.date);
+  assert.equal(row.current_value, 103);
+  assert.equal(row.baseline_value, 100);
+  assert.equal(row.history_points, 103);
+  assert.equal(row.history_truncated, false);
+});
+
+test('runIssueHistory retries the full history fetch when a later page gets a retryable error', async t => {
+  const headSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const output = {};
+  const requestedPages = [];
+  let pageTwoFailures = 0;
+  const originalFetch = globalThis.fetch;
+  const endTimestamp = Date.UTC(2026, 4, 5, 3, 0, 0);
+  const history = Array.from({ length: 203 }, (_, index) => ({
+    date: new Date(endTimestamp - (202 - index) * 24 * 60 * 60 * 1000).toISOString(),
+    value: String(index + 1),
+  }));
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async url => {
+    const parsedUrl = new URL(url);
+    assert.equal(parsedUrl.hostname, 'peach.sonarsource.com');
+    assert.equal(parsedUrl.pathname, '/api/measures/search_history');
+    assert.equal(parsedUrl.searchParams.get('component'), 'js:RetriedProject');
+    assert.equal(parsedUrl.searchParams.get('metrics'), 'violations');
+
+    const pageIndex = Number(parsedUrl.searchParams.get('p') ?? '1');
+    const pageSize = Number(parsedUrl.searchParams.get('ps') ?? '100');
+    const start = (pageIndex - 1) * pageSize;
+    requestedPages.push(pageIndex);
+
+    if (pageIndex === 2 && pageTwoFailures === 0) {
+      pageTwoFailures += 1;
+      return createErrorFetchResponse(503);
+    }
+
+    return createFetchResponse({
+      paging: {
+        pageIndex,
+        pageSize,
+        total: history.length,
+      },
+      measures: [
+        {
+          metric: 'violations',
+          history: history.slice(start, start + pageSize),
+        },
+      ],
+    });
+  };
+
+  await runIssueHistory(
+    {
+      jobsJsonPath: '/tmp/project-jobs.json',
+      peacheeRoot: '/tmp/peachee-js',
+      outputPath: '/tmp/peach-issue-history.json',
+      apiToken: 'test-token',
+    },
+    {
+      readFileSync: filePath => {
+        assert.equal(filePath, '/tmp/project-jobs.json');
+        return JSON.stringify({
+          total_jobs: 1,
+          jobs: [
+            {
+              name: 'retried-project',
+              conclusion: 'success',
+              head_sha: headSha,
+              started_at: '2026-05-05T03:10:46Z',
+              completed_at: '2026-05-05T03:16:08Z',
+            },
+          ],
+        });
+      },
+      writeFileSync: (filePath, content) => {
+        output[filePath] = content;
+      },
+      existsSync: filePath => {
+        assert.equal(filePath, '/tmp/peachee-js/retried-project/sonar-project.properties');
+        return true;
+      },
+      execFileSync: createGitExecFileSyncStub(headSha, {
+        'retried-project/sonar-project.properties': 'sonar.projectKey=js:RetriedProject\n',
+      }),
+      sleep: async () => {},
+      random: () => 0,
+    },
+  );
+
+  assert.equal(pageTwoFailures, 1);
+  assert.deepEqual(requestedPages, [1, 2, 1, 2, 3]);
+
+  const report = JSON.parse(output['/tmp/peach-issue-history.json']);
+  assert.deepEqual(report.summary, { OK: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.project_key, 'js:RetriedProject');
+  assert.equal(row.status, 'OK');
+  assert.equal(row.analysis_date, '2026-05-05T03:00:00.000Z');
+  assert.equal(row.current_value, 203);
+  assert.equal(row.baseline_value, 200);
+});
+
+test('runIssueHistory omits drop metrics when a row has no measured drop', async () => {
+  const report = await runSingleProjectIssueHistory({
+    baselineValues: [100, 100],
+    currentValue: 90,
+    headSha: '8888888888888888888888888888888888888888',
+    projectKey: 'js:ShortHistory',
+    projectName: 'short-history',
+  });
+
+  assert.deepEqual(report.summary, { INSUFFICIENT_HISTORY: 1 });
+
+  const row = report.rows[0];
+  assert.equal(row.status, 'INSUFFICIENT_HISTORY');
+  assert.equal(Object.hasOwn(row, 'drop_abs'), false);
+  assert.equal(Object.hasOwn(row, 'drop_pct'), false);
+});

--- a/.claude/skills/peach-check/peach-run-jobs.js
+++ b/.claude/skills/peach-check/peach-run-jobs.js
@@ -1,0 +1,198 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync as nodeExecFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_REPO = 'SonarSource/peachee-js';
+const DEFAULT_PAGE_SIZE = 100;
+const WORKFLOW_ONLY_JOBS = new Set(['prepare-project-matrix', 'diff-validation-aggregated']);
+
+export async function collectRunJobs(options, runtime = {}) {
+  const runId = readRunId(options.runId);
+  const outputDir = options.outputDir ?? 'target';
+  const repo = options.repo ?? DEFAULT_REPO;
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+  const execFileSync = runtime.execFileSync ?? defaultExecFileSync;
+  const mkdirSync = runtime.mkdirSync ?? fs.mkdirSync;
+  const writeFileSync = runtime.writeFileSync ?? fs.writeFileSync;
+
+  mkdirSync(outputDir, { recursive: true });
+
+  let pages = fetchPaginatedJobPages(runId, repo, pageSize, execFileSync);
+  let mergedJobs = mergeJobPages(pages);
+
+  if (!mergedJobs.countsMatch && mergedJobs.expectedTotal > mergedJobs.totalJobs) {
+    pages = fetchJobPagesExplicitly(runId, repo, pageSize, mergedJobs.expectedTotal, execFileSync);
+    mergedJobs = mergeJobPages(pages);
+  }
+
+  if (!mergedJobs.countsMatch) {
+    throw new Error(
+      `Expected ${mergedJobs.expectedTotal} jobs for Peach run ${runId}, but collected ${mergedJobs.totalJobs}`,
+    );
+  }
+
+  const analyzedJobs = mergedJobs.jobs.filter(job => !WORKFLOW_ONLY_JOBS.has(job.name));
+  const failedJobs = analyzedJobs.filter(job => job.conclusion === 'failure');
+  const projectJobs = analyzedJobs.filter(job => job.conclusion === 'success');
+  const excludedWorkflowJobs = mergedJobs.jobs.length - analyzedJobs.length;
+
+  const jobsMergedPath = path.join(outputDir, 'jobs-merged.json');
+  const analyzedJobsPath = path.join(outputDir, 'analyzed-jobs.json');
+  const exclusionCountsPath = path.join(outputDir, 'exclusion-counts.json');
+  const failedJobsPath = path.join(outputDir, 'failed-jobs.json');
+  const projectJobsPath = path.join(outputDir, 'project-jobs.json');
+
+  writeJson(writeFileSync, jobsMergedPath, {
+    expected_total: mergedJobs.expectedTotal,
+    total_jobs: mergedJobs.totalJobs,
+    failed_jobs: mergedJobs.failedJobs,
+    counts_match: mergedJobs.countsMatch,
+    jobs: mergedJobs.jobs,
+  });
+  writeJson(writeFileSync, analyzedJobsPath, {
+    total_jobs: analyzedJobs.length,
+    jobs: analyzedJobs,
+  });
+  writeJson(writeFileSync, exclusionCountsPath, {
+    excluded_workflow_jobs: excludedWorkflowJobs,
+    excluded_project_jobs: 0,
+  });
+  writeJson(writeFileSync, failedJobsPath, {
+    total_jobs: failedJobs.length,
+    jobs: failedJobs,
+  });
+  writeJson(writeFileSync, projectJobsPath, {
+    total_jobs: projectJobs.length,
+    jobs: projectJobs,
+  });
+
+  return {
+    jobsMergedPath,
+    analyzedJobsPath,
+    exclusionCountsPath,
+    failedJobsPath,
+    projectJobsPath,
+    expectedTotal: mergedJobs.expectedTotal,
+    totalJobs: mergedJobs.totalJobs,
+  };
+}
+
+function readRunId(runId) {
+  if (typeof runId === 'string' && runId.length > 0) {
+    return runId;
+  }
+
+  throw new Error('runId is required');
+}
+
+function fetchPaginatedJobPages(runId, repo, pageSize, execFileSync) {
+  const output = execFileSync('gh', [
+    'api',
+    `repos/${repo}/actions/runs/${runId}/jobs?per_page=${pageSize}`,
+    '--paginate',
+    '--slurp',
+  ]);
+  const payload = parseJson(output);
+
+  if (!Array.isArray(payload)) {
+    throw new Error('Expected paginated gh api output to be a JSON array');
+  }
+
+  return payload;
+}
+
+function fetchJobPagesExplicitly(runId, repo, pageSize, expectedTotal, execFileSync) {
+  const pageCount = Math.max(1, Math.ceil(expectedTotal / pageSize));
+  return Array.from({ length: pageCount }, (_, index) => {
+    const pageIndex = index + 1;
+    const output = execFileSync('gh', [
+      'api',
+      `repos/${repo}/actions/runs/${runId}/jobs?per_page=${pageSize}&page=${pageIndex}`,
+    ]);
+    return parseJson(output);
+  });
+}
+
+function mergeJobPages(pages) {
+  const normalizedPages = pages.flatMap(normalizePage);
+  const jobs = normalizedPages.flatMap(page => (Array.isArray(page.jobs) ? page.jobs : []));
+  const expectedTotal = normalizedPages[0]?.total_count ?? 0;
+  const failedJobs = jobs.filter(job => job?.conclusion === 'failure').length;
+
+  return {
+    expectedTotal,
+    totalJobs: jobs.length,
+    failedJobs,
+    countsMatch: expectedTotal === jobs.length,
+    jobs,
+  };
+}
+
+function normalizePage(page) {
+  if (!page || typeof page !== 'object') {
+    return [];
+  }
+
+  return [page];
+}
+
+function parseJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse gh api JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function writeJson(writeFileSync, filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+function defaultExecFileSync(command, args, options = {}) {
+  return nodeExecFileSync(command, args, {
+    cwd: options.cwd,
+    encoding: options.encoding ?? 'utf-8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+export async function main(argv = process.argv.slice(2), runtime = {}) {
+  if (argv.length < 1 || argv.length > 2) {
+    throw new Error('Usage: node .claude/skills/peach-check/peach-run-jobs.js <run-id> [output-dir]');
+  }
+
+  const [runId, outputDir] = argv;
+  await collectRunJobs(
+    {
+      runId,
+      outputDir,
+    },
+    runtime,
+  );
+}
+
+const entrypoint = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === entrypoint) {
+  main().catch(error => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/.claude/skills/peach-check/peach-run-jobs.test.js
+++ b/.claude/skills/peach-check/peach-run-jobs.test.js
@@ -1,0 +1,206 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { collectRunJobs } from './peach-run-jobs.js';
+
+function parseOutputJson(output, filePath) {
+  const content = output[filePath];
+  assert.notEqual(content, undefined, `missing output for ${filePath}`);
+  return JSON.parse(content);
+}
+
+test('collectRunJobs writes merged and derived job files from paginated gh api output', async () => {
+  const output = {};
+  const mkdirCalls = [];
+  const execCalls = [];
+
+  await collectRunJobs(
+    {
+      runId: '25710841728',
+      outputDir: '/tmp/peach-target',
+    },
+    {
+      execFileSync: (command, args) => {
+        execCalls.push([command, ...args]);
+        assert.equal(command, 'gh');
+        assert.deepEqual(args, [
+          'api',
+          'repos/SonarSource/peachee-js/actions/runs/25710841728/jobs?per_page=100',
+          '--paginate',
+          '--slurp',
+        ]);
+
+        return JSON.stringify([
+          {
+            total_count: 4,
+            jobs: [
+              { name: 'prepare-project-matrix', conclusion: 'success' },
+              { name: 'project-a', conclusion: 'failure' },
+              { name: 'project-b', conclusion: 'success' },
+            ],
+          },
+          {
+            total_count: 4,
+            jobs: [{ name: 'diff-validation-aggregated', conclusion: 'failure' }],
+          },
+        ]);
+      },
+      mkdirSync: (dirPath, options) => {
+        mkdirCalls.push([dirPath, options]);
+      },
+      writeFileSync: (filePath, content) => {
+        output[filePath] = content;
+      },
+    },
+  );
+
+  assert.deepEqual(execCalls, [
+    [
+      'gh',
+      'api',
+      'repos/SonarSource/peachee-js/actions/runs/25710841728/jobs?per_page=100',
+      '--paginate',
+      '--slurp',
+    ],
+  ]);
+  assert.deepEqual(mkdirCalls, [['/tmp/peach-target', { recursive: true }]]);
+
+  assert.deepEqual(parseOutputJson(output, '/tmp/peach-target/jobs-merged.json'), {
+    expected_total: 4,
+    total_jobs: 4,
+    failed_jobs: 2,
+    counts_match: true,
+    jobs: [
+      { name: 'prepare-project-matrix', conclusion: 'success' },
+      { name: 'project-a', conclusion: 'failure' },
+      { name: 'project-b', conclusion: 'success' },
+      { name: 'diff-validation-aggregated', conclusion: 'failure' },
+    ],
+  });
+
+  assert.deepEqual(parseOutputJson(output, '/tmp/peach-target/analyzed-jobs.json'), {
+    total_jobs: 2,
+    jobs: [
+      { name: 'project-a', conclusion: 'failure' },
+      { name: 'project-b', conclusion: 'success' },
+    ],
+  });
+
+  assert.deepEqual(parseOutputJson(output, '/tmp/peach-target/exclusion-counts.json'), {
+    excluded_workflow_jobs: 2,
+    excluded_project_jobs: 0,
+  });
+
+  assert.deepEqual(parseOutputJson(output, '/tmp/peach-target/failed-jobs.json'), {
+    total_jobs: 1,
+    jobs: [{ name: 'project-a', conclusion: 'failure' }],
+  });
+
+  assert.deepEqual(parseOutputJson(output, '/tmp/peach-target/project-jobs.json'), {
+    total_jobs: 1,
+    jobs: [{ name: 'project-b', conclusion: 'success' }],
+  });
+});
+
+test('collectRunJobs falls back to explicit page fetches when the paginated total is short', async () => {
+  const output = {};
+  const execCalls = [];
+
+  await collectRunJobs(
+    {
+      runId: '25710841728',
+      outputDir: '/tmp/peach-target',
+      pageSize: 2,
+    },
+    {
+      execFileSync: (command, args) => {
+        execCalls.push([command, ...args]);
+        assert.equal(command, 'gh');
+
+        const endpoint = args[1];
+        if (args.includes('--slurp')) {
+          return JSON.stringify([
+            {
+              total_count: 3,
+              jobs: [
+                { name: 'project-a', conclusion: 'success' },
+                { name: 'project-b', conclusion: 'failure' },
+              ],
+            },
+          ]);
+        }
+
+        if (endpoint.endsWith('&page=1')) {
+          return JSON.stringify({
+            total_count: 3,
+            jobs: [
+              { name: 'project-a', conclusion: 'success' },
+              { name: 'project-b', conclusion: 'failure' },
+            ],
+          });
+        }
+
+        if (endpoint.endsWith('&page=2')) {
+          return JSON.stringify({
+            total_count: 3,
+            jobs: [{ name: 'project-c', conclusion: 'success' }],
+          });
+        }
+
+        throw new Error(`unexpected args: ${args.join(' ')}`);
+      },
+      mkdirSync: () => {},
+      writeFileSync: (filePath, content) => {
+        output[filePath] = content;
+      },
+    },
+  );
+
+  assert.deepEqual(execCalls, [
+    [
+      'gh',
+      'api',
+      'repos/SonarSource/peachee-js/actions/runs/25710841728/jobs?per_page=2',
+      '--paginate',
+      '--slurp',
+    ],
+    [
+      'gh',
+      'api',
+      'repos/SonarSource/peachee-js/actions/runs/25710841728/jobs?per_page=2&page=1',
+    ],
+    [
+      'gh',
+      'api',
+      'repos/SonarSource/peachee-js/actions/runs/25710841728/jobs?per_page=2&page=2',
+    ],
+  ]);
+
+  assert.deepEqual(parseOutputJson(output, '/tmp/peach-target/jobs-merged.json'), {
+    expected_total: 3,
+    total_jobs: 3,
+    failed_jobs: 1,
+    counts_match: true,
+    jobs: [
+      { name: 'project-a', conclusion: 'success' },
+      { name: 'project-b', conclusion: 'failure' },
+      { name: 'project-c', conclusion: 'success' },
+    ],
+  });
+});

--- a/.codex/skills/peach-check/SKILL.md
+++ b/.codex/skills/peach-check/SKILL.md
@@ -1,20 +1,13 @@
 ---
 name: peach-check
 description: Use before a SonarJS release or when the Peach Main Analysis workflow on SonarSource/peachee-js shows failed jobs or suspicious project issue-count drops that need triage. Classify failed Peach jobs and flag likely project-configuration regressions using docs/peach-main-analysis.md.
-argument-hint: "[run-id]"
 allowed-tools: Bash(gh auth status:*), Bash(gh run list:*), Bash(gh api:*), Bash(mkdir:*), Bash(jq:*), Bash(sed --sandbox:*), Bash(node:*), Read, Agent
 ---
 
 # Peach Main Analysis Check
 
-Canonical instructions for this skill live in `.claude/skills/peach-check/INSTRUCTIONS.md`
-relative to the SonarJS repository root.
-
-Before doing anything else:
-
-1. Read `.claude/skills/peach-check/INSTRUCTIONS.md`.
-2. Follow that file verbatim.
-3. Treat `.claude/skills/peach-check/peach-issue-history.js` as the canonical issue-history
-   implementation for this skill.
+Canonical instructions live in `.claude/skills/peach-check/INSTRUCTIONS.md` relative to the
+SonarJS repository root; follow that file verbatim and treat
+`.claude/skills/peach-check/peach-issue-history.js` as the canonical issue-history helper.
 
 Do not duplicate or fork the instructions in this wrapper.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -776,7 +776,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_without_node_alpine:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: QA without Node on Alpine SQ:LATEST_RELEASE
     needs: [setup, get_build_number, build]
     if: github.event_name == 'schedule'
@@ -883,7 +883,7 @@ jobs:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).licenses_token }}
 
   plugin_qa_fast_without_node_alpine:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Fast QA without Node on Alpine SQ:LATEST_RELEASE
     needs: [setup, get_build_number, build]
     if: github.event_name == 'schedule'

--- a/.github/workflows/docker-a3s-repox.yml
+++ b/.github/workflows/docker-a3s-repox.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   get_build_number:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Get build number
     permissions:
       id-token: write
@@ -33,7 +33,7 @@ jobs:
 
   build_and_publish:
     name: Build and publish Docker image
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     needs: get_build_number
     permissions:
       id-token: write

--- a/.github/workflows/docker-a3s.yml
+++ b/.github/workflows/docker-a3s.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   get_build_number:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Get build number
     permissions:
       id-token: write
@@ -35,7 +35,7 @@ jobs:
 
   build_and_publish:
     name: Build and publish Docker image
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     needs: get_build_number
     environment: ${{ inputs.environment == 'Prod' && 'Prod' || 'Dev5' }}
     permissions:

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -18,7 +18,7 @@ jobs:
   dogfood_merge:
     # Run if triggered by push to dogfood/*, or if Build workflow succeeded on master
     if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Update dogfood branch
     permissions:
       id-token: write # required for SonarSource/vault-action-wrapper

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ lcov.info
 .claude/*
 !.claude/*.md
 !.claude/skills/
+
+.codex/*
+!.codex/skills/
+.mcp.json

--- a/docs/peach-main-analysis.md
+++ b/docs/peach-main-analysis.md
@@ -12,8 +12,9 @@ before a release is essential to ensure the analyzer is stable.
 
 ## Failure Classification
 
-Not all failures indicate an analyzer problem. The workflow involves several phases before the
-actual scan, and failures in early phases are unrelated to the SonarJS analyzer.
+Not all failures indicate an analyzer problem. The workflow involves several phases before and
+after the actual scan, and failures outside the scanner step are usually unrelated to the
+SonarJS analyzer.
 
 ## SonarJS Sensor Names
 
@@ -28,29 +29,114 @@ log shows one of these names in the failing sensor context:
 Any other sensor name (e.g. `Sensor Declarative Rule Engine for Shell`, `Java sensor`,
 `Security SonarQube`) belongs to a **different plugin** and is not a SonarJS issue.
 
+### Last Sensor Wins
+
+When classifying a scanner failure, use the **last sensor that started before the stack trace**
+as the owner of the crash.
+
+- If `Sensor JavaScript/TypeScript/CSS analysis [javascript]` is the last active sensor and the
+  stack trace contains `org.sonar.plugins.javascript`, treat it as a SonarJS failure.
+- If the JavaScript sensor finished successfully and a later non-SonarJS sensor started, the
+  later sensor owns the failure even if JavaScript analysis ran earlier in the job.
+- Do not blame SonarJS just because the log contains earlier JavaScript sensor lines. The
+  failing sensor context matters, not the first sensor that appeared in the job.
+
+Example:
+
+```text
+Sensor JavaScript/TypeScript/CSS analysis [javascript] (done)
+Sensor JsSecuritySensorV2 [jasmin]
+...
+java.lang.OutOfMemoryError: Java heap space
+```
+
+This is **not** a SonarJS analyzer failure. The last active sensor is `JsSecuritySensorV2
+[jasmin]`, so the failure belongs to Jasmin/security.
+
 ### Decision Flowchart
 
 ```
 1. At which step did the job fail?
-   ├─ Pre-scan step (checkout, vault secrets, dependency install) → IGNORE
-   ├─ During sonar-scanner execution → go to step 2
+   ├─ Pre-scan step (checkout, vault secrets, clone, cache, dependency install) → IGNORE
+   ├─ During `Analyze project` / sonar-scanner execution → go to step 2
+   ├─ Job is `diff-validation-aggregated` → EXCLUDE from analyzed-job counts and findings
+   ├─ `Diff Val` / `diff-val` monitoring step → IGNORE
+   ├─ After analysis completed (report upload / Diff Val / artifact upload / pages publishing / other post-scan step) → usually IGNORE
    └─ Unclear / no recognizable step → NEEDS-MANUAL-REVIEW
 
-2. What is the scanner exit code?
+Before classifying from the step name, check whether multiple steps are marked failed.
+Use the earliest failed step that actually ran as the phase owner.
+If `Analyze project` was skipped, do not classify from later `Report analyzer version` noise.
+Also, do not assume that the GitHub Actions step name `Analyze project` means the owning phase is
+`analyze`: if the JavaScript sensor already finished and the stack trace later shows
+`ReportPublisher.upload` or `/api/ce/submit`, the real owner is `post-scan`.
+
+2. Only now inspect the scanner exit code.
    ├─ Exit code 3 → read the error message:
    │   ├─ "The folder X does not exist" or "Invalid value of sonar.X" → IGNORE (project misconfiguration)
    │   └─ Java stack trace present → go to step 3
    ├─ Exit code 137 → CRITICAL (out-of-memory, escalate)
    └─ Other exit code → NEEDS-MANUAL-REVIEW
 
-3. Which component crashed?
+3. Which component crashed? Use the last sensor that started before the error.
    ├─ Stack trace is in `ReportPublisher.upload` → IGNORE (Peach server / report upload timeout)
+   ├─ Log says `Node.js process running out of memory` or suggests `sonar.javascript.node.maxspace` → CRITICAL (SonarJS bridge Node heap exhausted)
+   ├─ Log says `Failed to get response from analysis` and then `Failed to analyze file ...` with `Rule: "sonarjs/Sxxxx"` → CRITICAL (SonarJS rule crash)
    ├─ Stack trace contains `org.sonar.plugins.javascript` frames but no sensor name → CRITICAL (SonarJS plugin initialization failure)
-   ├─ Sensor name is one of the SonarJS sensors listed above → CRITICAL (SonarJS analyzer crash)
-   └─ Sensor name is something else (DRE Shell, Java, Security...) → IGNORE (different plugin, not our problem)
+   ├─ Last active sensor is one of the SonarJS sensors listed above → CRITICAL (SonarJS analyzer crash)
+   └─ Last active sensor is something else (DRE Shell, Java, Security...) → IGNORE (different plugin, not our problem)
 ```
 
+Do not classify by exit code before you know the failing phase. For example, exit code `1`
+during `npm install` is a dependency/setup problem, not a scanner problem.
+Likewise, do not classify from the first matching exit-code line in the log alone: nested commands
+can emit intermediate non-fatal `Process completed with exit code 1` lines that the job then
+recovers from before the real terminal failure.
+
 ## Failure Categories
+
+### IGNORE: Diff Val Monitoring Failure
+
+**Verdict:** IGNORE — the failure happened in differential-validation monitoring, not in project
+analysis.
+
+**How to identify:**
+- The failing step name contains `Diff Val` or `diff-val`
+- Examples:
+  - `Setup Diff Val`
+  - `Diff Val Snapshot generation`
+  - `Diff Val aggregated snapshot generation`
+  - `Upload diff-val artifacts`
+- These steps run after analysis or as workflow-level post-processing to compare daily snapshots
+  for monitoring purposes
+- Failures here often come from the same Peach API flakiness seen elsewhere, but they do not say
+  anything about SonarJS analyzer correctness
+- This category applies to per-project jobs only. The standalone workflow job
+  `diff-validation-aggregated` is excluded entirely from analyzed-job counts and detailed findings.
+
+**Detection patterns:**
+- Classify from step metadata first; do not require log inspection
+- Phase 1 log hints may include `/502 Bad Gateway/`, `/503 Service Unavailable/`,
+  `/timeout/`, `/difference is found/`, or non-zero exit codes from diff-val tooling
+
+**Example outcomes:**
+```
+Diff Val Snapshot generation
+Process failed ... SnapshotHttpException: HTTP request failed with error code '502' ...
+##[error]Process completed with exit code 1.
+```
+
+```
+Diff Val aggregated snapshot generation
+Application run failed ... ExitDiffAppException: The difference is found for projects: ...
+##[error]Process completed with exit code 2.
+```
+
+**Action:** None for SonarJS release triage. Ignore and silence these failures in the detailed
+review output. If needed, track them separately as Peach monitoring noise. Do not use this
+category for `diff-validation-aggregated`; exclude that workflow job entirely instead.
+
+---
 
 ### CRITICAL: SonarJS Plugin Failure
 
@@ -70,6 +156,7 @@ Any other sensor name (e.g. `Sensor Declarative Rule Engine for Shell`, `Java se
 
 - Phase 1: `/EXECUTION FAILURE/`, `/Process completed with exit code/` — exit code 3 with no misconfiguration signal escalates to Phase 2
 - Phase 2: `/org\.sonar\.plugins\.javascript/` — any match → CRITICAL; `/Sensor /` — confirm the failing sensor is a SonarJS sensor
+- Phase 2: `/Failed to get response from analysis/`, `/Failed to analyze file/`, `/Rule: "sonarjs\/S[0-9]+"/` — rule crash inside the JavaScript sensor → CRITICAL
 
 **Example log excerpt (sensor crash):**
 
@@ -94,7 +181,80 @@ EXECUTION FAILURE
 ##[error]Process completed with exit code 3.
 ```
 
+**Example log excerpt (protobuf recursion limit exceeded — 2026-04-23, affected 53 projects):**
+```
+Sensor JavaScript/TypeScript/CSS analysis [javascript]
+ERROR Failed to get response from analysis
+java.lang.IllegalStateException: The bridge server is unresponsive...
+  at org.sonar.plugins.javascript.bridge.BridgeServerImpl.unresponsiveServerException(BridgeServerImpl.java:430)
+  at org.sonar.plugins.javascript.bridge.BridgeServerImpl.analyzeProject(BridgeServerImpl.java:395)
+  at org.sonar.plugins.javascript.analysis.WebSensor.execute(WebSensor.java:155)
+Caused by: io.grpc.StatusRuntimeException: INTERNAL: Invalid protobuf byte sequence
+Caused by: com.google.protobuf.InvalidProtocolBufferException:
+  Protocol message had too many levels of nesting. May be malicious.
+  Use setRecursionLimit() to increase the recursion depth limit.
+EXECUTION FAILURE
+##[error]Process completed with exit code 3.
+```
+
+**Example log excerpt (rule crash inside the JavaScript sensor):**
+```
+Sensor JavaScript/TypeScript/CSS analysis [javascript]
+ERROR Failed to get response from analysis
+java.lang.IllegalStateException: Failed to analyze file ...: <rule-specific error>
+Occurred while linting ...:<line>
+Rule: "sonarjs/S6437"
+  at org.sonar.plugins.javascript.analysis.WebSensor$AnalyzeProjectHandler.handleFileResult(...)
+EXECUTION FAILURE
+##[error]Process completed with exit code 3.
+```
+
+The protobuf recursion-limit pattern above occurs when a source file contains a deeply nested AST (e.g. deeply nested arrow
+functions or call expressions) that exceeds the default protobuf recursion limit when the Java
+side deserializes the gRPC response from the Node.js bridge. The fix is to call
+`setRecursionLimit()` with a higher value on the `CodedInputStream` used in
+`BridgeServerImpl.analyzeProject`. In the log, an `Artifact has expired (HTTP 410)` line may
+appear earlier (exit code 1) — that is pre-scan noise the scanner recovers from; the protobuf
+crash is the real terminal failure.
+
 **Action:** File a bug or investigate the SonarJS analyzer code. Do not release until resolved.
+
+---
+
+### CRITICAL: SonarJS Node Heap Exhaustion
+
+**Verdict:** CRITICAL — investigate analyzer memory use before release.
+
+**How to identify:**
+- Failure occurs during the SonarScanner execution step
+- The last active sensor is `JavaScript/TypeScript/CSS analysis [javascript]`
+- The log contains one or more of:
+  - `The analysis will stop due to the Node.js process running out of memory`
+  - `sonar.javascript.node.maxspace`
+  - `sonar.javascript.node.debugMemory`
+- The Java stack trace often ends with `WebSocket connection closed abnormally` and
+  `Analysis of JS/TS files failed`
+
+**Detection patterns:**
+- Phase 2: `/Node\.js process running out of memory/`,
+  `/sonar\.javascript\.node\.(maxspace|debugMemory)/`,
+  `/org\.sonar\.plugins\.javascript/`
+
+**Example log excerpt (`tape`, 2026-04-07):**
+```
+Sensor JavaScript/TypeScript/CSS analysis [javascript]
+ERROR The analysis will stop due to the Node.js process running out of memory (heap size limit 4288 MB)
+ERROR You can see how Node.js heap usage evolves during analysis with "sonar.javascript.node.debugMemory=true"
+ERROR Try setting "sonar.javascript.node.maxspace" to a higher value to increase Node.js heap size limit
+...
+java.lang.IllegalStateException: Analysis of JS/TS files failed
+  at org.sonar.plugins.javascript.analysis.WebSensor.execute(WebSensor.java:175)
+EXECUTION FAILURE
+##[error]Process completed with exit code 3.
+```
+
+**Action:** Raise the heap size for the affected project and investigate whether the analyzer
+has a memory regression or pathological input pattern.
 
 ---
 
@@ -130,7 +290,7 @@ EXECUTION FAILURE
 
 - Failure occurs during the SonarScanner execution step
 - Scanner exits with code 3 and a Java stack trace is present
-- The failing sensor name is **not** one of the SonarJS sensors listed above
+- The **last active** sensor name is **not** one of the SonarJS sensors listed above
 - Common non-SonarJS sensor names seen on Peach:
   - `Sensor Declarative Rule Engine for Shell` — belongs to **sonar-iac**
   - `Sensor Declarative Rule Engine for Terraform` — belongs to **sonar-iac**
@@ -141,7 +301,7 @@ EXECUTION FAILURE
 **Detection patterns:**
 
 - Phase 1: `/EXECUTION FAILURE/`, `/Process completed with exit code/` — exit code 3 with no misconfiguration signal escalates to Phase 2
-- Phase 2: `/Sensor /` — last sensor name is not a SonarJS sensor; `/org\.sonar\.plugins\.javascript/` absent → IGNORE
+- Phase 2: `/Sensor /` — last sensor name is not a SonarJS sensor and no later SonarJS sensor appears after it; `/org\.sonar\.plugins\.javascript/` absent → IGNORE
 
 **Example log excerpt (gutenberg, 2026-03-11):**
 
@@ -157,7 +317,7 @@ EXECUTION FAILURE
 
 The class `com.A.A.D.H` is from the sonar-iac plugin (obfuscated). No `org.sonar.plugins.javascript` frame is present — this is not a SonarJS crash.
 
-**Action:** None for the SonarJS team. Optionally notify the team responsible for the failing sensor (e.g. sonar-iac team for DRE Shell failures).
+**Action:** None for the SonarJS team. Optionally notify the team responsible for the failing sensor (e.g. sonar-iac team for DRE Shell failures). If the project should stay green on Peach, create or update a Peach tracking task.
 
 ---
 
@@ -187,7 +347,41 @@ The class `com.A.A.D.H` is from the sonar-iac plugin (obfuscated). No `org.sonar
 ##[error]Process completed with exit code 3.
 ```
 
-**Action:** None. The analyzed project's sonar-project.properties references a path that no longer exists. Not a SonarJS issue.
+**Action:** No SonarJS release blocker. The analyzed project's sonar-project.properties references a path that no longer exists. Create or update a Peach tracking task if the project should stay green.
+
+---
+
+### IGNORE: Upstream Repository Removed / Inaccessible
+
+**Verdict:** IGNORE — the target project can no longer be fetched from GitHub, so analysis never
+started and this is not a SonarJS analyzer issue.
+
+**How to identify:**
+- Failure occurs during `Checkout project`
+- `Analyze project` is skipped
+- The checkout URL points to a repository or owner that is no longer accessible
+- The log shows repeated clone retries ending with messages such as:
+  - `fatal: could not read Username for 'https://github.com': No such device or address`
+  - `All 3 attempts failed`
+
+This can happen when the upstream owner or repository has been removed from GitHub, for example
+after abuse or malware takedowns.
+
+**Detection patterns:**
+- Phase 1: `/fatal: could not read Username for 'https:\/\/github\.com'/`
+- Phase 1: `/All 3 attempts failed/`
+
+**Example log excerpt (`vote-coin-demo`, 2026-04-14):**
+```
+Checking out vote-coin-demo at ed7b9fd5d9504311598bd05d622fc4244c78848f from https://github.com/scholtz/vote-coin-demo
+fatal: could not read Username for 'https://github.com': No such device or address
+Attempt 3 failed with exit code 128
+All 3 attempts failed
+##[error]Process completed with exit code 1.
+```
+
+**Action:** No SonarJS release blocker. Remove or replace the Peach project entry, or track it as a
+Peach maintenance issue if the matrix should remain green.
 
 ---
 
@@ -205,7 +399,8 @@ The class `com.A.A.D.H` is from the sonar-iac plugin (obfuscated). No `org.sonar
 **Detection patterns:**
 
 - Phase 1: `/EXECUTION FAILURE/`, `/Process completed with exit code/` — exit code 3 with no misconfiguration signal escalates to Phase 2
-- Phase 2: `/org\.sonar\.plugins\.javascript/` absent; `/Sensor /` present (analysis ran) but no SonarJS frame → escalate to Phase 3 to confirm `ReportPublisher.upload` in stack trace
+- Phase 2: `/ReportPublisher\.upload/`, `/api\/ce\/submit/`, or `/SocketTimeoutException/`
+- Phase 2: `/org\.sonar\.plugins\.javascript/` absent; `/Sensor /` present and the SonarJS sensor already finished → IGNORE
 
 **Example log excerpt (fossflow, 2026-03-13):**
 
@@ -220,7 +415,60 @@ Caused by: java.net.SocketTimeoutException: timeout
 
 Multiple jobs failing this way within the same ~2-minute window is a strong indicator that the Peach server was temporarily unavailable or overloaded.
 
+This can still appear under the GitHub step name `Analyze project`. If
+`Sensor JavaScript/TypeScript/CSS analysis [javascript] (done)` appears before the stack trace,
+the analysis completed and the job should be classified as `post-scan`, not as an analyzer crash.
+
 **Action:** None for the SonarJS team. Re-run the workflow if needed; the failures are unrelated to the analyzer.
+
+---
+
+### IGNORE: Diff Val Artifact / Aggregation Failure
+
+**Verdict:** IGNORE — the scan completed, but the post-analysis Diff Val workflow failed.
+
+**How to identify:**
+- Project jobs complete `Analyze project` successfully and fail later in `Setup Diff Val`
+- The failing Diff Val setup step shows a missing artifact download such as:
+  - `Download snapshot-app-<VERSION>.tar`
+  - `curl: (22) The requested URL returned error: 404`
+- These jobs typically exit with code 22
+- The downstream `diff-validation-aggregated` job may then fail because no project produced a
+  successful Diff Val result
+- Typical downstream signals are:
+  - `No successful diff-val projects found`
+  - `tar: diff-val-download/diff-app-<VERSION>.tar: Cannot open: No such file or directory`
+  - `mv: cannot stat '../diff_aggregated_*.html': No such file or directory`
+
+**Detection patterns:**
+- Phase 1: `/Download snapshot-app-/`, `/curl: (22) The requested URL returned error: 404/`,
+  `/No successful diff-val projects found/`, `/diff-val-download\/diff-app-/` — post-scan
+  Diff Val artifact failure
+
+**Example log excerpt (mass failure, 2026-05-01):**
+```
+Analyze project
+...
+Run SonarSource/differential-validation-actions/setup-diff-val@master
+Downloading snapshot and diff app
+Download snapshot-app-1.10.0.3931.tar
+curl: (22) The requested URL returned error: 404
+##[error]Process completed with exit code 22.
+```
+
+**Example aggregated-job excerpt (downstream effect):**
+```
+No successful diff-val projects found
+##[error]Process completed with exit code 1.
+tar: diff-val-download/diff-app-1.10.0.3931.tar: Cannot open: No such file or directory
+##[error]Process completed with exit code 2.
+```
+
+If most or all project jobs fail this way in the same run, treat it as a shared Diff Val
+artifact publication problem, not a SonarJS analyzer regression.
+
+**Action:** Safe for SonarJS release triage. Re-run after the Diff Val artifact issue is fixed
+or notify the Peach / Diff Val owners if it persists.
 
 ---
 
@@ -231,6 +479,7 @@ Multiple jobs failing this way within the same ~2-minute window is a strong indi
 **How to identify:**
 
 - Failure occurs during the dependency install step (npm/pnpm/yarn install)
+- The `Analyze project` step never starts
 - Error messages such as:
   - `ERR_PNPM_OUTDATED_LOCKFILE` — pnpm lockfile out of sync with package.json
   - `npm error notarget No matching version found for <package>` — package version doesn't exist
@@ -238,8 +487,8 @@ Multiple jobs failing this way within the same ~2-minute window is a strong indi
   - `Cannot find module` — missing dependency
 
 **Detection patterns:**
-
 - Phase 1: `/ERR_PNPM/`, `/ERESOLVE/`, `/ETARGET/`, `/notarget/`, `/Process completed with exit code/` — exit code 1
+- Confirm from surrounding log lines that the failure is in the install step and not in `Analyze project`
 
 **Example log excerpt (pnpm lockfile mismatch):**
 
@@ -259,7 +508,7 @@ npm error notarget a package version that doesn't exist.
 ##[error]Process completed with exit code 1.
 ```
 
-**Action:** None. The analyzed project needs to update its dependencies. Not a SonarJS issue.
+**Action:** No SonarJS release blocker. The analyzed project needs to update its dependencies. Create or update a Peach tracking task if the project should stay green.
 
 ---
 
@@ -344,6 +593,52 @@ INFO  EXECUTION FAILURE
 
 ---
 
+### IGNORE: Scanner Bootstrap / Plugin Download Timeout
+
+**Verdict:** IGNORE — the scanner timed out while provisioning its engine or downloading plugins
+from Peach; the analyzer never started.
+
+**How to identify:**
+- Failure occurs during the `Analyze project` step
+- No `Sensor ...` line appears before the stack trace, so no analyzer sensor owned the failure
+- Error message contains one of:
+  - `Fail to download plugin [javascript]`
+  - `Call to URL [https://peach.sonarsource.com/api/v2/analysis/engine] failed`
+  - `ScannerEngineLauncherFactory` or `PluginFiles.downloadBinaryTo`
+  - `SocketTimeoutException: timeout`, `Connection timed out`, or `failed: closed`
+- Scanner exits with code 1 or 3
+- No `org.sonar.plugins.javascript` frame is present from the plugin itself; the failure is in
+  scanner bootstrap / download code, not a SonarJS sensor
+
+**Detection patterns:**
+- Phase 1: `/Process completed with exit code/` — exit code 1 or 3 inside `Analyze project`
+- Phase 2/3: no `/Sensor /` match before the stack trace, plus bootstrap markers such as
+  `/Fail to download plugin \[javascript\]/`, `/api\/v2\/analysis\/engine/`,
+  `/ScannerEngineLauncherFactory/`, or `/PluginFiles\.downloadBinaryTo/`
+
+**Example log excerpt (`strapi`, 2026-04-13):**
+```
+ERROR Error during SonarScanner Engine execution
+java.lang.IllegalStateException: Fail to download plugin [javascript] into ...
+Caused by: java.net.SocketTimeoutException: timeout
+INFO  EXECUTION FAILURE
+##[error]Process completed with exit code 3.
+```
+
+**Example log excerpt (`open-lovable`, 2026-04-13):**
+```
+ERROR Error during SonarScanner CLI execution
+java.lang.IllegalStateException: Call to URL [https://peach.sonarsource.com/api/v2/analysis/engine] failed: closed
+Caused by: java.io.IOException: Connection timed out
+##[error]Process completed with exit code 1.
+```
+
+**Action:** None for the SonarJS team. Re-run the workflow if needed; if this pattern becomes
+frequent, treat it as Peach / scanner bootstrap infrastructure noise rather than an analyzer
+regression.
+
+---
+
 ### IGNORE: Artifact Expired
 
 **Verdict:** IGNORE — the SonarJS JAR artifact used by the workflow has expired; the analyzer never ran.
@@ -398,39 +693,79 @@ Identifies which step failed and what exit code was produced. Run on every faile
 
 ```bash
 sed --sandbox -n '
+/\[36;1m/b                             # skip GitHub Actions script-preview lines (ANSI-colored)
 /Process completed with exit code/p    # universal — exit code value drives the flowchart
 /EXECUTION FAILURE/p                   # scanner ran and failed (exit code 3)
 /OutOfMemoryError/p                    # OOM / Runner Killed
 /502 Bad Gateway/p                     # Peach Server Unreachable (502)
 /503 Service Unavailable/p             # Peach Server Unreachable (503)
+/Diff Val/p                           # Diff Val monitoring failure
+/diff-val/p                           # Diff Val monitoring failure
+/Fail to download plugin \[javascript\]/p  # Scanner Bootstrap / Plugin Download Timeout
+/api\/v2\/analysis\/engine/p          # Scanner Bootstrap / Plugin Download Timeout
 /Artifact has expired/p                # Artifact Expired
 /All 3 attempts failed/p               # Git Clone / Network Timeout
+/Download snapshot-app-/p             # Diff Val artifact missing in post-scan setup
+/curl: (22) The requested URL returned error: 404/p
+/No successful diff-val projects found/p
+/diff-val-download\/diff-app-/p
 /ERR_PNPM/p                            # Dependency Install Failure (pnpm)
 /ERESOLVE/p                            # Dependency Install Failure (npm peer conflict)
 /ETARGET/p                             # Dependency Install Failure (npm version not found)
 /notarget/p                            # Dependency Install Failure (npm version not found)
 /Invalid value of sonar/p              # Project Misconfiguration
 /does not exist for/p                  # Project Misconfiguration
+/SocketTimeoutException/p              # Peach report upload timeout (post-scan)
+/ReportPublisher\.upload/p             # Peach report upload timeout (post-scan)
 ' target/peach-logs/JOB_ID.log
 ```
 
 If Phase 1 shows exit code 3 with `EXECUTION FAILURE` but none of the misconfiguration patterns,
 escalate to Phase 2 — a Java stack trace may be present that Phase 1 does not surface.
+Do not assume the first printed exit code is the terminal failure. Logs may contain earlier
+non-fatal subcommand failures such as `gh: Artifact has expired (HTTP 410)` followed by
+`Process completed with exit code 1`, even though the job later proceeds to a different real
+failure.
 
 ### Phase 2 — Sensor and stack trace detection
 
 Identifies which sensor was running and whether the SonarJS plugin is involved. Run only for
-jobs where Phase 1 showed exit code 3 without a clear misconfiguration signal.
+jobs where Phase 1 showed exit code 3 without a clear misconfiguration signal. Apply the
+**last sensor wins** rule: the last sensor that started before the error owns the failure unless
+the stack trace proves a later phase such as `ReportPublisher.upload`.
 
 ```bash
 sed --sandbox -n '
+/\[36;1m/b                             # skip GitHub Actions script-preview lines (ANSI-colored)
 /Sensor /p                             # last sensor name — is it a SonarJS sensor?
 /EXECUTION FAILURE/p                   # scanner failure marker
 /OutOfMemoryError/p                    # OOM inside scanner
+/Node\.js process running out of memory/p   # SonarJS bridge Node heap exhaustion
+/sonar\.javascript\.node\.maxspace/p        # SonarJS heap tuning hint
+/sonar\.javascript\.node\.debugMemory/p     # SonarJS memory debugging hint
+/ReportPublisher\.upload/p            # Peach report-upload timeout / post-scan failure
+/api\/ce\/submit/p                    # Peach report submission endpoint
+/SocketTimeoutException/p             # timeout during report upload
 /Process completed with exit code/p    # exit code confirmation
 /org\.sonar\.plugins\.javascript/p     # SonarJS plugin frame in stack trace → CRITICAL
 ' target/peach-logs/JOB_ID.log
 ```
+
+This surfaces both the last sensor that ran and any `org.sonar.plugins.javascript` frames in the
+stack trace, plus the explicit Node-heap hints used by the `tape` failure pattern and the
+post-scan report-upload timeout pattern.
+
+---
+
+## Output Guidance
+
+When summarizing a run for SonarJS release triage:
+
+- Treat Diff Val / `diff-validation-aggregated` failures as silenced `IGNORE` items
+- Do not emit one detailed line per ignored Diff Val failure unless they are the only failures
+- Prefer a short roll-up note such as `Ignored 4 Diff Val monitoring failures`
+- If every failed job is either a Diff Val monitoring failure or another `IGNORE` category, the
+  release verdict is `SAFE`
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "esbuild-plugin-text-replace": "1.3.0",
         "eslint-doc-generator": "3.3.2",
         "esprima": "4.0.1",
-        "expect": "30.3.0",
+        "expect": "30.4.0",
         "glob": "13.0.6",
         "husky": "9.1.7",
         "json-schema-to-ts": "3.1.1",
@@ -3476,9 +3476,9 @@
       }
     },
     "node_modules/@jest/diff-sequences": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3486,9 +3486,9 @@
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.0.tgz",
+      "integrity": "sha512-+7IjdIwKEvViPvFizspuFeFAJhQGYkbOWBBWq+XVLsSl4t3H6lOk9QlxYC3et6GRgJ+jJvnVOAv2CpN4kJowzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3509,23 +3509,23 @@
       }
     },
     "node_modules/@jest/pattern": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-regex-util": "30.0.1"
+        "jest-regex-util": "30.4.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.0.tgz",
+      "integrity": "sha512-tJLUhzktAsL7VKYJzdkNKxYTKGnkQvd6bMZQtxWnaE4V1VJyzzwt5WrCG5hwC+mB55uZbNSsxQUXLKjla08XPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3536,14 +3536,14 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.0.tgz",
+      "integrity": "sha512-C951KSoEicxFUsUIO4T8lqWEemuMgMb3vlI8FO4OP369GSf6SOJd681nOcv7XR0TV5vCO4Jypvq3rBGEqfy9KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.0",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
@@ -4878,9 +4878,9 @@
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.48",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -8219,18 +8219,18 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.0.tgz",
+      "integrity": "sha512-wwj3yHn8F2Uj4fyL+2n1M1cjfYFGtYq7cF00OjMHBxX5eTeX/EcVdHHIMkhxO6nFfopwHtaQEasP1WfxzQaZPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.3.0",
+        "@jest/expect-utils": "30.4.0",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
+        "jest-matcher-utils": "30.4.0",
+        "jest-message-util": "30.4.0",
+        "jest-mock": "30.4.0",
+        "jest-util": "30.4.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -9987,51 +9987,52 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.0.tgz",
+      "integrity": "sha512-8SHpYWUtt2LyH5tw5Oa+larOuy5WHDH7vklFxbxf4LJfYkepoA2eu/loHmvYDlrHrdB3JZ89197oG2A1V982yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.3.0",
+        "@jest/diff-sequences": "30.4.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.3.0"
+        "pretty-format": "30.4.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.0.tgz",
+      "integrity": "sha512-m28k6fJ1hsHxYRBMbQvIfHz8FQA1e8U/I3o/Z+id0etJJL7Af6mJqMKvH11lTFX6rRKANi/8iVwdche9E+wz8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.3.0",
-        "pretty-format": "30.3.0"
+        "jest-diff": "30.4.0",
+        "pretty-format": "30.4.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.0.tgz",
+      "integrity": "sha512-XjJEhPYwvJezXMYuPKX52xIE7CPNNVocuUzEJcMts82HhmXii7zC3KZVjlFDXdp8khX4lwWj9Rva9bs+8oucLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.0",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.0",
         "picomatch": "^4.0.3",
-        "pretty-format": "30.3.0",
+        "pretty-format": "30.4.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -10050,24 +10051,24 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.0.tgz",
+      "integrity": "sha512-Xy8aJikWCFMLFdAvmBTWgFzik3+qnYVEqDz1n/NQQqJX14e48J31XGx+km/0INV7YPzfl6SXmjsaVidUs3zQ5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.0",
         "@types/node": "*",
-        "jest-util": "30.3.0"
+        "jest-util": "30.4.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10075,13 +10076,13 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.0.tgz",
+      "integrity": "sha512-nae+Oh7CEdSTC5+uL4HCVDCLusj5IcypnVXWBSRjCUDkh7dX/FwreTsgvLROwHnEWW5dcdvLkW9RvmmMzKw+aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -12251,15 +12252,16 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.0.tgz",
+      "integrity": "sha512-PzJLEF72RqCj01UTBWqBi2ar3U2iJ0oG0+HzcdHPW+rzfpzDCuiVeiy6lns8L3Nbpp4Ajw+nBsW2KuKPPyPlCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.0.5",
+        "@jest/schemas": "30.4.0",
         "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -12518,10 +12520,19 @@
       ],
       "license": "MIT"
     },
-    "node_modules/react-is": {
+    "node_modules/react-is-18": {
+      "name": "react-is",
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@types/estree-jsx": "1.0.5",
         "@types/functional-red-black-tree": "1.0.6",
         "@types/lodash.merge": "4.6.9",
-        "@types/node": "24.12.2",
+        "@types/node": "24.12.3",
         "@types/semver": "7.7.1",
         "cpy-cli": "7.0.0",
         "cross-env": "10.1.0",
@@ -5098,9 +5098,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "glob": "13.0.6",
         "husky": "9.1.7",
         "json-schema-to-ts": "3.1.1",
-        "knip": "6.12.0",
+        "knip": "6.12.1",
         "license-checker": "25.0.1",
         "memfs": "4.57.2",
         "node-reporter-sonarqube": "1.0.3",
@@ -10094,9 +10094,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -10370,9 +10370,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-6.12.0.tgz",
-      "integrity": "sha512-nRg8+DOFcfBD6NjmNzu9+3D35QnEmMsnojJGOHQUqv+70r1aOx99wpSUXvEV7syQVOL5E6tNXXkoyG1Fuz8BWg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.12.1.tgz",
+      "integrity": "sha512-9JRZB1mENe8xNMpP4jJRiFXkRVBHTWzD7YtiLywkO7aKXCefbvI+hA0YDl7H7dPvJt7gcVolgxKgABJQ31NL3w==",
       "dev": true,
       "funding": [
         {
@@ -10389,7 +10389,7 @@
         "fdir": "^6.5.0",
         "formatly": "^0.3.0",
         "get-tsconfig": "4.14.0",
-        "jiti": "^2.6.0",
+        "jiti": "^2.7.0",
         "minimist": "^1.2.8",
         "oxc-parser": "^0.128.0",
         "oxc-resolver": "^11.19.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "glob": "13.0.6",
     "husky": "9.1.7",
     "json-schema-to-ts": "3.1.1",
-    "knip": "6.12.0",
+    "knip": "6.12.1",
     "license-checker": "25.0.1",
     "memfs": "4.57.2",
     "node-reporter-sonarqube": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "esbuild-plugin-text-replace": "1.3.0",
     "eslint-doc-generator": "3.3.2",
     "esprima": "4.0.1",
-    "expect": "30.3.0",
+    "expect": "30.4.0",
     "glob": "13.0.6",
     "husky": "9.1.7",
     "json-schema-to-ts": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/estree-jsx": "1.0.5",
     "@types/functional-red-black-tree": "1.0.6",
     "@types/lodash.merge": "4.6.9",
-    "@types/node": "24.12.2",
+    "@types/node": "24.12.3",
     "@types/semver": "7.7.1",
     "cpy-cli": "7.0.0",
     "cross-env": "10.1.0",


### PR DESCRIPTION
### Summary
Split parser-option construction by parser (TypeScript / Babel / Vue) and feed the analyzer's detected ECMAScript year, module type, and JSX intent into parsing. As a result, [JS-674](https://sonarsource.atlassian.net/browse/JS-674) is fixed: TypeScript angle-bracket type assertions inside `.vue` files no longer break parsing.

### Changes
- Replace the single `buildParserOptions` with one builder per parser (TS / Babel / Vue).
- Feed the analyzer's detected ES year, module type, and JSX intent (from `tsconfig.compilerOptions.jsx`) into parser options.
- Vue+TS parse failures retry with the opposite JSX setting; the original error wins if both fail.

### Validation

Download `js-1499-validation.zip` (attached), unzip it, then run:

```bash
./validate.sh /path/to/SonarJS
```

- On `master`: prints `FAILED — Identifier expected.`
- On this branch: prints `OK — JS-674 reproducer parses cleanly. Fix verified.`

The companion `jsts-test-sources` PR adds the same scenario as a ruling-test fixture under `it-tools/src/components/`.

[js-1499-validation.zip](https://github.com/user-attachments/files/27790617/js-1499-validation.zip)


⚠️ N.B: One commit will be added to this branch to update the expected ruling test result and to update the git submodule once this PR on `jsts-test-sources` repo is reviewed.



[JS-674]: https://sonarsource.atlassian.net/browse/JS-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ