### PR TITLE
JS-1776 Update S5845 issue wording

### DIFF
--- a/packages/analysis/src/jsts/rules/S5845/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5845/rule.ts
@@ -27,10 +27,8 @@ import { getTypeFromTreeNode } from '../helpers/type.js';
 import * as meta from './generated-meta.js';
 
 const messages = {
-  alwaysFails:
-    'Change this assertion; it always fails because it compares dissimilar types ("{{actual}}" and "{{expected}}").',
-  alwaysSucceeds:
-    'Change this assertion; it always succeeds because it compares dissimilar types ("{{actual}}" and "{{expected}}").',
+  incompatibleStaticTypes:
+    'Review this strict equality assertion: the compared expressions have incompatible static types ("{{actual}}" and "{{expected}}").',
 };
 
 type PrimitiveCategory =
@@ -48,9 +46,10 @@ export const rule: Rule.RuleModule = {
   /*
    * High-level idea:
    * - only run when the parser provides type information;
+   * - only analyse strict equality assertions;
    * - reduce both assertion operands to broad primitive families instead of comparing exact
-   *   TypeScript types, because the rule is only meant to catch obviously impossible equality
-   *   assertions;
+   *   TypeScript types, because the rule is meant to highlight incompatible static typings on
+   *   strict equality checks rather than to model all runtime equality behavior;
    * - stay conservative whenever the type is imprecise (`any`, `unknown`, type parameters, etc.),
    *   or when a mutable identifier may have been reassigned to a different family.
    */
@@ -65,7 +64,7 @@ export const rule: Rule.RuleModule = {
     // Expressions that are not rooted in a mutable local binding can rely directly on the
     // expression type at the assertion site:
     //   expect(getCount()).toBe('1');
-    //   expect(Number(title)).toStrictEqual('1');
+    //   expect(Number(title)).toBe('1');
     //
     // Bare identifiers and member expressions rooted in an identifier need one extra guard.
     // `getTypeAtLocation(value)` can stay narrow even after an imprecise write, so using the
@@ -110,7 +109,7 @@ export const rule: Rule.RuleModule = {
       if (incompatibility) {
         context.report({
           node: assertion.reportNode,
-          messageId: assertion.negated ? 'alwaysSucceeds' : 'alwaysFails',
+          messageId: 'incompatibleStaticTypes',
           data: incompatibility,
         });
       }
@@ -143,12 +142,13 @@ export const rule: Rule.RuleModule = {
   },
 };
 
-// Only strict comparison-style assertions are in scope. Loose equality is intentionally excluded
-// because coercion rules make "always true/false" reasoning much less reliable there.
+// Only strict equality assertions are in scope. Loose equality depends on coercion, and deep
+// equality compares runtime shapes rather than identity-compatible static types.
 function isRelevantAssertion(assertion: Assertion | null): assertion is Assertion & {
   kind: 'comparison';
+  comparison: 'strict';
 } {
-  return assertion?.kind === 'comparison' && assertion.comparison !== 'loose';
+  return assertion?.kind === 'comparison' && assertion.comparison === 'strict';
 }
 
 // The rule reports only when the two operands have no plausible primitive-family overlap.

--- a/packages/analysis/src/jsts/rules/S5845/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5845/rule.ts
@@ -28,7 +28,7 @@ import * as meta from './generated-meta.js';
 
 const messages = {
   incompatibleStaticTypes:
-    'Review this strict equality assertion: the compared expressions have incompatible static types ("{{actual}}" and "{{expected}}").',
+    'Review this equality assertion: the compared expressions have incompatible static types ("{{actual}}" and "{{expected}}").',
 };
 
 type PrimitiveCategory =
@@ -46,10 +46,10 @@ export const rule: Rule.RuleModule = {
   /*
    * High-level idea:
    * - only run when the parser provides type information;
-   * - only analyse strict equality assertions;
+   * - only analyse strict and deep equality assertions;
    * - reduce both assertion operands to broad primitive families instead of comparing exact
    *   TypeScript types, because the rule is meant to highlight incompatible static typings on
-   *   strict equality checks rather than to model all runtime equality behavior;
+   *   equality checks rather than to model all runtime equality behavior;
    * - stay conservative whenever the type is imprecise (`any`, `unknown`, type parameters, etc.),
    *   or when a mutable identifier may have been reassigned to a different family.
    */
@@ -142,13 +142,16 @@ export const rule: Rule.RuleModule = {
   },
 };
 
-// Only strict equality assertions are in scope. Loose equality depends on coercion, and deep
-// equality compares runtime shapes rather than identity-compatible static types.
+// Strict and deep equality assertions are in scope. Loose equality depends on coercion, while
+// deep equality is relevant here because the rule only reasons about primitive type families.
 function isRelevantAssertion(assertion: Assertion | null): assertion is Assertion & {
   kind: 'comparison';
-  comparison: 'strict';
+  comparison: 'strict' | 'deep';
 } {
-  return assertion?.kind === 'comparison' && assertion.comparison === 'strict';
+  return (
+    assertion?.kind === 'comparison' &&
+    (assertion.comparison === 'strict' || assertion.comparison === 'deep')
+  );
 }
 
 // The rule reports only when the two operands have no plausible primitive-family overlap.

--- a/packages/analysis/src/jsts/rules/S5845/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5845/unit.test.ts
@@ -212,10 +212,11 @@ describe('S5845', () => {
             import { expect } from 'vitest';
 
             const id: number = 123;
+            const otherId: number = 123;
             const name: string = '123';
 
-            expect(id).toEqual(name);
-            expect(id).toStrictEqual(name);
+            expect(id).toEqual(otherId);
+            expect(name).toStrictEqual('123');
           `,
         },
         {
@@ -223,20 +224,19 @@ describe('S5845', () => {
             import assert from 'node:assert';
 
             const port: number = 8080;
-            const portText: string = '8080';
+            const portCopy: number = 8080;
 
-            assert.deepStrictEqual(port, portText);
+            assert.deepStrictEqual(port, portCopy);
           `,
         },
         {
           code: `
             import { expect } from 'chai';
 
-            const version: number = 3;
             const versionText: string = '3';
 
-            expect(versionText).to.deep.equal(version);
-            expect(versionText).to.eql(version);
+            expect(versionText).to.deep.equal('3');
+            expect(versionText).to.eql('3');
           `,
         },
         {
@@ -244,10 +244,10 @@ describe('S5845', () => {
             import 'cypress';
 
             const count: number = 1;
-            const label: string = '1';
+            const otherCount: number = 1;
 
-            cy.wrap(count).should('deep.equal', label);
-            cy.wrap(count).should('not.deep.equal', label);
+            cy.wrap(count).should('deep.equal', otherCount);
+            cy.wrap(count).should('not.deep.equal', 2);
           `,
         },
         {
@@ -297,7 +297,7 @@ describe('S5845', () => {
               const enabled: boolean = true;
 
               expect(title).toBe(count);
-              expect(enabled).not.toBe('true');
+              expect(enabled).not.toEqual('true');
             });
           `,
           errors: [
@@ -315,8 +315,8 @@ describe('S5845', () => {
               const title: string = '1';
               const enabled: boolean = true;
 
-              assert.strictEqual(count, title);
-              assert.notStrictEqual(enabled, 1);
+              assert.deepStrictEqual(count, title);
+              assert.notDeepStrictEqual(enabled, 1);
             });
           `,
           errors: [
@@ -333,8 +333,8 @@ describe('S5845', () => {
             const score: number = 10;
             const scoreText: string = '10';
 
-            expect(id).toBe(name);
-            expect(score).toBe(scoreText);
+            expect(id).toEqual(name);
+            expect(score).toStrictEqual(scoreText);
           `,
           errors: [
             { messageId: 'incompatibleStaticTypes' },
@@ -417,8 +417,8 @@ describe('S5845', () => {
             const quantityText: string = '2';
             const inStock: boolean = true;
 
-            assert.strictEqual(quantity, quantityText);
-            assert.notStrictEqual(inStock, 1);
+            assert.deepEqual(quantity, quantityText);
+            assert.notDeepEqual(inStock, 1);
           `,
           errors: [
             { messageId: 'incompatibleStaticTypes' },
@@ -433,8 +433,8 @@ describe('S5845', () => {
             const versionText: string = '3';
             const deprecated: boolean = false;
 
-            expect(version).to.equal(versionText);
-            expect(deprecated).to.equal(version);
+            expect(version).to.deep.equal(versionText);
+            expect(deprecated).to.eql(version);
           `,
           errors: [
             { messageId: 'incompatibleStaticTypes' },
@@ -448,8 +448,8 @@ describe('S5845', () => {
             const timeout: number = 1000;
             const timeoutText: string = '1000';
 
-            timeout.should.equal(timeoutText);
-            timeout.should.equal('1000');
+            timeout.should.deep.equal(timeoutText);
+            timeout.should.deep.equal('1000');
           `,
           errors: [
             { messageId: 'incompatibleStaticTypes' },
@@ -472,8 +472,8 @@ describe('S5845', () => {
 
             const id: number = 1;
             const idText: string = '1';
-            cy.wrap(id).should('equal', idText);
-            cy.wrap(true).should('equal', id);
+            cy.wrap(id).should('deep.equal', idText);
+            cy.wrap(true).should('deep.equal', id);
           `,
           errors: [
             { messageId: 'incompatibleStaticTypes' },
@@ -486,7 +486,7 @@ describe('S5845', () => {
 
             const count: number = 1;
             const label: string = '1';
-            cy.wrap(count).should('not.equal', label);
+            cy.wrap(count).should('not.deep.equal', label);
           `,
           errors: [{ messageId: 'incompatibleStaticTypes' }],
         },

--- a/packages/analysis/src/jsts/rules/S5845/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5845/unit.test.ts
@@ -209,6 +209,49 @@ describe('S5845', () => {
         },
         {
           code: `
+            import { expect } from 'vitest';
+
+            const id: number = 123;
+            const name: string = '123';
+
+            expect(id).toEqual(name);
+            expect(id).toStrictEqual(name);
+          `,
+        },
+        {
+          code: `
+            import assert from 'node:assert';
+
+            const port: number = 8080;
+            const portText: string = '8080';
+
+            assert.deepStrictEqual(port, portText);
+          `,
+        },
+        {
+          code: `
+            import { expect } from 'chai';
+
+            const version: number = 3;
+            const versionText: string = '3';
+
+            expect(versionText).to.deep.equal(version);
+            expect(versionText).to.eql(version);
+          `,
+        },
+        {
+          code: `
+            import 'cypress';
+
+            const count: number = 1;
+            const label: string = '1';
+
+            cy.wrap(count).should('deep.equal', label);
+            cy.wrap(count).should('not.deep.equal', label);
+          `,
+        },
+        {
+          code: `
             import 'chai/register-should';
 
             const timeout: number = 1000;
@@ -254,10 +297,13 @@ describe('S5845', () => {
               const enabled: boolean = true;
 
               expect(title).toBe(count);
-              expect(enabled).not.toEqual('true');
+              expect(enabled).not.toBe('true');
             });
           `,
-          errors: [{ messageId: 'alwaysFails' }, { messageId: 'alwaysSucceeds' }],
+          errors: [
+            { messageId: 'incompatibleStaticTypes' },
+            { messageId: 'incompatibleStaticTypes' },
+          ],
         },
         {
           code: `
@@ -273,7 +319,10 @@ describe('S5845', () => {
               assert.notStrictEqual(enabled, 1);
             });
           `,
-          errors: [{ messageId: 'alwaysFails' }, { messageId: 'alwaysSucceeds' }],
+          errors: [
+            { messageId: 'incompatibleStaticTypes' },
+            { messageId: 'incompatibleStaticTypes' },
+          ],
         },
         {
           code: `
@@ -284,10 +333,13 @@ describe('S5845', () => {
             const score: number = 10;
             const scoreText: string = '10';
 
-            expect(id).toEqual(name);
-            expect(score).toStrictEqual(scoreText);
+            expect(id).toBe(name);
+            expect(score).toBe(scoreText);
           `,
-          errors: [{ messageId: 'alwaysFails' }, { messageId: 'alwaysFails' }],
+          errors: [
+            { messageId: 'incompatibleStaticTypes' },
+            { messageId: 'incompatibleStaticTypes' },
+          ],
         },
         {
           code: `
@@ -299,7 +351,7 @@ describe('S5845', () => {
 
             expect(getCount()).toBe('1');
           `,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
         {
           code: `
@@ -310,7 +362,7 @@ describe('S5845', () => {
 
             expect(value).toBe(true);
           `,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
         {
           code: `
@@ -328,7 +380,7 @@ describe('S5845', () => {
               expect(value).toBe(true);
             }
           `,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
         {
           code: `
@@ -346,7 +398,7 @@ describe('S5845', () => {
               expect(user.id).toBe(true);
             }
           `,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
         {
           code: `
@@ -355,20 +407,7 @@ describe('S5845', () => {
             const token: symbol = Symbol('token');
             expect(token).toBe(1);
           `,
-          errors: [{ messageId: 'alwaysFails' }],
-        },
-        {
-          code: `
-            import assert from 'node:assert';
-
-            const port: number = 8080;
-            const portText: string = '8080';
-            const active: boolean = true;
-
-            assert.deepStrictEqual(port, portText);
-            assert.notDeepStrictEqual(active, 0);
-          `,
-          errors: [{ messageId: 'alwaysFails' }, { messageId: 'alwaysSucceeds' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
         {
           code: `
@@ -380,12 +419,10 @@ describe('S5845', () => {
 
             assert.strictEqual(quantity, quantityText);
             assert.notStrictEqual(inStock, 1);
-            assert.deepEqual(quantity, inStock);
           `,
           errors: [
-            { messageId: 'alwaysFails' },
-            { messageId: 'alwaysSucceeds' },
-            { messageId: 'alwaysFails' },
+            { messageId: 'incompatibleStaticTypes' },
+            { messageId: 'incompatibleStaticTypes' },
           ],
         },
         {
@@ -397,13 +434,11 @@ describe('S5845', () => {
             const deprecated: boolean = false;
 
             expect(version).to.equal(versionText);
-            expect(versionText).to.deep.equal(version);
-            expect(deprecated).to.eql(version);
+            expect(deprecated).to.equal(version);
           `,
           errors: [
-            { messageId: 'alwaysFails' },
-            { messageId: 'alwaysFails' },
-            { messageId: 'alwaysFails' },
+            { messageId: 'incompatibleStaticTypes' },
+            { messageId: 'incompatibleStaticTypes' },
           ],
         },
         {
@@ -414,9 +449,12 @@ describe('S5845', () => {
             const timeoutText: string = '1000';
 
             timeout.should.equal(timeoutText);
-            timeoutText.should.deep.equal(timeout);
+            timeout.should.equal('1000');
           `,
-          errors: [{ messageId: 'alwaysFails' }, { messageId: 'alwaysFails' }],
+          errors: [
+            { messageId: 'incompatibleStaticTypes' },
+            { messageId: 'incompatibleStaticTypes' },
+          ],
         },
         {
           code: `
@@ -426,7 +464,7 @@ describe('S5845', () => {
             const expectedCount: number = 1;
             expect(pageTitle).toBe(expectedCount);
           `,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
         {
           code: `
@@ -435,9 +473,12 @@ describe('S5845', () => {
             const id: number = 1;
             const idText: string = '1';
             cy.wrap(id).should('equal', idText);
-            cy.wrap(idText).should('deep.equal', id);
+            cy.wrap(true).should('equal', id);
           `,
-          errors: [{ messageId: 'alwaysFails' }, { messageId: 'alwaysFails' }],
+          errors: [
+            { messageId: 'incompatibleStaticTypes' },
+            { messageId: 'incompatibleStaticTypes' },
+          ],
         },
         {
           code: `
@@ -445,19 +486,9 @@ describe('S5845', () => {
 
             const count: number = 1;
             const label: string = '1';
-            cy.wrap(count).should('not.deep.equal', label);
+            cy.wrap(count).should('not.equal', label);
           `,
-          errors: [{ messageId: 'alwaysSucceeds' }],
-        },
-        {
-          code: `
-            import 'chai/register-should';
-
-            const timeout: number = 1000;
-            const timeoutText: string = '1000';
-            timeout.should.deep.equal(timeoutText);
-          `,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
         {
           code: `
@@ -467,7 +498,7 @@ describe('S5845', () => {
             const count: number = 1;
             expect(big).toBe(count);
           `,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
         {
           code: `
@@ -477,7 +508,7 @@ describe('S5845', () => {
             const name: string = 'token';
             expect(token).toBe(name);
           `,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
       ],
     });
@@ -518,7 +549,7 @@ describe('S5845', () => {
             expect(count).toBe(title);
           `,
           filename: jsFixture,
-          errors: [{ messageId: 'alwaysFails' }],
+          errors: [{ messageId: 'incompatibleStaticTypes' }],
         },
       ],
     });

--- a/packages/analysis/src/jsts/rules/S5845/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5845/unit.test.ts
@@ -188,6 +188,16 @@ describe('S5845', () => {
         },
         {
           code: `
+            import 'cypress';
+            import assert from 'node:assert';
+
+            const count: number = 1;
+            const title: string = '1';
+            assert.deepEqual(count, title);
+          `,
+        },
+        {
+          code: `
             import { assert } from 'chai';
 
             const price = 19.99;

--- a/packages/analysis/src/jsts/rules/S5845/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5845/unit.test.ts
@@ -178,6 +178,16 @@ describe('S5845', () => {
         },
         {
           code: `
+            import assert from 'node:assert';
+
+            const count: number = 1;
+            const title: string = '1';
+            assert.deepEqual(count, title);
+            assert.notDeepEqual(count, title);
+          `,
+        },
+        {
+          code: `
             import { assert } from 'chai';
 
             const price = 19.99;
@@ -315,11 +325,15 @@ describe('S5845', () => {
               const title: string = '1';
               const enabled: boolean = true;
 
+              assert.deepEqual(count, title);
+              assert.notDeepEqual(enabled, 1);
               assert.deepStrictEqual(count, title);
               assert.notDeepStrictEqual(enabled, 1);
             });
           `,
           errors: [
+            { messageId: 'incompatibleStaticTypes' },
+            { messageId: 'incompatibleStaticTypes' },
             { messageId: 'incompatibleStaticTypes' },
             { messageId: 'incompatibleStaticTypes' },
           ],

--- a/packages/analysis/src/jsts/rules/S5914/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5914/unit.test.ts
@@ -149,6 +149,12 @@ describe('S5914', () => {
         {
           code: `
             import assert from 'node:assert';
+            assert.deepEqual(getValue(), {});
+          `,
+        },
+        {
+          code: `
+            import assert from 'node:assert';
             assert.deepStrictEqual(getUser(), {});
           `,
         },
@@ -644,6 +650,13 @@ describe('S5914', () => {
           code: `
             import assert from 'node:assert';
             assert.strictEqual(1, 2);
+          `,
+          errors: [{ messageId: 'issue' }],
+        },
+        {
+          code: `
+            import assert from 'node:assert';
+            assert.deepEqual(1, '1');
           `,
           errors: [{ messageId: 'issue' }],
         },

--- a/packages/analysis/src/jsts/rules/S5914/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5914/unit.test.ts
@@ -660,6 +660,14 @@ describe('S5914', () => {
           `,
           errors: [{ messageId: 'issue' }],
         },
+        {
+          code: `
+            import 'cypress';
+            import assert from 'node:assert';
+            assert.deepEqual(1, '1');
+          `,
+          errors: [{ messageId: 'issue' }],
+        },
         // regex literals create a fresh RegExp on each evaluation
         {
           code: `

--- a/packages/analysis/src/jsts/rules/helpers/assertions.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions.ts
@@ -64,10 +64,12 @@ type PredicateAssertion = AssertionBase & {
  */
 type ComparisonAssertion = AssertionBase & {
   kind: 'comparison';
-  comparison: 'strict' | 'deep' | 'loose';
+  comparison: ComparisionAssertionStrictness;
   actual: estree.Node;
   expected: estree.Node;
 };
+
+type ComparisionAssertionStrictness = 'strict' | 'deep' | 'loose';
 
 /**
  * Maps common Jest matcher names to their corresponding assertion predicates.
@@ -88,6 +90,8 @@ type NodeAssertMethod =
   | 'ok'
   | 'strictEqual'
   | 'notStrictEqual'
+  | 'deepEqual'
+  | 'notDeepEqual'
   | 'deepStrictEqual'
   | 'notDeepStrictEqual';
 
@@ -194,7 +198,7 @@ function extractExpectAssertion(expectCall: estree.Node): Assertion | null {
   return null;
 }
 
-function getJestComparison(name: string): ComparisonAssertion['comparison'] | null {
+function getJestComparison(name: string): ComparisionAssertionStrictness | null {
   switch (name) {
     case 'toBe':
       return 'strict';
@@ -309,7 +313,7 @@ function extractChaiAssertAssertion(
   };
 }
 
-function getChaiAssertComparison(method: ChaiAssertMethod): ComparisonAssertion['comparison'] {
+function getChaiAssertComparison(method: ChaiAssertMethod): ComparisionAssertionStrictness {
   switch (method) {
     case 'equal':
     case 'notEqual':
@@ -695,8 +699,11 @@ function extractNodeJSAssertion(
   };
 }
 
-function getNodeJSComparison(method: NodeAssertMethod): ComparisonAssertion['comparison'] {
+function getNodeJSComparison(method: NodeAssertMethod): ComparisionAssertionStrictness {
   switch (method) {
+    case 'deepEqual':
+    case 'notDeepEqual':
+      return 'loose';
     case 'deepStrictEqual':
     case 'notDeepStrictEqual':
       return 'deep';
@@ -740,6 +747,14 @@ function getNodeJSAssertMethodFromFqn(fqn: string | null): NodeAssertMethod | nu
     case 'assert.notStrictEqual':
     case 'assert.strict.notStrictEqual':
       return 'notStrictEqual';
+    case 'assert.deepEqual':
+      return 'deepEqual';
+    case 'assert.notDeepEqual':
+      return 'notDeepEqual';
+    case 'assert.strict.deepEqual':
+      return 'deepStrictEqual';
+    case 'assert.strict.notDeepEqual':
+      return 'notDeepStrictEqual';
     case 'assert.deepStrictEqual':
     case 'assert.strict.deepStrictEqual':
       return 'deepStrictEqual';
@@ -759,6 +774,8 @@ function getNodeJSAssertMethodFromName(name: string): NodeAssertMethod | null {
     case 'ok':
     case 'strictEqual':
     case 'notStrictEqual':
+    case 'deepEqual':
+    case 'notDeepEqual':
     case 'deepStrictEqual':
     case 'notDeepStrictEqual':
       return name;
@@ -821,7 +838,7 @@ function extractCypressChainAssertion(node: estree.Node): Assertion | null {
   };
 }
 
-function parseCypressComparisonString(predicate: string): ComparisonAssertion['comparison'] | null {
+function parseCypressComparisonString(predicate: string): ComparisionAssertionStrictness | null {
   const parts = predicate.split('.');
   let idx = 0;
   if (parts[idx] === 'not') {

--- a/packages/analysis/src/jsts/rules/helpers/assertions.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions.ts
@@ -64,12 +64,12 @@ type PredicateAssertion = AssertionBase & {
  */
 type ComparisonAssertion = AssertionBase & {
   kind: 'comparison';
-  comparison: ComparisionAssertionStrictness;
+  comparison: ComparisonAssertionStrictness;
   actual: estree.Node;
   expected: estree.Node;
 };
 
-type ComparisionAssertionStrictness = 'strict' | 'deep' | 'loose';
+type ComparisonAssertionStrictness = 'strict' | 'deep' | 'loose';
 
 /**
  * Maps common Jest matcher names to their corresponding assertion predicates.
@@ -198,7 +198,7 @@ function extractExpectAssertion(expectCall: estree.Node): Assertion | null {
   return null;
 }
 
-function getJestComparison(name: string): ComparisionAssertionStrictness | null {
+function getJestComparison(name: string): ComparisonAssertionStrictness | null {
   switch (name) {
     case 'toBe':
       return 'strict';
@@ -313,7 +313,7 @@ function extractChaiAssertAssertion(
   };
 }
 
-function getChaiAssertComparison(method: ChaiAssertMethod): ComparisionAssertionStrictness {
+function getChaiAssertComparison(method: ChaiAssertMethod): ComparisonAssertionStrictness {
   switch (method) {
     case 'equal':
     case 'notEqual':
@@ -699,7 +699,7 @@ function extractNodeJSAssertion(
   };
 }
 
-function getNodeJSComparison(method: NodeAssertMethod): ComparisionAssertionStrictness {
+function getNodeJSComparison(method: NodeAssertMethod): ComparisonAssertionStrictness {
   switch (method) {
     case 'deepEqual':
     case 'notDeepEqual':
@@ -838,7 +838,7 @@ function extractCypressChainAssertion(node: estree.Node): Assertion | null {
   };
 }
 
-function parseCypressComparisonString(predicate: string): ComparisionAssertionStrictness | null {
+function parseCypressComparisonString(predicate: string): ComparisonAssertionStrictness | null {
   const parts = predicate.split('.');
   let idx = 0;
   if (parts[idx] === 'not') {

--- a/packages/analysis/src/jsts/rules/helpers/assertions.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions.ts
@@ -16,7 +16,7 @@
  */
 import type { Rule } from 'eslint';
 import type estree from 'estree';
-import { isIdentifier, isMethodCall } from './ast.js';
+import { getVariableFromName, isIdentifier, isMethodCall } from './ast.js';
 import { getFullyQualifiedName, importsModule, importsOrDependsOnModule } from './module.js';
 
 const JEST_LIKE_MODULES = ['vitest', 'bun:test', '@jest/globals', '@playwright/test'];
@@ -336,11 +336,20 @@ function getChaiAssertCall(
     return { method: fqnMethod, reportNode: node.callee };
   }
 
-  if (allowGlobal && isIdentifier(node.callee, 'assert')) {
+  if (
+    allowGlobal &&
+    isIdentifier(node.callee, 'assert') &&
+    isGlobalAssertReference(context, node)
+  ) {
     return { method: 'assert', reportNode: node.callee };
   }
 
-  if (allowGlobal && isMethodCall(node) && isIdentifier(node.callee.object, 'assert')) {
+  if (
+    allowGlobal &&
+    isMethodCall(node) &&
+    isIdentifier(node.callee.object, 'assert') &&
+    isGlobalAssertReference(context, node)
+  ) {
     const method = getChaiAssertMethodFromName(node.callee.property.name);
     if (method) {
       return { method, reportNode: node.callee.property };
@@ -348,6 +357,13 @@ function getChaiAssertCall(
   }
 
   return null;
+}
+
+// Chai global `assert` should not steal calls from a locally-bound `assert`
+// such as `import assert from 'node:assert'`.
+function isGlobalAssertReference(context: Rule.RuleContext, node: estree.Node) {
+  const variable = getVariableFromName(context, 'assert', node);
+  return !variable || variable.defs.length === 0;
 }
 
 function getChaiAssertMethodFromFqn(fqn: string | null): ChaiAssertMethod | null {


### PR DESCRIPTION
Part of [JS-1678](https://sonarsource.atlassian.net/browse/JS-1678)
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

This updates `S5845` to report a review-oriented message instead of claiming the assertion will always fail or succeed. The rule now flags strict equality assertions whose compared expressions have incompatible static types, using the message: `Review this strict equality assertion: the compared expressions have incompatible static types ("{{actual}}" and "{{expected}}").`

To keep that wording accurate, the rule is now limited to strict comparisons only. Deep and loose equality assertions are excluded, and the unit tests were updated accordingly to keep strict cases covered while treating deep-equality mismatches as valid. Focused `S5845` unit tests and the targeted `rxjs` / `vitest` ruling tests pass with no expected-ruling updates needed.

[JS-1678]: https://sonarsource.atlassian.net/browse/JS-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Node.js assertions:**
  - Added `isGlobalAssertReference` to prevent Chai global `assert` from incorrectly capturing locally imported `node:assert` calls.
  - Updated `getChaiAssertCall` to enforce global reference checks for `assert` identifiers.
- **Test coverage:**
  - Added test cases in `S5845` and `S5914` ensuring `assert.deepEqual` is correctly resolved when `node:assert` is imported.

<sub>This will update automatically on new commits.</sub>