### PR TITLE
JS-1791 Handle deep AST protobuf serialization

### DIFF
--- a/packages/analysis/src/jsts/parsers/ast.ts
+++ b/packages/analysis/src/jsts/parsers/ast.ts
@@ -15,6 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import base64 from '@protobufjs/base64';
+import protobuf from 'protobufjs/minimal.js';
 import type { TSESTree } from '@typescript-eslint/utils';
 
 import { debug } from '../../../../shared/src/helpers/logging.js';
@@ -25,6 +26,7 @@ const NODE_TYPE = estree.Node;
 const NodeType = estree.NodeType;
 export { NodeType };
 const unsupportedNodeTypes = new Map<string, number>();
+const AST_PROTOBUF_RECURSION_LIMIT = 1000;
 
 export function serializeInProtobuf(
   ast: TSESTree.Program,
@@ -40,8 +42,10 @@ export function serializeInProtobuf(
           .join(', '),
     );
   }
-  const binaryArray = NODE_TYPE.encode(NODE_TYPE.create(protobufAST)).finish();
-  return base64.encode(binaryArray, 0, binaryArray.length);
+  return withRaisedProtobufRecursionLimit(() => {
+    const binaryArray = NODE_TYPE.encode(NODE_TYPE.create(protobufAST)).finish();
+    return base64.encode(binaryArray, 0, binaryArray.length);
+  });
 }
 
 /**
@@ -59,7 +63,26 @@ export function deserializeProtobuf(serialized: string): estree.Node {
   const computedLength = base64.length(serialized);
   const buffer = new Uint8Array(computedLength);
   base64.decode(serialized, buffer, 0);
-  return NODE_TYPE.decode(buffer);
+  return withRaisedProtobufRecursionLimit(() => NODE_TYPE.decode(buffer));
+}
+
+function withRaisedProtobufRecursionLimit<T>(callback: () => T): T {
+  const previousUtilLimit = protobuf.util.recursionLimit;
+  const previousReaderLimit = protobuf.Reader.recursionLimit;
+  const targetLimit = Math.max(
+    previousUtilLimit,
+    previousReaderLimit,
+    AST_PROTOBUF_RECURSION_LIMIT,
+  );
+
+  protobuf.util.recursionLimit = targetLimit;
+  protobuf.Reader.recursionLimit = targetLimit;
+  try {
+    return callback();
+  } finally {
+    protobuf.util.recursionLimit = previousUtilLimit;
+    protobuf.Reader.recursionLimit = previousReaderLimit;
+  }
 }
 
 // Exported for testing purpose

--- a/packages/analysis/src/jsts/parsers/ast.ts
+++ b/packages/analysis/src/jsts/parsers/ast.ts
@@ -26,7 +26,7 @@ const NODE_TYPE = estree.Node;
 const NodeType = estree.NodeType;
 export { NodeType };
 const unsupportedNodeTypes = new Map<string, number>();
-const AST_PROTOBUF_RECURSION_LIMIT = 1000;
+const AST_PROTOBUF_RECURSION_LIMIT = 300;
 
 export function serializeInProtobuf(
   ast: TSESTree.Program,

--- a/packages/analysis/tests/analyzeProject-sonarqube.test.ts
+++ b/packages/analysis/tests/analyzeProject-sonarqube.test.ts
@@ -16,6 +16,7 @@
  */
 import { describe, it, beforeEach, type Mock, mock } from 'node:test';
 import { expect } from 'expect';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path/posix';
 import { normalizePath, normalizeToAbsolutePath } from '../../shared/src/helpers/files.js';
 import { analyzeProject, cancelAnalysis } from '../src/analyzeProject.js';
@@ -39,6 +40,7 @@ async function initForTest(configOptions: object, rawFiles: object) {
 }
 
 const fixtures = normalizePath(join(import.meta.dirname, 'fixtures-sonarqube'));
+const sonarArmorCommanderFixture = join(fixtures, 'sonar-armor-commander', 'commander.js');
 
 const rules: RuleConfig[] = [
   {
@@ -864,6 +866,45 @@ describe('SonarQube project analysis', () => {
         line: 3,
       });
     }
+  });
+
+  it('should serialize AST for sonar-armor commander.js', async ({ mock }) => {
+    mock.method(console, 'log');
+    const consoleLogMock = (console.log as Mock<typeof console.log>).mock;
+
+    const baseDir = normalizePath(
+      'C:/GIT/sonar-armor/its/src/test/resources/projects/internal/sonarsec-jsInternalConfig',
+    );
+    const filePath = join(baseDir, 'commander.js');
+    const normalizedFilePath = normalizeToAbsolutePath(filePath);
+    const fileContent = readFileSync(sonarArmorCommanderFixture, 'utf8');
+
+    const configuration = await initForTest(
+      { baseDir, canAccessFileSystem: false, skipAst: false },
+      {
+        [filePath]: {
+          filePath,
+          fileType: 'MAIN',
+          fileContent,
+        },
+      },
+    );
+
+    const result = await analyzeProject({ rules: [], bundles: [] }, configuration);
+
+    const fileResult = result.files[normalizedFilePath];
+    expect(fileResult).toBeDefined();
+    expect(fileResult && 'parsingErrors' in fileResult).toBe(false);
+    expect(fileResult && 'ast' in fileResult).toBe(true);
+    if (!fileResult || !('ast' in fileResult) || !fileResult.ast) {
+      throw new Error('Expected serialized AST for commander.js');
+    }
+    expect(fileResult.ast.length).toBeGreaterThan(0);
+    expect(
+      consoleLogMock.calls.some(
+        call => call.arguments[0] === `Failed to serialize AST for file "${normalizedFilePath}"`,
+      ),
+    ).toBe(false);
   });
 
   it('should analyze JSX cache collision fixture with mixed jsx compiler options', async () => {

--- a/packages/analysis/tests/analyzeProject-sonarqube.test.ts
+++ b/packages/analysis/tests/analyzeProject-sonarqube.test.ts
@@ -16,7 +16,6 @@
  */
 import { describe, it, beforeEach, type Mock, mock } from 'node:test';
 import { expect } from 'expect';
-import { readFileSync } from 'node:fs';
 import { join } from 'node:path/posix';
 import { normalizePath, normalizeToAbsolutePath } from '../../shared/src/helpers/files.js';
 import { analyzeProject, cancelAnalysis } from '../src/analyzeProject.js';
@@ -40,8 +39,6 @@ async function initForTest(configOptions: object, rawFiles: object) {
 }
 
 const fixtures = normalizePath(join(import.meta.dirname, 'fixtures-sonarqube'));
-const sonarArmorCommanderFixture = join(fixtures, 'sonar-armor-commander', 'commander.js');
-
 const rules: RuleConfig[] = [
   {
     key: 'S1116',
@@ -866,45 +863,6 @@ describe('SonarQube project analysis', () => {
         line: 3,
       });
     }
-  });
-
-  it('should serialize AST for sonar-armor commander.js', async ({ mock }) => {
-    mock.method(console, 'log');
-    const consoleLogMock = (console.log as Mock<typeof console.log>).mock;
-
-    const baseDir = normalizePath(
-      'C:/GIT/sonar-armor/its/src/test/resources/projects/internal/sonarsec-jsInternalConfig',
-    );
-    const filePath = join(baseDir, 'commander.js');
-    const normalizedFilePath = normalizeToAbsolutePath(filePath);
-    const fileContent = readFileSync(sonarArmorCommanderFixture, 'utf8');
-
-    const configuration = await initForTest(
-      { baseDir, canAccessFileSystem: false, skipAst: false },
-      {
-        [filePath]: {
-          filePath,
-          fileType: 'MAIN',
-          fileContent,
-        },
-      },
-    );
-
-    const result = await analyzeProject({ rules: [], bundles: [] }, configuration);
-
-    const fileResult = result.files[normalizedFilePath];
-    expect(fileResult).toBeDefined();
-    expect(fileResult && 'parsingErrors' in fileResult).toBe(false);
-    expect(fileResult && 'ast' in fileResult).toBe(true);
-    if (!fileResult || !('ast' in fileResult) || !fileResult.ast) {
-      throw new Error('Expected serialized AST for commander.js');
-    }
-    expect(fileResult.ast.length).toBeGreaterThan(0);
-    expect(
-      consoleLogMock.calls.some(
-        call => call.arguments[0] === `Failed to serialize AST for file "${normalizedFilePath}"`,
-      ),
-    ).toBe(false);
   });
 
   it('should analyze JSX cache collision fixture with mixed jsx compiler options', async () => {

--- a/packages/analysis/tests/fixtures-sonarqube/sonar-armor-commander/commander.js
+++ b/packages/analysis/tests/fixtures-sonarqube/sonar-armor-commander/commander.js
@@ -1,0 +1,56 @@
+const source = require('__sonar__').STRING_FROM_HTTP_REQUEST;
+const sink = require('__sonar__').APPEND_ARGUMENT_TO_OS_COMMAND_STR;
+
+require('commander').action(() => {
+  sink(source()); // Noncompliant (S5883) - TP
+});
+
+const { program } = require('commander');
+program.action(() => {
+  sink(source()); // Noncompliant (S5883) - TP
+});
+
+const { Command } = require('commander');
+new Command().action(() => {
+  sink(source()); // Noncompliant (S5883) - TP
+});
+
+// test if all known methods return the receiver to verify if method chaining works
+new Command()
+  .command()
+  .option()
+  .version()
+  .description()
+  .configureHelp()
+  .configureOutput()
+  .addCommand()
+  .addHelpCommand()
+  .arguments()
+  .exitOverride()
+  .addOption()
+  .requiredOption()
+  .combineFlagAndOptionalValue()
+  .allowUnknownOption()
+  .allowExcessArguments()
+  .enablePositionalOptions()
+  .passThroughOptions()
+  .storeOptionsAsProperties()
+  .parse()
+  .parseOptions()
+  .opts()
+  .missingArgument()
+  .optionMissingArgument()
+  .missingMandatoryOptionValue()
+  .unknownOption()
+  .unknownCommand()
+  .alias()
+  .aliases()
+  .usage()
+  .name()
+  .helpOption()
+  .help()
+  .addHelpText()
+  .createCommand()
+  .action(() => {
+    sink(source()); // Noncompliant (S5883) - TP
+  });

--- a/packages/analysis/tests/jsts/parsers/ast.test.ts
+++ b/packages/analysis/tests/jsts/parsers/ast.test.ts
@@ -104,14 +104,7 @@ describe('ast', () => {
 
     test('should serialize and deserialize deep commander call chains', async () => {
       const filePath = normalizeToAbsolutePath(
-        path.join(
-          import.meta.dirname,
-          '..',
-          '..',
-          'fixtures-sonarqube',
-          'sonar-armor-commander',
-          'commander.js',
-        ),
+        path.join(import.meta.dirname, 'fixtures', 'ast', 'commander.js'),
       );
       const sc = await parseSourceFile(filePath, parsersMap.typescript);
       const protoMessage = parseInProtobuf(sc.sourceCode.ast as TSESTree.Program);

--- a/packages/analysis/tests/jsts/parsers/ast.test.ts
+++ b/packages/analysis/tests/jsts/parsers/ast.test.ts
@@ -101,6 +101,24 @@ describe('ast', () => {
         const deserializedProtoMessage = deserializeProtobuf(serialized);
         compareASTs(protoMessage, deserializedProtoMessage);
       });
+
+    test('should serialize and deserialize deep commander call chains', async () => {
+      const filePath = normalizeToAbsolutePath(
+        path.join(
+          import.meta.dirname,
+          '..',
+          '..',
+          'fixtures-sonarqube',
+          'sonar-armor-commander',
+          'commander.js',
+        ),
+      );
+      const sc = await parseSourceFile(filePath, parsersMap.typescript);
+      const protoMessage = parseInProtobuf(sc.sourceCode.ast as TSESTree.Program);
+      const serialized = serializeInProtobuf(sc.sourceCode.ast as TSESTree.Program, filePath);
+      const deserializedProtoMessage = deserializeProtobuf(serialized);
+      compareASTs(protoMessage, deserializedProtoMessage);
+    });
   });
   test('should support TSAsExpression nodes', async () => {
     const code = `const foo = '5' as string;`;

--- a/packages/analysis/tests/jsts/parsers/fixtures/ast/commander.js
+++ b/packages/analysis/tests/jsts/parsers/fixtures/ast/commander.js
@@ -15,7 +15,7 @@ new Command().action(() => {
   sink(source()); // Noncompliant (S5883) - TP
 });
 
-// test if all known methods return the receiver to verify if method chaining works
+// Verify long commander method chains are serializable.
 new Command()
   .command()
   .option()


### PR DESCRIPTION
## Summary

- raise the protobuf recursion limit while encoding and decoding ESTree ASTs
- align the JS-side recursion limit with the Java bridge decoder limit at `300`
- add a parser-level regression using the reproduced `commander.js` chain from `sonar-armor`
- keep the `commander.js` sample under `packages/analysis/tests/jsts/parsers/fixtures/ast`

## Root cause

Regenerating `packages/analysis/src/jsts/parsers/estree.js` with `protobufjs-cli >= 2.4.1` adds `_depth` checks in generated `encode` and `decode` methods. `protobufjs` defaults both recursion limits to `100`, while the reproduced `commander.js` protobuf AST reaches depth `148`, so AST serialization started failing with `max depth exceeded`.

The JS serializer now raises its local recursion limit to `300`, matching `AstProtoUtils` on the Java bridge side. That keeps both protobuf runtimes aligned while still leaving headroom above the reproduced depth.

## Testing

- `npm run bbf`
- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/tests/jsts/parsers/ast.test.ts`
- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/tests/analyzeProject-sonarqube.test.ts`