### PR TITLE
JS-1597 support OpenAPI generated-source outputs

### DIFF
--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/contracts.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/contracts.ts
@@ -19,11 +19,15 @@ import type { DependenciesList } from '../dependency-manifests/resolvers/types.j
 import type { TaskInvocation } from './task-invocations.js';
 
 export const GRAPHQL_CODEGEN_FAMILY = '@graphql-codegen/cli';
+export const OPENAPI_GENERATOR_FAMILY = '@openapitools/openapi-generator-cli';
+// Keep the family contract open-ended so later detector PRs can add new families
+// without modifying the shared detector/store API.
+export type GeneratedSourceFamily = string;
 
 export type GeneratedSourceFileMatcher = (filePath: NormalizedAbsolutePath) => boolean;
 
 export type DerivedGeneratedSources = {
-  familyByFile: Map<NormalizedAbsolutePath, string>;
+  familyByFile: Map<NormalizedAbsolutePath, GeneratedSourceFamily>;
   configPaths: Set<NormalizedAbsolutePath>;
   watchedOutputPaths: Set<NormalizedAbsolutePath>;
 };
@@ -37,7 +41,7 @@ export type DerivedGeneratedSources = {
  * - reporting any config files and declared output paths it inferred so the store can refresh on change
  */
 export interface GeneratedSourceDetector {
-  readonly family: string;
+  readonly family: GeneratedSourceFamily;
   readonly watchedFilenames?: readonly string[];
   detect(context: {
     baseDir: NormalizedAbsolutePath;

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -16,9 +16,11 @@
  */
 import type { GeneratedSourceDetector } from '../contracts.js';
 import { graphqlCodegenDetector } from './graphql-codegen.js';
+import { openApiGeneratorDetector } from './openapi-generator.js';
 
 export const GENERATED_SOURCE_DETECTORS: readonly GeneratedSourceDetector[] = [
   graphqlCodegenDetector,
+  openApiGeneratorDetector,
 ];
 
 export const GENERATED_SOURCE_WATCHED_FILENAMES = [

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
@@ -54,7 +54,7 @@ export const openApiGeneratorDetector = {
     return deriveSourcesFromOutputDirectories(
       OPENAPI_GENERATOR_FAMILY,
       outputDirectories,
-      true,
+      false,
       sourceFileMatcher,
     );
   },

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
@@ -15,12 +15,20 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { type GeneratedSourceDetector, OPENAPI_GENERATOR_FAMILY } from '../contracts.js';
-import { createDerivedGeneratedSources } from '../shared.js';
+import { extractFlagValuesFromTokens, createDerivedGeneratedSources } from '../shared.js';
 import {
   deriveSourcesFromOutputDirectories,
   resolveOutputDirectoriesFromTaskInvocations,
 } from '../detector-api.js';
 import { taskInvocationInvokesCommand, type TaskInvocation } from '../task-invocations.js';
+
+const JS_TS_OPENAPI_GENERATORS = new Set([
+  'k6',
+  'nodejs-express-server',
+  'graphql-nodejs-express-server',
+]);
+
+const OPENAPI_GENERATOR_NAME_FLAGS = ['-g', '--generator-name'];
 
 export const openApiGeneratorDetector = {
   family: OPENAPI_GENERATOR_FAMILY,
@@ -28,7 +36,10 @@ export const openApiGeneratorDetector = {
   async detect({ baseDir, packageDir, taskInvocations, sourceFileMatcher }) {
     const matchesTaskInvocation = (taskInvocation: TaskInvocation) =>
       taskInvocationInvokesCommand(taskInvocation, 'openapi-generator-cli') &&
-      taskInvocation.args[0] === 'generate';
+      taskInvocation.args[0] === 'generate' &&
+      extractFlagValuesFromTokens(taskInvocation.args, OPENAPI_GENERATOR_NAME_FLAGS).some(
+        isJsTsOpenApiGenerator,
+      );
     if (!taskInvocations.some(matchesTaskInvocation)) {
       return createDerivedGeneratedSources();
     }
@@ -48,3 +59,11 @@ export const openApiGeneratorDetector = {
     );
   },
 } satisfies GeneratedSourceDetector;
+
+function isJsTsOpenApiGenerator(generatorName: string) {
+  return (
+    generatorName.startsWith('javascript') ||
+    generatorName.startsWith('typescript') ||
+    JS_TS_OPENAPI_GENERATORS.has(generatorName)
+  );
+}

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
@@ -15,11 +15,8 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { type GeneratedSourceDetector, OPENAPI_GENERATOR_FAMILY } from '../contracts.js';
-import { extractFlagValuesFromTokens, createDerivedGeneratedSources } from '../shared.js';
-import {
-  deriveSourcesFromOutputDirectories,
-  resolveOutputDirectoriesFromTaskInvocations,
-} from '../detector-api.js';
+import { addFamilyFiles, createDerivedGeneratedSources, extractFlagValuesFromTokens } from '../shared.js';
+import { resolveGeneratedOutputsFromLiteralPaths } from '../detector-api.js';
 import { taskInvocationInvokesCommand, type TaskInvocation } from '../task-invocations.js';
 
 const JS_TS_OPENAPI_GENERATORS = new Set([
@@ -44,19 +41,26 @@ export const openApiGeneratorDetector = {
       return createDerivedGeneratedSources();
     }
 
-    const outputDirectories = await resolveOutputDirectoriesFromTaskInvocations({
+    const outputPaths = taskInvocations.flatMap(taskInvocation => {
+      if (!matchesTaskInvocation(taskInvocation)) {
+        return [];
+      }
+
+      return extractFlagValuesFromTokens(taskInvocation.args, ['-o', '--output']);
+    });
+    const resolvedOutputs = await resolveGeneratedOutputsFromLiteralPaths(
       baseDir,
       packageDir,
-      taskInvocations,
-      matchesTaskInvocation,
-      flags: ['-o', '--output'],
-    });
-    return deriveSourcesFromOutputDirectories(
-      OPENAPI_GENERATOR_FAMILY,
-      outputDirectories,
+      outputPaths,
       false,
       sourceFileMatcher,
     );
+    const derived = createDerivedGeneratedSources();
+    addFamilyFiles(OPENAPI_GENERATOR_FAMILY, resolvedOutputs.filePaths, derived);
+    for (const watchedOutputPath of resolvedOutputs.watchedOutputPaths) {
+      derived.watchedOutputPaths.add(watchedOutputPath);
+    }
+    return derived;
   },
 } satisfies GeneratedSourceDetector;
 

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
@@ -1,0 +1,50 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { type GeneratedSourceDetector, OPENAPI_GENERATOR_FAMILY } from '../contracts.js';
+import { createDerivedGeneratedSources } from '../shared.js';
+import {
+  deriveSourcesFromOutputDirectories,
+  resolveOutputDirectoriesFromTaskInvocations,
+} from '../detector-api.js';
+import { taskInvocationInvokesCommand, type TaskInvocation } from '../task-invocations.js';
+
+export const openApiGeneratorDetector = {
+  family: OPENAPI_GENERATOR_FAMILY,
+
+  async detect({ baseDir, packageDir, taskInvocations, sourceFileMatcher }) {
+    const matchesTaskInvocation = (taskInvocation: TaskInvocation) =>
+      taskInvocationInvokesCommand(taskInvocation, 'openapi-generator-cli') &&
+      taskInvocation.args[0] === 'generate';
+    if (!taskInvocations.some(matchesTaskInvocation)) {
+      return createDerivedGeneratedSources();
+    }
+
+    const outputDirectories = await resolveOutputDirectoriesFromTaskInvocations({
+      baseDir,
+      packageDir,
+      taskInvocations,
+      matchesTaskInvocation,
+      flags: ['-o', '--output'],
+    });
+    return deriveSourcesFromOutputDirectories(
+      OPENAPI_GENERATOR_FAMILY,
+      outputDirectories,
+      true,
+      sourceFileMatcher,
+    );
+  },
+} satisfies GeneratedSourceDetector;

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -14,7 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-export { GRAPHQL_CODEGEN_FAMILY } from './contracts.js';
+export {
+  GRAPHQL_CODEGEN_FAMILY,
+  OPENAPI_GENERATOR_FAMILY,
+  type GeneratedSourceFamily,
+} from './contracts.js';
 export {
   GENERATED_SOURCE_DETECTORS,
   GENERATED_SOURCE_WATCHED_FILENAMES,

--- a/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/openapi/build/api/ignored.ts
+++ b/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/openapi/build/api/ignored.ts
@@ -1,0 +1,1 @@
+export const ignored = true;

--- a/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/openapi/package.json
+++ b/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/openapi/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "openapi-fixture",
+  "scripts": {
+    "codegen": "openapi-generator-cli generate -i ./spec.yaml -g typescript-axios -o ./src/api",
+    "dynamic": "openapi-generator-cli generate -i ./spec.yaml -g typescript-axios -o $OPENAPI_OUT",
+    "build-output": "openapi-generator-cli generate -i ./spec.yaml -g typescript-axios -o ./build/api"
+  },
+  "devDependencies": {
+    "@openapitools/openapi-generator-cli": "7.0.0"
+  }
+}

--- a/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/openapi/src/api/index.ts
+++ b/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/openapi/src/api/index.ts
@@ -1,0 +1,1 @@
+export const openApiClient = {};

--- a/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/openapi/src/api/models/pet.ts
+++ b/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/openapi/src/api/models/pet.ts
@@ -1,0 +1,3 @@
+export type Pet = {
+  id: string;
+};

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -854,6 +854,57 @@ export default config;
     }
   });
 
+  it('refreshes generated-source metadata when a declared OpenAPI output file is created later', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'src', 'api', 'index.ts');
+
+    try {
+      await writeFixtureFile(
+        join(baseDir, 'package.json'),
+        JSON.stringify(
+          {
+            devDependencies: {
+              [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
+            },
+            scripts: {
+              generate:
+                'openapi-generator-cli generate -g typescript-axios --output ./src/api',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      await initFileStores(createConfiguration({ baseDir }));
+      expect(generatedSourceStore.getFamily(outputPath)).toBeUndefined();
+
+      await writeFixtureFile(outputPath, 'export const api = true;\n');
+
+      const configuration = createConfiguration({
+        baseDir,
+        fsEvents: {
+          [outputPath]: 'CREATED',
+        },
+      });
+      const { files: inputFiles } = await sanitizeRawInputFiles(
+        {
+          [outputPath]: {
+            filePath: outputPath,
+            fileType: 'MAIN',
+          },
+        },
+        configuration,
+      );
+
+      await initFileStores(configuration, inputFiles);
+
+      expect(generatedSourceStore.getFamily(outputPath)).toEqual(OPENAPI_GENERATOR_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   it('does not derive OpenAPI outputs when openapi-generator-cli is only echoed', async () => {
     const baseDir = await createTempBaseDir();
     const outputPath = joinPaths(baseDir, 'src', 'api', 'index.ts');

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -788,7 +788,7 @@ export default config;
     }
   });
 
-  it('derives OpenAPI outputs from the standard fixture', async () => {
+  it('derives OpenAPI outputs only from immediate output directory children', async () => {
     const baseDir = joinPaths(fixtures, 'openapi');
     await initFileStores(createConfiguration({ baseDir }));
 
@@ -797,7 +797,7 @@ export default config;
     );
     expect(
       generatedSourceStore.getFamily(joinPaths(baseDir, 'src', 'api', 'models', 'pet.ts')),
-    ).toEqual(OPENAPI_GENERATOR_FAMILY);
+    ).toBeUndefined();
     expect(
       generatedSourceStore.getFamily(joinPaths(baseDir, 'build', 'api', 'ignored.ts')),
     ).toEqual(OPENAPI_GENERATOR_FAMILY);

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -817,7 +817,8 @@ export default config;
             [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
           },
           scripts: {
-            generate: 'openapi-generator-cli generate --output=./src/api',
+            generate:
+              'openapi-generator-cli generate --generator-name=typescript-axios --output=./src/api',
           },
         }),
       );
@@ -842,7 +843,7 @@ export default config;
             [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
           },
           scripts: {
-            generate: 'npx openapi-generator-cli generate --output ./src/api',
+            generate: 'npx openapi-generator-cli generate -g typescript-axios --output ./src/api',
           },
         }),
       );
@@ -868,6 +869,56 @@ export default config;
           },
           scripts: {
             generate: 'echo openapi-generator-cli generate --output=./src/api',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not derive OpenAPI outputs without an explicit JS/TS generator name', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'src', 'api', 'index.ts');
+
+    try {
+      await writeFixtureFile(outputPath, 'export const api = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
+          },
+          scripts: {
+            generate: 'openapi-generator-cli generate --output=./src/api',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not derive OpenAPI outputs for non-JS generators', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'src', 'index.ts');
+
+    try {
+      await writeFixtureFile(outputPath, 'export const handwritten = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
+          },
+          scripts: {
+            generate: 'openapi-generator-cli generate -g java -o .',
           },
         }),
       );

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -33,6 +33,7 @@ import {
 } from '../../../src/jsts/rules/helpers/generated-sources/derive.js';
 import {
   GRAPHQL_CODEGEN_FAMILY,
+  OPENAPI_GENERATOR_FAMILY,
   GENERATED_SOURCE_DETECTORS,
   GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS,
   GENERATED_SOURCE_WATCHED_FILENAMES,
@@ -77,9 +78,10 @@ describe('generated sources project metadata', () => {
     sourceFileStore.clearCache();
   });
 
-  it('registers the GraphQL detector through the shared contract', () => {
+  it('registers the GraphQL and OpenAPI detectors through the shared contract', () => {
     expect(GENERATED_SOURCE_DETECTORS.map(detector => detector.family)).toEqual([
       GRAPHQL_CODEGEN_FAMILY,
+      OPENAPI_GENERATOR_FAMILY,
     ]);
     expect(GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS.map(provider => provider.kind)).toEqual([
       'package-json-scripts',
@@ -116,6 +118,7 @@ describe('generated sources project metadata', () => {
         packageJson: {
           scripts: {
             codegen: 'graphql-codegen --config ./codegen.yml && prettier src/generated',
+            openapi: 'npx openapi-generator-cli generate --output ./src/api',
             wrapped: 'npx graphql-codegen --config ./codegen.yml',
             rawYarn: 'yarn graphql-codegen --config ./codegen.yml',
           },
@@ -139,6 +142,13 @@ describe('generated sources project metadata', () => {
         },
         {
           source: 'package-json-script',
+          taskName: 'openapi',
+          commandLine: 'npx openapi-generator-cli generate --output ./src/api',
+          command: 'openapi-generator-cli',
+          args: ['generate', '--output', './src/api'],
+        },
+        {
+          source: 'package-json-script',
           taskName: 'wrapped',
           commandLine: 'npx graphql-codegen --config ./codegen.yml',
           command: 'graphql-codegen',
@@ -157,12 +167,18 @@ describe('generated sources project metadata', () => {
     }
   });
 
-  it('extracts output flag values from separate and equals syntax', () => {
+  it('extracts flag values from separate and equals syntax', () => {
     expect(
       extractFlagValues('graphql-codegen --config ./codegen.yml --config=./other.yml', [
         '--config',
       ]),
     ).toEqual(['./codegen.yml', './other.yml']);
+    expect(
+      extractFlagValues('openapi-generator-cli generate -o ./src/api --output=./src/other', [
+        '-o',
+        '--output',
+      ]),
+    ).toEqual(['./src/api', './src/other']);
   });
 
   it('derives GraphQL outputs from the standard fixture', async () => {
@@ -767,6 +783,96 @@ export default config;
 
       expect(derived.configPaths).toEqual(new Set([configPath]));
       expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives OpenAPI outputs from the standard fixture', async () => {
+    const baseDir = joinPaths(fixtures, 'openapi');
+    await initFileStores(createConfiguration({ baseDir }));
+
+    expect(generatedSourceStore.getFamily(joinPaths(baseDir, 'src', 'api', 'index.ts'))).toEqual(
+      OPENAPI_GENERATOR_FAMILY,
+    );
+    expect(
+      generatedSourceStore.getFamily(joinPaths(baseDir, 'src', 'api', 'models', 'pet.ts')),
+    ).toEqual(OPENAPI_GENERATOR_FAMILY);
+    expect(
+      generatedSourceStore.getFamily(joinPaths(baseDir, 'build', 'api', 'ignored.ts')),
+    ).toEqual(OPENAPI_GENERATOR_FAMILY);
+  });
+
+  it('derives OpenAPI outputs from an output flag using equals syntax', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'src', 'api', 'index.ts');
+
+    try {
+      await writeFixtureFile(outputPath, 'export const api = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
+          },
+          scripts: {
+            generate: 'openapi-generator-cli generate --output=./src/api',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toEqual(OPENAPI_GENERATOR_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives OpenAPI outputs from an npx-wrapped command', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'src', 'api', 'index.ts');
+
+    try {
+      await writeFixtureFile(outputPath, 'export const api = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
+          },
+          scripts: {
+            generate: 'npx openapi-generator-cli generate --output ./src/api',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toEqual(OPENAPI_GENERATOR_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not derive OpenAPI outputs when openapi-generator-cli is only echoed', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'src', 'api', 'index.ts');
+
+    try {
+      await writeFixtureFile(outputPath, 'export const api = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
+          },
+          scripts: {
+            generate: 'echo openapi-generator-cli generate --output=./src/api',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
     } finally {
       await rm(baseDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add an `openapi-generator-cli` generated-source detector based on literal `-o` / `--output` paths
- restrict detection to explicit JS/TS OpenAPI generators
- keep the detector shallow by classifying only immediate child source files under the declared output directory
- watch declared output paths even when they do not exist yet so later-created files are reclassified on refresh

## Why
- PR #7133 added the GraphQL foundation for generated-source metadata; this stacked PR extends the same approach to OpenAPI outputs
- the initial OpenAPI shape needed the same conservative path-watching behavior as GraphQL to avoid missing outputs created after the first scan
- current Peachee evidence supports top-level generated files under dedicated API output directories, not recursive nested source discovery

## Impact
- committed JS/TS OpenAPI client outputs can now be recognized as generated sources from package script metadata
- non-JS generators remain out of scope
- nested directories without evidence remain out of scope for now

## Validation
- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts`
- `npm run bbf`
- `git diff --check`
