### PR TITLE
JS-1715 Implement sonar-resolve support in the SonarJS plugin

### DIFF
--- a/its/plugin/projects/sonar-resolve-html/index.html
+++ b/its/plugin/projects/sonar-resolve-html/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+console.log('x');; // sonar-resolve javascript:S1116 "accepted in HTML"
+</script>
+</body>
+</html>

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarResolveTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarResolveTest.java
@@ -59,6 +59,10 @@ class SonarResolveTest {
         assertThat(issue.getIssueStatus()).isEqualTo("ACCEPTED");
         assertThat(issue.hasResolution()).isTrue();
         assertThat(issue.getResolution()).isNotBlank();
+        assertThat(issue.hasComments()).isTrue();
+        assertThat(issue.getComments().getCommentsList()).anySatisfy(comment ->
+          assertThat(comment.getMarkdown()).contains("accepted in HTML")
+        );
       });
   }
 

--- a/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarResolveTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/javascript/it/plugin/SonarResolveTest.java
@@ -1,0 +1,94 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package com.sonar.javascript.it.plugin;
+
+import static com.sonar.javascript.it.plugin.OrchestratorStarter.getSonarScanner;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sonar.orchestrator.Orchestrator;
+import com.sonar.orchestrator.build.SonarScanner;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.sonarqube.ws.Issues.Issue;
+import org.sonarqube.ws.client.issues.SearchRequest;
+
+@ExtendWith(OrchestratorStarter.class)
+class SonarResolveTest {
+
+  private static final Orchestrator orchestrator = OrchestratorStarter.ORCHESTRATOR;
+
+  @Test
+  void should_persist_sonar_resolve_from_embedded_javascript_in_html() {
+    String projectKey = "sonar-resolve-html";
+    SonarScanner build = getSonarScanner()
+      .setProjectKey(projectKey)
+      .setSourceEncoding("UTF-8")
+      .setSourceDirs(".")
+      .setProjectDir(TestUtils.projectDir(projectKey));
+
+    OrchestratorStarter.setProfiles(
+      projectKey,
+      Map.of("html-profile", "web", "nosonar-profile", "js")
+    );
+    enableIssueResolution(projectKey);
+    orchestrator.executeBuild(build);
+
+    String fileKey = projectKey + ":index.html";
+
+    assertThat(searchIssues(fileKey))
+      .singleElement()
+      .satisfies(issue -> {
+        assertThat(issue.getRule()).isEqualTo("javascript:S1116");
+        assertThat(issue.getLine()).isEqualTo(5);
+        assertThat(issue.getIssueStatus()).isEqualTo("ACCEPTED");
+        assertThat(issue.hasResolution()).isTrue();
+        assertThat(issue.getResolution()).isNotBlank();
+      });
+  }
+
+  private static void enableIssueResolution(String projectKey) {
+    orchestrator
+      .getServer()
+      .post(
+        "api/settings/set",
+        Map.of("key", "sonar.issues.issueResolution.global.enabled", "value", "true")
+      );
+    orchestrator
+      .getServer()
+      .post(
+        "api/settings/set",
+        Map.of(
+          "component",
+          projectKey,
+          "key",
+          "sonar.issues.issueResolution.enabled",
+          "value",
+          "true"
+        )
+      );
+  }
+
+  private static List<Issue> searchIssues(String componentKey) {
+    SearchRequest request = new SearchRequest()
+      .setComponentKeys(List.of(componentKey))
+      .setAdditionalFields(List.of("_all"))
+      .setRules(List.of("javascript:S1116"));
+    return OrchestratorStarter.newWsClient(orchestrator).issues().search(request).getIssuesList();
+  }
+}

--- a/packages/analysis/src/analyzeFile.ts
+++ b/packages/analysis/src/analyzeFile.ts
@@ -174,13 +174,24 @@ async function mergeAdditionalCssAnalysis(
     return result;
   }
   result.issues.push(...cssResult.issues);
+  const cssSonarResolveComments =
+    'sonarResolveComments' in cssResult ? (cssResult.sonarResolveComments ?? []) : [];
+  const sonarResolveComments = [...(result.sonarResolveComments ?? []), ...cssSonarResolveComments];
   if ('parsingErrors' in cssResult && cssResult.parsingErrors?.length) {
     const parsingErrors = [...(result.parsingErrors ?? []), ...cssResult.parsingErrors];
     return {
       ...result,
       parsingErrors,
+      ...(sonarResolveComments.length > 0 ? { sonarResolveComments } : {}),
     };
   }
 
-  return result;
+  if (sonarResolveComments.length === 0) {
+    return result;
+  }
+
+  return {
+    ...result,
+    sonarResolveComments,
+  };
 }

--- a/packages/analysis/src/common/sonar-resolve.ts
+++ b/packages/analysis/src/common/sonar-resolve.ts
@@ -91,7 +91,12 @@ function extractSonarResolveComments(comments: CommentSource[]): SonarResolveCom
 
   for (const comment of orderedComments) {
     if (comment.kind === 'line') {
-      if (lineCommentRun.length > 0 && lineCommentRun.at(-1)!.endLine + 1 !== comment.line) {
+      const previousLineComment = lineCommentRun.at(-1);
+      if (
+        lineCommentRun.length > 0 &&
+        previousLineComment != null &&
+        previousLineComment.endLine + 1 !== comment.line
+      ) {
         pushLineCommentRun(lineCommentRun, extracted);
         lineCommentRun = [];
       }

--- a/packages/analysis/src/common/sonar-resolve.ts
+++ b/packages/analysis/src/common/sonar-resolve.ts
@@ -1,0 +1,155 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { Comment as PostCssComment, Document, Root } from 'postcss';
+import type { SonarResolveComment } from '../contracts/analysis.js';
+
+const SONAR_RESOLVE_KEYWORD = 'sonar-resolve';
+
+type CommentSource = {
+  column: number;
+  endLine: number;
+  kind: 'block' | 'line';
+  line: number;
+  text: string;
+};
+
+type JsTsComment = {
+  loc?: {
+    start: { line: number; column: number };
+    end: { line: number };
+  } | null;
+  type: string;
+  value: string;
+};
+
+export function extractSonarResolveCommentsFromJsTsComments(
+  comments: readonly JsTsComment[] = [],
+): SonarResolveComment[] {
+  return extractSonarResolveComments(
+    comments.flatMap(comment => {
+      if (comment.loc == null) {
+        return [];
+      }
+
+      return [
+        {
+          column: comment.loc.start.column,
+          endLine: comment.loc.end.line,
+          kind: comment.type === 'Line' ? 'line' : 'block',
+          line: comment.loc.start.line,
+          text: comment.value,
+        } satisfies CommentSource,
+      ];
+    }),
+  );
+}
+
+export function extractSonarResolveCommentsFromCssRoot(
+  root: Root | Document,
+): SonarResolveComment[] {
+  const comments: CommentSource[] = [];
+
+  root.walkComments(comment => {
+    const line = comment.source?.start?.line;
+    const column = comment.source?.start?.column;
+    if (line == null || column == null) {
+      return;
+    }
+
+    comments.push({
+      column,
+      endLine: comment.source?.end?.line ?? line,
+      kind: isCssLineComment(comment) ? 'line' : 'block',
+      line,
+      text: comment.text,
+    });
+  });
+
+  return extractSonarResolveComments(comments);
+}
+
+function extractSonarResolveComments(comments: CommentSource[]): SonarResolveComment[] {
+  const extracted: SonarResolveComment[] = [];
+  const orderedComments = [...comments].sort(
+    (left, right) => left.line - right.line || left.column - right.column,
+  );
+  let lineCommentRun: CommentSource[] = [];
+
+  for (const comment of orderedComments) {
+    if (comment.kind === 'line') {
+      if (
+        lineCommentRun.length > 0 &&
+        lineCommentRun[lineCommentRun.length - 1].endLine + 1 !== comment.line
+      ) {
+        pushLineCommentRun(lineCommentRun, extracted);
+        lineCommentRun = [];
+      }
+
+      lineCommentRun.push(comment);
+      continue;
+    }
+
+    if (lineCommentRun.length > 0) {
+      pushLineCommentRun(lineCommentRun, extracted);
+      lineCommentRun = [];
+    }
+
+    if (containsDirective(comment.text)) {
+      extracted.push({
+        line: comment.line,
+        text: comment.text,
+      });
+    }
+  }
+
+  if (lineCommentRun.length > 0) {
+    pushLineCommentRun(lineCommentRun, extracted);
+  }
+
+  return extracted;
+}
+
+function pushLineCommentRun(lineCommentRun: CommentSource[], extracted: SonarResolveComment[]) {
+  const text = lineCommentRun.map(comment => comment.text).join('\n');
+  if (!containsDirective(text)) {
+    return;
+  }
+
+  extracted.push({
+    line: lineCommentRun[0].line,
+    text,
+  });
+}
+
+function containsDirective(text: string) {
+  return splitLines(text).some(startsWithDirectiveKeyword);
+}
+
+function splitLines(text: string) {
+  return text.split(/\r\n|\r|\n/u);
+}
+
+function startsWithDirectiveKeyword(line: string) {
+  return (
+    line.trimStart().slice(0, SONAR_RESOLVE_KEYWORD.length).toLowerCase() === SONAR_RESOLVE_KEYWORD
+  );
+}
+
+function isCssLineComment(comment: PostCssComment) {
+  const raws = comment.raws as { begin?: string; inline?: boolean };
+  return raws.inline === true || raws.begin === '//';
+}

--- a/packages/analysis/src/common/sonar-resolve.ts
+++ b/packages/analysis/src/common/sonar-resolve.ts
@@ -91,10 +91,7 @@ function extractSonarResolveComments(comments: CommentSource[]): SonarResolveCom
 
   for (const comment of orderedComments) {
     if (comment.kind === 'line') {
-      if (
-        lineCommentRun.length > 0 &&
-        lineCommentRun[lineCommentRun.length - 1].endLine + 1 !== comment.line
-      ) {
+      if (lineCommentRun.length > 0 && lineCommentRun.at(-1)!.endLine + 1 !== comment.line) {
         pushLineCommentRun(lineCommentRun, extracted);
         lineCommentRun = [];
       }

--- a/packages/analysis/src/common/sonar-resolve.ts
+++ b/packages/analysis/src/common/sonar-resolve.ts
@@ -93,9 +93,9 @@ function extractSonarResolveComments(comments: CommentSource[]): SonarResolveCom
     if (comment.kind === 'line') {
       const previousLineComment = lineCommentRun.at(-1);
       if (
-        lineCommentRun.length > 0 &&
         previousLineComment != null &&
-        previousLineComment.endLine + 1 !== comment.line
+        (previousLineComment.endLine + 1 !== comment.line ||
+          startsWithDirectiveKeyword(comment.text))
       ) {
         pushLineCommentRun(lineCommentRun, extracted);
         lineCommentRun = [];

--- a/packages/analysis/src/contracts/analysis.ts
+++ b/packages/analysis/src/contracts/analysis.ts
@@ -55,6 +55,11 @@ export interface BaseIssue {
   endColumn?: number;
 }
 
+export interface SonarResolveComment {
+  line: number;
+  text: string;
+}
+
 /**
  * An analysis output
  *
@@ -65,6 +70,7 @@ export interface BaseIssue {
  */
 export interface AnalysisOutput<I extends BaseIssue = BaseIssue> {
   issues: I[];
+  sonarResolveComments?: SonarResolveComment[];
 }
 
 /**

--- a/packages/analysis/src/css/analysis/analyzer.ts
+++ b/packages/analysis/src/css/analysis/analyzer.ts
@@ -25,6 +25,7 @@ import {
 } from '../../contracts/project-analysis.js';
 import { warn } from '../../../../shared/src/helpers/logging.js';
 import type { CssIssue } from '../linter/issues/issue.js';
+import { extractSonarResolveCommentsFromCssRoot } from '../../common/sonar-resolve.js';
 
 /**
  * Analyzes a CSS analysis input
@@ -74,11 +75,15 @@ export async function analyzeCSS(
   const { root, issues: lintingIssues } = lintResult;
   throwIfCssParsingError(lintingIssues);
   const issues = isTestFile ? [] : lintingIssues;
+  const sonarResolveComments = root ? extractSonarResolveCommentsFromCssRoot(root) : [];
 
   // Skip metrics and highlighting for non-pure-CSS files
   // (HTML/Vue files are handled by their own analyzers for metrics)
   if (!includeMetrics || !root) {
-    return { issues };
+    return {
+      issues,
+      ...(sonarResolveComments.length > 0 ? { sonarResolveComments } : {}),
+    };
   }
 
   try {
@@ -88,21 +93,30 @@ export async function analyzeCSS(
       return {
         issues,
         metrics: { nosonarLines: metrics.nosonarLines },
+        ...(sonarResolveComments.length > 0 ? { sonarResolveComments } : {}),
       };
     } else {
       const highlights = computeHighlighting(root, sanitizedCode);
       if (isTestFile) {
-        return { issues, highlights };
+        return {
+          issues,
+          highlights,
+          ...(sonarResolveComments.length > 0 ? { sonarResolveComments } : {}),
+        };
       }
       return {
         issues,
         highlights,
         metrics: computeMetrics(root),
+        ...(sonarResolveComments.length > 0 ? { sonarResolveComments } : {}),
       };
     }
   } catch (err) {
     warn(`Failed to compute metrics/highlighting for ${filePath}: ${err}`);
-    return { issues };
+    return {
+      issues,
+      ...(sonarResolveComments.length > 0 ? { sonarResolveComments } : {}),
+    };
   }
 }
 

--- a/packages/analysis/src/jsts/analysis/analyzer.ts
+++ b/packages/analysis/src/jsts/analysis/analyzer.ts
@@ -21,6 +21,7 @@ import type { TSESTree } from '@typescript-eslint/utils';
 import { Linter } from '../linter/linter.js';
 import { build } from '../builders/build.js';
 import { serializeInProtobuf } from '../parsers/ast.js';
+import { extractSonarResolveCommentsFromJsTsComments } from '../../common/sonar-resolve.js';
 import {
   collectMainFileArtifacts,
   collectNoSonarMetrics,
@@ -102,10 +103,14 @@ export async function analyzeJSTS(input: JsTsAnalysisInput): Promise<JsTsAnalysi
     parseResult.sourceCode,
     metricsSink?.cognitiveComplexity,
   );
+  const sonarResolveComments = extractSonarResolveCommentsFromJsTsComments(
+    parseResult.sourceCode.ast.comments ?? [],
+  );
 
   const result = {
     issues,
     ...extendedMetrics,
+    ...(sonarResolveComments.length > 0 ? { sonarResolveComments } : {}),
   };
 
   if (!input.skipAst) {

--- a/packages/analysis/src/jsts/embedded/analysis/analyzer.ts
+++ b/packages/analysis/src/jsts/embedded/analysis/analyzer.ts
@@ -22,6 +22,8 @@ import type { EmbeddedAnalysisInput, EmbeddedAnalysisOutput } from './analysis.j
 import { collectNclocLines } from '../../analysis/file-artifacts.js';
 import { type ExtendedParseResult, type LanguageParser, build } from '../builder/build.js';
 import { debug } from '../../../../../shared/src/helpers/logging.js';
+import { extractSonarResolveCommentsFromJsTsComments } from '../../../common/sonar-resolve.js';
+import type { SonarResolveComment } from '../../../contracts/analysis.js';
 
 /**
  * Analyzes a file containing JS snippets
@@ -52,23 +54,35 @@ export async function analyzeEmbedded(
   debug(`Analyzing file "${input.filePath}"`);
   const extendedParseResults = build(input, languageParser);
   const aggregatedIssues: JsTsIssue[] = [];
+  const aggregatedSonarResolveComments: SonarResolveComment[] = [];
   let ncloc: number[] = [];
   for (const extendedParseResult of extendedParseResults) {
-    const { issues, ncloc: singleNcLoc } = analyzeSnippet(extendedParseResult);
+    const {
+      issues,
+      ncloc: singleNcLoc,
+      sonarResolveComments: singleSonarResolveComments,
+    } = analyzeSnippet(extendedParseResult);
     ncloc = ncloc.concat(singleNcLoc);
     const filteredIssues = removeNonJsIssues(extendedParseResult.sourceCode, issues);
     aggregatedIssues.push(...filteredIssues);
+    aggregatedSonarResolveComments.push(...singleSonarResolveComments);
   }
   return {
     issues: aggregatedIssues,
     metrics: { ncloc },
+    ...(aggregatedSonarResolveComments.length > 0
+      ? { sonarResolveComments: aggregatedSonarResolveComments }
+      : {}),
   };
 }
 
 function analyzeSnippet(extendedParseResult: ExtendedParseResult) {
   const issues = Linter.lint(extendedParseResult, extendedParseResult.syntheticFilePath, 'MAIN');
   const ncloc = collectNclocLines(extendedParseResult.sourceCode);
-  return { issues, ncloc };
+  const sonarResolveComments = extractSonarResolveCommentsFromJsTsComments(
+    extendedParseResult.sourceCode.ast.comments ?? [],
+  );
+  return { issues, ncloc, sonarResolveComments };
 }
 
 /**

--- a/packages/analysis/tests/analyzeProject-sonarqube.test.ts
+++ b/packages/analysis/tests/analyzeProject-sonarqube.test.ts
@@ -491,6 +491,52 @@ describe('SonarQube project analysis', () => {
     }
   });
 
+  it('should merge sonar-resolve comments from embedded JS and CSS for HTML files', async () => {
+    const baseDir = join(fixtures, 'html-yaml');
+    const htmlFile = join(baseDir, 'sonar-resolve.html');
+    const cssRules: CssRuleConfig[] = [{ key: 'no-extra-semicolons', configurations: [] }];
+
+    const configuration = await initForTest(
+      { baseDir },
+      {
+        [htmlFile]: {
+          filePath: htmlFile,
+          fileType: 'MAIN',
+          fileContent: [
+            '<html>',
+            '<script>',
+            '// sonar-resolve javascript:S1116 "js reason"',
+            'const x = 1;',
+            '</script>',
+            '<style>',
+            '/* sonar-resolve css:no-extra-semicolons "css reason" */',
+            'a { color: pink; }',
+            '</style>',
+            '</html>',
+          ].join('\n'),
+        },
+      },
+    );
+
+    const result = await analyzeProject({ rules: [], cssRules, bundles: [] }, configuration);
+
+    const fileResult = result.files[normalizeToAbsolutePath(htmlFile)];
+    expect(fileResult).toBeDefined();
+    expect('issues' in fileResult!).toBe(true);
+    if ('issues' in fileResult!) {
+      expect(fileResult.sonarResolveComments).toEqual([
+        {
+          line: 3,
+          text: ' sonar-resolve javascript:S1116 "js reason"',
+        },
+        {
+          line: 7,
+          text: 'sonar-resolve css:no-extra-semicolons "css reason"',
+        },
+      ]);
+    }
+  });
+
   it('should not include CSS issues from style blocks for TEST HTML files', async () => {
     const baseDir = join(fixtures, 'html-yaml');
     const htmlFile = join(baseDir, 'file.html');

--- a/packages/analysis/tests/css/analysis/analyzer.test.ts
+++ b/packages/analysis/tests/css/analysis/analyzer.test.ts
@@ -73,6 +73,63 @@ describe('analyzeCSS', () => {
     );
   });
 
+  it('should extract sonar-resolve directives from block comments in CSS', async () => {
+    const result = await analyzeCSS(
+      await input(
+        '/some/fake/path.css',
+        '/* sonar-resolve css:no-extra-semicolons "reason" */\na { color: red; }',
+      ),
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 1,
+        text: 'sonar-resolve css:no-extra-semicolons "reason"',
+      },
+    ]);
+  });
+
+  it('should preserve multiline sonar-resolve directives across consecutive SCSS line comments', async () => {
+    const result = await analyzeCSS(
+      await input(
+        '/some/fake/path.scss',
+        [
+          '// sonar-resolve css:no-extra-semicolons "reason',
+          '// continued"',
+          'a { color: red; }',
+        ].join('\n'),
+      ),
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 1,
+        text: 'sonar-resolve css:no-extra-semicolons "reason\ncontinued"',
+      },
+    ]);
+  });
+
+  it('should extract sonar-resolve directives from CSS inside HTML style blocks', async () => {
+    const result = await analyzeCSS(
+      await input(
+        '/some/fake/path.html',
+        [
+          '<style>',
+          '/* sonar-resolve css:no-extra-semicolons "reason" */',
+          'a { color: red; }',
+          '</style>',
+        ].join('\n'),
+      ),
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 2,
+        text: 'sonar-resolve css:no-extra-semicolons "reason"',
+      },
+    ]);
+  });
+
   it('should still parse and compute metrics/highlighting with no rules', async () => {
     const fileContent = 'a { color: red; }';
     const result = await analyzeCSS(await input('/some/fake/path', fileContent, []));

--- a/packages/analysis/tests/html/analysis/analyzer.test.ts
+++ b/packages/analysis/tests/html/analysis/analyzer.test.ts
@@ -57,6 +57,32 @@ describe('analyzeHTML', () => {
     );
   });
 
+  it('should preserve host line numbers for sonar-resolve directives in embedded JS', async () => {
+    await Linter.initialize({ baseDir: fixturesPath, rules: [] });
+
+    const result = await analyzeEmbedded(
+      await embeddedInput({
+        filePath: normalizeToAbsolutePath(join(fixturesPath, 'sonar-resolve.html')),
+        fileContent: [
+          '<html>',
+          '<script>',
+          '// sonar-resolve javascript:S1116 "reason"',
+          'const x = 1;',
+          '</script>',
+          '</html>',
+        ].join('\n'),
+      }),
+      parseHTML,
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 3,
+        text: ' sonar-resolve javascript:S1116 "reason"',
+      },
+    ]);
+  });
+
   it('should not break when using a rule with a quickfix', async () => {
     await Linter.initialize({
       baseDir: fixturesPath,

--- a/packages/analysis/tests/jsts/analysis/analyzer.test.ts
+++ b/packages/analysis/tests/jsts/analysis/analyzer.test.ts
@@ -99,6 +99,71 @@ describe('await analyzeJSTS', () => {
     );
   });
 
+  it('should extract sonar-resolve directives from block comments', async () => {
+    await Linter.initialize({ baseDir: normalizeToAbsolutePath(fixtures), rules: [] });
+
+    const result = await analyzeJSTS(
+      await jsTsInput({
+        filePath: path.join(fixtures, 'sonar-resolve-block.js'),
+        fileContent: '/* sonar-resolve javascript:S1116 "reason" */\nfoo();\n',
+      }),
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 1,
+        text: ' sonar-resolve javascript:S1116 "reason" ',
+      },
+    ]);
+  });
+
+  it('should preserve multiline sonar-resolve directives across consecutive line comments', async () => {
+    await Linter.initialize({ baseDir: normalizeToAbsolutePath(fixtures), rules: [] });
+
+    const result = await analyzeJSTS(
+      await jsTsInput({
+        filePath: path.join(fixtures, 'sonar-resolve-line.js'),
+        fileContent: ['// sonar-resolve javascript:S1116 "reason', '// continued"', 'foo();'].join(
+          '\n',
+        ),
+      }),
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 1,
+        text: ' sonar-resolve javascript:S1116 "reason\n continued"',
+      },
+    ]);
+  });
+
+  it('should extract sonar-resolve directives from Vue script comments only', async () => {
+    await Linter.initialize({ baseDir: normalizeToAbsolutePath(fixtures), rules: [] });
+
+    const result = await analyzeJSTS(
+      await jsTsInput({
+        filePath: path.join(fixtures, 'sonar-resolve.vue'),
+        fileContent: [
+          '<template>',
+          '  <!-- sonar-resolve javascript:S1116 "template" -->',
+          '  <div />',
+          '</template>',
+          '<script>',
+          '// sonar-resolve javascript:S1116 "script"',
+          'const x = 1;',
+          '</script>',
+        ].join('\n'),
+      }),
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 6,
+        text: ' sonar-resolve javascript:S1116 "script"',
+      },
+    ]);
+  });
+
   it('should not analyze Vue.js with type checking', async () => {
     const rules: RuleConfig[] = [
       {

--- a/packages/analysis/tests/jsts/analysis/analyzer.test.ts
+++ b/packages/analysis/tests/jsts/analysis/analyzer.test.ts
@@ -137,6 +137,32 @@ describe('await analyzeJSTS', () => {
     ]);
   });
 
+  it('should split adjacent sonar-resolve directives in consecutive line comments', async () => {
+    await Linter.initialize({ baseDir: normalizeToAbsolutePath(fixtures), rules: [] });
+
+    const result = await analyzeJSTS(
+      await jsTsInput({
+        filePath: path.join(fixtures, 'sonar-resolve-adjacent-line.js'),
+        fileContent: [
+          '// sonar-resolve javascript:S1116 "first',
+          '// sonar-resolve javascript:S1121 "second"',
+          'foo();',
+        ].join('\n'),
+      }),
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 1,
+        text: ' sonar-resolve javascript:S1116 "first',
+      },
+      {
+        line: 2,
+        text: ' sonar-resolve javascript:S1121 "second"',
+      },
+    ]);
+  });
+
   it('should extract sonar-resolve directives from Vue script comments only', async () => {
     await Linter.initialize({ baseDir: normalizeToAbsolutePath(fixtures), rules: [] });
 

--- a/packages/analysis/tests/yaml/analysis/analyzer.test.ts
+++ b/packages/analysis/tests/yaml/analysis/analyzer.test.ts
@@ -70,6 +70,36 @@ describe('analyzeYAML', () => {
     );
   });
 
+  it('should preserve host line numbers for sonar-resolve directives in embedded YAML JS', async () => {
+    await Linter.initialize({ baseDir: fixturesPath, rules: [] });
+
+    const result = await analyzeEmbedded(
+      await embeddedInput({
+        filePath: join(fixturesPath, 'sonar-resolve.yaml'),
+        fileContent: [
+          'AWSTemplateFormatVersion: 2010-09-09',
+          'Resources:',
+          '  SomeLambdaFunction:',
+          '    Type: "AWS::Lambda::Function"',
+          '    Properties:',
+          '      Runtime: "nodejs16.0"',
+          '      Code:',
+          '        ZipFile: |',
+          '          // sonar-resolve javascript:S1116 "reason"',
+          '          exports.handler = async () => {};',
+        ].join('\n'),
+      }),
+      parseAwsFromYaml,
+    );
+
+    expect(result.sonarResolveComments).toEqual([
+      {
+        line: 9,
+        text: ' sonar-resolve javascript:S1116 "reason"',
+      },
+    ]);
+  });
+
   it('should return an empty issues list on parsing error', async () => {
     await Linter.initialize({
       baseDir: fixturesPath,

--- a/packages/grpc/src/analyze-project-convert.ts
+++ b/packages/grpc/src/analyze-project-convert.ts
@@ -35,6 +35,7 @@ import type {
   Location as InternalLocation,
   SymbolHighlight,
 } from '../../analysis/src/jsts/analysis/file-artifacts.js';
+import type { SonarResolveComment as InternalSonarResolveComment } from '../../analysis/src/contracts/analysis.js';
 import { ErrorCode } from '../../analysis/src/contracts/error.js';
 import { sonarjs } from './proto/analyze-project.js';
 
@@ -127,6 +128,7 @@ function toProjectAnalysisFileResult(
     metrics: result.metrics ? toMetrics(result.metrics) : undefined,
     cpdTokens: ('cpdTokens' in result ? result.cpdTokens : undefined)?.map(toCpdToken) ?? [],
     ast: 'ast' in result && result.ast != null ? Buffer.from(result.ast, 'base64') : undefined,
+    sonarResolveComments: (result.sonarResolveComments ?? []).map(toSonarResolveComment),
   };
 }
 
@@ -246,6 +248,15 @@ function toCpdToken(cpdToken: InternalCpdToken): sonarjs.analyzeproject.v1.ICpdT
   return {
     location: toLocation(cpdToken.location),
     image: cpdToken.image,
+  };
+}
+
+function toSonarResolveComment(
+  comment: InternalSonarResolveComment,
+): sonarjs.analyzeproject.v1.ISonarResolveComment {
+  return {
+    line: comment.line,
+    text: comment.text,
   };
 }
 

--- a/packages/grpc/src/proto/analyze-project.proto
+++ b/packages/grpc/src/proto/analyze-project.proto
@@ -176,6 +176,7 @@ message ProjectAnalysisFileResult {
   repeated CpdToken cpd_tokens = 6;
   bytes ast = 7;
   optional string error = 8;
+  repeated SonarResolveComment sonar_resolve_comments = 9;
 }
 
 message ParsingError {
@@ -254,6 +255,11 @@ message Metrics {
 message CpdToken {
   Location location = 1;
   string image = 2;
+}
+
+message SonarResolveComment {
+  int32 line = 1;
+  string text = 2;
 }
 
 message ProjectAnalysisMeta {

--- a/packages/grpc/tests/analyze-project-server.test.ts
+++ b/packages/grpc/tests/analyze-project-server.test.ts
@@ -500,6 +500,30 @@ async function withAnalyzeProjectServer(
 }
 
 describe('analyze-project gRPC server', () => {
+  it('should preserve sonar-resolve comments in unary responses', () => {
+    const unaryResponse = createAnalyzeProjectUnaryResponse({
+      files: {
+        [basicFixtureFile]: {
+          issues: [],
+          sonarResolveComments: [
+            {
+              line: 7,
+              text: 'sonar-resolve javascript:S1116 "reason"',
+            },
+          ],
+        },
+      } as unknown as ProjectAnalysisOutput['files'],
+      meta: { warnings: [] },
+    });
+
+    expect(unaryResponse.files?.[basicFixtureFile]?.sonarResolveComments).toEqual([
+      {
+        line: 7,
+        text: 'sonar-resolve javascript:S1116 "reason"',
+      },
+    ]);
+  });
+
   it('should handle unary analyze-project requests', async t => {
     for (const mode of serverModes) {
       await t.test(mode.label, async () => {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
@@ -424,8 +424,13 @@ public class AnalysisProcessor {
         saveIssueResolution(context, parser.result());
       } else if (state == SonarResolve.StreamingParser.State.INVALID) {
         logInvalidDirective(directiveLine, parser.errorMessage());
-      } else if (parser.finish() == SonarResolve.StreamingParser.State.INVALID) {
-        logInvalidDirective(directiveLine, parser.errorMessage());
+      } else {
+        var finalState = parser.finish();
+        if (finalState == SonarResolve.StreamingParser.State.COMPLETE) {
+          saveIssueResolution(context, parser.result());
+        } else if (finalState == SonarResolve.StreamingParser.State.INVALID) {
+          logInvalidDirective(directiveLine, parser.errorMessage());
+        }
       }
 
       index = lastConsumedIndex + 1;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/AnalysisProcessor.java
@@ -58,8 +58,10 @@ import org.sonar.plugins.javascript.analyzeproject.grpc.Metrics;
 import org.sonar.plugins.javascript.analyzeproject.grpc.ParsingError;
 import org.sonar.plugins.javascript.analyzeproject.grpc.ParsingErrorCode;
 import org.sonar.plugins.javascript.analyzeproject.grpc.ProjectAnalysisFileResult;
+import org.sonar.plugins.javascript.analyzeproject.grpc.SonarResolveComment;
 import org.sonar.plugins.javascript.analyzeproject.grpc.TextType;
 import org.sonar.plugins.javascript.api.Language;
+import org.sonarsource.analyzer.commons.SonarResolve;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 import org.sonarsource.sonarlint.plugin.api.SonarLintRuntime;
 
@@ -68,6 +70,7 @@ import org.sonarsource.sonarlint.plugin.api.SonarLintRuntime;
 public class AnalysisProcessor {
 
   private static final Logger LOG = LoggerFactory.getLogger(AnalysisProcessor.class);
+  private static final Version ISSUE_RESOLUTION_API_MIN_VERSION = Version.create(13, 5);
 
   private final NoSonarFilter noSonarFilter;
   private final FileLinesContextFactory fileLinesContextFactory;
@@ -119,6 +122,7 @@ public class AnalysisProcessor {
       // sonar-html plugin.
       saveIssues(context, issues);
     }
+    saveIssueResolutions(context, response.getSonarResolveCommentsList());
 
     return issues;
   }
@@ -376,6 +380,58 @@ public class AnalysisProcessor {
     }
   }
 
+  private void saveIssueResolutions(
+    JsTsContext<?> context,
+    List<SonarResolveComment> sonarResolveComments
+  ) {
+    if (!supportsIssueResolution(context)) {
+      return;
+    }
+
+    for (SonarResolveComment sonarResolveComment : sonarResolveComments) {
+      processSonarResolveComment(context, sonarResolveComment);
+    }
+  }
+
+  private void processSonarResolveComment(
+    JsTsContext<?> context,
+    SonarResolveComment sonarResolveComment
+  ) {
+    String[] commentLines = sonarResolveComment.getText().split("\\R", -1);
+    int index = 0;
+    while (index < commentLines.length) {
+      int directiveLine = sonarResolveComment.getLine() + index;
+      String line = commentLines[index];
+      if (!startsWithDirectiveKeyword(line)) {
+        index++;
+        continue;
+      }
+
+      SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(directiveLine);
+      SonarResolve.StreamingParser.State state = parser.consumeLine(directiveLine, line);
+      int lastConsumedIndex = index;
+
+      while (
+        state == SonarResolve.StreamingParser.State.INCOMPLETE &&
+        lastConsumedIndex + 1 < commentLines.length
+      ) {
+        lastConsumedIndex++;
+        int lineNumber = sonarResolveComment.getLine() + lastConsumedIndex;
+        state = parser.consumeLine(lineNumber, commentLines[lastConsumedIndex]);
+      }
+
+      if (state == SonarResolve.StreamingParser.State.COMPLETE) {
+        saveIssueResolution(context, parser.result());
+      } else if (state == SonarResolve.StreamingParser.State.INVALID) {
+        logInvalidDirective(directiveLine, parser.errorMessage());
+      } else if (parser.finish() == SonarResolve.StreamingParser.State.INVALID) {
+        logInvalidDirective(directiveLine, parser.errorMessage());
+      }
+
+      index = lastConsumedIndex + 1;
+    }
+  }
+
   void saveIssue(JsTsContext<?> context, Issue issue) {
     var newIssue = context.getSensorContext().newIssue();
     var location = newIssue.newLocation().on(file);
@@ -445,6 +501,17 @@ public class AnalysisProcessor {
         .runtime()
         .getApiVersion()
         .isGreaterThanOrEqual(Version.create(9, 2))
+    );
+  }
+
+  private static boolean supportsIssueResolution(JsTsContext<?> context) {
+    return (
+      !context.isSonarLint() &&
+      context
+        .getSensorContext()
+        .runtime()
+        .getApiVersion()
+        .isGreaterThanOrEqual(ISSUE_RESOLUTION_API_MIN_VERSION)
     );
   }
 
@@ -518,6 +585,27 @@ public class AnalysisProcessor {
         yield null;
       }
     };
+  }
+
+  private static boolean startsWithDirectiveKeyword(String line) {
+    String trimmed = line.stripLeading();
+    return trimmed.regionMatches(true, 0, SonarResolve.KEYWORD, 0, SonarResolve.KEYWORD.length());
+  }
+
+  private void saveIssueResolution(JsTsContext<?> context, SonarResolve sonarResolve) {
+    context
+      .getSensorContext()
+      .newIssueResolution()
+      .on(file)
+      .at(file.selectLine(sonarResolve.targetLine()))
+      .status(sonarResolve.status())
+      .forRules(sonarResolve.ruleKeys())
+      .comment(sonarResolve.justification())
+      .save();
+  }
+
+  private void logInvalidDirective(int line, String errorMessage) {
+    LOG.warn("{} in file {} at line {}", errorMessage, file.uri(), line);
   }
 
   @Nullable

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisProcessorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisProcessorTest.java
@@ -311,6 +311,38 @@ class AnalysisProcessorTest {
   }
 
   @Test
+  void should_save_multiline_sonar_resolve_directive() {
+    var processor = createProcessor();
+    var sensorContext = SensorContextTester.create(baseDir);
+    sensorContext.setRuntime(
+      SonarRuntimeImpl.forSonarQube(
+        Version.create(13, 5),
+        SonarQubeSide.SCANNER,
+        SonarEdition.COMMUNITY
+      )
+    );
+    var context = new JsTsContext<>(sensorContext);
+    var file = createInputFile(sensorContext, "js", "file.js", "const x = 1;\nconst y = 2;\n");
+    var response = responseWithSonarResolveComments(
+      SonarResolveComment.newBuilder()
+        .setLine(1)
+        .setText("sonar-resolve javascript:S1116 \"reason\ncontinued\"")
+        .build()
+    );
+
+    processor.processResponse(context, mock(JsTsChecks.class), file, response);
+
+    assertThat(issueResolutions(sensorContext, file))
+      .singleElement()
+      .satisfies(issueResolution -> {
+        assertThat(issueResolution.status()).isEqualTo(IssueResolution.Status.DEFAULT);
+        assertThat(issueResolution.ruleKeys()).containsExactly(RuleKey.of("javascript", "S1116"));
+        assertThat(issueResolution.comment()).isEqualTo("reason\ncontinued");
+        assertThat(issueResolution.textRange().start().line()).isEqualTo(1);
+      });
+  }
+
+  @Test
   void should_ignore_sonar_resolve_before_supported_runtime() {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisProcessorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisProcessorTest.java
@@ -26,12 +26,19 @@ import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.sonar.api.SonarEdition;
+import org.sonar.api.SonarQubeSide;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.IssueResolution;
+import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
+import org.sonar.api.rule.RuleKey;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.api.utils.Version;
 import org.sonar.css.CssRules;
 import org.sonar.plugins.javascript.analyzeproject.grpc.AnalysisLanguage;
 import org.sonar.plugins.javascript.analyzeproject.grpc.CpdToken;
@@ -43,6 +50,7 @@ import org.sonar.plugins.javascript.analyzeproject.grpc.Metrics;
 import org.sonar.plugins.javascript.analyzeproject.grpc.ParsingError;
 import org.sonar.plugins.javascript.analyzeproject.grpc.ParsingErrorCode;
 import org.sonar.plugins.javascript.analyzeproject.grpc.ProjectAnalysisFileResult;
+import org.sonar.plugins.javascript.analyzeproject.grpc.SonarResolveComment;
 import org.sonar.plugins.javascript.analyzeproject.grpc.TextType;
 
 class AnalysisProcessorTest {
@@ -268,5 +276,176 @@ class AnalysisProcessorTest {
         file.uri() +
         " at line 1, column 2. Falling back to file start."
     );
+  }
+
+  @Test
+  void should_save_sonar_resolve_at_supported_runtime() {
+    var processor = createProcessor();
+    var sensorContext = SensorContextTester.create(baseDir);
+    sensorContext.setRuntime(
+      SonarRuntimeImpl.forSonarQube(
+        Version.create(13, 5),
+        SonarQubeSide.SCANNER,
+        SonarEdition.COMMUNITY
+      )
+    );
+    var context = new JsTsContext<>(sensorContext);
+    var file = createInputFile(sensorContext, "js", "file.js", "const x = 1;\nconst y = 2;\n");
+    var response = responseWithSonarResolveComments(
+      SonarResolveComment.newBuilder()
+        .setLine(1)
+        .setText("sonar-resolve javascript:S1116 \"reason\"")
+        .build()
+    );
+
+    processor.processResponse(context, mock(JsTsChecks.class), file, response);
+
+    assertThat(issueResolutions(sensorContext, file))
+      .singleElement()
+      .satisfies(issueResolution -> {
+        assertThat(issueResolution.status()).isEqualTo(IssueResolution.Status.DEFAULT);
+        assertThat(issueResolution.ruleKeys()).containsExactly(RuleKey.of("javascript", "S1116"));
+        assertThat(issueResolution.comment()).isEqualTo("reason");
+        assertThat(issueResolution.textRange().start().line()).isEqualTo(1);
+      });
+  }
+
+  @Test
+  void should_ignore_sonar_resolve_before_supported_runtime() {
+    var processor = createProcessor();
+    var sensorContext = SensorContextTester.create(baseDir);
+    sensorContext.setRuntime(
+      SonarRuntimeImpl.forSonarQube(
+        Version.create(13, 4),
+        SonarQubeSide.SCANNER,
+        SonarEdition.COMMUNITY
+      )
+    );
+    var context = new JsTsContext<>(sensorContext);
+    var file = createInputFile(sensorContext, "js", "file.js", "const x = 1;\n");
+    var response = responseWithSonarResolveComments(
+      SonarResolveComment.newBuilder()
+        .setLine(1)
+        .setText("sonar-resolve javascript:S1116 \"reason\"")
+        .build()
+    );
+
+    processor.processResponse(context, mock(JsTsChecks.class), file, response);
+
+    assertThat(issueResolutions(sensorContext, file)).isEmpty();
+  }
+
+  @Test
+  void should_ignore_sonar_resolve_in_sonarlint() {
+    var processor = createProcessor();
+    var sensorContext = SensorContextTester.create(baseDir);
+    sensorContext.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(13, 6)));
+    var context = new JsTsContext<>(sensorContext);
+    var file = createInputFile(sensorContext, "js", "file.js", "const x = 1;\n");
+    var response = responseWithSonarResolveComments(
+      SonarResolveComment.newBuilder()
+        .setLine(1)
+        .setText("sonar-resolve javascript:S1116 \"reason\"")
+        .build()
+    );
+
+    processor.processResponse(context, mock(JsTsChecks.class), file, response);
+
+    assertThat(issueResolutions(sensorContext, file)).isEmpty();
+  }
+
+  @Test
+  void should_warn_and_continue_on_invalid_sonar_resolve_directive() {
+    var processor = createProcessor();
+    var sensorContext = SensorContextTester.create(baseDir);
+    sensorContext.setRuntime(
+      SonarRuntimeImpl.forSonarQube(
+        Version.create(13, 5),
+        SonarQubeSide.SCANNER,
+        SonarEdition.COMMUNITY
+      )
+    );
+    var context = new JsTsContext<>(sensorContext);
+    var file = createInputFile(sensorContext, "js", "file.js", "const x = 1;\nconst y = 2;\n");
+    var response = responseWithSonarResolveComments(
+      SonarResolveComment.newBuilder().setLine(1).setText("sonar-resolve [oops]").build(),
+      SonarResolveComment.newBuilder()
+        .setLine(2)
+        .setText("sonar-resolve javascript:S1116 \"reason\"")
+        .build()
+    );
+
+    processor.processResponse(context, mock(JsTsChecks.class), file, response);
+
+    assertThat(issueResolutions(sensorContext, file))
+      .singleElement()
+      .satisfies(issueResolution ->
+        assertThat(issueResolution.textRange().start().line()).isEqualTo(2)
+      );
+    assertThat(logTester.logs()).anySatisfy(log ->
+      assertThat(log).contains("Invalid sonar-resolve directive:")
+    );
+  }
+
+  @Test
+  void should_save_sonar_resolve_for_non_js_owned_files() {
+    var processor = createProcessor();
+    var sensorContext = SensorContextTester.create(baseDir);
+    sensorContext.setRuntime(
+      SonarRuntimeImpl.forSonarQube(
+        Version.create(13, 5),
+        SonarQubeSide.SCANNER,
+        SonarEdition.COMMUNITY
+      )
+    );
+    var context = new JsTsContext<>(sensorContext);
+    var file = createInputFile(sensorContext, "yaml", "file.yaml", "key: value\n");
+    var response = responseWithSonarResolveComments(
+      SonarResolveComment.newBuilder()
+        .setLine(1)
+        .setText("sonar-resolve javascript:S1116 \"reason\"")
+        .build()
+    );
+
+    processor.processResponse(context, mock(JsTsChecks.class), file, response);
+
+    assertThat(issueResolutions(sensorContext, file)).hasSize(1);
+  }
+
+  private AnalysisProcessor createProcessor() {
+    var fileLinesContextFactory = mock(FileLinesContextFactory.class);
+    when(fileLinesContextFactory.createFor(any())).thenReturn(mock(FileLinesContext.class));
+    return new AnalysisProcessor(
+      mock(NoSonarFilter.class),
+      fileLinesContextFactory,
+      mock(CssRules.class)
+    );
+  }
+
+  private InputFile createInputFile(
+    SensorContextTester sensorContext,
+    String language,
+    String filename,
+    String contents
+  ) {
+    var inputFile = TestInputFileBuilder.create("moduleKey", filename)
+      .setContents(contents)
+      .setLanguage(language)
+      .build();
+    sensorContext.fileSystem().add(inputFile);
+    return inputFile;
+  }
+
+  private ProjectAnalysisFileResult responseWithSonarResolveComments(
+    SonarResolveComment... sonarResolveComments
+  ) {
+    return ProjectAnalysisFileResult.newBuilder()
+      .setMetrics(Metrics.getDefaultInstance())
+      .addAllSonarResolveComments(List.of(sonarResolveComments))
+      .build();
+  }
+
+  private List<IssueResolution> issueResolutions(SensorContextTester tester, InputFile inputFile) {
+    return tester.getIssueResolutions().getOrDefault(inputFile.key(), List.of());
   }
 }


### PR DESCRIPTION
## Summary
- extract sonar-resolve comment candidates from JS/TS/CSS analysis results, including embedded content
- persist issue resolutions in the SonarJS plugin through `AnalysisProcessor` using analyzer-commons parsing
- add a plugin integration test covering sonar-resolve in embedded JavaScript inside HTML

## Testing
- mvn -pl sonar-plugin/sonar-javascript-plugin -am -DskipTests -Dskip-java-generation package
- mvn -pl its/plugin/tests -am -DskipTests=false -Dtest=SonarResolveTest -Dsurefire.failIfNoSpecifiedTests=false -Dskip-java-generation test