### PR TITLE
JS-1394 Refactor S6767 false-positive escape helpers

### DIFF
--- a/packages/analysis/src/jsts/rules/S6767/custom-superclass-forwarding.ts
+++ b/packages/analysis/src/jsts/rules/S6767/custom-superclass-forwarding.ts
@@ -1,0 +1,74 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import type { Rule } from 'eslint';
+import type estree from 'estree';
+import { isIdentifier } from '../helpers/ast.js';
+
+/**
+ * False-positive remediation escape:
+ * returns true when the component constructor forwards `props` to its own
+ * non-React superclass, which this decorator treats as sufficient usage.
+ */
+export function hasOwnCustomSuperclassPropsForwarding(
+  componentNode: estree.Node,
+  _context: Rule.RuleContext,
+  _propName: string | undefined,
+): boolean {
+  if (componentNode.type !== 'ClassDeclaration' && componentNode.type !== 'ClassExpression') {
+    return false;
+  }
+
+  const superClass = componentNode.superClass;
+  if (superClass == null || isBuiltinReactSuperclass(superClass)) {
+    return false;
+  }
+
+  return componentNode.body.body.some(
+    member =>
+      member.type === 'MethodDefinition' &&
+      member.kind === 'constructor' &&
+      member.value.body?.body.some(isWholePropsSuperCallStatement) === true,
+  );
+}
+
+function isBuiltinReactSuperclass(superClass: estree.Expression): boolean {
+  return (
+    isIdentifier(superClass, 'Component') ||
+    isIdentifier(superClass, 'PureComponent') ||
+    (superClass.type === 'MemberExpression' &&
+      isIdentifier(superClass.object, 'React') &&
+      (isIdentifier(superClass.property, 'Component') ||
+        isIdentifier(superClass.property, 'PureComponent')))
+  );
+}
+
+function isWholePropsSuperCallStatement(statement: estree.Statement): boolean {
+  if (
+    statement.type !== 'ExpressionStatement' ||
+    statement.expression.type !== 'CallExpression' ||
+    statement.expression.callee.type !== 'Super'
+  ) {
+    return false;
+  }
+
+  // This decorator intentionally treats direct whole-props forwarding to a custom
+  // superclass as sufficient usage. Deeper validation of actual superclass prop
+  // consumption is intentionally out of scope for this decorator-based design, even
+  // though that accepts a small false-negative risk when forwarded props are not read.
+  return statement.expression.arguments.some(argument => isIdentifier(argument, 'props'));
+}

--- a/packages/analysis/src/jsts/rules/S6767/custom-superclass-forwarding.ts
+++ b/packages/analysis/src/jsts/rules/S6767/custom-superclass-forwarding.ts
@@ -15,7 +15,6 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 
-import type { Rule } from 'eslint';
 import type estree from 'estree';
 import { isIdentifier } from '../helpers/ast.js';
 
@@ -24,11 +23,7 @@ import { isIdentifier } from '../helpers/ast.js';
  * returns true when the component constructor forwards `props` to its own
  * non-React superclass, which this decorator treats as sufficient usage.
  */
-export function hasOwnCustomSuperclassPropsForwarding(
-  componentNode: estree.Node,
-  _context: Rule.RuleContext,
-  _propName: string | undefined,
-): boolean {
+export function hasOwnCustomSuperclassPropsForwarding(componentNode: estree.Node): boolean {
   if (componentNode.type !== 'ClassDeclaration' && componentNode.type !== 'ClassExpression') {
     return false;
   }

--- a/packages/analysis/src/jsts/rules/S6767/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator.ts
@@ -34,8 +34,8 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
       const componentNode = findComponentNode(node, context);
       if (
         componentNode &&
-        (hasSupportedWholePropsUsage(componentNode, context, undefined) ||
-          hasOwnCustomSuperclassPropsForwarding(componentNode, context, undefined))
+        (hasSupportedWholePropsUsage(componentNode, context) ||
+          hasOwnCustomSuperclassPropsForwarding(componentNode))
       ) {
         return;
       }

--- a/packages/analysis/src/jsts/rules/S6767/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator.ts
@@ -16,33 +16,15 @@
  */
 // https://sonarsource.github.io/rspec/#/rspec/S6767/javascript
 
-import type { Rule, Scope, SourceCode } from 'eslint';
+import type { Rule } from 'eslint';
 import type estree from 'estree';
-import type { JSXSpreadAttribute } from 'estree-jsx';
-import { childrenOf, getNodeParent } from '../helpers/ancestor.js';
-import { isFunctionNode, isIdentifier } from '../helpers/ast.js';
 import { interceptReportForReact } from '../helpers/decorators/interceptor.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { findComponentNode } from '../helpers/react.js';
+import { hasOwnCustomSuperclassPropsForwarding } from './custom-superclass-forwarding.js';
+import { hasForwardRefCallbackPropUsage } from './forward-ref-indirect-prop-usage.js';
 import * as meta from './generated-meta.js';
-
-/** Composable pattern checkers — extend via Array.some() for future FP patterns. */
-const propsArgPatterns: Array<(arg: estree.Node) => boolean> = [
-  arg => isIdentifier(arg, 'props'),
-  arg =>
-    arg.type === 'MemberExpression' &&
-    arg.object.type === 'ThisExpression' &&
-    isIdentifier(arg.property, 'props'),
-];
-
-/** Composable callee checkers for forwardRef call detection. */
-const forwardRefCalleePatterns: Array<(callee: estree.Expression | estree.Super) => boolean> = [
-  callee => isIdentifier(callee, 'forwardRef'),
-  callee =>
-    callee.type === 'MemberExpression' &&
-    isIdentifier(callee.object, 'React') &&
-    isIdentifier(callee.property, 'forwardRef'),
-];
+import { hasSupportedWholePropsUsage } from './whole-props-usage.js';
 
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
   return interceptReportForReact(
@@ -52,8 +34,8 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
       const componentNode = findComponentNode(node, context);
       if (
         componentNode &&
-        (hasPropsCall(componentNode, context.sourceCode.visitorKeys) ||
-          hasOwnCustomSuperclassPropsForwarding(componentNode))
+        (hasSupportedWholePropsUsage(componentNode, context, undefined) ||
+          hasOwnCustomSuperclassPropsForwarding(componentNode, context, undefined))
       ) {
         return;
       }
@@ -63,172 +45,11 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
       if (
         propName &&
         componentNode &&
-        hasPropMemberReference(context.sourceCode, componentNode, propName)
+        hasForwardRefCallbackPropUsage(componentNode, context, propName)
       ) {
         return;
       }
       context.report(descriptor);
     },
-  );
-}
-
-function hasOwnCustomSuperclassPropsForwarding(componentNode: estree.Node): boolean {
-  if (componentNode.type !== 'ClassDeclaration' && componentNode.type !== 'ClassExpression') {
-    return false;
-  }
-
-  const superClass = componentNode.superClass;
-  if (superClass == null || isBuiltinReactSuperclass(superClass)) {
-    return false;
-  }
-
-  return componentNode.body.body.some(
-    member =>
-      member.type === 'MethodDefinition' &&
-      member.kind === 'constructor' &&
-      member.value.body?.body.some(isWholePropsSuperCallStatement) === true,
-  );
-}
-
-function isBuiltinReactSuperclass(superClass: estree.Expression): boolean {
-  return (
-    isIdentifier(superClass, 'Component') ||
-    isIdentifier(superClass, 'PureComponent') ||
-    (superClass.type === 'MemberExpression' &&
-      isIdentifier(superClass.object, 'React') &&
-      (isIdentifier(superClass.property, 'Component') ||
-        isIdentifier(superClass.property, 'PureComponent')))
-  );
-}
-
-function isWholePropsSuperCallStatement(statement: estree.Statement): boolean {
-  if (
-    statement.type !== 'ExpressionStatement' ||
-    statement.expression.type !== 'CallExpression' ||
-    statement.expression.callee.type !== 'Super'
-  ) {
-    return false;
-  }
-
-  // This decorator intentionally treats direct whole-props forwarding to a custom
-  // superclass as sufficient usage. Deeper validation of actual superclass prop
-  // consumption is intentionally out of scope for this decorator-based design, even
-  // though that accepts a small false-negative risk when forwarded props are not read.
-  return statement.expression.arguments.some(argument =>
-    isIdentifier(argument as estree.Node, 'props'),
-  );
-}
-
-/**
- * Returns true only when `propName` is referenced through the component's actual
- * first parameter binding and the matching member access sits inside a forwardRef callback.
- */
-function hasPropMemberReference(
-  sourceCode: SourceCode,
-  componentNode: estree.Node,
-  propName: string,
-): boolean {
-  if (!isFunctionNode(componentNode)) {
-    return false;
-  }
-
-  const propsParam = componentNode.params[0];
-  if (!isIdentifier(propsParam)) {
-    return false;
-  }
-
-  const variable = sourceCode.getScope(componentNode).set.get(propsParam.name);
-  if (!variable) {
-    return false;
-  }
-
-  return variable.references.some(reference =>
-    isPropReferenceInForwardRefCallback(reference, propName),
-  );
-}
-
-function isPropReferenceInForwardRefCallback(
-  reference: Scope.Reference,
-  propName: string,
-): boolean {
-  const memberExpression = getNodeParent(reference.identifier);
-  if (
-    memberExpression?.type !== 'MemberExpression' ||
-    memberExpression.object !== reference.identifier ||
-    memberExpression.computed ||
-    !isIdentifier(memberExpression.property, propName)
-  ) {
-    return false;
-  }
-
-  // Walk up ancestors. Track `prev` so that when we find a forwardRef CallExpression
-  // we can confirm the reference sits inside its first argument (the render callback),
-  // not in the callee position or a later argument.
-  let prev: estree.Node = memberExpression;
-  let current: estree.Node | undefined = getNodeParent(memberExpression);
-  while (current) {
-    if (current.type === 'CallExpression') {
-      const call = current;
-      if (
-        forwardRefCalleePatterns.some(pattern => pattern(call.callee)) &&
-        call.arguments[0] === prev
-      ) {
-        return true;
-      }
-    }
-    prev = current;
-    current = getNodeParent(current);
-  }
-  return false;
-}
-
-function hasPropsCall(root: estree.Node, keys: SourceCode.VisitorKeys): boolean {
-  if (!root) {
-    return false;
-  }
-
-  // Check if this is a CallExpression with props as argument
-  if (root.type === 'CallExpression') {
-    const call = root as estree.CallExpression;
-    if (
-      call.callee.type !== 'Super' &&
-      !isPropTypesCheckCall(call) &&
-      call.arguments.some(a => propsArgPatterns.some(p => p(a as estree.Node)))
-    ) {
-      return true;
-    }
-  }
-
-  // Check if this is a SpreadElement with props (for {...props} in JSX)
-  if (root.type === 'SpreadElement' && propsArgPatterns.some(p => p(root.argument))) {
-    return true;
-  }
-
-  // Check if this is a JSXSpreadAttribute with props (for {...props} or {...this.props} in JSX elements)
-  if (
-    root.type === 'JSXSpreadAttribute' &&
-    propsArgPatterns.some(p => p((root as unknown as JSXSpreadAttribute).argument))
-  ) {
-    return true;
-  }
-
-  // Check if this is a computed MemberExpression with props (for props[key] or this.props[key])
-  if (
-    root.type === 'MemberExpression' &&
-    root.computed &&
-    propsArgPatterns.some(p => p(root.object))
-  ) {
-    return true;
-  }
-
-  // Recursively check all children
-  return childrenOf(root, keys).some(child => hasPropsCall(child, keys));
-}
-
-function isPropTypesCheckCall(call: estree.CallExpression): boolean {
-  return (
-    call.callee.type === 'MemberExpression' &&
-    isIdentifier(call.callee.object, 'PropTypes') &&
-    isIdentifier(call.callee.property, 'checkPropTypes')
   );
 }

--- a/packages/analysis/src/jsts/rules/S6767/forward-ref-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/forward-ref-indirect-prop-usage.ts
@@ -1,0 +1,109 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import type { Rule, Scope } from 'eslint';
+import type estree from 'estree';
+import { getNodeParent } from '../helpers/ancestor.js';
+import { isFunctionNode, isIdentifier } from '../helpers/ast.js';
+
+/** Composable callee checkers for forwardRef call detection. */
+const forwardRefCalleePatterns: Array<(callee: estree.Expression | estree.Super) => boolean> = [
+  callee => isIdentifier(callee, 'forwardRef'),
+  callee =>
+    callee.type === 'MemberExpression' &&
+    isIdentifier(callee.object, 'React') &&
+    isIdentifier(callee.property, 'forwardRef'),
+];
+
+/**
+ * False-positive remediation escape:
+ * returns true when the specific reported prop is consumed through a `forwardRef`
+ * callback that closes over the component's props binding.
+ *
+ * function Component(props) {
+ *   forwardRef(() => props.propName);
+ * }
+ */
+export function hasForwardRefCallbackPropUsage(
+  componentNode: estree.Node,
+  context: Rule.RuleContext,
+  propName: string | undefined,
+): boolean {
+  if (!propName || !isFunctionNode(componentNode)) {
+    return false;
+  }
+
+  const propsParam = componentNode.params[0];
+  if (!isIdentifier(propsParam)) {
+    return false;
+  }
+
+  const variable = context.sourceCode.getScope(componentNode).set.get(propsParam.name);
+  if (!variable) {
+    return false;
+  }
+
+  return variable.references.some(reference =>
+    isPropReferenceInForwardRefCallback(reference, propName),
+  );
+}
+
+/**
+ * Pseudo code for the matched AST:
+ * forwardRef(
+ *   (...) => {
+ *     referenceIdentifier.propName;
+ *   },
+ * );
+ *
+ * The matched reference must be the object side of a direct member access,
+ * and that member access must appear somewhere inside the first argument of `forwardRef(...)`.
+ */
+function isPropReferenceInForwardRefCallback(
+  reference: Scope.Reference,
+  propName: string,
+): boolean {
+  const memberExpression = getNodeParent(reference.identifier);
+  if (
+    memberExpression?.type !== 'MemberExpression' ||
+    memberExpression.object !== reference.identifier ||
+    memberExpression.computed ||
+    !isIdentifier(memberExpression.property, propName)
+  ) {
+    return false;
+  }
+
+  // Walk up ancestors. Track `prev` so that when we find a forwardRef CallExpression
+  // we can confirm the reference sits inside its first argument (the render callback),
+  // not in the callee position or a later argument.
+  let prev: estree.Node = memberExpression;
+  let current: estree.Node | undefined = getNodeParent(memberExpression);
+  while (current) {
+    if (current.type === 'CallExpression') {
+      const call = current;
+      if (
+        forwardRefCalleePatterns.some(pattern => pattern(call.callee)) &&
+        call.arguments[0] === prev
+      ) {
+        return true;
+      }
+    }
+    prev = current;
+    current = getNodeParent(current);
+  }
+  return false;
+}

--- a/packages/analysis/src/jsts/rules/S6767/forward-ref-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/forward-ref-indirect-prop-usage.ts
@@ -41,9 +41,9 @@ const forwardRefCalleePatterns: Array<(callee: estree.Expression | estree.Super)
 export function hasForwardRefCallbackPropUsage(
   componentNode: estree.Node,
   context: Rule.RuleContext,
-  propName: string | undefined,
+  propName: string,
 ): boolean {
-  if (!propName || !isFunctionNode(componentNode)) {
+  if (!isFunctionNode(componentNode)) {
     return false;
   }
 

--- a/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
+++ b/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
@@ -34,7 +34,7 @@ describe('S6767 TypeScript coverage', () => {
       valid: [
         {
           // FP: TypeScript function component with props delegation — Strategy C finds
-          // the component and hasPropsCall suppresses the report.
+          // the component and recognizes the whole props object as used.
           code: `
 declare const React: any;
 interface CardProps {
@@ -49,7 +49,7 @@ function Card(props: CardProps) {
         },
         {
           // FP: TypeScript class component with this.props delegation — Strategy C
-          // matches BarProps to Bar via matchesClassProps, hasPropsCall finds getStyle(this.props).
+          // matches BarProps to Bar via matchesClassProps and recognizes getStyle(this.props).
           code: `
 declare const React: any;
 interface BarProps {
@@ -66,7 +66,7 @@ class Bar extends React.Component<BarProps> {
         },
         {
           // FP: TypeScript function component spreads props — Strategy C matches
-          // MyComponentProps to MyComponent, hasPropsCall finds the SpreadElement.
+          // MyComponentProps to MyComponent and recognizes the SpreadElement.
           code: `
 declare const React: any;
 interface MyComponentProps {
@@ -81,7 +81,7 @@ function MyComponent(props: MyComponentProps) {
         },
         {
           // FP: TypeScript class component with this.props[key] — Strategy C matches
-          // VictoryAxisProps to VictoryAxis via matchesClassProps, hasPropsCall finds computed MemberExpression.
+          // VictoryAxisProps to VictoryAxis via matchesClassProps and recognizes computed member access.
           code: `
 declare const React: any;
 interface VictoryAxisProps {
@@ -169,7 +169,7 @@ class ForwardedCounterPanel extends CounterPanelBase {
         },
         {
           // FP: whole props are only forwarded to the custom superclass, never accessed locally.
-          // This isolates hasOwnCustomSuperclassPropsForwarding from hasPropsCall.
+          // This isolates hasOwnCustomSuperclassPropsForwarding from other whole-props escapes.
           code: `
 declare const React: any;
 interface ForwardedOnlyProps {

--- a/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
@@ -1,0 +1,173 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import type { Rule, SourceCode } from 'eslint';
+import type estree from 'estree';
+import { childrenOf } from '../helpers/ancestor.js';
+import { isIdentifier } from '../helpers/ast.js';
+
+/**
+ * False-positive remediation escape:
+ * returns true when the component consumes whole props through a supported
+ * indirect pattern such as helper-call forwarding, spread usage, or computed access.
+ */
+export function hasSupportedWholePropsUsage(
+  componentNode: estree.Node,
+  context: Rule.RuleContext,
+  _propName: string | undefined,
+): boolean {
+  return hasSupportedWholePropsUsageInSubtree(componentNode, context.sourceCode.visitorKeys);
+}
+
+function hasSupportedWholePropsUsageInSubtree(
+  root: estree.Node,
+  keys: SourceCode.VisitorKeys,
+): boolean {
+  if (isSupportedWholePropsUsage(root, isWholePropsArgument)) {
+    return true;
+  }
+
+  // Recursively check all children
+  return childrenOf(root, keys).some(child => hasSupportedWholePropsUsageInSubtree(child, keys));
+}
+
+/**
+ * Returns true when `node` matches any supported whole-props usage shape for the
+ * provided `isPropsArgument` predicate and is not filtered out by the ignore rules.
+ *
+ * Pseudo code:
+ *   consume(props)
+ *   [...props]
+ *   <Component {...props} />
+ *   props[key]
+ *
+ * Ignored pseudo code:
+ *   PropTypes.checkPropTypes(props, ...)
+ */
+export function isSupportedWholePropsUsage(
+  node: estree.Node,
+  isPropsArgument: (argument: estree.Node) => boolean,
+): boolean {
+  return matchesWholePropsUsage(node, isPropsArgument) && !isIgnoredWholePropsUsage(node);
+}
+
+/**
+ * Returns true when `node` matches any supported whole-props usage shape for the
+ * provided `isPropsArgument` predicate.
+ */
+function matchesWholePropsUsage(
+  node: estree.Node,
+  isPropsArgument: (argument: estree.Node) => boolean,
+): boolean {
+  return (
+    isWholePropsPassedToCall(node, isPropsArgument) ||
+    isWholePropsSpreadElement(node, isPropsArgument) ||
+    isWholePropsJsxSpreadAttribute(node, isPropsArgument) ||
+    isWholePropsComputedMemberAccess(node, isPropsArgument)
+  );
+}
+
+/**
+ * Returns true when a whole-props usage should be ignored rather than treated as
+ * evidence that the component really consumes props.
+ *
+ * Pseudo code:
+ *   ignore: PropTypes.checkPropTypes(props, ...)
+ */
+function isIgnoredWholePropsUsage(node: estree.Node): boolean {
+  return node.type === 'CallExpression' && isPropTypesCheckCall(node);
+}
+
+/**
+ * Pseudo code:
+ *   props
+ *   this.props
+ */
+function isWholePropsArgument(argument: estree.Node): boolean {
+  return (
+    isIdentifier(argument, 'props') ||
+    (argument.type === 'MemberExpression' &&
+      argument.object.type === 'ThisExpression' &&
+      isIdentifier(argument.property, 'props'))
+  );
+}
+
+/**
+ * Pseudo code:
+ *   consume(props)
+ *   consume(this.props)
+ * but not:
+ *   super(props)
+ */
+function isWholePropsPassedToCall(
+  node: estree.Node,
+  isPropsArgument: (arg: estree.Node) => boolean,
+): boolean {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type !== 'Super' &&
+    node.arguments.some(argument => isPropsArgument(argument))
+  );
+}
+
+/**
+ * Pseudo code:
+ *   [...props]
+ *   [...this.props]
+ */
+function isWholePropsSpreadElement(
+  node: estree.Node,
+  isPropsArgument: (arg: estree.Node) => boolean,
+): boolean {
+  return node.type === 'SpreadElement' && isPropsArgument(node.argument);
+}
+
+/**
+ * Pseudo code:
+ *   <Component {...props} />
+ *   <Component {...this.props} />
+ */
+function isWholePropsJsxSpreadAttribute(
+  node: estree.Node,
+  isPropsArgument: (arg: estree.Node) => boolean,
+): boolean {
+  return node.type === 'JSXSpreadAttribute' && isPropsArgument(node.argument);
+}
+
+/**
+ * Pseudo code:
+ *   props[key]
+ *   this.props[key]
+ */
+function isWholePropsComputedMemberAccess(
+  node: estree.Node,
+  isPropsArgument: (arg: estree.Node) => boolean,
+): boolean {
+  return node.type === 'MemberExpression' && node.computed && isPropsArgument(node.object);
+}
+
+/**
+ * Pseudo code:
+ *   PropTypes.checkPropTypes(...)
+ */
+function isPropTypesCheckCall(call: estree.CallExpression): boolean {
+  return (
+    call.callee.type === 'MemberExpression' &&
+    isIdentifier(call.callee.object, 'PropTypes') &&
+    isIdentifier(call.callee.property, 'checkPropTypes')
+  );
+}

--- a/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
@@ -58,7 +58,7 @@ function hasSupportedWholePropsUsageInSubtree(
  * Ignored pseudo code:
  *   PropTypes.checkPropTypes(props, ...)
  */
-export function isSupportedWholePropsUsage(
+function isSupportedWholePropsUsage(
   node: estree.Node,
   isPropsArgument: (argument: estree.Node) => boolean,
 ): boolean {

--- a/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
@@ -28,7 +28,6 @@ import { isIdentifier } from '../helpers/ast.js';
 export function hasSupportedWholePropsUsage(
   componentNode: estree.Node,
   context: Rule.RuleContext,
-  _propName: string | undefined,
 ): boolean {
   return hasSupportedWholePropsUsageInSubtree(componentNode, context.sourceCode.visitorKeys);
 }


### PR DESCRIPTION
## Summary
Refactor the existing S6767 false-positive escape logic into focused helpers without changing behavior.

## Included
- extract whole-props usage detection
- extract forwardRef callback prop-usage detection
- extract custom superclass props forwarding detection
- keep the decorator wiring behavior unchanged

## Verification
- node --import=tsx --test --test-reporter=spec packages/analysis/src/jsts/rules/S6767/unit.test.ts packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts packages/analysis/src/jsts/rules/S6767/unit.upstream.test.ts