### PR TITLE
JS-1803 Fix S6478 false positives for react-table headers

### DIFF
--- a/packages/analysis/src/jsts/rules/S6478/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6478/decorator.ts
@@ -37,6 +37,8 @@ const REACT_INTL_COMPONENTS = new Set([
   '$t', // common alias
 ]);
 
+const REACT_TABLE_COLUMN_PROPERTIES = new Set(['accessor', 'columns', 'id']);
+
 /**
  * Checks if a JSXExpressionContainer is the `values` attribute of a react-intl component.
  */
@@ -120,6 +122,48 @@ function isReactIntlFormattingValue(node: estree.Node): boolean {
   return false;
 }
 
+/**
+ * Checks if a function is used as a react-table column header renderer.
+ * react-table accepts `Header` functions in column definitions as render callbacks.
+ */
+function isReactTableColumnHeaderRenderer(node: estree.Node): boolean {
+  if (node.type !== 'ArrowFunctionExpression' && node.type !== 'FunctionExpression') {
+    return false;
+  }
+
+  const property = (node as TSESTree.Node).parent as TSESTree.Property | undefined;
+  const columnDefinition = property?.parent as TSESTree.ObjectExpression | undefined;
+  if (
+    property?.type !== 'Property' ||
+    columnDefinition?.type !== 'ObjectExpression' ||
+    getStaticPropertyName(property) !== 'Header'
+  ) {
+    return false;
+  }
+
+  return columnDefinition.properties.some(
+    columnProperty =>
+      columnProperty.type === 'Property' &&
+      REACT_TABLE_COLUMN_PROPERTIES.has(getStaticPropertyName(columnProperty) ?? ''),
+  );
+}
+
+function getStaticPropertyName(property: TSESTree.Property) {
+  if (property.computed) {
+    return undefined;
+  }
+
+  const { key } = property;
+  if (key.type === 'Identifier') {
+    return key.name;
+  }
+  if (key.type === 'Literal' && typeof key.value === 'string') {
+    return key.value;
+  }
+
+  return undefined;
+}
+
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
   return interceptReportForReact(
     {
@@ -132,6 +176,11 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
       // Skip functions used as react-intl rich text formatting values.
       // These are render callbacks, not React components.
       if (isReactIntlFormattingValue(node)) {
+        return;
+      }
+
+      // Skip react-table column header renderers.
+      if (isReactTableColumnHeaderRenderer(node)) {
         return;
       }
 

--- a/packages/analysis/src/jsts/rules/S6478/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6478/decorator.ts
@@ -131,8 +131,8 @@ function isReactTableColumnHeaderRenderer(node: estree.Node): boolean {
     return false;
   }
 
-  const property = (node as TSESTree.Node).parent as TSESTree.Property | undefined;
-  const columnDefinition = property?.parent as TSESTree.ObjectExpression | undefined;
+  const property = (node as TSESTree.Node).parent;
+  const columnDefinition = property?.parent;
   if (
     property?.type !== 'Property' ||
     columnDefinition?.type !== 'ObjectExpression' ||

--- a/packages/analysis/src/jsts/rules/S6478/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6478/unit.test.ts
@@ -90,6 +90,20 @@ describe('S6478', () => {
             function Parent() {
               const columns = [
                 {
+                  'Header': () => <CustomHeader />,
+                  'accessor': 'name',
+                },
+              ];
+              useTable({ columns });
+              return <Table columns={columns} />;
+            }
+          `,
+        },
+        {
+          code: `
+            function Parent() {
+              const columns = [
+                {
                   Header: function Header() {
                     return <CustomHeader />;
                   },
@@ -168,6 +182,18 @@ describe('S6478', () => {
             function Parent() {
               const renderers = {
                 Header: () => <div />,
+              };
+              return <Something renderers={renderers} />;
+            }
+          `,
+          errors: 1,
+        },
+        {
+          code: `
+            function Parent() {
+              const renderers = {
+                [Header]: () => <div />,
+                accessor: 'name',
               };
               return <Something renderers={renderers} />;
             }

--- a/packages/analysis/src/jsts/rules/S6478/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6478/unit.test.ts
@@ -71,6 +71,41 @@ describe('S6478', () => {
             }
           `,
         },
+        {
+          code: `
+            function Parent() {
+              const columns = [
+                {
+                  Header: () => <CustomHeader />,
+                  accessor: 'name',
+                },
+              ];
+              useTable({ columns });
+              return <Table columns={columns} />;
+            }
+          `,
+        },
+        {
+          code: `
+            function Parent() {
+              const columns = [
+                {
+                  Header: function Header() {
+                    return <CustomHeader />;
+                  },
+                  columns: [
+                    {
+                      Header: () => <NestedHeader />,
+                      id: 'nested',
+                    },
+                  ],
+                },
+              ];
+              useTable({ columns });
+              return <Table columns={columns} />;
+            }
+          `,
+        },
       ],
       invalid: [
         {
@@ -124,6 +159,17 @@ describe('S6478', () => {
                 return <div />;
               }
               return <Child />;
+            }
+          `,
+          errors: 1,
+        },
+        {
+          code: `
+            function Parent() {
+              const renderers = {
+                Header: () => <div />,
+              };
+              return <Something renderers={renderers} />;
             }
           `,
           errors: 1,


### PR DESCRIPTION
## Summary

Fixes a React false positive in S6478 by treating react-table column `Header` functions as render callbacks, not nested component definitions.

The exemption is scoped to column-like objects containing `Header` plus `accessor`, `columns`, or `id`, and a regression test keeps generic `Header` renderer objects noncompliant.

## Validation

- `./node_modules/.bin/tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/src/jsts/rules/S6478/unit.test.ts`
- `git diff --check`

`npm run bridge:compile` was attempted, but this fresh worktree lacks the ignored generated rule metadata/index artifacts expected by the command, so it fails before branch-specific checking.
