### PR TITLE
JS-537 Fix LCOV resolution for duplicate suffix paths

### DIFF
--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/CoverageSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/CoverageSensor.java
@@ -113,7 +113,7 @@ public class CoverageSensor implements Sensor {
       );
     FileLocator fileLocator = new FileLocator(fileSystem.inputFiles(mainFilePredicate));
 
-    LCOVParser parser = LCOVParser.create(context, lcovFiles, fileLocator);
+    LCOVParser parser = new LCOVParser(context, lcovFiles, fileLocator);
     Map<InputFile, NewCoverage> coveredFiles = parser.coverageByFile();
 
     for (InputFile inputFile : fileSystem.inputFiles(mainFilePredicate)) {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/FileLocator.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/FileLocator.java
@@ -24,6 +24,8 @@ class FileLocator {
 
   private final ReversePathTree tree = new ReversePathTree();
 
+  record Resolution(@CheckForNull InputFile inputFile, boolean guessed) {}
+
   FileLocator(Iterable<InputFile> inputFiles) {
     inputFiles.forEach(inputFile -> {
       String[] path = inputFile.relativePath().split("/");
@@ -31,13 +33,17 @@ class FileLocator {
     });
   }
 
-  @CheckForNull
-  InputFile getInputFile(String filePath) {
+  Resolution resolve(String filePath) {
     String sanitizedPath = PathUtils.sanitize(filePath);
     if (sanitizedPath == null) {
-      return null;
+      return new Resolution(null, false);
     }
     String[] pathElements = sanitizedPath.split("/");
     return tree.getFileWithSuffix(pathElements);
+  }
+
+  @CheckForNull
+  InputFile getInputFile(String filePath) {
+    return resolve(filePath).inputFile();
   }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -215,8 +215,15 @@ class LCOVParser {
 
   @CheckForNull
   private InputFile inputFileByExactPath(String filePath) {
+    String sanitizedPath = PathUtils.sanitize(filePath);
+    if (sanitizedPath == null) {
+      return null;
+    }
     FilePredicates predicates = context.fileSystem().predicates();
-    return context.fileSystem().inputFile(predicates.hasPath(filePath));
+    if (new File(sanitizedPath).isAbsolute()) {
+      return context.fileSystem().inputFile(predicates.hasAbsolutePath(sanitizedPath));
+    }
+    return context.fileSystem().inputFile(predicates.hasPath(sanitizedPath));
   }
 
   @CheckForNull

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -188,18 +188,30 @@ class LCOVParser {
    * Resolves the SF path to an indexed input file.
    * <p>
    * Resolution order:
-   * 1) exact filesystem predicate match (absolute or project-relative path),
+   * 1) exact absolute-path match,
    * 2) relative-to-report lookup for package-local LCOV paths,
-   * 3) suffix-based lookup through {@link FileLocator}, preferring unique matches and falling back
+   * 3) exact project-relative match,
+   * 4) suffix-based lookup through {@link FileLocator}, preferring unique matches and falling back
    * to the historical deterministic guess when several analyzed files share the same suffix.
    */
   @CheckForNull
   private InputFile inputFileForSourceFile(File reportFile, String line) {
     // SF:<absolute path to the source file>
     String filePath = line.substring(SF.length());
-    InputFile inputFile = inputFileByExactPath(filePath);
-    if (inputFile == null) {
-      inputFile = inputFileRelativeToReport(reportFile, filePath);
+    String sanitizedPath = PathUtils.sanitize(filePath);
+    if (sanitizedPath == null) {
+      unresolvedPaths.add(filePath);
+      return null;
+    }
+
+    InputFile inputFile;
+    if (new File(sanitizedPath).isAbsolute()) {
+      inputFile = inputFileByAbsolutePath(context.fileSystem().predicates(), sanitizedPath);
+    } else {
+      inputFile = inputFileRelativeToReport(reportFile, sanitizedPath);
+      if (inputFile == null) {
+        inputFile = inputFileByProjectRelativePath(sanitizedPath);
+      }
     }
     if (inputFile == null) {
       FileLocator.Resolution resolution = fileLocator.resolve(filePath);
@@ -220,25 +232,12 @@ class LCOVParser {
   }
 
   @CheckForNull
-  private InputFile inputFileByExactPath(String filePath) {
-    String sanitizedPath = PathUtils.sanitize(filePath);
-    if (sanitizedPath == null) {
-      return null;
-    }
-    FilePredicates predicates = context.fileSystem().predicates();
-    if (new File(sanitizedPath).isAbsolute()) {
-      return inputFileByAbsolutePath(predicates, sanitizedPath);
-    }
-    return context.fileSystem().inputFile(predicates.hasPath(sanitizedPath));
+  private InputFile inputFileByProjectRelativePath(String relativePath) {
+    return context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(relativePath));
   }
 
   @CheckForNull
   private InputFile inputFileRelativeToReport(File reportFile, String filePath) {
-    String sanitizedPath = PathUtils.sanitize(filePath);
-    if (sanitizedPath == null || new File(sanitizedPath).isAbsolute()) {
-      return null;
-    }
-
     File reportDirectory = reportFile.getParentFile();
     if (reportDirectory == null) {
       return null;
@@ -252,7 +251,7 @@ class LCOVParser {
     ) {
       InputFile inputFile = inputFileByAbsolutePath(
         predicates,
-        currentDirectory.resolve(sanitizedPath).normalize().toString()
+        currentDirectory.resolve(filePath).normalize().toString()
       );
       if (inputFile != null) {
         return inputFile;

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -18,21 +18,21 @@ package org.sonar.plugins.javascript.lcov;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.coverage.NewCoverage;
+import org.sonar.api.utils.PathUtils;
 
 /**
  * http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php
@@ -54,25 +54,17 @@ class LCOVParser {
 
   private static final Logger LOG = LoggerFactory.getLogger(LCOVParser.class);
 
-  private LCOVParser(List<String> lines, SensorContext context, FileLocator fileLocator) {
+  private LCOVParser(SensorContext context, List<File> files, FileLocator fileLocator) {
     this.context = context;
     this.fileLocator = fileLocator;
-    this.coverageByFile = parse(lines);
+    this.coverageByFile = parse(files);
   }
 
   /**
    * Reads all report files and parses them as a single LCOV stream.
    */
   static LCOVParser create(SensorContext context, List<File> files, FileLocator fileLocator) {
-    final List<String> lines = new LinkedList<>();
-    for (File file : files) {
-      try (Stream<String> fileLines = Files.lines(file.toPath())) {
-        lines.addAll(fileLines.toList());
-      } catch (IOException e) {
-        throw new IllegalArgumentException("Could not read content from file: " + file, e);
-      }
-    }
-    return new LCOVParser(lines, context, fileLocator);
+    return new LCOVParser(context, files, fileLocator);
   }
 
   Map<InputFile, NewCoverage> coverageByFile() {
@@ -94,25 +86,32 @@ class LCOVParser {
    * the active {@link FileData}. Every SF block gets a unique record index to support branch merge
    * logic across multiple reports.
    */
-  private Map<InputFile, NewCoverage> parse(List<String> lines) {
+  private Map<InputFile, NewCoverage> parse(List<File> reportFiles) {
     final Map<InputFile, FileData> files = new HashMap<>();
-    FileData fileData = null;
     int sourceFileRecordIndex = 0;
-    int reportLineNum = 0;
 
-    for (String line : lines) {
-      reportLineNum++;
-      if (line.startsWith(SF)) {
-        sourceFileRecordIndex++;
-        fileData = files.computeIfAbsent(inputFileForSourceFile(line), inputFile ->
-          inputFile == null ? null : new FileData(inputFile)
-        );
-      } else if (fileData != null) {
-        if (line.startsWith(DA)) {
-          parseLineCoverage(fileData, reportLineNum, line);
-        } else if (line.startsWith(BRDA)) {
-          parseBranchCoverage(fileData, sourceFileRecordIndex, reportLineNum, line);
+    for (File reportFile : reportFiles) {
+      FileData fileData = null;
+      int reportLineNum = 0;
+
+      try {
+        for (String line : java.nio.file.Files.readAllLines(reportFile.toPath())) {
+          reportLineNum++;
+          if (line.startsWith(SF)) {
+            sourceFileRecordIndex++;
+            fileData = files.computeIfAbsent(inputFileForSourceFile(reportFile, line), inputFile ->
+              inputFile == null ? null : new FileData(inputFile)
+            );
+          } else if (fileData != null) {
+            if (line.startsWith(DA)) {
+              parseLineCoverage(fileData, reportLineNum, line);
+            } else if (line.startsWith(BRDA)) {
+              parseBranchCoverage(fileData, sourceFileRecordIndex, reportLineNum, line);
+            }
+          }
         }
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Could not read content from file: " + reportFile, e);
       }
     }
 
@@ -191,16 +190,17 @@ class LCOVParser {
    * <p>
    * Resolution order:
    * 1) exact filesystem predicate match (absolute or project-relative path),
-   * 2) suffix-based lookup through {@link FileLocator} for cross-tool/cross-root path variants.
+   * 2) relative-to-report lookup for package-local LCOV paths,
+   * 3) unique suffix-based lookup through {@link FileLocator} for cross-tool/cross-root path variants.
    */
   @CheckForNull
-  private InputFile inputFileForSourceFile(String line) {
+  private InputFile inputFileForSourceFile(File reportFile, String line) {
     // SF:<absolute path to the source file>
     String filePath = line.substring(SF.length());
-    // some tools (like Istanbul, Karma) provide relative paths, so let's consider them relative to project directory
-    InputFile inputFile = context
-      .fileSystem()
-      .inputFile(context.fileSystem().predicates().hasPath(filePath));
+    InputFile inputFile = inputFileByExactPath(filePath);
+    if (inputFile == null) {
+      inputFile = inputFileRelativeToReport(reportFile, filePath);
+    }
     if (inputFile == null) {
       inputFile = fileLocator.getInputFile(filePath);
     }
@@ -208,6 +208,25 @@ class LCOVParser {
       unresolvedPaths.add(filePath);
     }
     return inputFile;
+  }
+
+  @CheckForNull
+  private InputFile inputFileByExactPath(String filePath) {
+    FilePredicates predicates = context.fileSystem().predicates();
+    return context.fileSystem().inputFile(predicates.hasPath(filePath));
+  }
+
+  @CheckForNull
+  private InputFile inputFileRelativeToReport(File reportFile, String filePath) {
+    String sanitizedPath = PathUtils.sanitize(filePath);
+    if (sanitizedPath == null || new File(sanitizedPath).isAbsolute()) {
+      return null;
+    }
+
+    Path resolvedPath = reportFile.getParentFile().toPath().resolve(sanitizedPath).normalize();
+    return context
+      .fileSystem()
+      .inputFile(context.fileSystem().predicates().hasAbsolutePath(resolvedPath.toString()));
   }
 
   private static class FileData {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -184,7 +184,8 @@ class LCOVParser {
    * Resolution order:
    * 1) exact filesystem predicate match (absolute or project-relative path),
    * 2) relative-to-report lookup for package-local LCOV paths,
-   * 3) unique suffix-based lookup through {@link FileLocator} for cross-tool/cross-root path variants.
+   * 3) suffix-based lookup through {@link FileLocator}, preferring unique matches and falling back
+   * to the historical deterministic guess when several analyzed files share the same suffix.
    */
   @CheckForNull
   private InputFile inputFileForSourceFile(File reportFile, String line) {
@@ -195,7 +196,16 @@ class LCOVParser {
       inputFile = inputFileRelativeToReport(reportFile, filePath);
     }
     if (inputFile == null) {
-      inputFile = fileLocator.getInputFile(filePath);
+      FileLocator.Resolution resolution = fileLocator.resolve(filePath);
+      inputFile = resolution.inputFile();
+      if (inputFile != null && resolution.guessed() && LOG.isDebugEnabled()) {
+        LOG.debug(
+          "Ambiguous LCOV path '{}' in '{}' matched multiple analyzed files; falling back to '{}'.",
+          filePath,
+          reportFile,
+          inputFile.relativePath()
+        );
+      }
     }
     if (inputFile == null) {
       unresolvedPaths.add(filePath);

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -203,7 +203,7 @@ class LCOVParser {
           "Ambiguous LCOV path '{}' in '{}' matched multiple analyzed files; falling back to '{}'.",
           filePath,
           reportFile,
-          inputFile.relativePath()
+          inputFile
         );
       }
     }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -32,6 +32,7 @@ import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.coverage.NewCoverage;
+import org.sonar.api.scan.filesystem.PathResolver;
 import org.sonar.api.utils.PathUtils;
 
 /**
@@ -44,9 +45,12 @@ class LCOVParser {
   private static final String SF = "SF:";
   private static final String DA = "DA:";
   private static final String BRDA = "BRDA:";
+  private static final PathResolver PATH_RESOLVER = new PathResolver();
 
   private final Map<InputFile, NewCoverage> coverageByFile;
   private final SensorContext context;
+  private final Path analysisBaseDir;
+  private final Path realAnalysisBaseDir;
   // deduplicated list of unresolved paths (keep order of insertion)
   private final Set<String> unresolvedPaths = new LinkedHashSet<>();
   private final FileLocator fileLocator;
@@ -57,6 +61,8 @@ class LCOVParser {
   LCOVParser(SensorContext context, List<File> files, FileLocator fileLocator) {
     this.context = context;
     this.fileLocator = fileLocator;
+    this.analysisBaseDir = context.fileSystem().baseDir().toPath().toAbsolutePath().normalize();
+    this.realAnalysisBaseDir = resolveRealPath(analysisBaseDir);
     this.coverageByFile = parse(files);
   }
 
@@ -239,7 +245,6 @@ class LCOVParser {
     }
 
     FilePredicates predicates = context.fileSystem().predicates();
-    Path analysisBaseDir = context.fileSystem().baseDir().toPath().toAbsolutePath().normalize();
     for (
       Path currentDirectory = reportDirectory.toPath().toAbsolutePath().normalize();
       currentDirectory != null;
@@ -263,7 +268,39 @@ class LCOVParser {
 
   @CheckForNull
   private InputFile inputFileByAbsolutePath(FilePredicates predicates, String absolutePath) {
-    return context.fileSystem().inputFile(predicates.hasAbsolutePath(absolutePath));
+    InputFile inputFile = context.fileSystem().inputFile(predicates.hasAbsolutePath(absolutePath));
+    if (inputFile != null) {
+      return inputFile;
+    }
+
+    String relativePath = relativePathFromAnalysisBaseDir(absolutePath);
+    if (relativePath != null) {
+      return context.fileSystem().inputFile(predicates.hasPath(relativePath));
+    }
+    return null;
+  }
+
+  @CheckForNull
+  private String relativePathFromAnalysisBaseDir(String absolutePath) {
+    Path absoluteFilePath = new File(absolutePath).toPath().toAbsolutePath().normalize();
+
+    String relativePath = PATH_RESOLVER.relativePath(analysisBaseDir, absoluteFilePath);
+    if (relativePath != null) {
+      return relativePath;
+    }
+
+    if (!realAnalysisBaseDir.equals(analysisBaseDir)) {
+      return PATH_RESOLVER.relativePath(realAnalysisBaseDir, absoluteFilePath);
+    }
+    return null;
+  }
+
+  private static Path resolveRealPath(Path path) {
+    try {
+      return path.toRealPath();
+    } catch (IOException e) {
+      return path;
+    }
   }
 
   private static class FileData {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -247,7 +247,7 @@ class LCOVParser {
     FilePredicates predicates = context.fileSystem().predicates();
     for (
       Path currentDirectory = reportDirectory.toPath().toAbsolutePath().normalize();
-      currentDirectory != null;
+      isInsideAnalysisBaseDir(currentDirectory);
       currentDirectory = currentDirectory.getParent()
     ) {
       InputFile inputFile = inputFileByAbsolutePath(
@@ -257,33 +257,59 @@ class LCOVParser {
       if (inputFile != null) {
         return inputFile;
       }
-      if (
-        currentDirectory.equals(analysisBaseDir) || !currentDirectory.startsWith(analysisBaseDir)
-      ) {
+      if (isAnalysisBaseDir(currentDirectory)) {
         break;
       }
     }
     return null;
   }
 
+  private boolean isInsideAnalysisBaseDir(@CheckForNull Path path) {
+    return (
+      path != null && (path.startsWith(analysisBaseDir) || path.startsWith(realAnalysisBaseDir))
+    );
+  }
+
+  private boolean isAnalysisBaseDir(Path path) {
+    return path.equals(analysisBaseDir) || path.equals(realAnalysisBaseDir);
+  }
+
   @CheckForNull
   private InputFile inputFileByAbsolutePath(FilePredicates predicates, String absolutePath) {
-    InputFile inputFile = context.fileSystem().inputFile(predicates.hasAbsolutePath(absolutePath));
+    Path normalizedAbsolutePath = new File(absolutePath).toPath().toAbsolutePath().normalize();
+    InputFile inputFile = context
+      .fileSystem()
+      .inputFile(predicates.hasAbsolutePath(normalizedAbsolutePath.toString()));
     if (inputFile != null) {
       return inputFile;
     }
 
-    String relativePath = relativePathFromAnalysisBaseDir(absolutePath);
-    if (relativePath != null) {
-      return context.fileSystem().inputFile(predicates.hasPath(relativePath));
+    inputFile = inputFileByRelativePathFromAnalysisBaseDir(predicates, normalizedAbsolutePath);
+    if (inputFile != null) {
+      return inputFile;
+    }
+
+    Path canonicalAbsolutePath = canonicalizePathSpelling(normalizedAbsolutePath);
+    if (!canonicalAbsolutePath.equals(normalizedAbsolutePath)) {
+      return inputFileByRelativePathFromAnalysisBaseDir(predicates, canonicalAbsolutePath);
     }
     return null;
   }
 
   @CheckForNull
-  private String relativePathFromAnalysisBaseDir(String absolutePath) {
-    Path absoluteFilePath = new File(absolutePath).toPath().toAbsolutePath().normalize();
+  private InputFile inputFileByRelativePathFromAnalysisBaseDir(
+    FilePredicates predicates,
+    Path absoluteFilePath
+  ) {
+    String relativePath = relativePathFromAnalysisBaseDir(absoluteFilePath);
+    if (relativePath == null) {
+      return null;
+    }
+    return context.fileSystem().inputFile(predicates.hasPath(relativePath));
+  }
 
+  @CheckForNull
+  private String relativePathFromAnalysisBaseDir(Path absoluteFilePath) {
     String relativePath = PATH_RESOLVER.relativePath(analysisBaseDir, absoluteFilePath);
     if (relativePath != null) {
       return relativePath;
@@ -293,6 +319,24 @@ class LCOVParser {
       return PATH_RESOLVER.relativePath(realAnalysisBaseDir, absoluteFilePath);
     }
     return null;
+  }
+
+  private static Path canonicalizePathSpelling(Path path) {
+    Path normalizedPath = path.toAbsolutePath().normalize();
+    Path existingPath = normalizedPath;
+    while (existingPath != null && !java.nio.file.Files.exists(existingPath)) {
+      existingPath = existingPath.getParent();
+    }
+    if (existingPath == null) {
+      return normalizedPath;
+    }
+
+    Path realExistingPath = resolveRealPath(existingPath);
+    if (realExistingPath.equals(existingPath)) {
+      return normalizedPath;
+    }
+
+    return realExistingPath.resolve(existingPath.relativize(normalizedPath)).normalize();
   }
 
   private static Path resolveRealPath(Path path) {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -54,17 +54,10 @@ class LCOVParser {
 
   private static final Logger LOG = LoggerFactory.getLogger(LCOVParser.class);
 
-  private LCOVParser(SensorContext context, List<File> files, FileLocator fileLocator) {
+  LCOVParser(SensorContext context, List<File> files, FileLocator fileLocator) {
     this.context = context;
     this.fileLocator = fileLocator;
     this.coverageByFile = parse(files);
-  }
-
-  /**
-   * Reads all report files and parses them as a single LCOV stream.
-   */
-  static LCOVParser create(SensorContext context, List<File> files, FileLocator fileLocator) {
-    return new LCOVParser(context, files, fileLocator);
   }
 
   Map<InputFile, NewCoverage> coverageByFile() {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVParser.java
@@ -221,7 +221,7 @@ class LCOVParser {
     }
     FilePredicates predicates = context.fileSystem().predicates();
     if (new File(sanitizedPath).isAbsolute()) {
-      return context.fileSystem().inputFile(predicates.hasAbsolutePath(sanitizedPath));
+      return inputFileByAbsolutePath(predicates, sanitizedPath);
     }
     return context.fileSystem().inputFile(predicates.hasPath(sanitizedPath));
   }
@@ -233,10 +233,37 @@ class LCOVParser {
       return null;
     }
 
-    Path resolvedPath = reportFile.getParentFile().toPath().resolve(sanitizedPath).normalize();
-    return context
-      .fileSystem()
-      .inputFile(context.fileSystem().predicates().hasAbsolutePath(resolvedPath.toString()));
+    File reportDirectory = reportFile.getParentFile();
+    if (reportDirectory == null) {
+      return null;
+    }
+
+    FilePredicates predicates = context.fileSystem().predicates();
+    Path analysisBaseDir = context.fileSystem().baseDir().toPath().toAbsolutePath().normalize();
+    for (
+      Path currentDirectory = reportDirectory.toPath().toAbsolutePath().normalize();
+      currentDirectory != null;
+      currentDirectory = currentDirectory.getParent()
+    ) {
+      InputFile inputFile = inputFileByAbsolutePath(
+        predicates,
+        currentDirectory.resolve(sanitizedPath).normalize().toString()
+      );
+      if (inputFile != null) {
+        return inputFile;
+      }
+      if (
+        currentDirectory.equals(analysisBaseDir) || !currentDirectory.startsWith(analysisBaseDir)
+      ) {
+        break;
+      }
+    }
+    return null;
+  }
+
+  @CheckForNull
+  private InputFile inputFileByAbsolutePath(FilePredicates predicates, String absolutePath) {
+    return context.fileSystem().inputFile(predicates.hasAbsolutePath(absolutePath));
   }
 
   private static class FileData {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/ReversePathTree.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/ReversePathTree.java
@@ -34,32 +34,23 @@ class ReversePathTree {
     currentNode.file = inputFile;
   }
 
-  InputFile getFileWithSuffix(String[] path) {
+  FileLocator.Resolution getFileWithSuffix(String[] path) {
     Node currentNode = root;
 
     for (int i = path.length - 1; i >= 0; i--) {
       currentNode = currentNode.children.get(path[i]);
       if (currentNode == null) {
-        return null;
+        return new FileLocator.Resolution(null, false);
       }
     }
-    return getOnlyLeaf(currentNode);
+    return new FileLocator.Resolution(getFirstLeaf(currentNode), currentNode.leafCount > 1);
   }
 
-  private static InputFile getOnlyLeaf(Node node) {
-    if (node.leafCount != 1) {
-      return null;
+  private static InputFile getFirstLeaf(Node node) {
+    while (!node.children.isEmpty()) {
+      node = node.children.values().iterator().next();
     }
-    if (node.file != null) {
-      return node.file;
-    }
-    for (Node child : node.children.values()) {
-      InputFile inputFile = getOnlyLeaf(child);
-      if (inputFile != null) {
-        return inputFile;
-      }
-    }
-    return null;
+    return node.file;
   }
 
   static class Node {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/ReversePathTree.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/ReversePathTree.java
@@ -26,8 +26,10 @@ class ReversePathTree {
 
   void index(InputFile inputFile, String[] path) {
     Node currentNode = root;
+    currentNode.leafCount++;
     for (int i = path.length - 1; i >= 0; i--) {
       currentNode = currentNode.children.computeIfAbsent(path[i], e -> new Node());
+      currentNode.leafCount++;
     }
     currentNode.file = inputFile;
   }
@@ -41,19 +43,29 @@ class ReversePathTree {
         return null;
       }
     }
-    return getFirstLeaf(currentNode);
+    return getOnlyLeaf(currentNode);
   }
 
-  private static InputFile getFirstLeaf(Node node) {
-    while (!node.children.isEmpty()) {
-      node = node.children.values().iterator().next();
+  private static InputFile getOnlyLeaf(Node node) {
+    if (node.leafCount != 1) {
+      return null;
     }
-    return node.file;
+    if (node.file != null) {
+      return node.file;
+    }
+    for (Node child : node.children.values()) {
+      InputFile inputFile = getOnlyLeaf(child);
+      if (inputFile != null) {
+        return inputFile;
+      }
+    }
+    return null;
   }
 
   static class Node {
 
     final Map<String, Node> children = new LinkedHashMap<>();
     InputFile file = null;
+    int leafCount = 0;
   }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/ReversePathTree.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/ReversePathTree.java
@@ -47,7 +47,7 @@ class ReversePathTree {
   }
 
   private static InputFile getFirstLeaf(Node node) {
-    while (!node.children.isEmpty()) {
+    while (node.file == null && !node.children.isEmpty()) {
       node = node.children.values().iterator().next();
     }
     return node.file;

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
@@ -1,0 +1,219 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.javascript.lcov;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.event.Level;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.plugins.javascript.JavaScriptPlugin;
+
+class CoverageSensorDuplicateSuffixPathReproducerTest {
+
+  @TempDir
+  Path tempDir;
+
+  @RegisterExtension
+  public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
+
+  private final CoverageSensor coverageSensor = new CoverageSensor();
+  private SensorContextTester context;
+  private MapSettings settings;
+
+  @BeforeEach
+  void init() {
+    settings = new MapSettings();
+    context = SensorContextTester.create(tempDir.toFile());
+    context.setSettings(settings);
+  }
+
+  @Test
+  void should_resolve_package_relative_lcov_paths_against_each_report_directory() throws Exception {
+    DefaultInputFile packageA = tsInputFile(
+      "packages/a/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromA = 1;",
+          "export function fromPackageA() {",
+          "  return fromA;",
+          "}"
+        ) +
+        "\n"
+    );
+    DefaultInputFile packageB = tsInputFile(
+      "packages/b/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromB = 1;",
+          "export function fromPackageB() {",
+          "  return fromB + 1;",
+          "}",
+          "export const uncoveredButCounted = fromB + 2;"
+        ) +
+        "\n"
+    );
+
+    Path packageADir = Files.createDirectories(tempDir.resolve("packages/a"));
+    Path packageBDir = Files.createDirectories(tempDir.resolve("packages/b"));
+    Path packageALcov = packageADir.resolve("lcov.info");
+    Path packageBLcov = packageBDir.resolve("lcov.info");
+    Files.write(
+      packageALcov,
+      String.join("\n", "SF:src/index.ts", "DA:1,1", "end_of_record", "").getBytes(
+        StandardCharsets.UTF_8
+      )
+    );
+    Files.write(
+      packageBLcov,
+      String.join("\n", "SF:src/index.ts", "DA:5,1", "end_of_record", "").getBytes(
+        StandardCharsets.UTF_8
+      )
+    );
+
+    settings.setProperty(
+      JavaScriptPlugin.LCOV_REPORT_PATHS,
+      packageALcov.toAbsolutePath() + "," + packageBLcov.toAbsolutePath()
+    );
+    coverageSensor.execute(context);
+
+    assertThat(context.lineHits(packageA.key(), 1)).isEqualTo(1);
+    assertThat(context.lineHits(packageB.key(), 5)).isEqualTo(1);
+    assertThat(logTester.logs(Level.DEBUG)).noneMatch(log ->
+      log.contains("Line with number 5 doesn't belong to file index.ts")
+    );
+  }
+
+  @Test
+  void should_not_guess_when_duplicate_suffix_match_is_ambiguous() throws Exception {
+    DefaultInputFile packageA = tsInputFile(
+      "packages/a/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromA = 1;",
+          "export function fromPackageA() {",
+          "  return fromA;",
+          "}"
+        ) +
+        "\n"
+    );
+    DefaultInputFile packageB = tsInputFile(
+      "packages/b/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromB = 1;",
+          "export function fromPackageB() {",
+          "  return fromB + 1;",
+          "}",
+          "export const uncoveredButCounted = fromB + 2;"
+        ) +
+        "\n"
+    );
+
+    Path lcov = tempDir.resolve("duplicate-suffix-relative.lcov");
+    Files.write(
+      lcov,
+      String.join(
+        "\n",
+        "SF:src/index.ts",
+        "DA:1,1",
+        "end_of_record",
+        "SF:src/index.ts",
+        "DA:5,1",
+        "end_of_record",
+        ""
+      ).getBytes(StandardCharsets.UTF_8)
+    );
+
+    settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, lcov.toAbsolutePath().toString());
+    coverageSensor.execute(context);
+
+    assertThat(context.lineHits(packageA.key(), 1)).isNull();
+    assertThat(context.lineHits(packageB.key(), 5)).isNull();
+    assertThat(logTester.logs(Level.WARN)).contains(
+      "Could not resolve 1 file paths in [" + lcov.toAbsolutePath() + "]"
+    );
+  }
+
+  @Test
+  void should_import_duplicate_suffix_files_when_lcov_uses_absolute_paths() throws Exception {
+    DefaultInputFile packageA = tsInputFile(
+      "packages/a/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromA = 1;",
+          "export function fromPackageA() {",
+          "  return fromA;",
+          "}"
+        ) +
+        "\n"
+    );
+    DefaultInputFile packageB = tsInputFile(
+      "packages/b/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromB = 1;",
+          "export function fromPackageB() {",
+          "  return fromB + 1;",
+          "}",
+          "export const uncoveredButCounted = fromB + 2;"
+        ) +
+        "\n"
+    );
+
+    Path lcov = tempDir.resolve("duplicate-suffix-absolute.lcov");
+    Files.write(
+      lcov,
+      String.join(
+        "\n",
+        "SF:" + packageA.absolutePath(),
+        "DA:1,1",
+        "end_of_record",
+        "SF:" + packageB.absolutePath(),
+        "DA:5,1",
+        "end_of_record",
+        ""
+      ).getBytes(StandardCharsets.UTF_8)
+    );
+
+    settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, lcov.toAbsolutePath().toString());
+    coverageSensor.execute(context);
+
+    assertThat(context.lineHits(packageA.key(), 1)).isEqualTo(1);
+    assertThat(context.lineHits(packageB.key(), 5)).isEqualTo(1);
+  }
+
+  private DefaultInputFile tsInputFile(String relativePath, String contents) {
+    DefaultInputFile inputFile = new TestInputFileBuilder("moduleKey", relativePath)
+      .setModuleBaseDir(tempDir)
+      .setLanguage("ts")
+      .setContents(contents)
+      .build();
+    context.fileSystem().add(inputFile);
+    return inputFile;
+  }
+}

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
@@ -109,6 +109,63 @@ class CoverageSensorDuplicateSuffixPathReproducerTest {
   }
 
   @Test
+  void should_resolve_package_relative_lcov_paths_against_report_ancestor_directories()
+    throws Exception {
+    DefaultInputFile packageA = tsInputFile(
+      "packages/a/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromA = 1;",
+          "export function fromPackageA() {",
+          "  return fromA;",
+          "}"
+        ) +
+        "\n"
+    );
+    DefaultInputFile packageB = tsInputFile(
+      "packages/b/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromB = 1;",
+          "export function fromPackageB() {",
+          "  return fromB + 1;",
+          "}",
+          "export const uncoveredButCounted = fromB + 2;"
+        ) +
+        "\n"
+    );
+
+    Path packageACoverageDir = Files.createDirectories(tempDir.resolve("packages/a/coverage"));
+    Path packageBCoverageDir = Files.createDirectories(tempDir.resolve("packages/b/coverage"));
+    Path packageALcov = packageACoverageDir.resolve("lcov.info");
+    Path packageBLcov = packageBCoverageDir.resolve("lcov.info");
+    Files.write(
+      packageALcov,
+      String.join("\n", "SF:src/index.ts", "DA:1,1", "end_of_record", "").getBytes(
+        StandardCharsets.UTF_8
+      )
+    );
+    Files.write(
+      packageBLcov,
+      String.join("\n", "SF:src/index.ts", "DA:5,1", "end_of_record", "").getBytes(
+        StandardCharsets.UTF_8
+      )
+    );
+
+    settings.setProperty(
+      JavaScriptPlugin.LCOV_REPORT_PATHS,
+      packageALcov.toAbsolutePath() + "," + packageBLcov.toAbsolutePath()
+    );
+    coverageSensor.execute(context);
+
+    assertThat(context.lineHits(packageA.key(), 1)).isEqualTo(1);
+    assertThat(context.lineHits(packageB.key(), 5)).isEqualTo(1);
+    assertThat(logTester.logs(Level.DEBUG)).noneMatch(log ->
+      log.contains("Ambiguous LCOV path 'src/index.ts'")
+    );
+  }
+
+  @Test
   void should_guess_when_duplicate_suffix_match_is_ambiguous() throws Exception {
     DefaultInputFile packageA = tsInputFile(
       "packages/a/src/index.ts",

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
@@ -111,6 +111,43 @@ class CoverageSensorDuplicateSuffixPathReproducerTest {
   }
 
   @Test
+  void should_prefer_report_relative_match_over_repo_root_relative_match() throws Exception {
+    DefaultInputFile repoRoot = tsInputFile(
+      "src/index.ts",
+      String.join("\n", "export const fromRoot = 1;", "export const stillRoot = 2;") + "\n"
+    );
+    DefaultInputFile packageA = tsInputFile(
+      "packages/a/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromA = 1;",
+          "export function fromPackageA() {",
+          "  return fromA;",
+          "}"
+        ) +
+        "\n"
+    );
+
+    Path packageACoverageDir = Files.createDirectories(tempDir.resolve("packages/a/coverage"));
+    Path packageALcov = packageACoverageDir.resolve("lcov.info");
+    Files.write(
+      packageALcov,
+      String.join("\n", "SF:src/index.ts", "DA:1,1", "end_of_record", "").getBytes(
+        StandardCharsets.UTF_8
+      )
+    );
+
+    settings.setProperty(
+      JavaScriptPlugin.LCOV_REPORT_PATHS,
+      packageALcov.toAbsolutePath().toString()
+    );
+    coverageSensor.execute(context);
+
+    assertThat(context.lineHits(repoRoot.key(), 1)).isNull();
+    assertThat(context.lineHits(packageA.key(), 1)).isEqualTo(1);
+  }
+
+  @Test
   void should_resolve_package_relative_lcov_paths_against_report_ancestor_directories()
     throws Exception {
     DefaultInputFile packageA = tsInputFile(

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
@@ -17,7 +17,9 @@
 package org.sonar.plugins.javascript.lcov;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -266,13 +268,85 @@ class CoverageSensorDuplicateSuffixPathReproducerTest {
     assertThat(context.lineHits(packageB.key(), 5)).isEqualTo(1);
   }
 
+  @Test
+  void should_import_absolute_paths_when_analysis_base_dir_is_an_alias() throws Exception {
+    Path realBaseDir = Files.createDirectories(tempDir.resolve("real-base-dir"));
+    Path analysisBaseDir = createDirectoryAlias(tempDir.resolve("analysis-base-dir"), realBaseDir);
+
+    settings = new MapSettings();
+    context = SensorContextTester.create(analysisBaseDir.toFile());
+    context.setSettings(settings);
+
+    DefaultInputFile packageA = tsInputFile(
+      realBaseDir,
+      "packages/a/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromA = 1;",
+          "export function fromPackageA() {",
+          "  return fromA;",
+          "}"
+        ) +
+        "\n"
+    );
+
+    Path lcov = analysisBaseDir.resolve("duplicate-suffix-absolute-alias.lcov");
+    Files.write(
+      lcov,
+      String.join("\n", "SF:" + packageA.absolutePath(), "DA:1,1", "end_of_record", "").getBytes(
+        StandardCharsets.UTF_8
+      )
+    );
+
+    settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, lcov.toAbsolutePath().toString());
+    coverageSensor.execute(context);
+
+    assertThat(context.lineHits(packageA.key(), 1)).isEqualTo(1);
+  }
+
   private DefaultInputFile tsInputFile(String relativePath, String contents) {
+    return tsInputFile(tempDir, relativePath, contents);
+  }
+
+  private DefaultInputFile tsInputFile(Path moduleBaseDir, String relativePath, String contents) {
     DefaultInputFile inputFile = new TestInputFileBuilder("moduleKey", relativePath)
-      .setModuleBaseDir(tempDir)
+      .setModuleBaseDir(moduleBaseDir)
       .setLanguage("ts")
       .setContents(contents)
       .build();
     context.fileSystem().add(inputFile);
     return inputFile;
+  }
+
+  private static Path createDirectoryAlias(Path alias, Path target) throws Exception {
+    if (isWindows()) {
+      Process process = new ProcessBuilder(
+        "cmd",
+        "/c",
+        String.format("mklink /J \"%s\" \"%s\"", alias, target)
+      )
+        .redirectErrorStream(true)
+        .start();
+      String output;
+      try (var reader = process.inputReader(StandardCharsets.UTF_8)) {
+        output = reader.lines().reduce("", (left, right) -> left + right + System.lineSeparator());
+      }
+      assumeTrue(
+        process.waitFor() == 0,
+        () -> "Unable to create directory junction for test: " + output
+      );
+      return alias;
+    }
+
+    try {
+      return Files.createSymbolicLink(alias, target);
+    } catch (IOException | UnsupportedOperationException e) {
+      assumeTrue(false, () -> "Unable to create directory alias for test: " + e.getMessage());
+      return alias;
+    }
+  }
+
+  private static boolean isWindows() {
+    return System.getProperty("os.name").startsWith("Windows");
   }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
@@ -304,6 +304,50 @@ class CoverageSensorDuplicateSuffixPathReproducerTest {
     assertThat(context.lineHits(packageA.key(), 1)).isEqualTo(1);
   }
 
+  @Test
+  void should_import_absolute_paths_when_lcov_uses_an_alias_of_analysis_base_dir()
+    throws Exception {
+    Path realBaseDir = Files.createDirectories(tempDir.resolve("real-base-dir"));
+    Path analysisBaseDirAlias = createDirectoryAlias(
+      tempDir.resolve("analysis-base-dir-alias"),
+      realBaseDir
+    );
+
+    settings = new MapSettings();
+    context = SensorContextTester.create(realBaseDir.toFile());
+    context.setSettings(settings);
+
+    DefaultInputFile packageA = tsInputFile(
+      realBaseDir,
+      "packages/a/src/index.ts",
+      String.join(
+          "\n",
+          "export const fromA = 1;",
+          "export function fromPackageA() {",
+          "  return fromA;",
+          "}"
+        ) +
+        "\n"
+    );
+
+    Path lcov = realBaseDir.resolve("duplicate-suffix-absolute-alias-spelling.lcov");
+    Files.write(
+      lcov,
+      String.join(
+        "\n",
+        "SF:" + analysisBaseDirAlias.resolve("packages/a/src/index.ts").toAbsolutePath(),
+        "DA:1,1",
+        "end_of_record",
+        ""
+      ).getBytes(StandardCharsets.UTF_8)
+    );
+
+    settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, lcov.toAbsolutePath().toString());
+    coverageSensor.execute(context);
+
+    assertThat(context.lineHits(packageA.key(), 1)).isEqualTo(1);
+  }
+
   private DefaultInputFile tsInputFile(String relativePath, String contents) {
     return tsInputFile(tempDir, relativePath, contents);
   }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/CoverageSensorDuplicateSuffixPathReproducerTest.java
@@ -109,7 +109,7 @@ class CoverageSensorDuplicateSuffixPathReproducerTest {
   }
 
   @Test
-  void should_not_guess_when_duplicate_suffix_match_is_ambiguous() throws Exception {
+  void should_guess_when_duplicate_suffix_match_is_ambiguous() throws Exception {
     DefaultInputFile packageA = tsInputFile(
       "packages/a/src/index.ts",
       String.join(
@@ -152,10 +152,12 @@ class CoverageSensorDuplicateSuffixPathReproducerTest {
     settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATHS, lcov.toAbsolutePath().toString());
     coverageSensor.execute(context);
 
-    assertThat(context.lineHits(packageA.key(), 1)).isNull();
+    assertThat(context.lineHits(packageA.key(), 1)).isEqualTo(1);
     assertThat(context.lineHits(packageB.key(), 5)).isNull();
-    assertThat(logTester.logs(Level.WARN)).contains(
-      "Could not resolve 1 file paths in [" + lcov.toAbsolutePath() + "]"
+    assertThat(logTester.logs(Level.DEBUG)).anyMatch(
+      log ->
+        log.contains("Ambiguous LCOV path 'src/index.ts'") &&
+        log.contains("falling back to 'packages/a/src/index.ts'")
     );
   }
 

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/FileLocatorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/FileLocatorTest.java
@@ -67,6 +67,20 @@ class FileLocatorTest {
   }
 
   @Test
+  void should_prefer_exact_suffix_node_over_deeper_leaf() {
+    InputFile inputFile1 = new TestInputFileBuilder("module1", "lib/src/index.ts").build();
+    InputFile inputFile2 = new TestInputFileBuilder(
+      "module1",
+      "packages/a/lib/src/index.ts"
+    ).build();
+
+    FileLocator locator = new FileLocator(Arrays.asList(inputFile1, inputFile2));
+    FileLocator.Resolution resolution = locator.resolve("lib/src/index.ts");
+    assertThat(resolution.inputFile()).isEqualTo(inputFile1);
+    assertThat(resolution.guessed()).isTrue();
+  }
+
+  @Test
   void should_normalize_paths() {
     InputFile inputFile = new TestInputFileBuilder(
       "module1",

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/FileLocatorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/FileLocatorTest.java
@@ -50,7 +50,7 @@ class FileLocatorTest {
   }
 
   @Test
-  void should_match_first_with_many_options() {
+  void should_not_match_ambiguous_suffix() {
     InputFile inputFile1 = new TestInputFileBuilder(
       "module1",
       "src/main/java/org/sonar/test/File.java"
@@ -61,7 +61,7 @@ class FileLocatorTest {
     ).build();
 
     FileLocator locator = new FileLocator(Arrays.asList(inputFile1, inputFile2));
-    assertThat(locator.getInputFile("org/sonar/test/File.java")).isEqualTo(inputFile1);
+    assertThat(locator.getInputFile("org/sonar/test/File.java")).isNull();
   }
 
   @Test

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/FileLocatorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/FileLocatorTest.java
@@ -50,7 +50,7 @@ class FileLocatorTest {
   }
 
   @Test
-  void should_not_match_ambiguous_suffix() {
+  void should_match_first_with_many_options_and_mark_as_guess() {
     InputFile inputFile1 = new TestInputFileBuilder(
       "module1",
       "src/main/java/org/sonar/test/File.java"
@@ -61,7 +61,9 @@ class FileLocatorTest {
     ).build();
 
     FileLocator locator = new FileLocator(Arrays.asList(inputFile1, inputFile2));
-    assertThat(locator.getInputFile("org/sonar/test/File.java")).isNull();
+    FileLocator.Resolution resolution = locator.resolve("org/sonar/test/File.java");
+    assertThat(resolution.inputFile()).isEqualTo(inputFile1);
+    assertThat(resolution.guessed()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- resolve LCOV `SF:` paths in this order: exact analyzed path, path relative to the report directory, then suffix-based lookup
- fix the community case where package-local paths such as `src/index.ts` were incorrectly matched across modules by trying report-relative resolution before suffix matching
- walk report ancestor directories up to the analysis base dir so monorepo layouts like `<package>/coverage/lcov.info` still resolve package-local `SF:` paths strictly before guessing
- preserve the historical suffix fallback for ambiguous duplicates as a last resort by deterministically picking the first match and emitting a `DEBUG` log when we are explicitly guessing
- retry absolute `SF:` paths via the analysis base dir and its real path so Windows directory aliases such as junctions or symlinks still map to the indexed file before we ever fall back to guessing
- extend the reproducer coverage tests for package-relative reports, ambiguous duplicate suffix fallback, absolute-path control, and aliased analysis base directories

## Testing

```bash
mvn -pl sonar-plugin/sonar-javascript-plugin -am "-Dtest=org.sonar.plugins.javascript.lcov.CoverageSensorTest,org.sonar.plugins.javascript.lcov.FileLocatorTest,org.sonar.plugins.javascript.lcov.CoverageSensorDuplicateSuffixPathReproducerTest" "-Dsurefire.failIfNoSpecifiedTests=false" test
```