### PR TITLE
JS-1597 add generated-source suppression API

### DIFF
--- a/packages/analysis/src/jsts/linter/filters/filter-generated-source.ts
+++ b/packages/analysis/src/jsts/linter/filters/filter-generated-source.ts
@@ -1,0 +1,21 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { RuleFilter } from './rule-filter.js';
+
+export const filterGeneratedSource: RuleFilter = (_config, meta, ctx) => {
+  return !ctx.detectGeneratedCode || !ctx.isGeneratedSource || meta?.skipOnGeneratedSource !== true;
+};

--- a/packages/analysis/src/jsts/linter/filters/index.ts
+++ b/packages/analysis/src/jsts/linter/filters/index.ts
@@ -24,6 +24,7 @@ import { filterReactVue } from './filter-react-vue.js';
 import { filterEcmaVersion } from './filter-ecma-version.js';
 import { filterModuleType } from './filter-module-type.js';
 import { filterDependency } from './filter-dependency.js';
+import { filterGeneratedSource } from './filter-generated-source.js';
 
 export type { RuleFilterContext } from './rule-filter.js';
 
@@ -38,6 +39,7 @@ export const DEPENDENCY_INDEPENDENT_RULE_FILTERS: readonly RuleFilter[] = [
   filterAnalysisMode,
   filterLanguage,
   filterBlacklistedExtensions,
+  filterGeneratedSource,
   filterEcmaVersion,
   filterModuleType,
 ];

--- a/packages/analysis/src/jsts/linter/filters/rule-filter.ts
+++ b/packages/analysis/src/jsts/linter/filters/rule-filter.ts
@@ -31,6 +31,8 @@ export interface RuleFilterContext {
   analysisMode: AnalysisMode;
   detectedEsYear: number | undefined;
   detectedModuleType: ModuleType | undefined;
+  detectGeneratedCode: boolean;
+  isGeneratedSource: boolean;
   dependencies: DependenciesList;
 }
 

--- a/packages/analysis/src/jsts/linter/linter.ts
+++ b/packages/analysis/src/jsts/linter/linter.ts
@@ -307,20 +307,6 @@ export class Linter {
     // (getReactVersion, getDependenciesSanitizePaths) called from rules during linting.
     // Cleared by clearFileCaches() once linting completes.
     setCurrentFileInlineDependencies(sourceCode ? extractInlineNpmDependencies(sourceCode) : null);
-    const linterConfigKey = createLinterConfigKey(
-      filePath,
-      Linter.baseDir,
-      fileType,
-      fileLanguage,
-      analysisMode,
-      detectedEsYear,
-      detectedModuleType,
-      Linter.detectGeneratedCode,
-      isGeneratedSource,
-    );
-    let baseRules = Linter.dependencyIndependentRulesCache.get(linterConfigKey);
-    let dependencySensitiveRules = Linter.dependencySensitiveRulesCache.get(linterConfigKey);
-
     const baseContext = {
       extensionName: extname(normalizePath(filePath)),
       fileType,
@@ -331,6 +317,9 @@ export class Linter {
       detectGeneratedCode: Linter.detectGeneratedCode,
       isGeneratedSource,
     };
+    const linterConfigKey = createLinterConfigKey(filePath, Linter.baseDir, baseContext);
+    let baseRules = Linter.dependencyIndependentRulesCache.get(linterConfigKey);
+    let dependencySensitiveRules = Linter.dependencySensitiveRulesCache.get(linterConfigKey);
 
     if (baseRules === undefined || dependencySensitiveRules === undefined) {
       /**
@@ -456,13 +445,16 @@ function extractInlineNpmDependencies(sourceCode: SourceCode): DependenciesList 
 function createLinterConfigKey(
   filePath: NormalizedAbsolutePath,
   baseDir: NormalizedAbsolutePath,
-  fileType: FileType,
-  language: JsTsLanguage,
-  analysisMode: AnalysisMode,
-  detectedEsYear?: number,
-  detectedModuleType?: ModuleType,
-  detectGeneratedCode?: boolean,
-  isGeneratedSource?: boolean,
+  context: Pick<
+    RuleFilterContext,
+    | 'fileType'
+    | 'fileLanguage'
+    | 'analysisMode'
+    | 'detectedEsYear'
+    | 'detectedModuleType'
+    | 'detectGeneratedCode'
+    | 'isGeneratedSource'
+  >,
 ): string {
   // depending on the path, some rules may be enabled or disabled based on the dependencies found
   const normalizedPath = normalizeToAbsolutePath(filePath);
@@ -470,6 +462,6 @@ function createLinterConfigKey(
     dirnamePath(normalizedPath),
     baseDir,
   );
-  const linterConfigKey = `${fileType}-${language}-${analysisMode}-${extname(normalizedPath)}-${dependencyManifestDirName}`;
-  return `${linterConfigKey}:${detectedEsYear ?? 'esnext'}:${detectedModuleType ?? 'unknown'}:${detectGeneratedCode === false ? 'generated-off' : 'generated-on'}:${isGeneratedSource === true ? 'generated' : 'regular'}`;
+  const linterConfigKey = `${context.fileType}-${context.fileLanguage}-${context.analysisMode}-${extname(normalizedPath)}-${dependencyManifestDirName}`;
+  return `${linterConfigKey}:${context.detectedEsYear ?? 'esnext'}:${context.detectedModuleType ?? 'unknown'}:${context.detectGeneratedCode === false ? 'generated-off' : 'generated-on'}:${context.isGeneratedSource === true ? 'generated' : 'regular'}`;
 }

--- a/packages/analysis/src/jsts/linter/linter.ts
+++ b/packages/analysis/src/jsts/linter/linter.ts
@@ -299,7 +299,9 @@ export class Linter {
       detectedModuleType = getModuleType(normalizedFilePath, Linter.baseDir);
       getOptionalProjectAnalysisTelemetryCollector()?.recordModuleType(detectedModuleType);
     }
-    const isGeneratedSource = Linter.isGeneratedSourceFile(normalizedFilePath);
+    const isGeneratedSource = Linter.detectGeneratedCode
+      ? Linter.isGeneratedSourceFile(normalizedFilePath)
+      : false;
     const manifestDependencies = getDependencies(dirnamePath(normalizedFilePath), Linter.baseDir);
     // Make inline npm: imports visible to both rule activation and to dependency helpers
     // (getReactVersion, getDependenciesSanitizePaths) called from rules during linting.

--- a/packages/analysis/src/jsts/linter/linter.ts
+++ b/packages/analysis/src/jsts/linter/linter.ts
@@ -63,6 +63,8 @@ interface InitializeParams {
   environments?: string[];
   globals?: string[];
   baseDir: NormalizedAbsolutePath;
+  detectGeneratedCode?: boolean;
+  isGeneratedSourceFile?: (filePath: NormalizedAbsolutePath) => boolean;
   bundles?: NormalizedAbsolutePath[];
   rulesWorkdir?: NormalizedAbsolutePath;
   /** Union of jsSuffixes and tsSuffixes; exposed to rules via context.settings.testFileExtensions */
@@ -115,6 +117,8 @@ export class Linter {
   /** The rules working directory (used for architecture, dbd...) */
   private static rulesWorkdir?: NormalizedAbsolutePath;
   private static baseDir: NormalizedAbsolutePath;
+  private static detectGeneratedCode = true;
+  private static isGeneratedSourceFile = (_filePath: NormalizedAbsolutePath) => false;
   /** Union of jsSuffixes and tsSuffixes, surfaced to rules through ESLint settings. */
   private static testFileExtensions: string[] = [];
 
@@ -145,6 +149,8 @@ export class Linter {
     globals = [],
     bundles = [],
     baseDir,
+    detectGeneratedCode = true,
+    isGeneratedSourceFile = _filePath => false,
     rulesWorkdir,
     testFileExtensions = [],
   }: InitializeParams) {
@@ -156,6 +162,8 @@ export class Linter {
     Linter.dependencyIndependentRulesCache.clear();
     Linter.dependencySensitiveRulesCache.clear();
     Linter.baseDir = baseDir;
+    Linter.detectGeneratedCode = detectGeneratedCode;
+    Linter.isGeneratedSourceFile = isGeneratedSourceFile;
     Linter.testFileExtensions = testFileExtensions;
     /**
      * Context bundles define a set of external custom rules (like the architecture rule)
@@ -291,6 +299,7 @@ export class Linter {
       detectedModuleType = getModuleType(normalizedFilePath, Linter.baseDir);
       getOptionalProjectAnalysisTelemetryCollector()?.recordModuleType(detectedModuleType);
     }
+    const isGeneratedSource = Linter.isGeneratedSourceFile(normalizedFilePath);
     const manifestDependencies = getDependencies(dirnamePath(normalizedFilePath), Linter.baseDir);
     // Make inline npm: imports visible to both rule activation and to dependency helpers
     // (getReactVersion, getDependenciesSanitizePaths) called from rules during linting.
@@ -304,6 +313,8 @@ export class Linter {
       analysisMode,
       detectedEsYear,
       detectedModuleType,
+      Linter.detectGeneratedCode,
+      isGeneratedSource,
     );
     let baseRules = Linter.dependencyIndependentRulesCache.get(linterConfigKey);
     let dependencySensitiveRules = Linter.dependencySensitiveRulesCache.get(linterConfigKey);
@@ -315,6 +326,8 @@ export class Linter {
       analysisMode,
       detectedEsYear,
       detectedModuleType,
+      detectGeneratedCode: Linter.detectGeneratedCode,
+      isGeneratedSource,
     };
 
     if (baseRules === undefined || dependencySensitiveRules === undefined) {
@@ -446,6 +459,8 @@ function createLinterConfigKey(
   analysisMode: AnalysisMode,
   detectedEsYear?: number,
   detectedModuleType?: ModuleType,
+  detectGeneratedCode?: boolean,
+  isGeneratedSource?: boolean,
 ): string {
   // depending on the path, some rules may be enabled or disabled based on the dependencies found
   const normalizedPath = normalizeToAbsolutePath(filePath);
@@ -454,5 +469,5 @@ function createLinterConfigKey(
     baseDir,
   );
   const linterConfigKey = `${fileType}-${language}-${analysisMode}-${extname(normalizedPath)}-${dependencyManifestDirName}`;
-  return `${linterConfigKey}:${detectedEsYear ?? 'esnext'}:${detectedModuleType ?? 'unknown'}`;
+  return `${linterConfigKey}:${detectedEsYear ?? 'esnext'}:${detectedModuleType ?? 'unknown'}:${detectGeneratedCode === false ? 'generated-off' : 'generated-on'}:${isGeneratedSource === true ? 'generated' : 'regular'}`;
 }

--- a/packages/analysis/src/jsts/rules/helpers/generate-meta.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generate-meta.ts
@@ -27,6 +27,7 @@ export type SonarMeta = {
   eslintId: string;
   scope: 'All' | 'Main' | 'Tests';
   languages: ('ts' | 'js')[];
+  skipOnGeneratedSource?: boolean;
   blacklistedExtensions?: string[];
   schema?: JSONSchema4;
   hasSecondaries?: boolean;

--- a/packages/analysis/src/jsts/rules/helpers/generated-source.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-source.ts
@@ -14,16 +14,6 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { describe, it } from 'node:test';
-import { expect } from 'expect';
-import { shouldSkipOnGeneratedSource } from '../src/jsts/rules/helpers/generated-source.js';
-
-describe('generated-source RSPEC metadata', () => {
-  it('should enable generated-source suppression for editable-source rules', () => {
-    expect(shouldSkipOnGeneratedSource(['editable-source'])).toBe(true);
-  });
-
-  it('should keep generated-source suppression disabled when editable-source tag is absent', () => {
-    expect(shouldSkipOnGeneratedSource(['es2022', 'type-dependent'])).toBe(false);
-  });
-});
+export function shouldSkipOnGeneratedSource(tags: readonly string[]): boolean {
+  return tags.includes('editable-source');
+}

--- a/packages/analysis/tests/generate-eslint-meta-source.test.ts
+++ b/packages/analysis/tests/generate-eslint-meta-source.test.ts
@@ -16,15 +16,53 @@
  */
 import { describe, it } from 'node:test';
 import { expect } from 'expect';
-import { join } from 'node:path/posix';
-import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path/posix';
+import { existsSync, readFileSync } from 'node:fs';
 
-const generatorSource = readFileSync(
-  join(import.meta.dirname, '../../../tools/generate-eslint-meta.ts'),
-  'utf8',
-);
+function getGeneratorSourcePath(
+  testDirectory: string,
+  fileExists: (path: string) => boolean = existsSync,
+) {
+  let currentDirectory = testDirectory;
+
+  while (true) {
+    const candidatePath = join(currentDirectory, 'tools/generate-eslint-meta.ts');
+
+    if (fileExists(candidatePath)) {
+      return candidatePath;
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      throw new Error(`Could not resolve generator source path from ${testDirectory}`);
+    }
+
+    currentDirectory = parentDirectory;
+  }
+}
+
+const generatorSource = readFileSync(getGeneratorSourcePath(import.meta.dirname), 'utf8');
 
 describe('generate-eslint-meta source of truth', () => {
+  it('should locate the generator source from source-mode tests', () => {
+    const generatorSourcePath = '/repo/tools/generate-eslint-meta.ts';
+
+    expect(
+      getGeneratorSourcePath('/repo/packages/analysis/tests', path => path === generatorSourcePath),
+    ).toBe(generatorSourcePath);
+  });
+
+  it('should locate the generator source from compiled JS tests', () => {
+    const generatorSourcePath = '/repo/tools/generate-eslint-meta.ts';
+
+    expect(
+      getGeneratorSourcePath(
+        '/repo/lib/packages/analysis/tests',
+        path => path === generatorSourcePath,
+      ),
+    ).toBe(generatorSourcePath);
+  });
+
   it('should derive generated-source suppression from RSPEC tags', () => {
     expect(generatorSource).toContain("'editable-source'");
   });

--- a/packages/analysis/tests/generate-eslint-meta-source.test.ts
+++ b/packages/analysis/tests/generate-eslint-meta-source.test.ts
@@ -1,0 +1,31 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { expect } from 'expect';
+import { join } from 'node:path/posix';
+import { readFileSync } from 'node:fs';
+
+const generatorSource = readFileSync(
+  join(import.meta.dirname, '../../../tools/generate-eslint-meta.ts'),
+  'utf8',
+);
+
+describe('generate-eslint-meta source of truth', () => {
+  it('should derive generated-source suppression from RSPEC tags', () => {
+    expect(generatorSource).toContain("'editable-source'");
+  });
+});

--- a/packages/analysis/tests/jsts/linter/filter-generated-source.test.ts
+++ b/packages/analysis/tests/jsts/linter/filter-generated-source.test.ts
@@ -1,0 +1,87 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { expect } from 'expect';
+import type { RuleConfig } from '../../../src/jsts/linter/config/rule-config.js';
+import { filterGeneratedSource } from '../../../src/jsts/linter/filters/filter-generated-source.js';
+import type { RuleFilterContext } from '../../../src/jsts/linter/filters/index.js';
+import type { SonarMeta } from '../../../src/jsts/rules/helpers/generate-meta.js';
+
+const ruleConfig = {
+  key: 'S3776',
+  configurations: [],
+  fileTypeTargets: ['MAIN'],
+  language: 'ts',
+  analysisModes: ['DEFAULT'],
+} satisfies RuleConfig;
+
+const baseContext: RuleFilterContext = {
+  extensionName: '.ts',
+  fileType: 'MAIN',
+  fileLanguage: 'ts',
+  analysisMode: 'DEFAULT',
+  detectedEsYear: undefined,
+  detectedModuleType: undefined,
+  detectGeneratedCode: true,
+  isGeneratedSource: false,
+  dependencies: new Map(),
+};
+
+const generatedSourceMeta = {
+  meta: { type: 'problem', docs: {} },
+  sonarKey: 'S3776',
+  eslintId: 'cognitive-complexity',
+  scope: 'All',
+  languages: ['ts'],
+  skipOnGeneratedSource: true,
+  implementation: 'original',
+  requiredDependency: [],
+} satisfies SonarMeta;
+
+describe('filterGeneratedSource', () => {
+  it('should keep rules for non-generated files', () => {
+    expect(filterGeneratedSource(ruleConfig, generatedSourceMeta, baseContext)).toBe(true);
+  });
+
+  it('should keep rules that do not opt out on generated files', () => {
+    expect(
+      filterGeneratedSource(ruleConfig, undefined, {
+        ...baseContext,
+        isGeneratedSource: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('should disable rules that opt out on generated files', () => {
+    expect(
+      filterGeneratedSource(ruleConfig, generatedSourceMeta, {
+        ...baseContext,
+        isGeneratedSource: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('should keep opt-out rules when generated-code detection is disabled', () => {
+    expect(
+      filterGeneratedSource(ruleConfig, generatedSourceMeta, {
+        ...baseContext,
+        detectGeneratedCode: false,
+        isGeneratedSource: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/analysis/tests/jsts/linter/index.test.ts
+++ b/packages/analysis/tests/jsts/linter/index.test.ts
@@ -170,6 +170,31 @@ describe('Linter', () => {
     );
   });
 
+  it('should not invoke generated-source detector when generated-code detection is disabled', async ({
+    mock,
+  }) => {
+    const isGeneratedSourceFile = mock.fn((_filePath: NormalizedAbsolutePath) => {
+      throw new Error('Generated-source detector should not be called.');
+    });
+
+    await Linter.initialize({
+      baseDir: normalizeToAbsolutePath(import.meta.dirname),
+      rules: [],
+      detectGeneratedCode: false,
+      isGeneratedSourceFile,
+    });
+
+    expect(() =>
+      Linter.getRulesForFile(
+        normalizeToAbsolutePath(path.join(import.meta.dirname, 'file.js')),
+        'MAIN',
+        'DEFAULT',
+        'js',
+      ),
+    ).not.toThrow();
+    expect(isGeneratedSourceFile.mock.calls).toHaveLength(0);
+  });
+
   it('should keep Sonar defaults from config.ts when no explicit configuration is provided', async () => {
     await Linter.initialize({
       baseDir: normalizeToAbsolutePath(import.meta.dirname),

--- a/tools/generate-eslint-meta.ts
+++ b/tools/generate-eslint-meta.ts
@@ -49,11 +49,12 @@ export async function generateMetaForRule(
 
   const ruleFolder = join(RULES_FOLDER, sonarKey);
   const eslintConfiguration = await getESLintDefaultConfiguration(sonarKey);
+  const tags = ruleRspecMeta.tags;
 
   // Extract ES year from tags like ["es2022", "performance"]
-  const ecmaTag = ruleRspecMeta.tags.find((t: string) => /^es20\d\d$/i.test(t));
+  const ecmaTag = tags.find((t: string) => /^es20\d\d$/i.test(t));
   const requiredEcmaVersion = ecmaTag ? Number.parseInt(ecmaTag.slice(2), 10) : undefined;
-  const requiredModuleType = getRequiredModuleType(sonarKey, ruleRspecMeta.tags);
+  const requiredModuleType = getRequiredModuleType(sonarKey, tags);
 
   await inflateTemplateToFile(
     join(TS_TEMPLATES_FOLDER, 'generated-meta.template'),
@@ -64,13 +65,14 @@ export async function generateMetaForRule(
       ___RULE_KEY___: sonarKey,
       ___DESCRIPTION___: ruleRspecMeta.title.replace(/'/g, "\\'"),
       ___RECOMMENDED___: sonarWayProfile.ruleKeys.includes(sonarKey),
-      ___TYPE_CHECKING___: `${ruleRspecMeta.tags.includes('type-dependent')}`,
+      ___TYPE_CHECKING___: `${tags.includes('type-dependent')}`,
       ___FIXABLE___: ruleRspecMeta.quickfix === 'covered' ? "'code'" : undefined,
       ___DEPRECATED___: `${ruleRspecMeta.status === 'deprecated'}`,
       ___DEFAULT_OPTIONS___: JSON.stringify(defaultOptions(eslintConfiguration), null, 2),
       ___LANGUAGES___: JSON.stringify(ruleRspecMeta.compatibleLanguages),
       ___SCOPE___: ruleRspecMeta.scope,
       ___REQUIRED_DEPENDENCY___: JSON.stringify(ruleRspecMeta.extra?.requiredDependency ?? []),
+      ___SKIP_ON_GENERATED_SOURCE___: `${tags.includes('editable-source')}`,
       ___REQUIRED_MODULE_TYPE_EXPORT___:
         requiredModuleType !== undefined
           ? `export const requiredModuleType = '${requiredModuleType}';`

--- a/tools/generate-eslint-meta.ts
+++ b/tools/generate-eslint-meta.ts
@@ -16,6 +16,7 @@
  */
 import { join } from 'node:path/posix';
 import { defaultOptions } from '../packages/analysis/src/jsts/rules/helpers/configs.js';
+import { shouldSkipOnGeneratedSource } from '../packages/analysis/src/jsts/rules/helpers/generated-source.js';
 import {
   getESLintDefaultConfiguration,
   getRspecMeta,
@@ -72,7 +73,7 @@ export async function generateMetaForRule(
       ___LANGUAGES___: JSON.stringify(ruleRspecMeta.compatibleLanguages),
       ___SCOPE___: ruleRspecMeta.scope,
       ___REQUIRED_DEPENDENCY___: JSON.stringify(ruleRspecMeta.extra?.requiredDependency ?? []),
-      ___SKIP_ON_GENERATED_SOURCE___: `${tags.includes('editable-source')}`,
+      ___SKIP_ON_GENERATED_SOURCE___: `${shouldSkipOnGeneratedSource(tags)}`,
       ___REQUIRED_MODULE_TYPE_EXPORT___:
         requiredModuleType !== undefined
           ? `export const requiredModuleType = '${requiredModuleType}';`

--- a/tools/templates/ts/generated-meta.template
+++ b/tools/templates/ts/generated-meta.template
@@ -22,5 +22,6 @@ export const sonarKey = '___RULE_KEY___';
 export const scope = '___SCOPE___';
 export const languages: ('js' | 'ts')[] = ___LANGUAGES___;
 export const requiredDependency = ___REQUIRED_DEPENDENCY___;
+export const skipOnGeneratedSource = ___SKIP_ON_GENERATED_SOURCE___;
 ___REQUIRED_MODULE_TYPE_EXPORT___
 ___REQUIRED_ECMA_VERSION_EXPORT___


### PR DESCRIPTION
Part of JS-1597

## Summary
- add generated-source suppression metadata sourced from the RSPEC `editable-source` tag
- add a linter-level generated-source predicate hook and rule filter without introducing detector/store dependencies
- guard the generated-source predicate when `detectGeneratedCode` is disabled
- replace the brittle source-string generator test with a behavior-level helper test

## Testing
- npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/tests/jsts/linter/index.test.ts packages/analysis/tests/generate-eslint-meta-source.test.ts
- npx prettier --check packages/analysis/src/jsts/linter/linter.ts packages/analysis/tests/jsts/linter/index.test.ts packages/analysis/tests/generate-eslint-meta-source.test.ts packages/analysis/src/jsts/rules/helpers/generated-source.ts tools/generate-eslint-meta.ts