### PR TITLE
Refactor/rearrange component analysis

### DIFF
--- a/packages/analysis/src/jsts/rules/helpers/react/class-component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/class-component-analysis.ts
@@ -15,6 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import type { TSESTree } from '@typescript-eslint/utils';
+import type estree from 'estree';
 import ts from 'typescript';
 import { isIdentifier } from '../ast.js';
 import type { RequiredParserServices } from '../parser-services.js';

--- a/packages/analysis/src/jsts/rules/helpers/react/class-component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/class-component-analysis.ts
@@ -1,0 +1,170 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { TSESTree } from '@typescript-eslint/utils';
+import type estree from 'estree';
+import ts from 'typescript';
+import { isIdentifier } from '../ast.js';
+import type { RequiredParserServices } from '../parser-services.js';
+import type { ComponentAnalysis } from './component-analysis.js';
+import type { ClassComponentNode } from './component-nodes.js';
+
+const REACT_LOCAL_CLASS_SUPERS = new Set(['Component', 'PureComponent']);
+
+export function createClassComponentAnalysis(
+  componentNode: ClassComponentNode,
+  services: RequiredParserServices,
+): ComponentAnalysis | undefined {
+  if (!hasRenderMethodOrProperty(componentNode)) {
+    return undefined;
+  }
+
+  const checker = services.program.getTypeChecker();
+  const classTsNode = getClassComponentTsNode(componentNode, services);
+  const classPropsType = getClassPropsPropertyType(classTsNode, checker);
+  const memberPropsTypeCandidates = getClassComponentPropsTypeCandidates(componentNode, services);
+  return {
+    memberPropsTypeCandidates,
+    enclosingTypePropsTypeCandidates: classPropsType ? [classPropsType] : [],
+    classNonPropsTypeCandidates: getDeclaredClassNonPropsTypes(classTsNode, checker),
+  };
+}
+
+export function getClassComponentPropsTypeCandidates(
+  componentNode: ClassComponentNode,
+  services: RequiredParserServices,
+): ts.Type[] {
+  const checker = services.program.getTypeChecker();
+  const classTsNode = getClassComponentTsNode(componentNode, services);
+  const propsType =
+    getDeclaredClassPropsType(classTsNode, checker) ??
+    getClassPropsPropertyType(classTsNode, checker);
+  return propsType ? [propsType] : [];
+}
+
+function getClassComponentTsNode(
+  componentNode: ClassComponentNode,
+  services: RequiredParserServices,
+): ts.ClassLikeDeclaration {
+  return services.esTreeNodeToTSNodeMap.get(
+    componentNode as TSESTree.Node,
+  ) as ts.ClassLikeDeclaration;
+}
+
+function isReactClassSuperName(name: string): boolean {
+  return REACT_LOCAL_CLASS_SUPERS.has(name);
+}
+
+function isQualifiedReactClassSuper(objectName: string | undefined, propertyName: string): boolean {
+  return objectName === undefined
+    ? isReactClassSuperName(propertyName)
+    : objectName === 'React' && isReactClassSuperName(propertyName);
+}
+
+export function isBuiltinReactSuperclassName(
+  objectName: string | undefined,
+  propertyName: string,
+): boolean {
+  return isQualifiedReactClassSuper(objectName, propertyName);
+}
+
+function isBuiltinReactSuperclass(superClass: estree.Expression): boolean {
+  return (
+    (superClass.type === 'Identifier' && isQualifiedReactClassSuper(undefined, superClass.name)) ||
+    (superClass.type === 'MemberExpression' &&
+      isIdentifier(superClass.object, 'React') &&
+      superClass.property.type === 'Identifier' &&
+      isQualifiedReactClassSuper(superClass.object.name, superClass.property.name))
+  );
+}
+
+export function isReactClassComponent(
+  node: estree.Node,
+): node is estree.ClassDeclaration | estree.ClassExpression {
+  return (
+    (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') &&
+    node.superClass != null &&
+    isBuiltinReactSuperclass(node.superClass)
+  );
+}
+
+function isReactComponentHeritageSuperclass(superclass: ts.ExpressionWithTypeArguments): boolean {
+  const expression = superclass.expression;
+  if (ts.isIdentifier(expression)) {
+    return isQualifiedReactClassSuper(undefined, expression.text);
+  }
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    isQualifiedReactClassSuper(expression.expression.text, expression.name.text)
+  );
+}
+
+function getDeclaredClassPropsType(
+  classNode: ts.ClassLikeDeclaration,
+  checker: ts.TypeChecker,
+): ts.Type | undefined {
+  const propsTypeNode = getReactSuperclassTypeArguments(classNode)[0];
+  return propsTypeNode ? checker.getTypeAtLocation(propsTypeNode) : undefined;
+}
+
+function getReactSuperclassTypeArguments(
+  classNode: ts.ClassLikeDeclaration,
+): readonly ts.TypeNode[] {
+  const extendsClause = classNode.heritageClauses?.find(
+    clause => clause.token === ts.SyntaxKind.ExtendsKeyword,
+  );
+  const reactSuperclass = extendsClause?.types.find(type =>
+    isReactComponentHeritageSuperclass(type),
+  );
+  return reactSuperclass?.typeArguments ?? [];
+}
+
+function getDeclaredClassNonPropsTypes(
+  classNode: ts.ClassLikeDeclaration,
+  checker: ts.TypeChecker,
+): ts.Type[] {
+  return getReactSuperclassTypeArguments(classNode)
+    .slice(1)
+    .map(typeArgument => checker.getTypeAtLocation(typeArgument));
+}
+
+function getClassPropsPropertyType(
+  classNode: ts.ClassLikeDeclaration,
+  checker: ts.TypeChecker,
+): ts.Type | undefined {
+  if (!classNode.name) {
+    return undefined;
+  }
+
+  const classSymbol = checker.getSymbolAtLocation(classNode.name);
+  const propsSymbol = classSymbol
+    ? checker.getDeclaredTypeOfSymbol(classSymbol).getProperty('props')
+    : undefined;
+  return propsSymbol ? checker.getTypeOfSymbol(propsSymbol) : undefined;
+}
+
+function hasRenderMethodOrProperty(componentNode: estree.Node): boolean {
+  return (
+    (componentNode.type === 'ClassDeclaration' || componentNode.type === 'ClassExpression') &&
+    componentNode.body.body.some(
+      member =>
+        (member.type === 'MethodDefinition' || member.type === 'PropertyDefinition') &&
+        member.key.type === 'Identifier' &&
+        member.key.name === 'render',
+    )
+  );
+}

--- a/packages/analysis/src/jsts/rules/helpers/react/class-component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/class-component-analysis.ts
@@ -15,27 +15,23 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import type { TSESTree } from '@typescript-eslint/utils';
-import type estree from 'estree';
 import ts from 'typescript';
 import { isIdentifier } from '../ast.js';
 import type { RequiredParserServices } from '../parser-services.js';
 import type { ComponentAnalysis } from './component-analysis.js';
 import type { ClassComponentNode } from './component-nodes.js';
+import type { ClassComponentDescriptor } from './component-resolution.js';
 
 const REACT_LOCAL_CLASS_SUPERS = new Set(['Component', 'PureComponent']);
 
 export function createClassComponentAnalysis(
-  componentNode: ClassComponentNode,
+  component: ClassComponentDescriptor,
   services: RequiredParserServices,
-): ComponentAnalysis | undefined {
-  if (!hasRenderMethodOrProperty(componentNode)) {
-    return undefined;
-  }
-
+): ComponentAnalysis {
   const checker = services.program.getTypeChecker();
-  const classTsNode = getClassComponentTsNode(componentNode, services);
+  const classTsNode = getClassComponentTsNode(component.node, services);
   const classPropsType = getClassPropsPropertyType(classTsNode, checker);
-  const memberPropsTypeCandidates = getClassComponentPropsTypeCandidates(componentNode, services);
+  const memberPropsTypeCandidates = getClassComponentPropsTypeCandidates(component.node, services);
   return {
     memberPropsTypeCandidates,
     enclosingTypePropsTypeCandidates: classPropsType ? [classPropsType] : [],
@@ -56,7 +52,7 @@ export function getClassComponentPropsTypeCandidates(
 }
 
 function getClassComponentTsNode(
-  componentNode: ClassComponentNode,
+  componentNode: ClassComponentDescriptor['node'],
   services: RequiredParserServices,
 ): ts.ClassLikeDeclaration {
   return services.esTreeNodeToTSNodeMap.get(
@@ -155,16 +151,4 @@ function getClassPropsPropertyType(
     ? checker.getDeclaredTypeOfSymbol(classSymbol).getProperty('props')
     : undefined;
   return propsSymbol ? checker.getTypeOfSymbol(propsSymbol) : undefined;
-}
-
-function hasRenderMethodOrProperty(componentNode: estree.Node): boolean {
-  return (
-    (componentNode.type === 'ClassDeclaration' || componentNode.type === 'ClassExpression') &&
-    componentNode.body.body.some(
-      member =>
-        (member.type === 'MethodDefinition' || member.type === 'PropertyDefinition') &&
-        member.key.type === 'Identifier' &&
-        member.key.name === 'render',
-    )
-  );
 }

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -56,22 +56,15 @@ export function getComponentPropsType(
   componentNode: estree.Node,
   services: RequiredParserServices,
 ): ts.Type | undefined {
-  return getComponentPropsTypeCandidates(componentNode, services)[0];
-}
-
-function getComponentPropsTypeCandidates(
-  componentNode: estree.Node,
-  services: RequiredParserServices,
-): ts.Type[] {
   if (isFunctionComponentNode(componentNode)) {
-    return getFunctionComponentPropsTypeCandidates(componentNode, services);
+    return getFunctionComponentPropsTypeCandidates(componentNode, services)[0];
   }
 
   if (isClassComponentNode(componentNode)) {
-    return getClassComponentPropsTypeCandidates(componentNode, services);
+    return getClassComponentPropsTypeCandidates(componentNode, services)[0];
   }
 
-  return [];
+  return undefined;
 }
 
 export function createComponentAnalysis(

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -14,46 +14,39 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import type { SourceCode } from 'eslint';
 import type estree from 'estree';
 import ts from 'typescript';
-import { childrenOf } from '../ancestor.js';
 import type { RequiredParserServices } from '../parser-services.js';
-import { areSameTypeDeclarations, getTypeFromTreeNode } from '../type.js';
 import {
   createClassComponentAnalysis,
   getClassComponentPropsTypeCandidates,
 } from './class-component-analysis.js';
-import {
-  getComponentIdentifier,
-  getOwningVariableDeclarator,
-  isAnonymousDefaultExportComponent,
-} from './component-identity.js';
+import type { CollectedComponent } from './component-collection.js';
+import { getComponentIdentifier } from './component-identity.js';
 import {
   isClassComponentNode,
   isComponentNode,
   isFunctionComponentNode,
   type ComponentNode,
-  type FunctionComponentNode,
 } from './component-nodes.js';
-import { TSESTree } from '@typescript-eslint/utils';
+import {
+  createFunctionComponentAnalysis,
+  getFunctionComponentPropsTypeCandidates,
+} from './function-component-analysis.js';
 export { isComponentNode, type ComponentNode } from './component-nodes.js';
 export { getComponentIdentifier, getComponentVariable } from './component-identity.js';
+export {
+  collectComponentNodes,
+  collectComponents,
+  type CollectedComponent,
+} from './component-collection.js';
 export { isBuiltinReactSuperclassName, isReactClassComponent } from './class-component-analysis.js';
-
-const REACT_FUNCTION_COMPONENT_TYPES = new Set(['FC', 'FunctionComponent']);
-const REACT_FORWARD_REF_RENDER_FUNCTION_TYPES = new Set(['ForwardRefRenderFunction']);
 
 export type ComponentAnalysis = {
   memberPropsTypeCandidates: ts.Type[];
   enclosingTypePropsTypeCandidates: ts.Type[];
   classNonPropsTypeCandidates: ts.Type[];
 };
-export type CollectedComponent = {
-  componentNode: ComponentNode;
-  componentIdentifier: estree.Identifier | undefined;
-};
-
 const EMPTY_COMPONENT_ANALYSIS: ComponentAnalysis = {
   memberPropsTypeCandidates: [],
   enclosingTypePropsTypeCandidates: [],
@@ -82,123 +75,6 @@ function getComponentPropsTypeCandidates(
   return [];
 }
 
-function getFunctionComponentPropsTypeCandidates(
-  componentNode: FunctionComponentNode,
-  services: RequiredParserServices,
-): ts.Type[] {
-  const checker = services.program.getTypeChecker();
-  const propsTypes: ts.Type[] = [];
-  const primaryPropsType = getFunctionComponentParamPropsType(componentNode, services);
-  if (primaryPropsType) {
-    propsTypes.push(primaryPropsType);
-  }
-
-  const declaredVariablePropsType = getComponentPropsTypeFromVariableDeclaration(
-    componentNode,
-    services,
-  );
-  if (
-    declaredVariablePropsType &&
-    !(
-      primaryPropsType &&
-      areSameTypeDeclarations(checker, primaryPropsType, declaredVariablePropsType)
-    )
-  ) {
-    propsTypes.push(declaredVariablePropsType);
-  }
-
-  return propsTypes;
-}
-
-function isSpecificPropsType(type: ts.Type | undefined): type is ts.Type {
-  return !!type && (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) === 0;
-}
-
-function getFunctionComponentParamPropsType(
-  componentNode: FunctionComponentNode,
-  services: RequiredParserServices,
-): ts.Type | undefined {
-  const firstParam = componentNode.params[0];
-  const propsType = firstParam ? getTypeFromTreeNode(firstParam, services) : undefined;
-  return isSpecificPropsType(propsType) ? propsType : undefined;
-}
-
-function getComponentPropsTypeFromVariableDeclaration(
-  componentNode: estree.Node,
-  services: RequiredParserServices,
-): ts.Type | undefined {
-  const variableDeclarator = getOwningVariableDeclarator(componentNode);
-  if (!variableDeclarator) {
-    return undefined;
-  }
-
-  const declaredType = (variableDeclarator.id as TSESTree.Identifier).typeAnnotation
-    ?.typeAnnotation;
-  if (!declaredType) {
-    return undefined;
-  }
-
-  const propsTypeNode = findDeclaredFunctionComponentPropsType(declaredType);
-  return propsTypeNode
-    ? getTypeFromTreeNode(propsTypeNode as unknown as estree.Node, services)
-    : undefined;
-}
-
-function findDeclaredFunctionComponentPropsType(
-  typeNode: TSESTree.TypeNode,
-): TSESTree.TypeNode | undefined {
-  if (typeNode.type === 'TSIntersectionType') {
-    for (const type of typeNode.types) {
-      const propsType = findDeclaredFunctionComponentPropsType(type);
-      if (propsType) {
-        return propsType;
-      }
-    }
-    return undefined;
-  }
-
-  if (typeNode.type !== 'TSTypeReference') {
-    return undefined;
-  }
-
-  const typeName = getRightmostTypeName(typeNode.typeName);
-  const typeArguments = typeNode.typeArguments?.params ?? [];
-
-  if (typeName && REACT_FUNCTION_COMPONENT_TYPES.has(typeName)) {
-    return typeArguments[0];
-  }
-
-  if (typeName && REACT_FORWARD_REF_RENDER_FUNCTION_TYPES.has(typeName)) {
-    return typeArguments[1];
-  }
-
-  return undefined;
-}
-
-function getRightmostTypeName(typeName: TSESTree.EntityName): string | undefined {
-  if (typeName.type === 'Identifier') {
-    return typeName.name;
-  }
-  if (typeName.type === 'TSQualifiedName') {
-    return typeName.right.name;
-  }
-  return undefined;
-}
-
-/**
- * Returns whether a function component should participate in component analysis.
- * Named components must follow React's uppercase convention, while anonymous
- * function components stay eligible only when they are exported as default.
- */
-function isEligibleFunctionComponent(
-  componentNode: FunctionComponentNode,
-  componentIdentifier: estree.Identifier | undefined,
-): boolean {
-  return componentIdentifier === undefined
-    ? isAnonymousDefaultExportComponent(componentNode)
-    : /^[A-Z]/.test(componentIdentifier.name);
-}
-
 function isCollectedComponent(
   component: ComponentNode | CollectedComponent,
 ): component is CollectedComponent {
@@ -224,54 +100,12 @@ export function createComponentAnalysis(
     return createClassComponentAnalysis(componentNode, services) ?? EMPTY_COMPONENT_ANALYSIS;
   }
 
-  if (
-    !isFunctionComponentNode(componentNode) ||
-    !isEligibleFunctionComponent(componentNode, componentIdentifier)
-  ) {
-    return EMPTY_COMPONENT_ANALYSIS;
+  if (isFunctionComponentNode(componentNode)) {
+    return (
+      createFunctionComponentAnalysis(componentNode, componentIdentifier, services) ??
+      EMPTY_COMPONENT_ANALYSIS
+    );
   }
 
-  const propsTypeCandidates = getComponentPropsTypeCandidates(componentNode, services);
-  return {
-    memberPropsTypeCandidates: propsTypeCandidates,
-    enclosingTypePropsTypeCandidates: propsTypeCandidates,
-    classNonPropsTypeCandidates: [],
-  };
-}
-
-function collectComponent(componentNode: ComponentNode): CollectedComponent {
-  return {
-    componentNode,
-    componentIdentifier: getComponentIdentifier(componentNode),
-  };
-}
-
-export function collectComponents(
-  root: estree.Node,
-  keys: SourceCode.VisitorKeys,
-): CollectedComponent[] {
-  const result: CollectedComponent[] = [];
-  const stack = [root];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (node === undefined) {
-      continue;
-    }
-    if (isComponentNode(node)) {
-      result.push(collectComponent(node));
-      continue;
-    }
-    const children = childrenOf(node, keys);
-    for (let i = children.length - 1; i >= 0; i--) {
-      stack.push(children[i]);
-    }
-  }
-  return result;
-}
-
-export function collectComponentNodes(
-  root: estree.Node,
-  keys: SourceCode.VisitorKeys,
-): ComponentNode[] {
-  return collectComponents(root, keys).map(component => component.componentNode);
+  return EMPTY_COMPONENT_ANALYSIS;
 }

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -15,13 +15,17 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import type { TSESTree } from '@typescript-eslint/utils';
-import type { Scope, SourceCode } from 'eslint';
+import type { SourceCode } from 'eslint';
 import type estree from 'estree';
 import ts from 'typescript';
-import { childrenOf, getNodeParent } from '../ancestor.js';
-import { isIdentifier } from '../ast.js';
+import { childrenOf } from '../ancestor.js';
 import type { RequiredParserServices } from '../parser-services.js';
 import { areSameTypeDeclarations, getTypeFromTreeNode } from '../type.js';
+import {
+  getComponentIdentifier,
+  getOwningVariableDeclarator,
+  isAnonymousDefaultExportComponent,
+} from './component-identity.js';
 import {
   isClassComponentNode,
   isComponentNode,
@@ -32,11 +36,11 @@ import {
 } from './component-nodes.js';
 
 export { isComponentNode, type ComponentNode } from './component-nodes.js';
+export { getComponentIdentifier, getComponentVariable } from './component-identity.js';
 
 const REACT_LOCAL_CLASS_SUPERS = new Set(['Component', 'PureComponent']);
 const REACT_FUNCTION_COMPONENT_TYPES = new Set(['FC', 'FunctionComponent']);
 const REACT_FORWARD_REF_RENDER_FUNCTION_TYPES = new Set(['ForwardRefRenderFunction']);
-const REACT_COMPONENT_WRAPPER_CALLEES = new Set(['memo', 'forwardRef']);
 
 export type ComponentAnalysis = {
   memberPropsTypeCandidates: ts.Type[];
@@ -54,10 +58,6 @@ const EMPTY_COMPONENT_ANALYSIS: ComponentAnalysis = {
   classNonPropsTypeCandidates: [],
 };
 
-function hasIdentifierId(node: estree.Node): node is estree.Node & { id: estree.Identifier } {
-  return 'id' in node && node.id != null && isIdentifier(node.id);
-}
-
 function getClassComponentTsNode(
   componentNode: ClassComponentNode,
   services: RequiredParserServices,
@@ -65,77 +65,6 @@ function getClassComponentTsNode(
   return services.esTreeNodeToTSNodeMap.get(
     componentNode as TSESTree.Node,
   ) as ts.ClassLikeDeclaration;
-}
-
-function isVariableDeclaratorWithIdentifierId(
-  node: unknown,
-): node is estree.VariableDeclarator & { id: estree.Identifier } {
-  return (
-    !!node &&
-    typeof node === 'object' &&
-    'type' in node &&
-    node.type === 'VariableDeclarator' &&
-    'id' in node &&
-    !!node.id &&
-    typeof node.id === 'object' &&
-    'type' in node.id &&
-    node.id.type === 'Identifier'
-  );
-}
-
-function isVariableAssignedFunctionOrClassExpression(
-  componentNode: estree.Node,
-  parent: unknown,
-): parent is estree.VariableDeclarator & { id: estree.Identifier } {
-  return (
-    (componentNode.type === 'ClassExpression' || componentNode.type === 'FunctionExpression') &&
-    isVariableDeclaratorWithIdentifierId(parent)
-  );
-}
-
-function isReactComponentWrapperCallee(callee: estree.Expression | estree.Super): boolean {
-  return (
-    (callee.type === 'Identifier' && REACT_COMPONENT_WRAPPER_CALLEES.has(callee.name)) ||
-    (callee.type === 'MemberExpression' &&
-      isIdentifier(callee.object, 'React') &&
-      callee.property.type === 'Identifier' &&
-      REACT_COMPONENT_WRAPPER_CALLEES.has(callee.property.name))
-  );
-}
-
-function isWrappedInReactComponentCall(
-  node: estree.Node,
-  parent: estree.Node | undefined,
-): parent is estree.CallExpression {
-  return (
-    parent?.type === 'CallExpression' &&
-    parent.arguments.includes(node as unknown as estree.Expression) &&
-    isReactComponentWrapperCallee(parent.callee)
-  );
-}
-
-function getOutermostReactWrapperParent(componentNode: estree.Node): estree.Node | undefined {
-  let currentNode: estree.Node = componentNode;
-  let parent = getNodeParent(currentNode);
-
-  while (isWrappedInReactComponentCall(currentNode, parent)) {
-    currentNode = parent;
-    parent = getNodeParent(currentNode);
-  }
-
-  return parent;
-}
-
-function getOwningVariableDeclarator(
-  componentNode: estree.Node,
-): (estree.VariableDeclarator & { id: estree.Identifier }) | undefined {
-  const parent = getOutermostReactWrapperParent(componentNode);
-  return isVariableDeclaratorWithIdentifierId(parent) ? parent : undefined;
-}
-
-function isAnonymousDefaultExportComponent(componentNode: estree.Node): boolean {
-  const parent = getOutermostReactWrapperParent(componentNode);
-  return parent?.type === 'ExportDefaultDeclaration';
 }
 
 export function getComponentPropsType(
@@ -485,43 +414,4 @@ export function collectComponentNodes(
   keys: SourceCode.VisitorKeys,
 ): ComponentNode[] {
   return collectComponents(root, keys).map(component => component.componentNode);
-}
-
-export function getComponentVariable(
-  sourceCode: SourceCode,
-  componentNode: estree.Node,
-): Scope.Variable | undefined {
-  const componentIdentifier = getComponentIdentifier(componentNode);
-  if (!componentIdentifier) {
-    return undefined;
-  }
-
-  let scope: Scope.Scope | null = sourceCode.getScope(componentNode);
-  while (scope) {
-    const variable = scope.set.get(componentIdentifier.name);
-    if (variable) {
-      return variable;
-    }
-    scope = scope.upper;
-  }
-
-  return undefined;
-}
-
-export function getComponentIdentifier(componentNode: estree.Node): estree.Identifier | undefined {
-  const parent = getNodeParent(componentNode);
-  const owningVariableDeclarator = getOwningVariableDeclarator(componentNode);
-  if (parent?.type === 'CallExpression' && owningVariableDeclarator) {
-    return owningVariableDeclarator.id;
-  }
-
-  if (isVariableAssignedFunctionOrClassExpression(componentNode, parent)) {
-    return parent.id;
-  }
-
-  if (hasIdentifierId(componentNode)) {
-    return componentNode.id;
-  }
-
-  return isVariableDeclaratorWithIdentifierId(parent) ? parent.id : undefined;
 }

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -14,13 +14,16 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import type { TSESTree } from '@typescript-eslint/utils';
 import type { SourceCode } from 'eslint';
 import type estree from 'estree';
 import ts from 'typescript';
 import { childrenOf } from '../ancestor.js';
 import type { RequiredParserServices } from '../parser-services.js';
 import { areSameTypeDeclarations, getTypeFromTreeNode } from '../type.js';
+import {
+  createClassComponentAnalysis,
+  getClassComponentPropsTypeCandidates,
+} from './class-component-analysis.js';
 import {
   getComponentIdentifier,
   getOwningVariableDeclarator,
@@ -30,15 +33,14 @@ import {
   isClassComponentNode,
   isComponentNode,
   isFunctionComponentNode,
-  type ClassComponentNode,
   type ComponentNode,
   type FunctionComponentNode,
 } from './component-nodes.js';
-
+import { TSESTree } from '@typescript-eslint/utils';
 export { isComponentNode, type ComponentNode } from './component-nodes.js';
 export { getComponentIdentifier, getComponentVariable } from './component-identity.js';
+export { isBuiltinReactSuperclassName, isReactClassComponent } from './class-component-analysis.js';
 
-const REACT_LOCAL_CLASS_SUPERS = new Set(['Component', 'PureComponent']);
 const REACT_FUNCTION_COMPONENT_TYPES = new Set(['FC', 'FunctionComponent']);
 const REACT_FORWARD_REF_RENDER_FUNCTION_TYPES = new Set(['ForwardRefRenderFunction']);
 
@@ -57,15 +59,6 @@ const EMPTY_COMPONENT_ANALYSIS: ComponentAnalysis = {
   enclosingTypePropsTypeCandidates: [],
   classNonPropsTypeCandidates: [],
 };
-
-function getClassComponentTsNode(
-  componentNode: ClassComponentNode,
-  services: RequiredParserServices,
-): ts.ClassLikeDeclaration {
-  return services.esTreeNodeToTSNodeMap.get(
-    componentNode as TSESTree.Node,
-  ) as ts.ClassLikeDeclaration;
-}
 
 export function getComponentPropsType(
   componentNode: estree.Node,
@@ -115,18 +108,6 @@ function getFunctionComponentPropsTypeCandidates(
   }
 
   return propsTypes;
-}
-
-function getClassComponentPropsTypeCandidates(
-  componentNode: ClassComponentNode,
-  services: RequiredParserServices,
-): ts.Type[] {
-  const checker = services.program.getTypeChecker();
-  const classTsNode = getClassComponentTsNode(componentNode, services);
-  const propsType =
-    getDeclaredClassPropsType(classTsNode, checker) ??
-    getClassPropsPropertyType(classTsNode, checker);
-  return propsType ? [propsType] : [];
 }
 
 function isSpecificPropsType(type: ts.Type | undefined): type is ts.Type {
@@ -204,102 +185,6 @@ function getRightmostTypeName(typeName: TSESTree.EntityName): string | undefined
   return undefined;
 }
 
-function isReactClassSuperName(name: string): boolean {
-  return REACT_LOCAL_CLASS_SUPERS.has(name);
-}
-
-function isQualifiedReactClassSuper(
-  objectName: string | undefined,
-  propertyName: string,
-): boolean {
-  return objectName === undefined
-    ? isReactClassSuperName(propertyName)
-    : objectName === 'React' && isReactClassSuperName(propertyName);
-}
-
-function isBuiltinReactSuperclass(superClass: estree.Expression): boolean {
-  return (
-    (superClass.type === 'Identifier' && isQualifiedReactClassSuper(undefined, superClass.name)) ||
-    (superClass.type === 'MemberExpression' &&
-      isIdentifier(superClass.object, 'React') &&
-      superClass.property.type === 'Identifier' &&
-      isQualifiedReactClassSuper(superClass.object.name, superClass.property.name))
-  );
-}
-
-export function isReactClassComponent(
-  node: estree.Node,
-): node is estree.ClassDeclaration | estree.ClassExpression {
-  return (
-    isClassComponentNode(node) &&
-    node.superClass != null &&
-    isBuiltinReactSuperclass(node.superClass)
-  );
-}
-
-function isReactComponentHeritageSuperclass(superclass: ts.ExpressionWithTypeArguments): boolean {
-  const expression = superclass.expression;
-  if (ts.isIdentifier(expression)) {
-    return isQualifiedReactClassSuper(undefined, expression.text);
-  }
-  return (
-    ts.isPropertyAccessExpression(expression) &&
-    ts.isIdentifier(expression.expression) &&
-    isQualifiedReactClassSuper(expression.expression.text, expression.name.text)
-  );
-}
-
-export function isBuiltinReactSuperclassName(
-  objectName: string | undefined,
-  propertyName: string,
-): boolean {
-  return isQualifiedReactClassSuper(objectName, propertyName);
-}
-
-function getDeclaredClassPropsType(
-  classNode: ts.ClassLikeDeclaration,
-  checker: ts.TypeChecker,
-): ts.Type | undefined {
-  const propsTypeNode = getReactSuperclassTypeArguments(classNode)[0];
-  return propsTypeNode ? checker.getTypeAtLocation(propsTypeNode) : undefined;
-}
-
-function getReactSuperclassTypeArguments(
-  classNode: ts.ClassLikeDeclaration,
-): readonly ts.TypeNode[] {
-  const extendsClause = classNode.heritageClauses?.find(
-    clause => clause.token === ts.SyntaxKind.ExtendsKeyword,
-  );
-  const reactSuperclass = extendsClause?.types.find(type =>
-    isReactComponentHeritageSuperclass(type),
-  );
-  return reactSuperclass?.typeArguments ?? [];
-}
-
-function getDeclaredClassNonPropsTypes(
-  classNode: ts.ClassLikeDeclaration,
-  checker: ts.TypeChecker,
-): ts.Type[] {
-  return getReactSuperclassTypeArguments(classNode)
-    .slice(1)
-    .map(typeArgument => checker.getTypeAtLocation(typeArgument));
-}
-
-function getClassPropsPropertyType(
-  classNode: ts.ClassLikeDeclaration,
-  checker: ts.TypeChecker,
-): ts.Type | undefined {
-  if (!classNode.name) {
-    return undefined;
-  }
-
-  const classSymbol = checker.getSymbolAtLocation(classNode.name);
-  const propsSymbol = classSymbol
-    ? checker.getDeclaredTypeOfSymbol(classSymbol).getProperty('props')
-    : undefined;
-  return propsSymbol ? checker.getTypeOfSymbol(propsSymbol) : undefined;
-}
-
 /**
  * Returns whether a function component should participate in component analysis.
  * Named components must follow React's uppercase convention, while anonymous
@@ -312,19 +197,6 @@ function isEligibleFunctionComponent(
   return componentIdentifier === undefined
     ? isAnonymousDefaultExportComponent(componentNode)
     : /^[A-Z]/.test(componentIdentifier.name);
-}
-
-function hasRenderMethodOrProperty(componentNode: estree.Node): boolean {
-  if (!isClassComponentNode(componentNode)) {
-    return false;
-  }
-
-  return componentNode.body.body.some(
-    member =>
-      (member.type === 'MethodDefinition' || member.type === 'PropertyDefinition') &&
-      member.key.type === 'Identifier' &&
-      member.key.name === 'render',
-  );
 }
 
 function isCollectedComponent(
@@ -349,19 +221,7 @@ export function createComponentAnalysis(
   const { componentNode, componentIdentifier } = getCollectedComponent(component);
 
   if (isClassComponentNode(componentNode)) {
-    if (!hasRenderMethodOrProperty(componentNode)) {
-      return EMPTY_COMPONENT_ANALYSIS;
-    }
-
-    const checker = services.program.getTypeChecker();
-    const classTsNode = getClassComponentTsNode(componentNode, services);
-    const classPropsType = getClassPropsPropertyType(classTsNode, checker);
-    const memberPropsTypeCandidates = getComponentPropsTypeCandidates(componentNode, services);
-    return {
-      memberPropsTypeCandidates,
-      enclosingTypePropsTypeCandidates: classPropsType ? [classPropsType] : [],
-      classNonPropsTypeCandidates: getDeclaredClassNonPropsTypes(classTsNode, checker),
-    };
+    return createClassComponentAnalysis(componentNode, services) ?? EMPTY_COMPONENT_ANALYSIS;
   }
 
   if (

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -22,10 +22,9 @@ import {
   getClassComponentPropsTypeCandidates,
 } from './class-component-analysis.js';
 import type { CollectedComponent } from './component-collection.js';
-import { getComponentIdentifier } from './component-identity.js';
+import { resolveComponent } from './component-resolution.js';
 import {
   isClassComponentNode,
-  isComponentNode,
   isFunctionComponentNode,
   type ComponentNode,
 } from './component-nodes.js';
@@ -75,37 +74,18 @@ function getComponentPropsTypeCandidates(
   return [];
 }
 
-function isCollectedComponent(
-  component: ComponentNode | CollectedComponent,
-): component is CollectedComponent {
-  return 'componentNode' in component;
-}
-
-function getCollectedComponent(component: ComponentNode | CollectedComponent): CollectedComponent {
-  return isCollectedComponent(component)
-    ? component
-    : {
-        componentNode: component,
-        componentIdentifier: getComponentIdentifier(component),
-      };
-}
-
 export function createComponentAnalysis(
   component: ComponentNode | CollectedComponent,
   services: RequiredParserServices,
 ): ComponentAnalysis {
-  const { componentNode, componentIdentifier } = getCollectedComponent(component);
-
-  if (isClassComponentNode(componentNode)) {
-    return createClassComponentAnalysis(componentNode, services) ?? EMPTY_COMPONENT_ANALYSIS;
+  const resolvedComponent = resolveComponent(component);
+  if (!resolvedComponent) {
+    return EMPTY_COMPONENT_ANALYSIS;
   }
 
-  if (isFunctionComponentNode(componentNode)) {
-    return (
-      createFunctionComponentAnalysis(componentNode, componentIdentifier, services) ??
-      EMPTY_COMPONENT_ANALYSIS
-    );
+  if (resolvedComponent.kind === 'class') {
+    return createClassComponentAnalysis(resolvedComponent, services);
   }
 
-  return EMPTY_COMPONENT_ANALYSIS;
+  return createFunctionComponentAnalysis(resolvedComponent, services);
 }

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -22,14 +22,17 @@ import { childrenOf, getNodeParent } from '../ancestor.js';
 import { isIdentifier } from '../ast.js';
 import type { RequiredParserServices } from '../parser-services.js';
 import { areSameTypeDeclarations, getTypeFromTreeNode } from '../type.js';
+import {
+  isClassComponentNode,
+  isComponentNode,
+  isFunctionComponentNode,
+  type ClassComponentNode,
+  type ComponentNode,
+  type FunctionComponentNode,
+} from './component-nodes.js';
 
-const COMPONENT_NODE_TYPES = new Set([
-  'ClassDeclaration',
-  'ClassExpression',
-  'FunctionDeclaration',
-  'FunctionExpression',
-  'ArrowFunctionExpression',
-]);
+export { isComponentNode, type ComponentNode } from './component-nodes.js';
+
 const REACT_LOCAL_CLASS_SUPERS = new Set(['Component', 'PureComponent']);
 const REACT_FUNCTION_COMPONENT_TYPES = new Set(['FC', 'FunctionComponent']);
 const REACT_FORWARD_REF_RENDER_FUNCTION_TYPES = new Set(['ForwardRefRenderFunction']);
@@ -40,16 +43,6 @@ export type ComponentAnalysis = {
   enclosingTypePropsTypeCandidates: ts.Type[];
   classNonPropsTypeCandidates: ts.Type[];
 };
-export type ComponentNode =
-  | estree.ClassDeclaration
-  | estree.ClassExpression
-  | estree.FunctionDeclaration
-  | estree.FunctionExpression
-  | estree.ArrowFunctionExpression;
-type FunctionComponentNode =
-  | estree.FunctionDeclaration
-  | estree.FunctionExpression
-  | estree.ArrowFunctionExpression;
 export type CollectedComponent = {
   componentNode: ComponentNode;
   componentIdentifier: estree.Identifier | undefined;
@@ -61,26 +54,12 @@ const EMPTY_COMPONENT_ANALYSIS: ComponentAnalysis = {
   classNonPropsTypeCandidates: [],
 };
 
-function isClassComponentNode(
-  node: estree.Node,
-): node is estree.ClassDeclaration | estree.ClassExpression {
-  return node.type === 'ClassDeclaration' || node.type === 'ClassExpression';
-}
-
-function isFunctionComponentNode(node: estree.Node): node is FunctionComponentNode {
-  return (
-    node.type === 'FunctionDeclaration' ||
-    node.type === 'FunctionExpression' ||
-    node.type === 'ArrowFunctionExpression'
-  );
-}
-
 function hasIdentifierId(node: estree.Node): node is estree.Node & { id: estree.Identifier } {
   return 'id' in node && node.id != null && isIdentifier(node.id);
 }
 
 function getClassComponentTsNode(
-  componentNode: estree.ClassDeclaration | estree.ClassExpression,
+  componentNode: ClassComponentNode,
   services: RequiredParserServices,
 ): ts.ClassLikeDeclaration {
   return services.esTreeNodeToTSNodeMap.get(
@@ -210,7 +189,7 @@ function getFunctionComponentPropsTypeCandidates(
 }
 
 function getClassComponentPropsTypeCandidates(
-  componentNode: estree.ClassDeclaration | estree.ClassExpression,
+  componentNode: ClassComponentNode,
   services: RequiredParserServices,
 ): ts.Type[] {
   const checker = services.program.getTypeChecker();
@@ -417,10 +396,6 @@ function hasRenderMethodOrProperty(componentNode: estree.Node): boolean {
       member.key.type === 'Identifier' &&
       member.key.name === 'render',
   );
-}
-
-export function isComponentNode(node: estree.Node): node is ComponentNode {
-  return COMPONENT_NODE_TYPES.has(node.type);
 }
 
 function isCollectedComponent(

--- a/packages/analysis/src/jsts/rules/helpers/react/component-collection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-collection.ts
@@ -1,0 +1,63 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { SourceCode } from 'eslint';
+import type estree from 'estree';
+import { childrenOf } from '../ancestor.js';
+import { getComponentIdentifier } from './component-identity.js';
+import { isComponentNode, type ComponentNode } from './component-nodes.js';
+
+export type CollectedComponent = {
+  componentNode: ComponentNode;
+  componentIdentifier: estree.Identifier | undefined;
+};
+
+function collectComponent(componentNode: ComponentNode): CollectedComponent {
+  return {
+    componentNode,
+    componentIdentifier: getComponentIdentifier(componentNode),
+  };
+}
+
+export function collectComponents(
+  root: estree.Node,
+  keys: SourceCode.VisitorKeys,
+): CollectedComponent[] {
+  const result: CollectedComponent[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (node === undefined) {
+      continue;
+    }
+    if (isComponentNode(node)) {
+      result.push(collectComponent(node));
+      continue;
+    }
+    const children = childrenOf(node, keys);
+    for (let i = children.length - 1; i >= 0; i--) {
+      stack.push(children[i]);
+    }
+  }
+  return result;
+}
+
+export function collectComponentNodes(
+  root: estree.Node,
+  keys: SourceCode.VisitorKeys,
+): ComponentNode[] {
+  return collectComponents(root, keys).map(component => component.componentNode);
+}

--- a/packages/analysis/src/jsts/rules/helpers/react/component-identity.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-identity.ts
@@ -1,0 +1,136 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { Scope, SourceCode } from 'eslint';
+import type estree from 'estree';
+import { getNodeParent } from '../ancestor.js';
+import { isIdentifier } from '../ast.js';
+
+const REACT_COMPONENT_WRAPPER_CALLEES = new Set(['memo', 'forwardRef']);
+
+function hasIdentifierId(node: estree.Node): node is estree.Node & { id: estree.Identifier } {
+  return 'id' in node && node.id != null && isIdentifier(node.id);
+}
+
+function isVariableDeclaratorWithIdentifierId(
+  node: unknown,
+): node is estree.VariableDeclarator & { id: estree.Identifier } {
+  return (
+    !!node &&
+    typeof node === 'object' &&
+    'type' in node &&
+    node.type === 'VariableDeclarator' &&
+    'id' in node &&
+    !!node.id &&
+    typeof node.id === 'object' &&
+    'type' in node.id &&
+    node.id.type === 'Identifier'
+  );
+}
+
+function isVariableAssignedFunctionOrClassExpression(
+  componentNode: estree.Node,
+  parent: unknown,
+): parent is estree.VariableDeclarator & { id: estree.Identifier } {
+  return (
+    (componentNode.type === 'ClassExpression' || componentNode.type === 'FunctionExpression') &&
+    isVariableDeclaratorWithIdentifierId(parent)
+  );
+}
+
+function isReactComponentWrapperCallee(callee: estree.Expression | estree.Super): boolean {
+  return (
+    (callee.type === 'Identifier' && REACT_COMPONENT_WRAPPER_CALLEES.has(callee.name)) ||
+    (callee.type === 'MemberExpression' &&
+      isIdentifier(callee.object, 'React') &&
+      callee.property.type === 'Identifier' &&
+      REACT_COMPONENT_WRAPPER_CALLEES.has(callee.property.name))
+  );
+}
+
+function isWrappedInReactComponentCall(
+  node: estree.Node,
+  parent: estree.Node | undefined,
+): parent is estree.CallExpression {
+  return (
+    parent?.type === 'CallExpression' &&
+    parent.arguments.includes(node as unknown as estree.Expression) &&
+    isReactComponentWrapperCallee(parent.callee)
+  );
+}
+
+function getOutermostReactWrapperParent(componentNode: estree.Node): estree.Node | undefined {
+  let currentNode: estree.Node = componentNode;
+  let parent = getNodeParent(currentNode);
+
+  while (isWrappedInReactComponentCall(currentNode, parent)) {
+    currentNode = parent;
+    parent = getNodeParent(currentNode);
+  }
+
+  return parent;
+}
+
+export function getOwningVariableDeclarator(
+  componentNode: estree.Node,
+): (estree.VariableDeclarator & { id: estree.Identifier }) | undefined {
+  const parent = getOutermostReactWrapperParent(componentNode);
+  return isVariableDeclaratorWithIdentifierId(parent) ? parent : undefined;
+}
+
+export function isAnonymousDefaultExportComponent(componentNode: estree.Node): boolean {
+  const parent = getOutermostReactWrapperParent(componentNode);
+  return parent?.type === 'ExportDefaultDeclaration';
+}
+
+export function getComponentVariable(
+  sourceCode: SourceCode,
+  componentNode: estree.Node,
+): Scope.Variable | undefined {
+  const componentIdentifier = getComponentIdentifier(componentNode);
+  if (!componentIdentifier) {
+    return undefined;
+  }
+
+  let scope: Scope.Scope | null = sourceCode.getScope(componentNode);
+  while (scope) {
+    const variable = scope.set.get(componentIdentifier.name);
+    if (variable) {
+      return variable;
+    }
+    scope = scope.upper;
+  }
+
+  return undefined;
+}
+
+export function getComponentIdentifier(componentNode: estree.Node): estree.Identifier | undefined {
+  const parent = getNodeParent(componentNode);
+  const owningVariableDeclarator = getOwningVariableDeclarator(componentNode);
+  if (parent?.type === 'CallExpression' && owningVariableDeclarator) {
+    return owningVariableDeclarator.id;
+  }
+
+  if (isVariableAssignedFunctionOrClassExpression(componentNode, parent)) {
+    return parent.id;
+  }
+
+  if (hasIdentifierId(componentNode)) {
+    return componentNode.id;
+  }
+
+  return isVariableDeclaratorWithIdentifierId(parent) ? parent.id : undefined;
+}

--- a/packages/analysis/src/jsts/rules/helpers/react/component-nodes.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-nodes.ts
@@ -1,0 +1,55 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type estree from 'estree';
+
+const COMPONENT_NODE_TYPES = new Set([
+  'ClassDeclaration',
+  'ClassExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+]);
+
+export type ComponentNode =
+  | estree.ClassDeclaration
+  | estree.ClassExpression
+  | estree.FunctionDeclaration
+  | estree.FunctionExpression
+  | estree.ArrowFunctionExpression;
+
+export type ClassComponentNode = estree.ClassDeclaration | estree.ClassExpression;
+
+export type FunctionComponentNode =
+  | estree.FunctionDeclaration
+  | estree.FunctionExpression
+  | estree.ArrowFunctionExpression;
+
+export function isComponentNode(node: estree.Node): node is ComponentNode {
+  return COMPONENT_NODE_TYPES.has(node.type);
+}
+
+export function isClassComponentNode(node: estree.Node): node is ClassComponentNode {
+  return node.type === 'ClassDeclaration' || node.type === 'ClassExpression';
+}
+
+export function isFunctionComponentNode(node: estree.Node): node is FunctionComponentNode {
+  return (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'
+  );
+}

--- a/packages/analysis/src/jsts/rules/helpers/react/component-resolution.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-resolution.ts
@@ -1,0 +1,102 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type estree from 'estree';
+import type { CollectedComponent } from './component-collection.js';
+import { getComponentIdentifier, isAnonymousDefaultExportComponent } from './component-identity.js';
+import {
+  isClassComponentNode,
+  isFunctionComponentNode,
+  type ClassComponentNode,
+  type ComponentNode,
+  type FunctionComponentNode,
+} from './component-nodes.js';
+
+export type ClassComponentDescriptor = {
+  kind: 'class';
+  node: ClassComponentNode;
+};
+
+export type FunctionComponentDescriptor = {
+  kind: 'function';
+  node: FunctionComponentNode;
+};
+
+export type ComponentDescriptor = ClassComponentDescriptor | FunctionComponentDescriptor;
+
+function isCollectedComponent(
+  component: ComponentNode | CollectedComponent,
+): component is CollectedComponent {
+  return 'componentNode' in component;
+}
+
+function getCollectedComponent(component: ComponentNode | CollectedComponent): CollectedComponent {
+  return isCollectedComponent(component)
+    ? component
+    : {
+        componentNode: component,
+        componentIdentifier: getComponentIdentifier(component),
+      };
+}
+
+export function resolveComponent(
+  component: ComponentNode | CollectedComponent,
+): ComponentDescriptor | undefined {
+  const { componentNode, componentIdentifier } = getCollectedComponent(component);
+
+  if (isClassComponentNode(componentNode)) {
+    return hasRenderMethodOrProperty(componentNode)
+      ? {
+          kind: 'class',
+          node: componentNode,
+        }
+      : undefined;
+  }
+
+  if (isFunctionComponentNode(componentNode)) {
+    return isEligibleFunctionComponent(componentNode, componentIdentifier)
+      ? {
+          kind: 'function',
+          node: componentNode,
+        }
+      : undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns whether a function component should participate in component analysis.
+ * Named components must follow React's uppercase convention, while anonymous
+ * function components stay eligible only when they are exported as default.
+ */
+function isEligibleFunctionComponent(
+  componentNode: FunctionComponentNode,
+  componentIdentifier: estree.Identifier | undefined,
+): boolean {
+  return componentIdentifier === undefined
+    ? isAnonymousDefaultExportComponent(componentNode)
+    : /^[A-Z]/.test(componentIdentifier.name);
+}
+
+function hasRenderMethodOrProperty(componentNode: ClassComponentNode): boolean {
+  return componentNode.body.body.some(
+    member =>
+      (member.type === 'MethodDefinition' || member.type === 'PropertyDefinition') &&
+      member.key.type === 'Identifier' &&
+      member.key.name === 'render',
+  );
+}

--- a/packages/analysis/src/jsts/rules/helpers/react/function-component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/function-component-analysis.ts
@@ -19,26 +19,19 @@ import type estree from 'estree';
 import ts from 'typescript';
 import type { RequiredParserServices } from '../parser-services.js';
 import { areSameTypeDeclarations, getTypeFromTreeNode } from '../type.js';
-import {
-  getOwningVariableDeclarator,
-  isAnonymousDefaultExportComponent,
-} from './component-identity.js';
+import { getOwningVariableDeclarator } from './component-identity.js';
 import type { ComponentAnalysis } from './component-analysis.js';
 import type { FunctionComponentNode } from './component-nodes.js';
+import type { FunctionComponentDescriptor } from './component-resolution.js';
 
 const REACT_FUNCTION_COMPONENT_TYPES = new Set(['FC', 'FunctionComponent']);
 const REACT_FORWARD_REF_RENDER_FUNCTION_TYPES = new Set(['ForwardRefRenderFunction']);
 
 export function createFunctionComponentAnalysis(
-  componentNode: FunctionComponentNode,
-  componentIdentifier: estree.Identifier | undefined,
+  component: FunctionComponentDescriptor,
   services: RequiredParserServices,
-): ComponentAnalysis | undefined {
-  if (!isEligibleFunctionComponent(componentNode, componentIdentifier)) {
-    return undefined;
-  }
-
-  const propsTypeCandidates = getFunctionComponentPropsTypeCandidates(componentNode, services);
+): ComponentAnalysis {
+  const propsTypeCandidates = getFunctionComponentPropsTypeCandidates(component.node, services);
   return {
     memberPropsTypeCandidates: propsTypeCandidates,
     enclosingTypePropsTypeCandidates: propsTypeCandidates,
@@ -72,20 +65,6 @@ export function getFunctionComponentPropsTypeCandidates(
   }
 
   return propsTypes;
-}
-
-/**
- * Returns whether a function component should participate in component analysis.
- * Named components must follow React's uppercase convention, while anonymous
- * function components stay eligible only when they are exported as default.
- */
-function isEligibleFunctionComponent(
-  componentNode: FunctionComponentNode,
-  componentIdentifier: estree.Identifier | undefined,
-): boolean {
-  return componentIdentifier === undefined
-    ? isAnonymousDefaultExportComponent(componentNode)
-    : /^[A-Z]/.test(componentIdentifier.name);
 }
 
 function isSpecificPropsType(type: ts.Type | undefined): type is ts.Type {

--- a/packages/analysis/src/jsts/rules/helpers/react/function-component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/function-component-analysis.ts
@@ -1,0 +1,164 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { TSESTree } from '@typescript-eslint/utils';
+import type estree from 'estree';
+import ts from 'typescript';
+import type { RequiredParserServices } from '../parser-services.js';
+import { areSameTypeDeclarations, getTypeFromTreeNode } from '../type.js';
+import {
+  getOwningVariableDeclarator,
+  isAnonymousDefaultExportComponent,
+} from './component-identity.js';
+import type { ComponentAnalysis } from './component-analysis.js';
+import type { FunctionComponentNode } from './component-nodes.js';
+
+const REACT_FUNCTION_COMPONENT_TYPES = new Set(['FC', 'FunctionComponent']);
+const REACT_FORWARD_REF_RENDER_FUNCTION_TYPES = new Set(['ForwardRefRenderFunction']);
+
+export function createFunctionComponentAnalysis(
+  componentNode: FunctionComponentNode,
+  componentIdentifier: estree.Identifier | undefined,
+  services: RequiredParserServices,
+): ComponentAnalysis | undefined {
+  if (!isEligibleFunctionComponent(componentNode, componentIdentifier)) {
+    return undefined;
+  }
+
+  const propsTypeCandidates = getFunctionComponentPropsTypeCandidates(componentNode, services);
+  return {
+    memberPropsTypeCandidates: propsTypeCandidates,
+    enclosingTypePropsTypeCandidates: propsTypeCandidates,
+    classNonPropsTypeCandidates: [],
+  };
+}
+
+export function getFunctionComponentPropsTypeCandidates(
+  componentNode: FunctionComponentNode,
+  services: RequiredParserServices,
+): ts.Type[] {
+  const checker = services.program.getTypeChecker();
+  const propsTypes: ts.Type[] = [];
+  const primaryPropsType = getFunctionComponentParamPropsType(componentNode, services);
+  if (primaryPropsType) {
+    propsTypes.push(primaryPropsType);
+  }
+
+  const declaredVariablePropsType = getComponentPropsTypeFromVariableDeclaration(
+    componentNode,
+    services,
+  );
+  if (
+    declaredVariablePropsType &&
+    !(
+      primaryPropsType &&
+      areSameTypeDeclarations(checker, primaryPropsType, declaredVariablePropsType)
+    )
+  ) {
+    propsTypes.push(declaredVariablePropsType);
+  }
+
+  return propsTypes;
+}
+
+/**
+ * Returns whether a function component should participate in component analysis.
+ * Named components must follow React's uppercase convention, while anonymous
+ * function components stay eligible only when they are exported as default.
+ */
+function isEligibleFunctionComponent(
+  componentNode: FunctionComponentNode,
+  componentIdentifier: estree.Identifier | undefined,
+): boolean {
+  return componentIdentifier === undefined
+    ? isAnonymousDefaultExportComponent(componentNode)
+    : /^[A-Z]/.test(componentIdentifier.name);
+}
+
+function isSpecificPropsType(type: ts.Type | undefined): type is ts.Type {
+  return !!type && (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) === 0;
+}
+
+function getFunctionComponentParamPropsType(
+  componentNode: FunctionComponentNode,
+  services: RequiredParserServices,
+): ts.Type | undefined {
+  const firstParam = componentNode.params[0];
+  const propsType = firstParam ? getTypeFromTreeNode(firstParam, services) : undefined;
+  return isSpecificPropsType(propsType) ? propsType : undefined;
+}
+
+function getComponentPropsTypeFromVariableDeclaration(
+  componentNode: estree.Node,
+  services: RequiredParserServices,
+): ts.Type | undefined {
+  const variableDeclarator = getOwningVariableDeclarator(componentNode);
+  if (!variableDeclarator) {
+    return undefined;
+  }
+
+  const declaredType = (variableDeclarator.id as TSESTree.Identifier).typeAnnotation
+    ?.typeAnnotation;
+  if (!declaredType) {
+    return undefined;
+  }
+
+  const propsTypeNode = findDeclaredFunctionComponentPropsType(declaredType);
+  return propsTypeNode
+    ? getTypeFromTreeNode(propsTypeNode as unknown as estree.Node, services)
+    : undefined;
+}
+
+function findDeclaredFunctionComponentPropsType(
+  typeNode: TSESTree.TypeNode,
+): TSESTree.TypeNode | undefined {
+  if (typeNode.type === 'TSIntersectionType') {
+    for (const type of typeNode.types) {
+      const propsType = findDeclaredFunctionComponentPropsType(type);
+      if (propsType) {
+        return propsType;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeNode.type !== 'TSTypeReference') {
+    return undefined;
+  }
+
+  const typeName = getRightmostTypeName(typeNode.typeName);
+  const typeArguments = typeNode.typeArguments?.params ?? [];
+
+  if (typeName && REACT_FUNCTION_COMPONENT_TYPES.has(typeName)) {
+    return typeArguments[0];
+  }
+
+  if (typeName && REACT_FORWARD_REF_RENDER_FUNCTION_TYPES.has(typeName)) {
+    return typeArguments[1];
+  }
+
+  return undefined;
+}
+
+function getRightmostTypeName(typeName: TSESTree.EntityName): string | undefined {
+  if (typeName.type === 'Identifier') {
+    return typeName.name;
+  }
+  if (typeName.type === 'TSQualifiedName') {
+    return typeName.right.name;
+  }
+  return undefined;
+}


### PR DESCRIPTION
Refactor to rearrange the logic in component analysis file.

----
## Summary by Gitar

- **Refactoring:**
  - Rearranged component analysis logic by moving components into dedicated files.
- **Code Cleanup:**
  - Restricted internal module exports by changing several types from `export` to module-private in `component-resolution.ts`, `member-ownership.ts`, and `type-ownership.ts`.
- **Bug Fixes:**
  - Resolved `knip` issues and added a missing `estree` import in `class-component-analysis.ts`.


<sub>This will update automatically on new commits.</sub>