### PR TITLE
JS-1788 Fix S2094 crash on declaration-only constructors

### DIFF
--- a/packages/analysis/src/jsts/rules/S2094/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S2094/decorator.ts
@@ -80,6 +80,9 @@ function hasThisPropertyAssignmentInConstructor(
   }
 
   const constructorBody = ctor.value.body;
+  if (constructorBody == null) {
+    return false;
+  }
   return walkForThisAssignment(constructorBody, visitorKeys);
 }
 

--- a/packages/analysis/src/jsts/rules/S2094/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2094/unit.test.ts
@@ -169,6 +169,14 @@ describe('S2094', () => {
           errors: 1,
         },
         {
+          code: `declare class Stats {
+  private constructor();
+}`,
+          filename: 'file.ts',
+          options,
+          errors: 1,
+        },
+        {
           // Noncompliant: side effects only
           code: `class SideEffects {
   constructor() {


### PR DESCRIPTION
Part of [JS-1788](https://sonarsource.atlassian.net/browse/JS-1788)

Follow-up to [#6991](https://github.com/SonarSource/SonarJS/pull/6991) and its original ticket [JS-1663](https://sonarsource.atlassian.net/browse/JS-1663).

## Summary
- avoid walking constructor bodies when a declaration-only class has no constructor body
- add a regression test for a declaration-only class with a private constructor signature
- preserve the existing S2094 behavior by reporting the class instead of crashing

## Testing
- npx tsx --test packages/analysis/src/jsts/rules/S2094/unit.test.ts

[JS-1788]: https://sonarsource.atlassian.net/browse/JS-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JS-1663]: https://sonarsource.atlassian.net/browse/JS-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ