### PR TITLE
JS-1802 Fix S3801 false positives for React effect cleanups

### DIFF
--- a/its/ruling/src/test/expected/ant-design/typescript-S3801.json
+++ b/its/ruling/src/test/expected/ant-design/typescript-S3801.json
@@ -5,9 +5,6 @@
 "ant-design:components/button/button.tsx": [
 32
 ],
-"ant-design:components/checkbox/Checkbox.tsx": [
-77
-],
 "ant-design:components/drawer/index.tsx": [
 199
 ],

--- a/its/ruling/src/test/expected/eigen/typescript-S3801.json
+++ b/its/ruling/src/test/expected/eigen/typescript-S3801.json
@@ -19,8 +19,7 @@
 97
 ],
 "eigen:src/app/Components/ArtsyWebView.tsx": [
-101,
-298
+101
 ],
 "eigen:src/app/Components/ArtworkFilter/FilterModal.tests.tsx": [
 520
@@ -103,9 +102,6 @@
 "eigen:src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx": [
 56,
 77
-],
-"eigen:src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx": [
-177
 ],
 "eigen:src/app/Scenes/Artwork/Components/ImageCarousel/FullScreen/useDoublePressCallback.ts": [
 12
@@ -220,10 +216,6 @@
 "eigen:src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx": [
 46
 ],
-"eigen:src/app/Scenes/Onboarding/OnboardingWelcome.tsx": [
-54,
-67
-],
 "eigen:src/app/Scenes/OrderHistory/OrderDetails/OrderDetails.tests.tsx": [
 46
 ],
@@ -244,9 +236,6 @@
 ],
 "eigen:src/app/Scenes/SavedSearchAlert/pillExtractors.ts": [
 50
-],
-"eigen:src/app/Scenes/Search/components/SearchInput.tsx": [
-38
 ],
 "eigen:src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/addPhotoToConsignment.ts": [
 16
@@ -272,9 +261,6 @@
 "eigen:src/app/Scenes/Show/ShowViewingRoom.tests.tsx": [
 32
 ],
-"eigen:src/app/Websockets/auctions/AuctionSocketContext.tsx": [
-50
-],
 "eigen:src/app/navigation/useReloadedDevNavigationState.ts": [
 50
 ],
@@ -292,9 +278,6 @@
 31,
 68
 ],
-"eigen:src/app/utils/AboveTheFoldQueryRenderer.tsx": [
-90
-],
 "eigen:src/app/utils/getTestWrapper.tsx": [
 13
 ],
@@ -305,7 +288,6 @@
 100
 ],
 "eigen:src/palette/elements/Input/Input.tsx": [
-127,
 147
 ],
 "eigen:src/palette/elements/OpaqueImageView/OpaqueImageView2.tsx": [

--- a/its/ruling/src/test/expected/fireact/javascript-S3801.json
+++ b/its/ruling/src/test/expected/fireact/javascript-S3801.json
@@ -58,7 +58,6 @@
 49
 ],
 "fireact:src/pages/auth/user/Invite/index.js": [
-23,
 42,
 47,
 86,

--- a/its/ruling/src/test/expected/moose/typescript-S3801.json
+++ b/its/ruling/src/test/expected/moose/typescript-S3801.json
@@ -28,11 +28,7 @@
 37,
 54
 ],
-"moose:renderer/components/CastControl/CastControl.tsx": [
-63
-],
 "moose:renderer/components/Player/Player.tsx": [
-31,
 60
 ]
 }

--- a/its/ruling/src/test/expected/react-cloud-music/javascript-S3801.json
+++ b/its/ruling/src/test/expected/react-cloud-music/javascript-S3801.json
@@ -9,13 +9,7 @@
 89,
 113
 ],
-"react-cloud-music:src/application/User/Login/PhoneForm/step-two/index.jsx": [
-13
-],
 "react-cloud-music:src/baseUI/scroll/index.jsx": [
-115,
-123,
-137,
 165
 ],
 "react-cloud-music:ts-music/config/modules.js": [

--- a/its/ruling/src/test/expected/react-cloud-music/typescript-S3801.json
+++ b/its/ruling/src/test/expected/react-cloud-music/typescript-S3801.json
@@ -1,8 +1,5 @@
 {
 "react-cloud-music:ts-music/src/baseUI/scroll/index.tsx": [
-107,
-115,
-129,
 157
 ]
 }

--- a/its/ruling/src/test/expected/searchkit/javascript-S3801.json
+++ b/its/ruling/src/test/expected/searchkit/javascript-S3801.json
@@ -1,8 +1,5 @@
 {
 "searchkit:examples/next/components/geosearch-examples/Input.jsx": [
 19
-],
-"searchkit:examples/next/components/geosearch-examples/maps.jsx": [
-36
 ]
 }

--- a/packages/analysis/src/jsts/rules/S3801/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3801/rule.ts
@@ -200,10 +200,7 @@ export const rule: Rule.RuleModule = {
       }
 
       for (const specifier of importDeclaration.specifiers) {
-        if (
-          specifier.type === 'ImportSpecifier' &&
-          isImportedEffectHook(specifier.imported as TSESTree.Node)
-        ) {
+        if (specifier.type === 'ImportSpecifier' && isImportedEffectHook(specifier.imported)) {
           reactEffectHookNames.add(specifier.local.name);
         } else if (
           specifier.type === 'ImportDefaultSpecifier' ||

--- a/packages/analysis/src/jsts/rules/S3801/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3801/rule.ts
@@ -28,7 +28,10 @@ import { type RuleContext, getSignatureFromCallee, getTypeFromTreeNode } from '.
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getMainFunctionTokenLocation, report, toSecondaryLocation } from '../helpers/location.js';
 import { getParent } from '../helpers/ancestor.js';
+import { isIdentifier, isMethodCall } from '../helpers/ast.js';
 import * as meta from './generated-meta.js';
+
+const REACT_EFFECT_HOOKS = new Set(['useEffect', 'useInsertionEffect', 'useLayoutEffect']);
 
 interface FunctionContext {
   codePath: Rule.CodePath;
@@ -49,6 +52,10 @@ interface FunctionLikeDeclaration {
   returnType?: TSESTree.TSTypeAnnotation;
 }
 
+function isImportedEffectHook(node: TSESTree.Node) {
+  return node.type === 'Identifier' && REACT_EFFECT_HOOKS.has(node.name);
+}
+
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta),
   create(context: Rule.RuleContext) {
@@ -56,6 +63,8 @@ export const rule: Rule.RuleModule = {
     const services = sourceCode.parserServices;
     const hasTypeInformation = isRequiredParserServices(services);
     const functionContextStack: FunctionContext[] = [];
+    const reactEffectHookNames = new Set<string>();
+    const reactNames = new Set<string>();
     const checkOnFunctionExit = (node: estree.Node) =>
       checkFunctionLikeDeclaration(
         node,
@@ -76,6 +85,7 @@ export const rule: Rule.RuleModule = {
     ) {
       if (
         !functionContext ||
+        isReactEffectCallback(node as estree.Node) ||
         (!!node.returnType &&
           declaredReturnTypeContainsVoidOrNeverTypes(node.returnType.typeAnnotation))
       ) {
@@ -156,7 +166,56 @@ export const rule: Rule.RuleModule = {
       return secondaryLocations;
     }
 
+    function isReactEffectCallback(node: estree.Node) {
+      const parent = (node as TSESTree.Node).parent;
+      return (
+        parent?.type === 'CallExpression' &&
+        parent.arguments[0] === node &&
+        isReactEffectHookCall(parent as estree.CallExpression)
+      );
+    }
+
+    function isReactEffectHookCall(callExpression: estree.CallExpression) {
+      const { callee } = callExpression;
+      if (isIdentifier(callee)) {
+        return reactEffectHookNames.has(callee.name);
+      }
+
+      if (isMethodCall(callExpression)) {
+        const { object, property } = callExpression.callee;
+        return (
+          isIdentifier(object) &&
+          reactNames.has(object.name) &&
+          REACT_EFFECT_HOOKS.has(property.name)
+        );
+      }
+
+      return false;
+    }
+
+    function collectReactEffectHookImports(node: estree.Node) {
+      const importDeclaration = node as TSESTree.ImportDeclaration;
+      if (importDeclaration.source.value !== 'react') {
+        return;
+      }
+
+      for (const specifier of importDeclaration.specifiers) {
+        if (
+          specifier.type === 'ImportSpecifier' &&
+          isImportedEffectHook(specifier.imported as TSESTree.Node)
+        ) {
+          reactEffectHookNames.add(specifier.local.name);
+        } else if (
+          specifier.type === 'ImportDefaultSpecifier' ||
+          specifier.type === 'ImportNamespaceSpecifier'
+        ) {
+          reactNames.add(specifier.local.name);
+        }
+      }
+    }
+
     return {
+      ImportDeclaration: collectReactEffectHookImports,
       onCodePathStart(codePath: Rule.CodePath) {
         functionContextStack.push({
           codePath,

--- a/packages/analysis/src/jsts/rules/S3801/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S3801/unit.test.ts
@@ -163,6 +163,63 @@ describe('S3801', () => {
       }
     `,
         },
+        {
+          code: `
+      import { useEffect, useInsertionEffect, useLayoutEffect } from 'react';
+
+      function Component({ enabled }) {
+        useEffect(() => {
+          if (!enabled) {
+            return;
+          }
+          const subscription = subscribe();
+          return () => subscription.unsubscribe();
+        }, [enabled]);
+
+        useLayoutEffect(function () {
+          if (!enabled) {
+            return;
+          }
+          return () => cleanupLayout();
+        }, [enabled]);
+
+        useInsertionEffect(() => {
+          if (!enabled) {
+            return;
+          }
+          return () => cleanupInsertion();
+        }, [enabled]);
+      }
+    `,
+        },
+        {
+          code: `
+      import React from 'react';
+
+      function Component({ enabled }) {
+        React.useEffect(() => {
+          if (!enabled) {
+            return;
+          }
+          return () => cleanup();
+        }, [enabled]);
+      }
+    `,
+        },
+        {
+          code: `
+      import { useEffect as useReactEffect } from 'react';
+
+      function Component({ enabled }) {
+        useReactEffect(() => {
+          if (!enabled) {
+            return;
+          }
+          return () => cleanup();
+        }, [enabled]);
+      }
+    `,
+        },
       ],
       invalid: [
         {


### PR DESCRIPTION
## Summary

Fixes a React false positive in S3801 by skipping callbacks passed to React effect hooks. Effect callbacks may return a cleanup function or return nothing, so an early `return;` mixed with `return () => cleanup()` is valid React code rather than inconsistent API behavior.

The exemption covers `useEffect`, `useLayoutEffect`, and `useInsertionEffect` imported from `react`, including aliased named imports and `React.useEffect`-style calls.

## Validation

- `./node_modules/.bin/tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/src/jsts/rules/S3801/unit.test.ts`
- `git diff --check`

`npm run bridge:compile` was attempted, but this fresh worktree lacks the ignored generated rule metadata/index artifacts expected by the command, so it fails before branch-specific checking.
