### PR TITLE
JS-1394 Handle S6767 decorator callback prop usage

### DIFF
--- a/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
@@ -28,8 +28,7 @@ import { areSameTypeDeclarations, getTypeFromTreeNode } from '../helpers/type.js
 import { isSupportedWholePropsUsage } from './whole-props-usage.js';
 
 /**
- * False-positive remediation escape:
- * returns true when the specific reported prop is consumed through a decorator
+ * Returns true when the specific reported prop is consumed through a decorator
  * factory callback typed with the same props contract as the component.
  *
  * track((props: ComponentProps) => props.propName)(Component);

--- a/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
@@ -17,7 +17,7 @@
 
 import type { Rule, Scope, SourceCode } from 'eslint';
 import type estree from 'estree';
-import { childrenOf, getNodeParent } from '../helpers/ancestor.js';
+import { getNodeParent } from '../helpers/ancestor.js';
 import { isFunctionNode, isIdentifier } from '../helpers/ast.js';
 import { isRequiredParserServices } from '../helpers/parser-services.js';
 import {
@@ -56,42 +56,79 @@ function hasDecoratorFactoryCallPropUsage(
     return false;
   }
 
-  const stack: estree.Node[] = [sourceCode.ast];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (node === undefined) {
-      continue;
-    }
-
-    if (
-      node.type === 'CallExpression' &&
-      node.arguments.length === 1 &&
-      isDecoratorTargetingComponent(sourceCode, node.arguments[0], componentVariable) &&
-      node.callee.type === 'CallExpression' &&
-      node.callee.arguments.some(argument =>
-        isComponentPropsCallbackUsingProp(sourceCode, componentNode, argument, propName),
-      )
-    ) {
-      return true;
-    }
-
-    const children = childrenOf(node, sourceCode.visitorKeys);
-    for (let i = children.length - 1; i >= 0; i--) {
-      stack.push(children[i]);
-    }
-  }
-
-  return false;
+  return componentVariable.references.some(reference =>
+    isDecoratorFactoryTargetReference(sourceCode, componentNode, reference, propName),
+  );
 }
 
-function isDecoratorTargetingComponent(
+/**
+ * Pseudo code:
+ *   track(callback)(Component)
+ *
+ * The matched component reference must be the only outer application argument.
+ */
+function isDecoratorFactoryTargetReference(
   sourceCode: SourceCode,
-  targetNode: estree.Node,
-  componentVariable: Scope.Variable,
+  componentNode: estree.Node,
+  reference: Scope.Reference,
+  propName: string,
 ): boolean {
+  const decoratorApplication = getDecoratorApplicationForReference(reference);
   return (
-    isIdentifier(targetNode) &&
-    getVariableForIdentifier(sourceCode, targetNode) === componentVariable
+    !!decoratorApplication &&
+    hasMatchingDecoratorCallbackArgument(
+      sourceCode,
+      componentNode,
+      decoratorApplication.callee,
+      propName,
+    )
+  );
+}
+
+/**
+ * Pseudo code:
+ *   track(callback)(Component)
+ *
+ * Returns the outer application call when the reference is the only target argument.
+ */
+function getDecoratorApplicationForReference(
+  reference: Scope.Reference,
+): (estree.CallExpression & { callee: estree.CallExpression }) | undefined {
+  const parent = getNodeParent(reference.identifier);
+  return isDecoratorApplicationCall(parent, reference.identifier) ? parent : undefined;
+}
+
+function isDecoratorApplicationCall(
+  node: estree.Node | undefined,
+  targetNode: estree.Identifier,
+): node is estree.CallExpression & { callee: estree.CallExpression } {
+  return (
+    node?.type === 'CallExpression' &&
+    node.arguments.length === 1 &&
+    node.arguments[0] === targetNode &&
+    node.callee.type === 'CallExpression'
+  );
+}
+
+/**
+ * Pseudo code:
+ *   track(
+ *     (props: ComponentProps) => {
+ *       props.propName;
+ *     },
+ *   )(Component)
+ *
+ * At least one inner call argument must be a callback whose first parameter is typed
+ * with the same declared props contract as the component and uses the reported prop.
+ */
+function hasMatchingDecoratorCallbackArgument(
+  sourceCode: SourceCode,
+  componentNode: estree.Node,
+  decoratorFactoryCall: estree.CallExpression,
+  propName: string,
+): boolean {
+  return decoratorFactoryCall.arguments.some(argument =>
+    isComponentPropsCallbackUsingProp(sourceCode, componentNode, argument, propName),
   );
 }
 
@@ -101,8 +138,27 @@ function isComponentPropsCallbackUsingProp(
   callbackNode: estree.Node,
   propName: string,
 ): boolean {
+  const propsVariable = getMatchingCallbackPropsVariable(sourceCode, componentNode, callbackNode);
+  return (
+    !!propsVariable &&
+    propsVariable.references.some(reference => isComponentPropsUsageReference(reference, propName))
+  );
+}
+
+/**
+ * Pseudo code:
+ *   (props: ComponentProps) => ...
+ *
+ * The first callback parameter must be an identifier typed with the same declared props
+ * contract as the component. When that holds, return its scope variable.
+ */
+function getMatchingCallbackPropsVariable(
+  sourceCode: SourceCode,
+  componentNode: estree.Node,
+  callbackNode: estree.Node,
+): Scope.Variable | undefined {
   if (!isFunctionNode(callbackNode)) {
-    return false;
+    return undefined;
   }
 
   const firstParam = callbackNode.params[0];
@@ -110,15 +166,10 @@ function isComponentPropsCallbackUsingProp(
     !isIdentifier(firstParam) ||
     !isSameDeclaredPropsType(sourceCode, componentNode, firstParam)
   ) {
-    return false;
+    return undefined;
   }
 
-  const variable = sourceCode.getScope(callbackNode).set.get(firstParam.name);
-  if (!variable) {
-    return false;
-  }
-
-  return variable.references.some(reference => isComponentPropsUsageReference(reference, propName));
+  return sourceCode.getScope(callbackNode).set.get(firstParam.name);
 }
 
 function getVariableForIdentifier(
@@ -163,16 +214,39 @@ function isSameDeclaredPropsType(
 
 function isComponentPropsUsageReference(reference: Scope.Reference, propName: string): boolean {
   const parent = getNodeParent(reference.identifier);
-  if (
-    parent?.type === 'MemberExpression' &&
-    parent.object === reference.identifier &&
-    !parent.computed &&
-    isIdentifier(parent.property, propName)
-  ) {
-    return true;
-  }
-
   return (
-    !!parent && isSupportedWholePropsUsage(parent, argument => argument === reference.identifier)
+    isDirectPropMemberAccess(parent, reference.identifier, propName) ||
+    isWholePropsForwardingUsage(parent, reference.identifier)
   );
+}
+
+/**
+ * Pseudo code:
+ *   props.propName
+ */
+function isDirectPropMemberAccess(
+  node: estree.Node | undefined,
+  propsIdentifier: estree.Identifier,
+  propName: string,
+): boolean {
+  return (
+    node?.type === 'MemberExpression' &&
+    node.object === propsIdentifier &&
+    !node.computed &&
+    isIdentifier(node.property, propName)
+  );
+}
+
+/**
+ * Pseudo code:
+ *   consume(props)
+ *   [...props]
+ *   <Component {...props} />
+ *   props[key]
+ */
+function isWholePropsForwardingUsage(
+  node: estree.Node | undefined,
+  propsIdentifier: estree.Identifier,
+): boolean {
+  return !!node && isSupportedWholePropsUsage(node, argument => argument === propsIdentifier);
 }

--- a/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
@@ -50,7 +50,9 @@ function hasDecoratorFactoryCallPropUsage(
   propName: string,
 ): boolean {
   const componentIdentifier = getComponentIdentifier(componentNode);
-  if (!componentIdentifier) {
+  const componentVariable =
+    componentIdentifier && getVariableForIdentifier(sourceCode, componentIdentifier);
+  if (!componentVariable) {
     return false;
   }
 
@@ -64,7 +66,7 @@ function hasDecoratorFactoryCallPropUsage(
     if (
       node.type === 'CallExpression' &&
       node.arguments.length === 1 &&
-      isIdentifier(node.arguments[0], componentIdentifier.name) &&
+      isDecoratorTargetingComponent(sourceCode, node.arguments[0], componentVariable) &&
       node.callee.type === 'CallExpression' &&
       node.callee.arguments.some(argument =>
         isComponentPropsCallbackUsingProp(sourceCode, componentNode, argument, propName),
@@ -80,6 +82,17 @@ function hasDecoratorFactoryCallPropUsage(
   }
 
   return false;
+}
+
+function isDecoratorTargetingComponent(
+  sourceCode: SourceCode,
+  targetNode: estree.Node,
+  componentVariable: Scope.Variable,
+): boolean {
+  return (
+    isIdentifier(targetNode) &&
+    getVariableForIdentifier(sourceCode, targetNode) === componentVariable
+  );
 }
 
 function isComponentPropsCallbackUsingProp(
@@ -106,6 +119,30 @@ function isComponentPropsCallbackUsingProp(
   }
 
   return variable.references.some(reference => isComponentPropsUsageReference(reference, propName));
+}
+
+function getVariableForIdentifier(
+  sourceCode: SourceCode,
+  identifier: estree.Identifier,
+): Scope.Variable | undefined {
+  let scope: Scope.Scope | null = sourceCode.getScope(identifier);
+  while (scope) {
+    const reference = scope.references.find(candidate => candidate.identifier === identifier);
+    if (reference) {
+      return reference.resolved ?? undefined;
+    }
+
+    const variable = scope.variables.find(candidate =>
+      candidate.defs.some(definition => definition.name === identifier),
+    );
+    if (variable) {
+      return variable;
+    }
+
+    scope = scope.upper;
+  }
+
+  return undefined;
 }
 
 function isSameDeclaredPropsType(

--- a/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
@@ -54,7 +54,7 @@ function hasDecoratorFactoryCallPropUsage(
     return false;
   }
 
-  const stack = [sourceCode.ast];
+  const stack: estree.Node[] = [sourceCode.ast];
   while (stack.length > 0) {
     const node = stack.pop();
     if (node === undefined) {

--- a/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
@@ -1,0 +1,141 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import type { Rule, Scope, SourceCode } from 'eslint';
+import type estree from 'estree';
+import { childrenOf, getNodeParent } from '../helpers/ancestor.js';
+import { isFunctionNode, isIdentifier } from '../helpers/ast.js';
+import { isRequiredParserServices } from '../helpers/parser-services.js';
+import {
+  getComponentIdentifier,
+  getComponentPropsType,
+} from '../helpers/react/component-analysis.js';
+import { areSameTypeDeclarations, getTypeFromTreeNode } from '../helpers/type.js';
+import { isSupportedWholePropsUsage } from './whole-props-usage.js';
+
+/**
+ * False-positive remediation escape:
+ * returns true when the specific reported prop is consumed through a decorator
+ * factory callback typed with the same props contract as the component.
+ *
+ * track((props: ComponentProps) => props.propName)(Component);
+ */
+export function hasDecoratorPropUsage(
+  componentNode: estree.Node,
+  context: Rule.RuleContext,
+  propName: string | undefined,
+): boolean {
+  return (
+    !!propName && hasDecoratorFactoryCallPropUsage(context.sourceCode, componentNode, propName)
+  );
+}
+
+function hasDecoratorFactoryCallPropUsage(
+  sourceCode: SourceCode,
+  componentNode: estree.Node,
+  propName: string,
+): boolean {
+  const componentIdentifier = getComponentIdentifier(componentNode);
+  if (!componentIdentifier) {
+    return false;
+  }
+
+  const stack = [sourceCode.ast];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (node === undefined) {
+      continue;
+    }
+
+    if (
+      node.type === 'CallExpression' &&
+      node.arguments.length === 1 &&
+      isIdentifier(node.arguments[0], componentIdentifier.name) &&
+      node.callee.type === 'CallExpression' &&
+      node.callee.arguments.some(argument =>
+        isComponentPropsCallbackUsingProp(sourceCode, componentNode, argument, propName),
+      )
+    ) {
+      return true;
+    }
+
+    const children = childrenOf(node, sourceCode.visitorKeys);
+    for (let i = children.length - 1; i >= 0; i--) {
+      stack.push(children[i]);
+    }
+  }
+
+  return false;
+}
+
+function isComponentPropsCallbackUsingProp(
+  sourceCode: SourceCode,
+  componentNode: estree.Node,
+  callbackNode: estree.Node,
+  propName: string,
+): boolean {
+  if (!isFunctionNode(callbackNode)) {
+    return false;
+  }
+
+  const firstParam = callbackNode.params[0];
+  if (
+    !isIdentifier(firstParam) ||
+    !isSameDeclaredPropsType(sourceCode, componentNode, firstParam)
+  ) {
+    return false;
+  }
+
+  const variable = sourceCode.getScope(callbackNode).set.get(firstParam.name);
+  if (!variable) {
+    return false;
+  }
+
+  return variable.references.some(reference => isComponentPropsUsageReference(reference, propName));
+}
+
+function isSameDeclaredPropsType(
+  sourceCode: SourceCode,
+  componentNode: estree.Node,
+  callbackPropsParam: estree.Identifier,
+): boolean {
+  const services = sourceCode.parserServices;
+  if (!isRequiredParserServices(services)) {
+    return false;
+  }
+
+  const checker = services.program.getTypeChecker();
+  const componentPropsType = getComponentPropsType(componentNode, services);
+  const callbackPropsType = getTypeFromTreeNode(callbackPropsParam, services);
+  return areSameTypeDeclarations(checker, callbackPropsType, componentPropsType);
+}
+
+function isComponentPropsUsageReference(reference: Scope.Reference, propName: string): boolean {
+  const parent = getNodeParent(reference.identifier);
+  if (
+    parent?.type === 'MemberExpression' &&
+    parent.object === reference.identifier &&
+    !parent.computed &&
+    isIdentifier(parent.property, propName)
+  ) {
+    return true;
+  }
+
+  return (
+    !!parent && isSupportedWholePropsUsage(parent, argument => argument === reference.identifier)
+  );
+}

--- a/packages/analysis/src/jsts/rules/S6767/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator.ts
@@ -22,11 +22,15 @@ import { interceptReportForReact } from '../helpers/decorators/interceptor.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { findComponentNodes } from '../helpers/react.js';
 import { hasOwnCustomSuperclassPropsForwarding } from './custom-superclass-forwarding.js';
+import { hasDecoratorPropUsage } from './decorator-indirect-prop-usage.js';
 import { hasForwardRefCallbackPropUsage } from './forward-ref-indirect-prop-usage.js';
 import * as meta from './generated-meta.js';
 import { hasSupportedWholePropsUsage } from './whole-props-usage.js';
 
-function allMatch(componentNodes: estree.Node[], predicate: (componentNode: estree.Node) => boolean) {
+function allMatch(
+  componentNodes: estree.Node[],
+  predicate: (componentNode: estree.Node) => boolean,
+) {
   return componentNodes.length > 0 && componentNodes.every(predicate);
 }
 
@@ -38,15 +42,30 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
       const { data } = descriptor as { data?: Record<string, string> };
       const propName = data?.name;
       const componentNodes = findComponentNodes(node, context);
-      if (allMatch(componentNodes, componentNode => hasSupportedWholePropsUsage(componentNode, context))) {
+      if (
+        allMatch(componentNodes, componentNode =>
+          hasSupportedWholePropsUsage(componentNode, context),
+        )
+      ) {
         return;
       }
-      if (allMatch(componentNodes, componentNode => hasOwnCustomSuperclassPropsForwarding(componentNode))) {
+      if (
+        allMatch(componentNodes, componentNode =>
+          hasOwnCustomSuperclassPropsForwarding(componentNode),
+        )
+      ) {
         return;
       }
       if (
         allMatch(componentNodes, componentNode =>
           hasForwardRefCallbackPropUsage(componentNode, context, propName),
+        )
+      ) {
+        return;
+      }
+      if (
+        allMatch(componentNodes, componentNode =>
+          hasDecoratorPropUsage(componentNode, context, propName),
         )
       ) {
         return;

--- a/packages/analysis/src/jsts/rules/S6767/fixtures/tsconfig.json
+++ b/packages/analysis/src/jsts/rules/S6767/fixtures/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "experimentalDecorators": true,
     "jsx": "react",
     "noImplicitAny": false
   }

--- a/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
+++ b/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
@@ -168,8 +168,8 @@ class ForwardedCounterPanel extends CounterPanelBase {
           filename: fixtureFile,
         },
         {
-          // FP: wrapped callbacks should still resolve their owner, so the forwardRef
-          // closure escape continues to suppress WrappedProps.label.
+          // FP: wrapped callbacks still resolve through the owning variable, so the
+          // forwardRef closure escape continues to suppress WrappedProps.label.
           code: `
 declare const React: any;
 interface WrappedProps {
@@ -200,6 +200,70 @@ class ForwardedOnlyPanel extends CounterPanelBase {
   }
   render() {
     return <span>ready</span>;
+  }
+}
+`,
+          filename: fixtureFile,
+        },
+        {
+          // FP: decorator-factory callback reads typed component props.
+          code: `
+declare const React: any;
+declare function track<P>(
+  mapper: (props: P) => Record<string, unknown>,
+): <TComponent>(target: TComponent) => TComponent;
+interface DecoratorFactoryProps {
+  contextModule: string;
+  userId: string;
+}
+function DecoratorFactoryComponent(props: DecoratorFactoryProps) {
+  return <div />;
+}
+track((props: DecoratorFactoryProps) => ({
+  context_module: props.contextModule,
+  user_id: props.userId,
+}))(DecoratorFactoryComponent);
+`,
+          filename: fixtureFile,
+        },
+        {
+          // FP: decorator-factory callback forwards typed props to a helper.
+          code: `
+declare const React: any;
+declare function buildPayload<P>(props: P): Record<string, unknown>;
+declare function screenTrack<P>(
+  mapper: (props: P) => Record<string, unknown>,
+): <TComponent>(target: TComponent) => TComponent;
+interface DecoratorHelperProps {
+  screenName: string;
+}
+function DecoratorHelperComponent(props: DecoratorHelperProps) {
+  return <main />;
+}
+screenTrack(function (props: DecoratorHelperProps) {
+  return buildPayload(props);
+})(DecoratorHelperComponent);
+`,
+          filename: fixtureFile,
+        },
+        {
+          // FP: class decorator callback forwards typed props to a helper.
+          code: `
+declare const React: any;
+declare function buildPayload<P>(props: P): Record<string, unknown>;
+declare function screenTrack<P>(
+  mapper: (props: P) => Record<string, unknown>,
+): <TComponent>(target: TComponent) => TComponent;
+interface DecoratorAnnotationHelperProps {
+  screenName: string;
+}
+@screenTrack(function (props: DecoratorAnnotationHelperProps) {
+  return buildPayload(props);
+})
+class DecoratorAnnotationHelperComponent extends React.Component<DecoratorAnnotationHelperProps> {
+  props: DecoratorAnnotationHelperProps;
+  render() {
+    return <main />;
   }
 }
 `,

--- a/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
+++ b/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
@@ -246,29 +246,6 @@ screenTrack(function (props: DecoratorHelperProps) {
 `,
           filename: fixtureFile,
         },
-        {
-          // FP: class decorator callback forwards typed props to a helper.
-          code: `
-declare const React: any;
-declare function buildPayload<P>(props: P): Record<string, unknown>;
-declare function screenTrack<P>(
-  mapper: (props: P) => Record<string, unknown>,
-): <TComponent>(target: TComponent) => TComponent;
-interface DecoratorAnnotationHelperProps {
-  screenName: string;
-}
-@screenTrack(function (props: DecoratorAnnotationHelperProps) {
-  return buildPayload(props);
-})
-class DecoratorAnnotationHelperComponent extends React.Component<DecoratorAnnotationHelperProps> {
-  props: DecoratorAnnotationHelperProps;
-  render() {
-    return <main />;
-  }
-}
-`,
-          filename: fixtureFile,
-        },
       ],
       invalid: [
         {

--- a/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
+++ b/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
@@ -427,4 +427,80 @@ class PageWrapper extends React.Component<PageWrapperProps> {
       ],
     });
   });
+
+  it('should not report anonymous default-export component props used via forwardRef closure', () => {
+    const ruleTester = new RuleTester({
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: path.join(import.meta.dirname, 'fixtures'),
+      },
+    });
+
+    const fixtureFile = path.join(import.meta.dirname, 'fixtures', 'placeholder.tsx');
+
+    ruleTester.run('no-unused-prop-types', rule, {
+      valid: [
+        {
+          // Regression: anonymous default-export components still own typed props
+          // even though their component identifier is attached later in analysis.
+          code: `
+declare const React: any;
+interface Props {
+  label: string;
+}
+export default function (props: Props) {
+  const ForwardedInput = React.forwardRef((_: any, ref: any) => (
+    <label ref={ref}>{props.label}</label>
+  ));
+  return <ForwardedInput />;
+}
+`,
+          filename: fixtureFile,
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  it('should report props when a decorator target only matches a shadowed local binding', () => {
+    const ruleTester = new RuleTester({
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: path.join(import.meta.dirname, 'fixtures'),
+      },
+    });
+
+    const fixtureFile = path.join(import.meta.dirname, 'fixtures', 'placeholder.tsx');
+
+    ruleTester.run('no-unused-prop-types', rule, {
+      valid: [],
+      invalid: [
+        {
+          // Regression: the decorator callback matches the component props type,
+          // but the applied target is a nested shadowing binding, not the component.
+          code: `
+declare const React: any;
+declare function track<P>(
+  mapper: (props: P) => Record<string, unknown>,
+): <TComponent>(target: TComponent) => TComponent;
+interface Props {
+  label: string;
+  userId: string;
+}
+function Comp(props: Props) {
+  {
+    const Comp = 0;
+    track((decoratedProps: Props) => ({
+      user_id: decoratedProps.userId,
+    }))(Comp);
+  }
+  return <div>{props.label}</div>;
+}
+`,
+          filename: fixtureFile,
+          errors: 1,
+        },
+      ],
+    });
+  });
 });

--- a/packages/analysis/src/jsts/rules/S6767/unit.upstream.test.ts
+++ b/packages/analysis/src/jsts/rules/S6767/unit.upstream.test.ts
@@ -178,6 +178,50 @@ Wrapper.propTypes = {
     });
   });
 
+  it('upstream rule should NOT report direct class decorator prop access', () => {
+    // Characterizes the current upstream behavior for class decorators:
+    // direct prop reads inside @screenTrack(...) do not need an S6767 escape.
+    const upstreamRule = rules['no-unused-prop-types'];
+    const ruleTester = new RuleTester({
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: path.join(import.meta.dirname, 'fixtures'),
+      },
+    });
+    const fixtureFile = path.join(import.meta.dirname, 'fixtures', 'placeholder.tsx');
+
+    ruleTester.run(
+      'no-unused-prop-types (upstream, class decorator direct prop access)',
+      upstreamRule,
+      {
+        valid: [
+          {
+            code: `
+declare const React: any;
+declare function screenTrack<P>(
+  mapper: (props: P) => Record<string, unknown>,
+): ClassDecorator;
+interface DecoratorAnnotationProps {
+  screenName: string;
+}
+@screenTrack((props: DecoratorAnnotationProps) => ({
+  screen_name: props.screenName,
+}))
+class DecoratorAnnotationComponent extends React.Component<DecoratorAnnotationProps> {
+  props: DecoratorAnnotationProps;
+  render() {
+    return <main />;
+  }
+}
+`,
+            filename: fixtureFile,
+          },
+        ],
+        invalid: [],
+      },
+    );
+  });
+
   it('upstream rule should NOT report state interface properties when TypeScript type info is available', () => {
     // Confirms that the upstream rule uses TypeScript type information to distinguish
     // state types from props types. AnchorState (used as the second type parameter of

--- a/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
@@ -57,7 +57,7 @@ function hasSupportedWholePropsUsageInSubtree(
  * Ignored pseudo code:
  *   PropTypes.checkPropTypes(props, ...)
  */
-function isSupportedWholePropsUsage(
+export function isSupportedWholePropsUsage(
   node: estree.Node,
   isPropsArgument: (argument: estree.Node) => boolean,
 ): boolean {

--- a/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
@@ -48,6 +48,10 @@ function hasSupportedWholePropsUsageInSubtree(
  * Returns true when `node` matches any supported whole-props usage shape for the
  * provided `isPropsArgument` predicate and is not filtered out by the ignore rules.
  *
+ * Exported so sibling S6767 escapes can reuse the same whole-props shape matcher
+ * with a narrower props-binding predicate, for example a decorator callback
+ * parameter instead of only literal `props` or `this.props`.
+ *
  * Pseudo code:
  *   consume(props)
  *   [...props]

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -215,10 +215,7 @@ function isSpecificPropsType(type: ts.Type | undefined): type is ts.Type {
 }
 
 function getFunctionComponentParamPropsType(
-  componentNode:
-    | estree.FunctionDeclaration
-    | estree.FunctionExpression
-    | estree.ArrowFunctionExpression,
+  componentNode: FunctionComponentNode,
   services: RequiredParserServices,
 ): ts.Type | undefined {
   const firstParam = componentNode.params[0];
@@ -340,10 +337,7 @@ function getClassPropsPropertyType(
 }
 
 function isEligibleFunctionComponent(
-  componentNode:
-    | estree.FunctionDeclaration
-    | estree.FunctionExpression
-    | estree.ArrowFunctionExpression,
+  componentNode: FunctionComponentNode,
   componentIdentifier: estree.Identifier | undefined,
 ): boolean {
   return componentIdentifier === undefined

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -145,6 +145,18 @@ function getOwningVariableDeclarator(
   return isVariableDeclaratorWithIdentifierId(parent) ? parent : undefined;
 }
 
+function isAnonymousDefaultExportComponent(componentNode: estree.Node): boolean {
+  let currentNode: estree.Node = componentNode;
+  let parent = getNodeParent(currentNode);
+
+  while (isWrappedInReactComponentCall(currentNode, parent)) {
+    currentNode = parent;
+    parent = getNodeParent(currentNode);
+  }
+
+  return parent?.type === 'ExportDefaultDeclaration';
+}
+
 export function getComponentPropsType(
   componentNode: estree.Node,
   services: RequiredParserServices,
@@ -327,10 +339,16 @@ function getClassPropsPropertyType(
   return propsSymbol ? checker.getTypeOfSymbol(propsSymbol) : undefined;
 }
 
-function isPascalCaseFunctionComponent(
+function isEligibleFunctionComponent(
+  componentNode:
+    | estree.FunctionDeclaration
+    | estree.FunctionExpression
+    | estree.ArrowFunctionExpression,
   componentIdentifier: estree.Identifier | undefined,
 ): boolean {
-  return componentIdentifier !== undefined && /^[A-Z]/.test(componentIdentifier.name);
+  return componentIdentifier === undefined
+    ? isAnonymousDefaultExportComponent(componentNode)
+    : /^[A-Z]/.test(componentIdentifier.name);
 }
 
 function hasRenderMethodOrProperty(componentNode: estree.Node): boolean {
@@ -390,7 +408,7 @@ export function createComponentAnalysis(
 
   if (
     !isFunctionComponentNode(componentNode) ||
-    !isPascalCaseFunctionComponent(componentIdentifier)
+    !isEligibleFunctionComponent(componentNode, componentIdentifier)
   ) {
     return EMPTY_COMPONENT_ANALYSIS;
   }

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -131,9 +131,7 @@ function isWrappedInReactComponentCall(
   );
 }
 
-function getOwningVariableDeclarator(
-  componentNode: estree.Node,
-): (estree.VariableDeclarator & { id: estree.Identifier }) | undefined {
+function getOutermostReactWrapperParent(componentNode: estree.Node): estree.Node | undefined {
   let currentNode: estree.Node = componentNode;
   let parent = getNodeParent(currentNode);
 
@@ -142,18 +140,18 @@ function getOwningVariableDeclarator(
     parent = getNodeParent(currentNode);
   }
 
+  return parent;
+}
+
+function getOwningVariableDeclarator(
+  componentNode: estree.Node,
+): (estree.VariableDeclarator & { id: estree.Identifier }) | undefined {
+  const parent = getOutermostReactWrapperParent(componentNode);
   return isVariableDeclaratorWithIdentifierId(parent) ? parent : undefined;
 }
 
 function isAnonymousDefaultExportComponent(componentNode: estree.Node): boolean {
-  let currentNode: estree.Node = componentNode;
-  let parent = getNodeParent(currentNode);
-
-  while (isWrappedInReactComponentCall(currentNode, parent)) {
-    currentNode = parent;
-    parent = getNodeParent(currentNode);
-  }
-
+  const parent = getOutermostReactWrapperParent(componentNode);
   return parent?.type === 'ExportDefaultDeclaration';
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -145,7 +145,7 @@ function getOwningVariableDeclarator(
   return isVariableDeclaratorWithIdentifierId(parent) ? parent : undefined;
 }
 
-function getComponentPropsType(
+export function getComponentPropsType(
   componentNode: estree.Node,
   services: RequiredParserServices,
 ): ts.Type | undefined {
@@ -330,7 +330,7 @@ function getClassPropsPropertyType(
 function isPascalCaseFunctionComponent(
   componentIdentifier: estree.Identifier | undefined,
 ): boolean {
-  return componentIdentifier === undefined || /^[A-Z]/.test(componentIdentifier.name);
+  return componentIdentifier !== undefined && /^[A-Z]/.test(componentIdentifier.name);
 }
 
 function hasRenderMethodOrProperty(componentNode: estree.Node): boolean {

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -336,6 +336,11 @@ function getClassPropsPropertyType(
   return propsSymbol ? checker.getTypeOfSymbol(propsSymbol) : undefined;
 }
 
+/**
+ * Returns whether a function component should participate in component analysis.
+ * Named components must follow React's uppercase convention, while anonymous
+ * function components stay eligible only when they are exported as default.
+ */
 function isEligibleFunctionComponent(
   componentNode: FunctionComponentNode,
   componentIdentifier: estree.Identifier | undefined,

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -45,6 +45,10 @@ export type ComponentNode =
   | estree.FunctionDeclaration
   | estree.FunctionExpression
   | estree.ArrowFunctionExpression;
+type FunctionComponentNode =
+  | estree.FunctionDeclaration
+  | estree.FunctionExpression
+  | estree.ArrowFunctionExpression;
 export type CollectedComponent = {
   componentNode: ComponentNode;
   componentIdentifier: estree.Identifier | undefined;
@@ -61,9 +65,7 @@ function isClassComponentNode(
   return node.type === 'ClassDeclaration' || node.type === 'ClassExpression';
 }
 
-function isFunctionComponentNode(
-  node: estree.Node,
-): node is estree.FunctionDeclaration | estree.FunctionExpression | estree.ArrowFunctionExpression {
+function isFunctionComponentNode(node: estree.Node): node is FunctionComponentNode {
   return (
     node.type === 'FunctionDeclaration' ||
     node.type === 'FunctionExpression' ||

--- a/packages/analysis/tests/jsts/rules/helpers/react/component-analysis.test.ts
+++ b/packages/analysis/tests/jsts/rules/helpers/react/component-analysis.test.ts
@@ -63,7 +63,7 @@ const componentAnalysisRule: Rule.RuleModule = {
           { name: 'Button', memberCount: 1, typeCount: 1 },
           { name: 'MemoButton', memberCount: 1, typeCount: 1 },
           { name: 'ForwardedButton', memberCount: 1, typeCount: 1 },
-          { name: '<anonymous>', memberCount: 1, typeCount: 1 },
+          { name: '<anonymous>', memberCount: 0, typeCount: 0 },
           { name: 'Panel', memberCount: 1, typeCount: 1 },
         ]);
       },

--- a/packages/analysis/tests/jsts/rules/helpers/react/component-analysis.test.ts
+++ b/packages/analysis/tests/jsts/rules/helpers/react/component-analysis.test.ts
@@ -63,7 +63,7 @@ const componentAnalysisRule: Rule.RuleModule = {
           { name: 'Button', memberCount: 1, typeCount: 1 },
           { name: 'MemoButton', memberCount: 1, typeCount: 1 },
           { name: 'ForwardedButton', memberCount: 1, typeCount: 1 },
-          { name: '<anonymous>', memberCount: 0, typeCount: 0 },
+          { name: '<anonymous>', memberCount: 1, typeCount: 1 },
           { name: 'Panel', memberCount: 1, typeCount: 1 },
         ]);
       },


### PR DESCRIPTION
## Summary

- add a decorator-specific S6767 escape for typed decorator-factory callbacks and reuse the existing whole-props forwarding detection when the callback hands props to a helper
- keep anonymous default-export function components eligible for React owner/type analysis so `forwardRef` callback usage still suppresses S6767 for those components
- resolve decorator targets by binding identity instead of identifier text so a shadowed local with the same name does not suppress a real unused-prop issue
- remove the misleading class-annotation fixture from the decorated-rule suite and replace it with an upstream characterization test showing that direct class decorator prop access is already accepted upstream

## Why

- JS-1394 started as a false-positive fix for props consumed through decorator-factory callbacks
- review uncovered two follow-up regressions in S6767 ownership and suppression logic:
  - anonymous default-export function components dropped out of owner analysis after the React helper tightening
  - name-only decorator target matching could suppress a real issue when a nested binding shadowed the component name
- the class-annotation fixture was confusing because it did not exercise the new decorator escape; its behavior comes from existing traversal and current upstream handling, so the test coverage now documents that explicitly instead of implying annotation-specific support was added here

## Validation

- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/tests/jsts/rules/helpers/react/component-analysis.test.ts`
- `npx tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec packages/analysis/src/jsts/rules/S6767/unit.test.ts packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts packages/analysis/src/jsts/rules/S6767/unit.upstream.test.ts`
- GitHub PR checks on `a9563b2af` are green
