### PR TITLE
JS-1597 add generated-source foundation

### DIFF
--- a/docs/file-stores.md
+++ b/docs/file-stores.md
@@ -14,6 +14,17 @@ The analyzer needs more than the current source file contents:
 
 Those concerns change for different reasons, so they are cached separately instead of being recomputed as one large blob.
 
+## Scope Boundary
+
+This document is only about the file stores under `packages/analysis/src/file-stores/`.
+
+It does **not** describe:
+
+- the TypeScript program caches under `packages/analysis/src/jsts/program/cache/`
+- the higher-level dependency-helper caches under `packages/analysis/src/jsts/rules/helpers/dependency-manifests/`
+
+Those layers are downstream consumers of the file stores, not file stores themselves.
+
 ## Two Execution Models
 
 The analyzer has two execution models:
@@ -35,6 +46,46 @@ Its job is:
 4. Run each refreshed store's `postProcess()` step once source files are known.
 
 This means a store is only recomputed when its own invalidation rules say it must be.
+
+The main entrypoints that do this are:
+
+- `sanitizeProjectAnalysisInput()` in `packages/analysis/src/common/input-sanitize.ts`
+- `normalizeAnalyzeProjectRequest()` in `packages/grpc/src/analyze-project-normalize.ts`
+
+Both normalize `Configuration`, optionally sanitize explicit request files, and then call `initFileStores()`.
+
+## Population Modes
+
+`initFileStores()` can populate stores in two different ways.
+
+### Real Filesystem Traversal
+
+When `configuration.canAccessFileSystem === true`, `initFileStores()` walks the tree with `findFiles()`.
+
+That traversal:
+
+- starts from `baseDir`
+- skips paths matching `jsTsExclusions`
+- calls `processDirectory()` for directories
+- calls `processFile()` for files
+
+That walk is intentionally broader than the current analyzable source-file set.
+
+Its job is not only to find source files. It also needs to discover helper files such as `tsconfig.json` and dependency manifests. The `source-files` store applies source/test scope filtering itself during processing.
+
+In some direct filesystem-discovery request flows, callers clear the stores before calling `initFileStores()` so a same-`baseDir` rediscovery starts from empty state.
+
+### Simulated Traversal From Explicit Request Files
+
+When `configuration.canAccessFileSystem === false` and explicit `inputFiles` are present, `initFileStores()` calls `simulateFromInputFiles()`.
+
+That simulated walk:
+
+- synthesizes all parent directories from each request file up to `baseDir`
+- calls `processDirectory()` on those synthetic directories first
+- then calls `processFile()` on the explicit files
+
+This preserves parent-directory lookup semantics such as "closest manifest" and "closest tsconfig" lookups without inventing files that the request did not provide.
 
 ## Refresh Inputs
 
@@ -64,12 +115,13 @@ It depends on:
 
 When `inputFiles` are present, `sourceFileStore.isInitialized()` always rebuilds itself from that explicit file list.
 
-That is the IDE-style behavior:
+That is the main product behavior in SonarQube and SonarLint:
 
 - the store does **not** try to reuse the previous analyzed source-file set across analyses
+- the explicit request files are authoritative
 - the directory index is rebuilt from the new request files
 
-When `inputFiles` are not present, the store can be reused until the analyzable-file-selection configuration changes.
+When `inputFiles` are not present, the store behaves like a real discovery cache and can be reused until the analyzable-file-selection configuration changes or a caller explicitly clears it before rediscovery.
 
 ## `tsconfigs`
 
@@ -135,6 +187,8 @@ Like `tsconfigs`, this store is intentionally independent from the current set o
 ## `generated-sources`
 
 `generated-sources.ts` owns metadata about generated source files.
+
+See [Generated Source Detection](./generated-sources.md) for the detector pipeline, linter integration, and cache behavior behind this store.
 
 It stores:
 

--- a/docs/file-stores.md
+++ b/docs/file-stores.md
@@ -1,0 +1,197 @@
+# File Stores
+
+The file stores are long-lived analyzer caches that separate source-file selection from project-helper discovery.
+
+They live in `packages/analysis/src/file-stores/` and are initialized together by `initFileStores()`. Each store owns one kind of derived project state and decides independently when that state must be recomputed.
+
+## Why They Exist
+
+The analyzer needs more than the current source file contents:
+
+- it needs the set of analyzable source files
+- it needs project helper files such as `tsconfig.json` and `package.json`
+- it needs metadata derived from those helper files
+
+Those concerns change for different reasons, so they are cached separately instead of being recomputed as one large blob.
+
+## Two Execution Models
+
+The analyzer has two execution models:
+
+- **SonarQube** uses full-project analysis. In `analyzeProject.ts`, this goes through `analyzeWithProgram()` and falls back to `analyzeWithoutProgram()` for orphan files.
+- **SonarQube for IDE / SonarLint** uses request-driven analysis. In `analyzeProject.ts`, this goes through `analyzeWithIncrementalProgram()`, with `analyzeWithoutProgram()` as the fallback for orphan files.
+
+This matters for file stores because the IDE flow usually analyzes an explicit set of changed files, while the SonarQube flow typically scans the whole project.
+
+## Store Orchestration
+
+`initFileStores()` is the entrypoint for store refresh.
+
+Its job is:
+
+1. Ask each store whether its current state is still valid for the new `Configuration`.
+2. Re-initialize only the stores that report themselves stale.
+3. Populate those stores either by walking the filesystem or by simulating a walk from explicit request files.
+4. Run each refreshed store's `postProcess()` step once source files are known.
+
+This means a store is only recomputed when its own invalidation rules say it must be.
+
+## Refresh Inputs
+
+The current implementation uses two main cache domains:
+
+- **Analyzable-file selection**: configuration that decides which source files are kept for analysis.
+- **Project-file discovery**: configuration that decides which helper files can be discovered during the project walk.
+
+The analyzer models those domains explicitly because different stores depend on different inputs.
+
+## `source-files`
+
+`source-files.ts` owns the analyzable source-file set.
+
+It stores:
+
+- the normalized `AnalyzableFiles` map
+- ignored directories
+- a directory index used by TypeScript config resolution when filesystem access is unavailable
+
+It depends on:
+
+- the current analyzed file set when `inputFiles` are provided
+- source-file filtering configuration such as suffixes, inclusions, exclusions, tests, bundle detection, and JS/TS exclusions
+
+### Refresh Model
+
+When `inputFiles` are present, `sourceFileStore.isInitialized()` always rebuilds itself from that explicit file list.
+
+That is the IDE-style behavior:
+
+- the store does **not** try to reuse the previous analyzed source-file set across analyses
+- the directory index is rebuilt from the new request files
+
+When `inputFiles` are not present, the store can be reused until the analyzable-file-selection configuration changes.
+
+## `tsconfigs`
+
+`tsconfigs.ts` owns discovered TypeScript configuration files.
+
+It stores:
+
+- `tsconfig.json` files found by project lookup
+- explicit `sonar.typescript.tsconfigPaths` matches
+- referenced tsconfigs discovered while resolving project references
+
+It depends on:
+
+- project helper-file discovery, not on the current analyzed source-file set
+- `tsConfigPaths`
+- filesystem events that mention tsconfig files
+- whether filesystem access is available
+
+### Refresh Model
+
+`tsConfigStore` is refreshed when:
+
+- the base directory changes
+- filesystem access mode changes
+- the explicit `tsConfigPaths` setting changes
+- the project-file-discovery configuration changes
+- `fsEvents` mention an existing or potentially relevant tsconfig
+- `clearTsConfigCache` is requested
+
+The important point is that `tsconfigs` does **not** refresh just because a different subset of source files is being analyzed. It refreshes when tsconfig discovery itself may have changed.
+
+## `dependency-manifests`
+
+`dependency-manifests.ts` owns discovered dependency helper files such as:
+
+- `package.json`
+- supported Deno manifest files
+- supported workspace-level dependency manifests
+
+It also warms the dependency-resolution caches used later by:
+
+- dependency-sensitive rule activation
+- module-type detection
+- TypeScript and runtime signal extraction
+
+It depends on:
+
+- project helper-file discovery, not on the current analyzed source-file set
+- filesystem events that mention supported manifest files
+- whether filesystem access is available
+
+### Refresh Model
+
+`dependencyManifestStore` is refreshed when:
+
+- the base directory changes
+- filesystem access mode changes
+- the project-file-discovery configuration changes
+- `fsEvents` mention a supported dependency manifest
+
+Like `tsconfigs`, this store is intentionally independent from the current set of analyzed source files.
+
+## `generated-sources`
+
+`generated-sources.ts` owns metadata about generated source files.
+
+It stores:
+
+- generated-file to family mappings
+- config paths used by generated-source detectors
+- watched output paths
+- a filtered view of those matches for the current request
+
+It depends on a mix of the other stores:
+
+- **project helper files** because detectors derive metadata from files such as `package.json`
+- **source-file selection** because only analyzable source files should be surfaced to the linter
+- **explicit request files** in request-driven analysis, where the visible generated-file subset may change from one request to the next
+
+### Refresh Model
+
+`generatedSourceStore` is refreshed when:
+
+- the base directory changes
+- filesystem access mode changes
+- analyzable-file-selection configuration changes
+- project-file-discovery configuration changes
+- `fsEvents` mention a relevant helper file, generated-source config file, or watched output path
+
+It also has a lighter-weight request refresh:
+
+- when the explicit request file set changes but the derived metadata is still valid, the store can refresh its filtered view without recomputing everything
+
+This is why `generated-sources` is the hybrid store: it depends on both helper-file discovery and the currently visible source-file set.
+
+## `fsEvents`
+
+`fsEvents` is part of `Configuration` and is filled by the Java-side file watcher.
+
+The analyzer uses it as an invalidation signal for helper-file caches:
+
+- `tsconfigs` watches tsconfig-related file names and paths
+- `dependency-manifests` watches supported manifest file names and paths
+- `generated-sources` watches both helper files and detector-specific generated-source inputs and outputs
+
+This allows long-lived analyzer processes to keep caches warm while still clearing them as soon as relevant project files change.
+
+## Summary Table
+
+| Store                  | Primary responsibility                                       | Depends on analyzed source files | Depends on helper-file discovery         |
+| ---------------------- | ------------------------------------------------------------ | -------------------------------- | ---------------------------------------- |
+| `source-files`         | Current analyzable source-file set                           | Yes                              | Indirectly, through walk exclusions only |
+| `tsconfigs`            | Discovered tsconfig files                                    | No                               | Yes                                      |
+| `dependency-manifests` | Discovered dependency manifests and warmed dependency caches | No                               | Yes                                      |
+| `generated-sources`    | Generated-source metadata visible to the linter              | Yes                              | Yes                                      |
+
+## Practical Rule
+
+If a change affects:
+
+- **which source files are analyzed**, refresh `source-files`
+- **which helper files can be discovered**, refresh `tsconfigs` and `dependency-manifests`
+- **both**, refresh `generated-sources` too
+
+That split is the reason the file stores stay understandable even though they are all initialized from the same entrypoint.

--- a/docs/generated-sources.md
+++ b/docs/generated-sources.md
@@ -1,0 +1,294 @@
+# Generated Source Detection
+
+The generated-source detection subsystem identifies analyzable JS/TS files that were produced by project-local generators and exposes that information to the linter.
+
+This document explains the mechanism added on this branch from first principles. It is meant for readers who do not already know the file-store architecture or the generated-source helpers.
+
+## Why This Exists
+
+Some rules are less useful on generated code than on hand-written code.
+
+The analyzer therefore needs a way to answer a narrow question for each file:
+
+- is this file a generated source file?
+
+The new subsystem does **not** decide on its own which issues to suppress. It only produces metadata. The linter then uses that metadata when a rule explicitly declares that it should be skipped on generated sources.
+
+## What This Branch Adds
+
+This branch adds the foundation for generated-source detection:
+
+- a new `generatedSourceStore` file store
+- a detector contract for tool-specific generated-source detectors
+- helper functions for detector implementations
+- integration with `analyzeProject()` and the JS/TS linter
+- cache invalidation rules so long-lived analyzer processes can refresh when relevant project files change
+
+This branch does **not** register any built-in detector yet.
+
+That means:
+
+- the mechanism is wired through the analyzer end to end
+- the store stays empty until detectors are added to `GENERATED_SOURCE_DETECTORS`
+
+Reviewers should read this branch as “infrastructure for generated-source detection”, not as “support for a specific generator already shipped”.
+
+## Core Terms
+
+- **Generated source file**: an analyzable JavaScript or TypeScript file that a detector decided was produced by a generator.
+- **Family**: the detector-owned label attached to a generated file, such as a future tool family like `graphql-codegen`.
+- **Detector**: a plugin-like object that knows how to recognize one generator family.
+- **Task invocation**: a normalized command extracted from project metadata, currently from `package.json` scripts.
+- **Config path**: a generator configuration file path that should invalidate the cache if it changes.
+- **Watched output path**: an output file or directory that should invalidate the cache if it changes.
+
+## End-to-End Flow
+
+### 1. File stores are initialized before analysis
+
+`initFileStores()` initializes `source-files`, `dependency-manifests`, `generated-sources`, and `tsconfigs`.
+
+The new store is intentionally different from the others:
+
+- `generatedSourceStore.processFile()` does nothing during the file walk
+- the real work happens later in `postProcess()`
+
+That split exists because generated-source detection needs metadata from other stores before it can derive anything useful.
+
+### 2. Other stores prepare the inputs it depends on
+
+Before `generatedSourceStore.postProcess()` runs:
+
+- `sourceFileStore` has already computed the analyzable source-file set
+- `dependencyManifestStore` has already collected `package.json` files and warmed dependency caches
+
+This is why generated-source detection lives as its own store instead of being folded into file discovery.
+
+### 3. The store derives project-wide generated-source metadata
+
+When filesystem access is available, `generatedSourceStore.postProcess()` calls:
+
+```ts
+deriveGeneratedSources(baseDir, dependencyManifestStore.getPackageJsons(), {
+  sourceFileMatcher,
+});
+```
+
+`deriveGeneratedSources()` then:
+
+1. iterates over discovered `package.json` files
+2. parses each manifest
+3. collects task invocations from supported providers
+4. lazily resolves project dependencies for that package
+5. runs every registered detector
+6. merges the detector outputs into one project-level result
+
+If no detector is registered, the function returns immediately with empty metadata and does not even traverse package metadata.
+
+### 4. The store keeps both full and request-filtered views
+
+The store keeps two related maps:
+
+- `derivedFamilyByFile`: every generated file derived for the project
+- `familyByFile`: only the generated files that are visible for the current analysis request
+
+That filtered view matters because the analyzer has two execution styles:
+
+- full-project analysis, where all analyzable files are visible
+- request-driven analysis, where only an explicit file subset may be visible
+
+The store therefore never exposes generated files that are not part of the current analyzable file set.
+
+### 5. The linter consumes the metadata
+
+`analyzeProject()` passes this predicate into `Linter.initialize()`:
+
+```ts
+filePath => generatedSourceStore.getFamily(filePath) !== undefined;
+```
+
+During rule selection, the linter computes `isGeneratedSource` for the current file.
+
+That value is used by `filterGeneratedSource`, which disables only rules whose metadata sets:
+
+```ts
+skipOnGeneratedSource: true;
+```
+
+So the generated-source subsystem is a metadata source for rule filtering. It is not a blanket “ignore generated files” switch.
+
+## Detector Model
+
+Each detector implements the `GeneratedSourceDetector` contract and owns one family.
+
+The detector receives:
+
+- `baseDir`: the analysis root
+- `packageDir`: the directory that owns the current `package.json`
+- `getDependencies()`: a lazy dependency lookup for that package
+- `taskInvocations`: normalized command invocations derived from project metadata
+- `sourceFileMatcher`: the current analysis-time definition of “analyzable source file”
+
+The detector returns:
+
+- `familyByFile`: generated-file to family mappings
+- `configPaths`: config files that should invalidate the cache on change
+- `watchedOutputPaths`: output files or directories that should invalidate the cache on change
+
+### Important detector rule
+
+Detectors are expected to report only project-local paths under `baseDir`.
+
+The shared helpers enforce that boundary so one project cannot accidentally claim generated files outside the analysis root.
+
+## Shared Helper Responsibilities
+
+The helpers under `packages/analysis/src/jsts/rules/helpers/generated-sources/` exist so detectors can stay small and declarative.
+
+### Evidence helpers
+
+`hasToolEvidence()` answers “is this generator probably in use here?” by combining:
+
+- dependency evidence
+- task-invocation evidence
+
+This lets a detector avoid expensive work when the project shows no sign of using its tool.
+
+### Config-path resolution
+
+`resolveConfigPaths()` looks for generator config files in two ways:
+
+- explicit flag values in matching task invocations
+- fallback sibling basenames such as a default config filename
+
+If explicit config flags are present, they win over fallback basenames.
+
+### Output resolution
+
+`resolveGeneratedOutputsFromLiteralPaths()` resolves declared output paths and returns three things:
+
+- source files that currently exist
+- output directories that currently exist
+- watched output paths, even if the target does not exist yet
+
+That last point is intentional. A missing output today may be created tomorrow, and the cache still needs to invalidate when that happens.
+
+### Deterministic merging
+
+`mergeDerivedGeneratedSources()` sorts paths before insertion and keeps the first family that claimed a file.
+
+That gives two useful guarantees:
+
+- generated-source metadata is deterministic across runs and platforms
+- detector order in `GENERATED_SOURCE_DETECTORS` defines conflict resolution when two detectors claim the same file
+
+## Task Invocation Parsing
+
+Generated-source detectors need a small amount of project-task awareness, but not a full shell parser.
+
+The current implementation intentionally recognizes only simple, defensible cases:
+
+- direct commands in `package.json` scripts
+- command chains separated by `&&`
+- quoted arguments
+- `npx <tool> ...`
+- `npx -- <tool> ...`
+- `pnpm exec <tool> ...`
+
+It intentionally does **not** try to interpret broader shell behavior such as:
+
+- environment-assignment preambles like `NODE_ENV=production tool ...`
+- separators other than `&&`
+- runner options such as `npx --yes ...`
+- package-manager script indirection such as `yarn <script>` or `npm run <script>`
+- shell-generated or concatenated path expressions
+
+That restriction is deliberate. The goal is predictable detector behavior, not best-effort shell emulation.
+
+## Path and Filesystem Safety Rules
+
+The helper layer is conservative about which paths it trusts.
+
+### Literal paths only
+
+Only literal path tokens are resolved.
+
+Tokens containing shell interpolation or string construction are ignored, for example values containing:
+
+- `$`
+- backticks
+- `+`
+
+### `baseDir` boundary
+
+Resolved paths must stay under the current analysis `baseDir`.
+
+This prevents detectors from producing metadata for files outside the analyzed project.
+
+### Source-file filtering
+
+Generated outputs are filtered through the configured JS/TS suffix set used by the analysis.
+
+In practice, this means the generated-source subsystem only surfaces files that the current analysis would consider analyzable source files anyway.
+
+### Recursive directory pruning
+
+When a detector declares an output directory and asks for recursive scanning, the helper skips obvious nested build or cache directories such as:
+
+- `node_modules`
+- `dist`
+- `build`
+- `.cache`
+- `coverage`
+- `.next`
+
+This keeps a declared output directory from recursively pulling in unrelated nested artifacts.
+
+## Cache and Invalidation Model
+
+The generated-source store is the hybrid file store described in `file-stores.md`.
+
+It depends on three kinds of state at once:
+
+- project helper-file discovery
+- analyzable source-file selection
+- the current explicit request file set, when analysis is request-driven
+
+### Full recomputation happens when:
+
+- `baseDir` changes
+- filesystem access mode changes
+- analyzable-file-selection configuration changes
+- project-file-discovery configuration changes
+- `fsEvents` mention a relevant manifest, config file, generated file, or watched output path
+
+`fsEvents` can also invalidate the store through detector-declared watched basenames, even when the detector had not yet resolved a full config path.
+
+### Request-only refresh happens when:
+
+- the explicit set of request files changes
+- the derived metadata itself is still valid
+
+In that case the store does not recompute detector output. It only rebuilds the filtered `familyByFile` view for the new request.
+
+### No-filesystem mode
+
+Actual derivation currently requires filesystem access.
+
+If `canAccessFileSystem` is `false`, `postProcess()` keeps the store empty. The store still tracks its configuration state, but it does not attempt to derive generated-source metadata from partial request payloads alone.
+
+That is an important current limitation.
+
+## Review Notes
+
+These are the main design points worth keeping in mind when reviewing the implementation:
+
+- The mechanism is metadata-driven. It does not inspect source-file contents to guess whether a file is generated.
+- The store derives its data in `postProcess()` because it depends on outputs from other stores.
+- The store exposes only analyzable files for the current request, even if more generated files were derived for the project.
+- The detector foundation is intentionally conservative about shell parsing and path resolution.
+- The mechanism is fully wired into the linter, but no concrete detector family is registered on this branch yet.
+
+## Related Documentation
+
+- [File Stores](./file-stores.md)

--- a/packages/analysis/src/analyzeProject.ts
+++ b/packages/analysis/src/analyzeProject.ts
@@ -34,7 +34,7 @@ import { info, error } from '../../shared/src/helpers/logging.js';
 import { ProgressReport } from './common/progress-report.js';
 import type { WsIncrementalResult } from './incremental-result.js';
 import { setSourceFilesContext } from './jsts/program/cache/sourceFileCache.js';
-import { sourceFileStore } from './file-stores/index.js';
+import { generatedSourceStore, sourceFileStore } from './file-stores/index.js';
 import type { NormalizedAbsolutePath } from '../../shared/src/helpers/files.js';
 import { getProjectAnalysisTelemetry, resetProjectAnalysisTelemetry } from './telemetry.js';
 
@@ -88,6 +88,7 @@ export async function analyzeProject(
     globals,
     bundles,
     baseDir,
+    isGeneratedSourceFile: filePath => generatedSourceStore.getFamily(filePath) !== undefined,
     rulesWorkdir,
     testFileExtensions,
   });

--- a/packages/analysis/src/common/configuration.ts
+++ b/packages/analysis/src/common/configuration.ts
@@ -422,6 +422,37 @@ export function getFilterPathParams(configuration: Configuration): FilterPathPar
   };
 }
 
+function serializeMinimatchPatterns(patterns: Minimatch[]) {
+  return patterns.map(({ pattern }) => pattern);
+}
+
+/**
+ * Returns a stable cache key for the configuration fields that decide which files
+ * are discovered, kept, and classified for analysis.
+ */
+export function getAnalyzableFilesConfigKey(configuration: Configuration) {
+  const shouldIgnoreParams = getShouldIgnoreParams(configuration);
+  const filterPathParams = getFilterPathParams(configuration);
+
+  return JSON.stringify({
+    jsSuffixes: shouldIgnoreParams.jsSuffixes,
+    tsSuffixes: shouldIgnoreParams.tsSuffixes,
+    cssSuffixes: shouldIgnoreParams.cssSuffixes,
+    htmlSuffixes: shouldIgnoreParams.htmlSuffixes,
+    yamlSuffixes: shouldIgnoreParams.yamlSuffixes,
+    cssAdditionalSuffixes: shouldIgnoreParams.cssAdditionalSuffixes,
+    detectBundles: shouldIgnoreParams.detectBundles,
+    maxFileSize: shouldIgnoreParams.maxFileSize,
+    jsTsExclusions: serializeMinimatchPatterns(shouldIgnoreParams.jsTsExclusions),
+    sourcesPaths: filterPathParams.sourcesPaths,
+    testPaths: filterPathParams.testPaths,
+    inclusions: serializeMinimatchPatterns(filterPathParams.inclusions),
+    exclusions: serializeMinimatchPatterns(filterPathParams.exclusions),
+    testInclusions: serializeMinimatchPatterns(filterPathParams.testInclusions),
+    testExclusions: serializeMinimatchPatterns(filterPathParams.testExclusions),
+  });
+}
+
 function isJsFile(
   filePath: NormalizedAbsolutePath,
   jsSuffixes: string[] = DEFAULT_JS_EXTENSIONS,

--- a/packages/analysis/src/common/configuration.ts
+++ b/packages/analysis/src/common/configuration.ts
@@ -427,6 +427,16 @@ function serializeMinimatchPatterns(patterns: Minimatch[]) {
 }
 
 /**
+ * Returns a stable cache key for configuration fields that decide which project-level
+ * helper files can be discovered during the file-system walk.
+ */
+export function getProjectFileDiscoveryConfigKey(configuration: Configuration) {
+  return JSON.stringify({
+    jsTsExclusions: serializeMinimatchPatterns(configuration.jsTsExclusions),
+  });
+}
+
+/**
  * Returns a stable cache key for the configuration fields that decide which files
  * are discovered, kept, and classified for analysis.
  */

--- a/packages/analysis/src/file-stores/dependency-manifests.ts
+++ b/packages/analysis/src/file-stores/dependency-manifests.ts
@@ -47,9 +47,10 @@ function createManifestFilesByName(): ManifestFilesByName {
   ) as ManifestFilesByName;
 }
 
-export class DependencyManifestStore implements FileStore {
+class DependencyManifestStore implements FileStore {
   private readonly manifestsByName = createManifestFilesByName();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
+  private canAccessFileSystem: boolean | undefined = undefined;
   private readonly dirnameToParent: Map<
     NormalizedAbsolutePath,
     NormalizedAbsolutePath | undefined
@@ -68,8 +69,8 @@ export class DependencyManifestStore implements FileStore {
   }
 
   dirtyCachesIfNeeded(configuration: Configuration) {
-    const { baseDir, fsEvents } = configuration;
-    if (baseDir !== this.baseDir) {
+    const { baseDir, canAccessFileSystem, fsEvents } = configuration;
+    if (baseDir !== this.baseDir || canAccessFileSystem !== this.canAccessFileSystem) {
       this.clearCache();
       return;
     }
@@ -83,6 +84,7 @@ export class DependencyManifestStore implements FileStore {
 
   clearCache() {
     this.baseDir = undefined;
+    this.canAccessFileSystem = undefined;
     for (const manifestFiles of Object.values(this.manifestsByName)) {
       manifestFiles.clear();
     }
@@ -93,6 +95,7 @@ export class DependencyManifestStore implements FileStore {
 
   setup(configuration: Configuration) {
     this.baseDir = configuration.baseDir;
+    this.canAccessFileSystem = configuration.canAccessFileSystem;
     this.dirnameToParent.set(configuration.baseDir, undefined);
   }
 
@@ -133,3 +136,5 @@ export class DependencyManifestStore implements FileStore {
     }
   }
 }
+
+export const dependencyManifestStore = new DependencyManifestStore();

--- a/packages/analysis/src/file-stores/dependency-manifests.ts
+++ b/packages/analysis/src/file-stores/dependency-manifests.ts
@@ -32,6 +32,7 @@ import {
   type PreloadableDependencyManifestName,
   isPreloadableDependencyManifestPath,
 } from '../jsts/rules/helpers/dependency-manifests/index.js';
+import { getProjectFileDiscoveryConfigKey } from '../common/configuration.js';
 
 export const UNINITIALIZED_ERROR =
   'dependency manifest cache has not been initialized. Call loadFiles() first.';
@@ -51,6 +52,7 @@ class DependencyManifestStore implements FileStore {
   private readonly manifestsByName = createManifestFilesByName();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
+  private projectFileDiscoveryConfigKey: string | undefined = undefined;
   private readonly dirnameToParent: Map<
     NormalizedAbsolutePath,
     NormalizedAbsolutePath | undefined
@@ -70,7 +72,11 @@ class DependencyManifestStore implements FileStore {
 
   dirtyCachesIfNeeded(configuration: Configuration) {
     const { baseDir, canAccessFileSystem, fsEvents } = configuration;
-    if (baseDir !== this.baseDir || canAccessFileSystem !== this.canAccessFileSystem) {
+    if (
+      baseDir !== this.baseDir ||
+      canAccessFileSystem !== this.canAccessFileSystem ||
+      getProjectFileDiscoveryConfigKey(configuration) !== this.projectFileDiscoveryConfigKey
+    ) {
       this.clearCache();
       return;
     }
@@ -85,6 +91,7 @@ class DependencyManifestStore implements FileStore {
   clearCache() {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
+    this.projectFileDiscoveryConfigKey = undefined;
     for (const manifestFiles of Object.values(this.manifestsByName)) {
       manifestFiles.clear();
     }
@@ -96,6 +103,7 @@ class DependencyManifestStore implements FileStore {
   setup(configuration: Configuration) {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
+    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     this.dirnameToParent.set(configuration.baseDir, undefined);
   }
 

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -89,8 +89,9 @@ class GeneratedSourceStore implements FileStore {
       return;
     }
 
+    const generatedSourceWatchedFilenames = getGeneratedSourceWatchedFilenames();
     for (const filename of fsEvents) {
-      if (this.isRelevantEvent(filename)) {
+      if (this.isRelevantEvent(filename, generatedSourceWatchedFilenames)) {
         this.clearCache();
         return;
       }
@@ -155,11 +156,14 @@ class GeneratedSourceStore implements FileStore {
     );
   }
 
-  private isRelevantEvent(filename: NormalizedAbsolutePath) {
+  private isRelevantEvent(
+    filename: NormalizedAbsolutePath,
+    generatedSourceWatchedFilenames: readonly string[],
+  ) {
     const eventBaseName = basename(filename).toLowerCase();
     if (
       isPreloadableDependencyManifestPath(filename) ||
-      getGeneratedSourceWatchedFilenames().includes(eventBaseName)
+      generatedSourceWatchedFilenames.includes(eventBaseName)
     ) {
       return true;
     }

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -20,7 +20,10 @@ import type { FileStore } from './store-type.js';
 import type { Configuration } from '../common/configuration.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
-import { getAnalyzableFilesConfigKey } from '../common/configuration.js';
+import {
+  getAnalyzableFilesConfigKey,
+  getProjectFileDiscoveryConfigKey,
+} from '../common/configuration.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
 import { GENERATED_SOURCE_WATCHED_FILENAMES } from '../jsts/rules/helpers/generated-sources/index.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
@@ -35,6 +38,7 @@ class GeneratedSourceStore implements FileStore {
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
+  private projectFileDiscoveryConfigKey: string | undefined = undefined;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
   private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
@@ -79,6 +83,11 @@ class GeneratedSourceStore implements FileStore {
       return;
     }
 
+    if (getProjectFileDiscoveryConfigKey(configuration) !== this.projectFileDiscoveryConfigKey) {
+      this.clearCache();
+      return;
+    }
+
     for (const filename of fsEvents) {
       if (this.isRelevantEvent(filename)) {
         this.clearCache();
@@ -91,6 +100,7 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
     this.analyzableFilesConfigKey = undefined;
+    this.projectFileDiscoveryConfigKey = undefined;
     this.activeRequestFilesKey = undefined;
     this.clearDerivedState();
   }
@@ -99,6 +109,7 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
     this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     this.clearDerivedState();
   }
 
@@ -118,6 +129,7 @@ class GeneratedSourceStore implements FileStore {
       this.baseDir = configuration.baseDir;
       this.canAccessFileSystem = configuration.canAccessFileSystem;
       this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+      this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     }
 
     const { baseDir, canAccessFileSystem } = this;

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -1,0 +1,234 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { createHash } from 'node:crypto';
+import { basename, extname } from 'node:path/posix';
+import type { FileStore } from './store-type.js';
+import type { Configuration } from '../common/configuration.js';
+import type { AnalyzableFiles } from '../projectAnalysis.js';
+import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
+import { getAnalyzableFilesConfigKey } from '../common/configuration.js';
+import { dependencyManifestStore } from './dependency-manifests.js';
+import { GENERATED_SOURCE_WATCHED_FILENAMES } from '../jsts/rules/helpers/generated-sources/index.js';
+import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
+import { deriveGeneratedSources } from '../jsts/rules/helpers/generated-sources/derive.js';
+
+const ALL_FILES_REQUEST_KEY = 'all-files';
+const EXPLICIT_FILE_SET_REQUEST_KEY_PREFIX = 'explicit';
+
+type RequestFilesKey = string | undefined;
+
+class GeneratedSourceStore implements FileStore {
+  private baseDir: NormalizedAbsolutePath | undefined = undefined;
+  private canAccessFileSystem: boolean | undefined = undefined;
+  private analyzableFilesConfigKey: string | undefined = undefined;
+  private activeRequestFilesKey: RequestFilesKey = undefined;
+  private requestFilesKey: RequestFilesKey = undefined;
+  private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
+  private familyByFile = new Map<NormalizedAbsolutePath, string>();
+  private resolvedFiles = new Set<NormalizedAbsolutePath>();
+  private configPaths = new Set<NormalizedAbsolutePath>();
+  private watchedOutputPaths = new Set<NormalizedAbsolutePath>();
+
+  async isInitialized(configuration: Configuration, inputFiles?: AnalyzableFiles) {
+    this.dirtyCachesIfNeeded(configuration);
+    const requestFilesKey = getRequestFilesKey(configuration.canAccessFileSystem, inputFiles);
+    this.activeRequestFilesKey = requestFilesKey;
+    if (this.baseDir === undefined) {
+      return false;
+    }
+
+    if (requestFilesKey === this.requestFilesKey) {
+      return true;
+    }
+
+    if (requestFilesKey === undefined) {
+      return false;
+    }
+
+    this.refreshFilteredState(inputFiles, requestFilesKey);
+    return true;
+  }
+
+  getFamily(filePath: NormalizedAbsolutePath): string | undefined {
+    return this.familyByFile.get(filePath);
+  }
+
+  dirtyCachesIfNeeded(configuration: Configuration) {
+    const { baseDir, canAccessFileSystem, fsEvents } = configuration;
+    if (baseDir !== this.baseDir || canAccessFileSystem !== this.canAccessFileSystem) {
+      this.clearCache();
+      return;
+    }
+
+    if (getAnalyzableFilesConfigKey(configuration) !== this.analyzableFilesConfigKey) {
+      this.clearCache();
+      return;
+    }
+
+    for (const filename of fsEvents) {
+      if (this.isRelevantEvent(filename)) {
+        this.clearCache();
+        return;
+      }
+    }
+  }
+
+  clearCache() {
+    this.baseDir = undefined;
+    this.canAccessFileSystem = undefined;
+    this.analyzableFilesConfigKey = undefined;
+    this.activeRequestFilesKey = undefined;
+    this.clearDerivedState();
+  }
+
+  setup(configuration: Configuration) {
+    this.baseDir = configuration.baseDir;
+    this.canAccessFileSystem = configuration.canAccessFileSystem;
+    this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+    this.clearDerivedState();
+  }
+
+  async processFile(
+    _filename: NormalizedAbsolutePath,
+    _configuration: Configuration,
+  ): Promise<void> {
+    // Generated-source detection is derived from project metadata during postProcess.
+  }
+
+  async postProcess(configuration: Configuration, analyzableFiles?: AnalyzableFiles) {
+    if (
+      this.baseDir === undefined ||
+      this.canAccessFileSystem === undefined ||
+      this.analyzableFilesConfigKey === undefined
+    ) {
+      this.baseDir = configuration.baseDir;
+      this.canAccessFileSystem = configuration.canAccessFileSystem;
+      this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+    }
+
+    const { baseDir, canAccessFileSystem } = this;
+    if (!baseDir || !canAccessFileSystem) {
+      return;
+    }
+
+    const derived = await deriveGeneratedSources(
+      baseDir,
+      dependencyManifestStore.getPackageJsons(),
+      {
+        sourceFileMatcher: createConfiguredGeneratedSourceFileMatcher(configuration),
+      },
+    );
+    this.derivedFamilyByFile = new Map(derived.familyByFile);
+    this.resolvedFiles = new Set(this.derivedFamilyByFile.keys());
+    this.configPaths = derived.configPaths;
+    this.watchedOutputPaths = derived.watchedOutputPaths;
+    this.refreshFilteredState(
+      analyzableFiles,
+      this.activeRequestFilesKey ?? getRequestFilesKey(canAccessFileSystem, analyzableFiles),
+    );
+  }
+
+  private isRelevantEvent(filename: NormalizedAbsolutePath) {
+    const eventBaseName = basename(filename).toLowerCase();
+    if (
+      isPreloadableDependencyManifestPath(filename) ||
+      GENERATED_SOURCE_WATCHED_FILENAMES.includes(eventBaseName)
+    ) {
+      return true;
+    }
+
+    if (
+      this.configPaths.has(filename) ||
+      this.familyByFile.has(filename) ||
+      this.resolvedFiles.has(filename)
+    ) {
+      return true;
+    }
+
+    for (const watchedOutputPath of this.watchedOutputPaths) {
+      if (filename === watchedOutputPath || filename.startsWith(`${watchedOutputPath}/`)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private clearDerivedState() {
+    this.requestFilesKey = undefined;
+    this.derivedFamilyByFile = new Map();
+    this.familyByFile = new Map();
+    this.resolvedFiles = new Set();
+    this.configPaths = new Set();
+    this.watchedOutputPaths = new Set();
+  }
+
+  private refreshFilteredState(
+    analyzableFiles: AnalyzableFiles | undefined,
+    requestFilesKey: RequestFilesKey,
+  ) {
+    this.requestFilesKey = requestFilesKey;
+    this.familyByFile = filterAnalyzableGeneratedFiles(this.derivedFamilyByFile, analyzableFiles);
+  }
+}
+
+function filterAnalyzableGeneratedFiles(
+  familyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
+  analyzableFiles: AnalyzableFiles | undefined,
+) {
+  if (!analyzableFiles) {
+    return new Map(familyByFile);
+  }
+
+  const filtered = new Map<NormalizedAbsolutePath, string>();
+  for (const [filePath, family] of familyByFile) {
+    if (Object.hasOwn(analyzableFiles, filePath)) {
+      filtered.set(filePath, family);
+    }
+  }
+  return filtered;
+}
+
+function getRequestFilesKey(
+  canAccessFileSystem: boolean,
+  analyzableFiles?: AnalyzableFiles,
+): RequestFilesKey {
+  if (!analyzableFiles) {
+    return canAccessFileSystem ? ALL_FILES_REQUEST_KEY : undefined;
+  }
+
+  const filePaths = Object.keys(analyzableFiles).sort((left, right) => left.localeCompare(right));
+  const hash = createHash('sha256');
+  for (const filePath of filePaths) {
+    hash.update(filePath);
+    hash.update('\0');
+  }
+
+  return `${EXPLICIT_FILE_SET_REQUEST_KEY_PREFIX}:${filePaths.length}:${hash.digest('hex')}`;
+}
+
+function createConfiguredGeneratedSourceFileMatcher(configuration: Configuration) {
+  const supportedExtensions = new Set(
+    [...configuration.jsSuffixes, ...configuration.tsSuffixes].map(extension =>
+      extension.toLowerCase(),
+    ),
+  );
+  return (filePath: NormalizedAbsolutePath) =>
+    supportedExtensions.has(extname(filePath).toLowerCase());
+}
+
+export const generatedSourceStore = new GeneratedSourceStore();

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -35,6 +35,7 @@ const EXPLICIT_FILE_SET_REQUEST_KEY_PREFIX = 'explicit';
 type RequestFilesKey = string | undefined;
 
 class GeneratedSourceStore implements FileStore {
+  private readonly explicitRequestFilesKeys = new WeakMap<AnalyzableFiles, string>();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
@@ -49,7 +50,7 @@ class GeneratedSourceStore implements FileStore {
 
   async isInitialized(configuration: Configuration, inputFiles?: AnalyzableFiles) {
     this.dirtyCachesIfNeeded(configuration);
-    const requestFilesKey = getRequestFilesKey(configuration.canAccessFileSystem, inputFiles);
+    const requestFilesKey = this.getRequestFilesKey(configuration.canAccessFileSystem, inputFiles);
     this.activeRequestFilesKey = requestFilesKey;
     if (this.baseDir === undefined) {
       return false;
@@ -150,7 +151,7 @@ class GeneratedSourceStore implements FileStore {
     this.watchedOutputPaths = derived.watchedOutputPaths;
     this.refreshFilteredState(
       analyzableFiles,
-      this.activeRequestFilesKey ?? getRequestFilesKey(canAccessFileSystem, analyzableFiles),
+      this.activeRequestFilesKey ?? this.getRequestFilesKey(canAccessFileSystem, analyzableFiles),
     );
   }
 
@@ -189,6 +190,24 @@ class GeneratedSourceStore implements FileStore {
     this.watchedOutputPaths = new Set();
   }
 
+  private getRequestFilesKey(
+    canAccessFileSystem: boolean,
+    analyzableFiles?: AnalyzableFiles,
+  ): RequestFilesKey {
+    if (!analyzableFiles) {
+      return canAccessFileSystem ? ALL_FILES_REQUEST_KEY : undefined;
+    }
+
+    const cachedRequestFilesKey = this.explicitRequestFilesKeys.get(analyzableFiles);
+    if (cachedRequestFilesKey !== undefined) {
+      return cachedRequestFilesKey;
+    }
+
+    const requestFilesKey = createExplicitRequestFilesKey(analyzableFiles);
+    this.explicitRequestFilesKeys.set(analyzableFiles, requestFilesKey);
+    return requestFilesKey;
+  }
+
   private refreshFilteredState(
     analyzableFiles: AnalyzableFiles | undefined,
     requestFilesKey: RequestFilesKey,
@@ -215,14 +234,7 @@ function filterAnalyzableGeneratedFiles(
   return filtered;
 }
 
-function getRequestFilesKey(
-  canAccessFileSystem: boolean,
-  analyzableFiles?: AnalyzableFiles,
-): RequestFilesKey {
-  if (!analyzableFiles) {
-    return canAccessFileSystem ? ALL_FILES_REQUEST_KEY : undefined;
-  }
-
+function createExplicitRequestFilesKey(analyzableFiles: AnalyzableFiles) {
   const filePaths = Object.keys(analyzableFiles).sort((left, right) => left.localeCompare(right));
   const hash = createHash('sha256');
   for (const filePath of filePaths) {

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -25,7 +25,7 @@ import {
   getProjectFileDiscoveryConfigKey,
 } from '../common/configuration.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
-import { GENERATED_SOURCE_WATCHED_FILENAMES } from '../jsts/rules/helpers/generated-sources/index.js';
+import { getGeneratedSourceWatchedFilenames } from '../jsts/rules/helpers/generated-sources/index.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
 import { deriveGeneratedSources } from '../jsts/rules/helpers/generated-sources/derive.js';
 
@@ -159,7 +159,7 @@ class GeneratedSourceStore implements FileStore {
     const eventBaseName = basename(filename).toLowerCase();
     if (
       isPreloadableDependencyManifestPath(filename) ||
-      GENERATED_SOURCE_WATCHED_FILENAMES.includes(eventBaseName)
+      getGeneratedSourceWatchedFilenames().includes(eventBaseName)
     ) {
       return true;
     }

--- a/packages/analysis/src/file-stores/index.ts
+++ b/packages/analysis/src/file-stores/index.ts
@@ -15,7 +15,8 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { SourceFileStore } from './source-files.js';
-import { DependencyManifestStore } from './dependency-manifests.js';
+import { dependencyManifestStore } from './dependency-manifests.js';
+import { generatedSourceStore } from './generated-sources.js';
 import { TsConfigStore } from './tsconfigs.js';
 import { findFiles } from '../common/find-files.js';
 import type { FileStore } from './store-type.js';
@@ -28,14 +29,20 @@ import {
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 
 export const sourceFileStore = new SourceFileStore();
-export const dependencyManifestStore = new DependencyManifestStore();
 export const tsConfigStore = new TsConfigStore();
+export { dependencyManifestStore } from './dependency-manifests.js';
+export { generatedSourceStore } from './generated-sources.js';
 
 export async function initFileStores(configuration: Configuration, inputFiles?: AnalyzableFiles) {
   const { baseDir, canAccessFileSystem, jsTsExclusions } = configuration;
   const pendingStores: FileStore[] = [];
 
-  for (const store of [sourceFileStore, dependencyManifestStore, tsConfigStore]) {
+  for (const store of [
+    sourceFileStore,
+    dependencyManifestStore,
+    generatedSourceStore,
+    tsConfigStore,
+  ]) {
     if (!(await store.isInitialized(configuration, inputFiles))) {
       pendingStores.push(store);
     }
@@ -64,8 +71,9 @@ export async function initFileStores(configuration: Configuration, inputFiles?: 
     await simulateFromInputFiles(inputFiles, configuration, pendingStores);
   }
 
+  const analyzableFiles = sourceFileStore.getFiles();
   for (const store of pendingStores) {
-    await store.postProcess(configuration);
+    await store.postProcess(configuration, analyzableFiles);
   }
 }
 

--- a/packages/analysis/src/file-stores/source-files.ts
+++ b/packages/analysis/src/file-stores/source-files.ts
@@ -49,6 +49,7 @@ export class SourceFileStore implements FileStore {
   async isInitialized(configuration: Configuration, inputFiles?: AnalyzableFiles) {
     this.dirtyCachesIfNeeded(configuration);
     if (inputFiles) {
+      this.clearCache();
       this.setup(configuration);
       this.files = inputFiles;
       this.directoryIndex.buildFromFiles(Object.keys(inputFiles) as NormalizedAbsolutePath[]);

--- a/packages/analysis/src/file-stores/source-files.ts
+++ b/packages/analysis/src/file-stores/source-files.ts
@@ -19,6 +19,7 @@ import { JSTS_ANALYSIS_DEFAULTS } from '../jsts/analysis/analysis.js';
 import {
   isAnalyzableFile,
   type Configuration,
+  getAnalyzableFilesConfigKey,
   getShouldIgnoreParams,
   getFilterPathParams,
 } from '../common/configuration.js';
@@ -36,6 +37,8 @@ export const UNINITIALIZED_ERROR = 'Files cache has not been initialized. Call l
 
 export class SourceFileStore implements FileStore {
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
+  private canAccessFileSystem: boolean | undefined = undefined;
+  private analyzableFilesConfigKey: string | undefined = undefined;
   private readonly ignoredPaths = new Set<string>();
   private files: AnalyzableFiles | undefined = undefined;
   private readonly directoryIndex = new DirectoryIndex();
@@ -44,8 +47,7 @@ export class SourceFileStore implements FileStore {
    * Checks if the file store is initialized for the given base directory.
    */
   async isInitialized(configuration: Configuration, inputFiles?: AnalyzableFiles) {
-    const { baseDir } = configuration;
-    this.dirtyCachesIfNeeded(baseDir);
+    this.dirtyCachesIfNeeded(configuration);
     if (inputFiles) {
       this.setup(configuration);
       this.files = inputFiles;
@@ -71,13 +73,22 @@ export class SourceFileStore implements FileStore {
     return this.directoryIndex.getFilesInDirectory(dir);
   }
 
-  dirtyCachesIfNeeded(currentBaseDir: NormalizedAbsolutePath) {
-    if (currentBaseDir !== this.baseDir) {
+  dirtyCachesIfNeeded(configuration: Configuration) {
+    const { baseDir, canAccessFileSystem } = configuration;
+    if (baseDir !== this.baseDir || canAccessFileSystem !== this.canAccessFileSystem) {
+      this.clearCache();
+      return;
+    }
+
+    if (getAnalyzableFilesConfigKey(configuration) !== this.analyzableFilesConfigKey) {
       this.clearCache();
     }
   }
 
   clearCache() {
+    this.baseDir = undefined;
+    this.canAccessFileSystem = undefined;
+    this.analyzableFilesConfigKey = undefined;
     this.files = undefined;
     this.ignoredPaths.clear();
     this.directoryIndex.clear();
@@ -85,6 +96,8 @@ export class SourceFileStore implements FileStore {
 
   setup(configuration: Configuration) {
     this.baseDir = configuration.baseDir;
+    this.canAccessFileSystem = configuration.canAccessFileSystem;
+    this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
     this.files = createAnalyzableFiles();
   }
 

--- a/packages/analysis/src/file-stores/store-type.ts
+++ b/packages/analysis/src/file-stores/store-type.ts
@@ -46,8 +46,12 @@ export abstract class FileStore {
    * Performs post-processing after all files have been processed.
    *
    * @param configuration - The project configuration
+   * @param analyzableFiles - Optional analyzable files prepared during the scan
    */
-  abstract postProcess(configuration: Configuration): Promise<void>;
+  abstract postProcess(
+    configuration: Configuration,
+    analyzableFiles?: AnalyzableFiles,
+  ): Promise<void>;
 
   abstract processDirectory?(dir: NormalizedAbsolutePath, configuration: Configuration): void;
 }

--- a/packages/analysis/src/file-stores/tsconfigs.ts
+++ b/packages/analysis/src/file-stores/tsconfigs.ts
@@ -19,7 +19,7 @@ import { basename } from 'node:path/posix';
 import { Minimatch } from 'minimatch';
 import type { FileStore } from './store-type.js';
 import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
-import type { Configuration } from '../common/configuration.js';
+import { type Configuration, getProjectFileDiscoveryConfigKey } from '../common/configuration.js';
 import { clearTsConfigContentCache } from '../jsts/program/cache/tsconfigCache.js';
 import { clearProgramOptionsCache } from '../jsts/program/cache/programOptionsCache.js';
 import { getProgramCacheManager } from '../jsts/program/cache/programCache.js';
@@ -39,6 +39,8 @@ export class TsConfigStore implements FileStore {
   private providedPropertyTsConfigs: ProvidedTsConfig[] | undefined = undefined;
   private propertyTsConfigsHash: string | undefined = undefined;
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
+  private canAccessFileSystem: boolean | undefined = undefined;
+  private projectFileDiscoveryConfigKey: string | undefined = undefined;
 
   /**
    * Checks if the store is initialized for the given base directory.
@@ -77,10 +79,13 @@ export class TsConfigStore implements FileStore {
   }
 
   dirtyCachesIfNeeded(configuration: Configuration) {
-    const { baseDir, tsConfigPaths, fsEvents, clearTsConfigCache } = configuration;
+    const { baseDir, canAccessFileSystem, tsConfigPaths, fsEvents, clearTsConfigCache } =
+      configuration;
     if (
       this.baseDir !== baseDir ||
-      this.propertyTsConfigsHash !== this.computeTsConfigsHash(tsConfigPaths)
+      this.canAccessFileSystem !== canAccessFileSystem ||
+      this.propertyTsConfigsHash !== this.computeTsConfigsHash(tsConfigPaths) ||
+      this.projectFileDiscoveryConfigKey !== getProjectFileDiscoveryConfigKey(configuration)
     ) {
       this.clearCache();
       return;
@@ -104,6 +109,8 @@ export class TsConfigStore implements FileStore {
   clearCache() {
     debug(`Resetting the TsConfigCache`);
     this.baseDir = undefined;
+    this.canAccessFileSystem = undefined;
+    this.projectFileDiscoveryConfigKey = undefined;
     this.foundLookupTsConfigs = [];
     this.foundPropertyTsConfigs = [];
     this.providedPropertyTsConfigs = undefined;
@@ -116,8 +123,10 @@ export class TsConfigStore implements FileStore {
    * Sets up the store for processing files.
    */
   setup(configuration: Configuration) {
-    const { baseDir, tsConfigPaths } = configuration;
+    const { baseDir, canAccessFileSystem, tsConfigPaths } = configuration;
     this.baseDir = baseDir;
+    this.canAccessFileSystem = canAccessFileSystem;
+    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     const newHash = this.computeTsConfigsHash(tsConfigPaths);
     if (newHash !== this.propertyTsConfigsHash) {
       this.propertyTsConfigsHash = newHash;

--- a/packages/analysis/src/file-stores/tsconfigs.ts
+++ b/packages/analysis/src/file-stores/tsconfigs.ts
@@ -114,6 +114,7 @@ export class TsConfigStore implements FileStore {
     this.foundLookupTsConfigs = [];
     this.foundPropertyTsConfigs = [];
     this.providedPropertyTsConfigs = undefined;
+    this.propertyTsConfigsHash = undefined;
     clearTsConfigContentCache();
     clearProgramOptionsCache();
     getProgramCacheManager().clear();

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/contracts.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/contracts.ts
@@ -1,0 +1,47 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { NormalizedAbsolutePath } from '../../../../../../shared/src/helpers/files.js';
+import type { DependenciesList } from '../dependency-manifests/resolvers/types.js';
+import type { TaskInvocation } from './task-invocations.js';
+
+export type GeneratedSourceFileMatcher = (filePath: NormalizedAbsolutePath) => boolean;
+
+export type DerivedGeneratedSources = {
+  familyByFile: Map<NormalizedAbsolutePath, string>;
+  configPaths: Set<NormalizedAbsolutePath>;
+  watchedOutputPaths: Set<NormalizedAbsolutePath>;
+};
+
+/**
+ * Contract for generated-source detection plugins.
+ *
+ * Each detector owns one tool family and is responsible for:
+ * - declaring cache-invalidating config basenames through `watchedFilenames`
+ * - deriving only project-local generated files rooted under `baseDir`
+ * - reporting any config files and declared output paths it inferred so the store can refresh on change
+ */
+export interface GeneratedSourceDetector {
+  readonly family: string;
+  readonly watchedFilenames?: readonly string[];
+  detect(context: {
+    baseDir: NormalizedAbsolutePath;
+    packageDir: NormalizedAbsolutePath;
+    getDependencies: () => DependenciesList;
+    taskInvocations: readonly TaskInvocation[];
+    sourceFileMatcher?: GeneratedSourceFileMatcher;
+  }): Promise<DerivedGeneratedSources>;
+}

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/derive.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/derive.ts
@@ -1,0 +1,117 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import {
+  type File,
+  type NormalizedAbsolutePath,
+} from '../../../../../../shared/src/helpers/files.js';
+import type { PackageJson } from 'type-fest';
+import { getDependencies } from '../dependency-manifests/dependencies.js';
+import { parsePackageJson } from '../dependency-manifests/parsed-dependency-files.js';
+import type { DependenciesList } from '../dependency-manifests/resolvers/types.js';
+import type { DerivedGeneratedSources, GeneratedSourceFileMatcher } from './contracts.js';
+import { GENERATED_SOURCE_DETECTORS } from './detectors/index.js';
+import { collectGeneratedSourceTaskInvocations } from './task-invocations.js';
+import { createDerivedGeneratedSources, mergeDerivedGeneratedSources } from './shared.js';
+
+export async function deriveGeneratedSources(
+  baseDir: NormalizedAbsolutePath,
+  packageJsons: ReadonlyMap<NormalizedAbsolutePath, File>,
+  options?: {
+    sourceFileMatcher?: GeneratedSourceFileMatcher;
+  },
+): Promise<DerivedGeneratedSources> {
+  const derived = createDerivedGeneratedSources();
+  const { sourceFileMatcher } = options ?? {};
+
+  for (const [packageDir, file] of packageJsons) {
+    const packageJson = parsePackageJson(file);
+    if (!packageJson) {
+      continue;
+    }
+
+    const taskInvocations = await collectGeneratedSourceTaskInvocations({
+      baseDir,
+      packageDir,
+      packageJson,
+    });
+    let dependencies: DependenciesList | undefined;
+    const getGeneratedSourceDependencies = () => {
+      dependencies ??= resolveGeneratedSourceDependencies(packageDir, baseDir, packageJson);
+      return dependencies;
+    };
+    for (const detector of GENERATED_SOURCE_DETECTORS) {
+      mergeDerivedGeneratedSources(
+        derived,
+        await detector.detect({
+          baseDir,
+          packageDir,
+          getDependencies: getGeneratedSourceDependencies,
+          taskInvocations,
+          sourceFileMatcher,
+        }),
+      );
+    }
+  }
+
+  return derived;
+}
+
+function resolveGeneratedSourceDependencies(
+  packageDir: NormalizedAbsolutePath,
+  baseDir: NormalizedAbsolutePath,
+  packageJson: PackageJson,
+): DependenciesList {
+  const dependencies = getDependencies(packageDir, baseDir);
+
+  // Some unit tests call deriveGeneratedSources with synthetic package.json maps
+  // without initializing the manifest store or writing manifests to disk.
+  return dependencies.size > 0 || !hasRawDependencySections(packageJson)
+    ? dependencies
+    : createFallbackDependencies(packageJson);
+}
+
+function hasRawDependencySections(packageJson: PackageJson) {
+  return [
+    packageJson.dependencies,
+    packageJson.devDependencies,
+    packageJson.peerDependencies,
+    packageJson.optionalDependencies,
+  ].some(section => section !== undefined && Object.keys(section).length > 0);
+}
+
+function createFallbackDependencies(packageJson: PackageJson): DependenciesList {
+  const dependencies: DependenciesList = new Map();
+
+  for (const section of [
+    packageJson.dependencies,
+    packageJson.devDependencies,
+    packageJson.peerDependencies,
+    packageJson.optionalDependencies,
+  ]) {
+    if (!section) {
+      continue;
+    }
+
+    for (const [name, version] of Object.entries(section)) {
+      dependencies.set(name, typeof version === 'string' ? version : undefined);
+    }
+  }
+
+  return dependencies;
+}
+
+export { extractFlagValues } from './shared.js';

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/derive.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/derive.ts
@@ -35,6 +35,10 @@ export async function deriveGeneratedSources(
   },
 ): Promise<DerivedGeneratedSources> {
   const derived = createDerivedGeneratedSources();
+  if (GENERATED_SOURCE_DETECTORS.length === 0) {
+    return derived;
+  }
+
   const { sourceFileMatcher } = options ?? {};
 
   for (const [packageDir, file] of packageJsons) {

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/derive.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/derive.ts
@@ -81,8 +81,8 @@ function resolveGeneratedSourceDependencies(
 ): DependenciesList {
   const dependencies = getDependencies(packageDir, baseDir);
 
-  // Some unit tests call deriveGeneratedSources with synthetic package.json maps
-  // without initializing the manifest store or writing manifests to disk.
+  // Support in-memory package.json fixtures that do not populate the manifest caches.
+  // When raw dependency sections are still present, derive the dependency list from them.
   return dependencies.size > 0 || !hasRawDependencySections(packageJson)
     ? dependencies
     : createFallbackDependencies(packageJson);

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detector-api.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detector-api.ts
@@ -52,7 +52,6 @@ type ResolvePathsFromTaskInvocationsOptions = {
   taskInvocations: readonly TaskInvocation[];
   matchesTaskInvocation: TaskInvocationMatcher;
   flags: string[];
-  kind: ExistingPathKind;
 };
 
 type ResolveConfigPathsOptions = {
@@ -151,7 +150,7 @@ async function addResolvedGeneratedOutput(
   }
 
   if (stats.isFile()) {
-    if (isAcceptedGeneratedFile(resolvedPath, sourceFileMatcher)) {
+    if (isSourceFile(resolvedPath, sourceFileMatcher)) {
       resolvedOutputs.filePaths.add(resolvedPath);
       return true;
     }
@@ -163,30 +162,11 @@ async function addResolvedGeneratedOutput(
   }
 
   resolvedOutputs.outputDirectories.add(resolvedPath);
-  const childFiles = await listAcceptedGeneratedFilesInDirectory(
-    resolvedPath,
-    recursive,
-    sourceFileMatcher,
-  );
+  const childFiles = await listSourceFilesInDirectory(resolvedPath, recursive, sourceFileMatcher);
   for (const childFile of childFiles) {
     resolvedOutputs.filePaths.add(childFile);
   }
   return childFiles.length > 0;
-}
-
-function isAcceptedGeneratedFile(
-  filePath: NormalizedAbsolutePath,
-  sourceFileMatcher?: GeneratedSourceFileMatcher,
-) {
-  return isSourceFile(filePath, sourceFileMatcher);
-}
-
-async function listAcceptedGeneratedFilesInDirectory(
-  outputDirectory: NormalizedAbsolutePath,
-  recursive: boolean,
-  sourceFileMatcher?: GeneratedSourceFileMatcher,
-) {
-  return listSourceFilesInDirectory(outputDirectory, recursive, sourceFileMatcher);
 }
 
 function resolveDeclaredPathsFromTaskInvocations({
@@ -223,14 +203,10 @@ async function resolveExistingSiblingPaths(
 
   for (const basename of basenames) {
     const resolvedPath = normalizeToAbsolutePath(basename, packageDir);
-    if (await matchesExistingPathKind(resolvedPath, kind)) {
+    if ((kind === 'file' ? await isFile(resolvedPath) : await isDirectory(resolvedPath))) {
       resolvedPaths.add(resolvedPath);
     }
   }
 
   return resolvedPaths;
-}
-
-async function matchesExistingPathKind(path: NormalizedAbsolutePath, kind: ExistingPathKind) {
-  return kind === 'file' ? isFile(path) : isDirectory(path);
 }

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detector-api.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detector-api.ts
@@ -1,0 +1,236 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import {
+  normalizeToAbsolutePath,
+  type NormalizedAbsolutePath,
+} from '../../../../../../shared/src/helpers/files.js';
+import type { GeneratedSourceFileMatcher } from './contracts.js';
+import {
+  extractFlagValuesFromTokens,
+  isDirectory,
+  isFile,
+  isSourceFile,
+  listSourceFilesInDirectory,
+  resolveLiteralPath,
+  safeStat,
+} from './shared.js';
+import type { DependenciesList } from '../dependency-manifests/resolvers/types.js';
+import type { TaskInvocation } from './task-invocations.js';
+export type ResolvedGeneratedOutputs = {
+  filePaths: Set<NormalizedAbsolutePath>;
+  outputDirectories: Set<NormalizedAbsolutePath>;
+  watchedOutputPaths: Set<NormalizedAbsolutePath>;
+};
+
+type TaskInvocationMatcher = (taskInvocation: TaskInvocation) => boolean;
+type ExistingPathKind = 'file' | 'directory';
+
+type ToolEvidenceOptions = {
+  getDependencies: () => DependenciesList;
+  taskInvocations: readonly TaskInvocation[];
+  dependencyName?: string;
+  matchesTaskInvocation: TaskInvocationMatcher;
+};
+
+type ResolvePathsFromTaskInvocationsOptions = {
+  baseDir: NormalizedAbsolutePath;
+  packageDir: NormalizedAbsolutePath;
+  taskInvocations: readonly TaskInvocation[];
+  matchesTaskInvocation: TaskInvocationMatcher;
+  flags: string[];
+  kind: ExistingPathKind;
+};
+
+type ResolveConfigPathsOptions = {
+  baseDir: NormalizedAbsolutePath;
+  packageDir: NormalizedAbsolutePath;
+  taskInvocations: readonly TaskInvocation[];
+  matchesTaskInvocation: TaskInvocationMatcher;
+  flags: string[];
+  fallbackBasenames: readonly string[];
+};
+
+export function hasToolEvidence({
+  getDependencies,
+  taskInvocations,
+  dependencyName,
+  matchesTaskInvocation,
+}: ToolEvidenceOptions) {
+  if (taskInvocations.some(matchesTaskInvocation)) {
+    return true;
+  }
+
+  return dependencyName ? getDependencies().has(dependencyName) : false;
+}
+
+export async function resolveConfigPaths({
+  baseDir,
+  packageDir,
+  taskInvocations,
+  matchesTaskInvocation,
+  flags,
+  fallbackBasenames,
+}: ResolveConfigPathsOptions) {
+  const declaredConfigPaths = resolveDeclaredPathsFromTaskInvocations({
+    baseDir,
+    packageDir,
+    taskInvocations,
+    matchesTaskInvocation,
+    flags,
+  });
+
+  if (declaredConfigPaths.size > 0) {
+    return declaredConfigPaths;
+  }
+
+  return resolveExistingSiblingPaths(packageDir, fallbackBasenames, 'file');
+}
+
+export async function resolveGeneratedOutputsFromLiteralPaths(
+  baseDir: NormalizedAbsolutePath,
+  declaredFromDirs: NormalizedAbsolutePath | readonly NormalizedAbsolutePath[],
+  outputPaths: Iterable<string>,
+  recursive: boolean,
+  sourceFileMatcher?: GeneratedSourceFileMatcher,
+): Promise<ResolvedGeneratedOutputs> {
+  const resolvedOutputs: ResolvedGeneratedOutputs = {
+    filePaths: new Set<NormalizedAbsolutePath>(),
+    outputDirectories: new Set<NormalizedAbsolutePath>(),
+    watchedOutputPaths: new Set<NormalizedAbsolutePath>(),
+  };
+  const candidateDirs = Array.isArray(declaredFromDirs) ? declaredFromDirs : [declaredFromDirs];
+
+  for (const outputPath of outputPaths) {
+    const seenResolvedPaths = new Set<NormalizedAbsolutePath>();
+    for (const declaredFromDir of candidateDirs) {
+      const resolvedPath = resolveLiteralPath(outputPath, declaredFromDir, baseDir);
+      if (!resolvedPath || seenResolvedPaths.has(resolvedPath)) {
+        continue;
+      }
+      seenResolvedPaths.add(resolvedPath);
+      if (
+        await addResolvedGeneratedOutput(
+          resolvedOutputs,
+          resolvedPath,
+          recursive,
+          sourceFileMatcher,
+        )
+      ) {
+        break;
+      }
+    }
+  }
+
+  return resolvedOutputs;
+}
+
+async function addResolvedGeneratedOutput(
+  resolvedOutputs: ResolvedGeneratedOutputs,
+  resolvedPath: NormalizedAbsolutePath,
+  recursive: boolean,
+  sourceFileMatcher?: GeneratedSourceFileMatcher,
+) {
+  resolvedOutputs.watchedOutputPaths.add(resolvedPath);
+  const stats = await safeStat(resolvedPath);
+  if (!stats) {
+    return false;
+  }
+
+  if (stats.isFile()) {
+    if (isAcceptedGeneratedFile(resolvedPath, sourceFileMatcher)) {
+      resolvedOutputs.filePaths.add(resolvedPath);
+      return true;
+    }
+    return false;
+  }
+
+  if (!stats.isDirectory()) {
+    return false;
+  }
+
+  resolvedOutputs.outputDirectories.add(resolvedPath);
+  const childFiles = await listAcceptedGeneratedFilesInDirectory(
+    resolvedPath,
+    recursive,
+    sourceFileMatcher,
+  );
+  for (const childFile of childFiles) {
+    resolvedOutputs.filePaths.add(childFile);
+  }
+  return childFiles.length > 0;
+}
+
+function isAcceptedGeneratedFile(
+  filePath: NormalizedAbsolutePath,
+  sourceFileMatcher?: GeneratedSourceFileMatcher,
+) {
+  return isSourceFile(filePath, sourceFileMatcher);
+}
+
+async function listAcceptedGeneratedFilesInDirectory(
+  outputDirectory: NormalizedAbsolutePath,
+  recursive: boolean,
+  sourceFileMatcher?: GeneratedSourceFileMatcher,
+) {
+  return listSourceFilesInDirectory(outputDirectory, recursive, sourceFileMatcher);
+}
+
+function resolveDeclaredPathsFromTaskInvocations({
+  baseDir,
+  packageDir,
+  taskInvocations,
+  matchesTaskInvocation,
+  flags,
+}: Omit<ResolvePathsFromTaskInvocationsOptions, 'kind'>) {
+  const resolvedPaths = new Set<NormalizedAbsolutePath>();
+
+  for (const taskInvocation of taskInvocations) {
+    if (!matchesTaskInvocation(taskInvocation)) {
+      continue;
+    }
+
+    for (const token of extractFlagValuesFromTokens(taskInvocation.args, flags)) {
+      const resolvedPath = resolveLiteralPath(token, packageDir, baseDir);
+      if (resolvedPath) {
+        resolvedPaths.add(resolvedPath);
+      }
+    }
+  }
+
+  return resolvedPaths;
+}
+
+async function resolveExistingSiblingPaths(
+  packageDir: NormalizedAbsolutePath,
+  basenames: readonly string[],
+  kind: ExistingPathKind,
+) {
+  const resolvedPaths = new Set<NormalizedAbsolutePath>();
+
+  for (const basename of basenames) {
+    const resolvedPath = normalizeToAbsolutePath(basename, packageDir);
+    if (await matchesExistingPathKind(resolvedPath, kind)) {
+      resolvedPaths.add(resolvedPath);
+    }
+  }
+
+  return resolvedPaths;
+}
+
+async function matchesExistingPathKind(path: NormalizedAbsolutePath, kind: ExistingPathKind) {
+  return kind === 'file' ? isFile(path) : isDirectory(path);
+}

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -17,4 +17,13 @@
 import type { GeneratedSourceDetector } from '../contracts.js';
 
 export const GENERATED_SOURCE_DETECTORS: readonly GeneratedSourceDetector[] = [];
-export const GENERATED_SOURCE_WATCHED_FILENAMES: readonly string[] = [];
+
+export function getGeneratedSourceWatchedFilenames() {
+  return [
+    ...new Set(
+      GENERATED_SOURCE_DETECTORS.flatMap(detector =>
+        (detector.watchedFilenames ?? []).map(filename => filename.toLowerCase()),
+      ),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+}

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -16,8 +16,21 @@
  */
 import type { GeneratedSourceDetector } from '../contracts.js';
 
-export const GENERATED_SOURCE_DETECTORS: readonly GeneratedSourceDetector[] = [];
+const generatedSourceDetectors: GeneratedSourceDetector[] = [];
 
-export const GENERATED_SOURCE_WATCHED_FILENAMES = [
-  ...new Set(GENERATED_SOURCE_DETECTORS.flatMap(detector => detector.watchedFilenames ?? [])),
-].sort((left, right) => left.localeCompare(right));
+export const GENERATED_SOURCE_DETECTORS =
+  generatedSourceDetectors as readonly GeneratedSourceDetector[];
+
+export const GENERATED_SOURCE_WATCHED_FILENAMES =
+  collectGeneratedSourceWatchedFilenames(generatedSourceDetectors);
+
+function collectGeneratedSourceWatchedFilenames(detectors: Iterable<GeneratedSourceDetector>) {
+  const watchedFilenames = new Set<string>();
+  for (const detector of detectors) {
+    for (const watchedFilename of detector.watchedFilenames ?? []) {
+      watchedFilenames.add(watchedFilename);
+    }
+  }
+
+  return [...watchedFilenames].sort((left, right) => left.localeCompare(right));
+}

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -1,0 +1,23 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { GeneratedSourceDetector } from '../contracts.js';
+
+export const GENERATED_SOURCE_DETECTORS: readonly GeneratedSourceDetector[] = [];
+
+export const GENERATED_SOURCE_WATCHED_FILENAMES = [
+  ...new Set(GENERATED_SOURCE_DETECTORS.flatMap(detector => detector.watchedFilenames ?? [])),
+].sort((left, right) => left.localeCompare(right));

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -16,21 +16,5 @@
  */
 import type { GeneratedSourceDetector } from '../contracts.js';
 
-const generatedSourceDetectors: GeneratedSourceDetector[] = [];
-
-export const GENERATED_SOURCE_DETECTORS =
-  generatedSourceDetectors as readonly GeneratedSourceDetector[];
-
-export const GENERATED_SOURCE_WATCHED_FILENAMES =
-  collectGeneratedSourceWatchedFilenames(generatedSourceDetectors);
-
-function collectGeneratedSourceWatchedFilenames(detectors: Iterable<GeneratedSourceDetector>) {
-  const watchedFilenames = new Set<string>();
-  for (const detector of detectors) {
-    for (const watchedFilename of detector.watchedFilenames ?? []) {
-      watchedFilenames.add(watchedFilename);
-    }
-  }
-
-  return [...watchedFilenames].sort((left, right) => left.localeCompare(right));
-}
+export const GENERATED_SOURCE_DETECTORS: readonly GeneratedSourceDetector[] = [];
+export const GENERATED_SOURCE_WATCHED_FILENAMES: readonly string[] = [];

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -18,10 +18,12 @@ import type { GeneratedSourceDetector } from '../contracts.js';
 
 export const GENERATED_SOURCE_DETECTORS: GeneratedSourceDetector[] = [];
 
-export function getGeneratedSourceWatchedFilenames() {
+export function getGeneratedSourceWatchedFilenames(
+  detectors: readonly GeneratedSourceDetector[] = GENERATED_SOURCE_DETECTORS,
+) {
   return [
     ...new Set(
-      GENERATED_SOURCE_DETECTORS.flatMap(detector =>
+      detectors.flatMap(detector =>
         (detector.watchedFilenames ?? []).map(filename => filename.toLowerCase()),
       ),
     ),

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -16,7 +16,7 @@
  */
 import type { GeneratedSourceDetector } from '../contracts.js';
 
-export const GENERATED_SOURCE_DETECTORS: readonly GeneratedSourceDetector[] = [];
+export const GENERATED_SOURCE_DETECTORS: GeneratedSourceDetector[] = [];
 
 export function getGeneratedSourceWatchedFilenames() {
   return [

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -16,7 +16,7 @@
  */
 export {
   GENERATED_SOURCE_DETECTORS,
-  GENERATED_SOURCE_WATCHED_FILENAMES,
+  getGeneratedSourceWatchedFilenames,
 } from './detectors/index.js';
 export {
   GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS,

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -1,0 +1,24 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+export {
+  GENERATED_SOURCE_DETECTORS,
+  GENERATED_SOURCE_WATCHED_FILENAMES,
+} from './detectors/index.js';
+export {
+  GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS,
+  collectGeneratedSourceTaskInvocations,
+} from './task-invocations.js';

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
@@ -96,13 +96,7 @@ export function resolveLiteralPath(
 }
 
 export function isLiteralPathToken(value: string) {
-  return (
-    value.length > 0 &&
-    !value.includes('$') &&
-    !value.includes('`') &&
-    !value.includes('+') &&
-    !value.includes('$(')
-  );
+  return value.length > 0 && !value.includes('$') && !value.includes('`') && !value.includes('+');
 }
 
 export function isSourceFile(
@@ -387,7 +381,7 @@ function getLastPathSegment(path: string) {
 }
 
 function isShellGeneratedToken(token: string) {
-  return token.includes('$') || token.includes('`') || token.includes('$(');
+  return token.includes('$') || token.includes('`');
 }
 
 function isEnvironmentAssignment(token: string) {

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
@@ -1,0 +1,404 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { readdir, stat } from 'node:fs/promises';
+import { extname } from 'node:path/posix';
+import {
+  normalizeToAbsolutePath,
+  type NormalizedAbsolutePath,
+} from '../../../../../../shared/src/helpers/files.js';
+import type { DerivedGeneratedSources, GeneratedSourceFileMatcher } from './contracts.js';
+
+const OBVIOUS_BUILD_OR_CACHE_SEGMENTS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.cache',
+  'coverage',
+  '.next',
+]);
+const DEFAULT_GENERATED_SOURCE_EXTENSIONS = new Set([
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.jsx',
+  '.ts',
+  '.mts',
+  '.cts',
+  '.tsx',
+]);
+const defaultGeneratedSourceFileMatcher: GeneratedSourceFileMatcher = filePath =>
+  DEFAULT_GENERATED_SOURCE_EXTENSIONS.has(extname(filePath).toLowerCase());
+
+export function createDerivedGeneratedSources(): DerivedGeneratedSources {
+  return {
+    familyByFile: new Map<NormalizedAbsolutePath, string>(),
+    configPaths: new Set<NormalizedAbsolutePath>(),
+    watchedOutputPaths: new Set<NormalizedAbsolutePath>(),
+  };
+}
+
+export function mergeDerivedGeneratedSources(
+  target: DerivedGeneratedSources,
+  source: DerivedGeneratedSources,
+) {
+  for (const [filePath, family] of sortPathEntries(source.familyByFile.entries())) {
+    if (!target.familyByFile.has(filePath)) {
+      target.familyByFile.set(filePath, family);
+    }
+  }
+
+  for (const configPath of sortPaths(source.configPaths)) {
+    target.configPaths.add(configPath);
+  }
+
+  for (const outputPath of sortPaths(source.watchedOutputPaths)) {
+    target.watchedOutputPaths.add(outputPath);
+  }
+}
+
+export function addFamilyFiles(
+  family: string,
+  filePaths: Iterable<NormalizedAbsolutePath>,
+  target: DerivedGeneratedSources,
+) {
+  for (const filePath of sortPaths(filePaths)) {
+    target.familyByFile.set(filePath, family);
+  }
+}
+
+export function resolveLiteralPath(
+  maybePath: string,
+  declaredFromDir: NormalizedAbsolutePath,
+  baseDir: NormalizedAbsolutePath,
+) {
+  if (!isLiteralPathToken(maybePath)) {
+    return undefined;
+  }
+
+  const resolvedPath = normalizeToAbsolutePath(maybePath, declaredFromDir);
+  // Explicit generator outputs may legitimately be rooted under dist/build; only prune nested
+  // cache/build subtrees when walking inside those declared outputs.
+  return isWithinBaseDir(resolvedPath, baseDir) ? resolvedPath : undefined;
+}
+
+export function isLiteralPathToken(value: string) {
+  return (
+    value.length > 0 &&
+    !value.includes('$') &&
+    !value.includes('`') &&
+    !value.includes('+') &&
+    !value.includes('$(')
+  );
+}
+
+export function isSourceFile(
+  path: NormalizedAbsolutePath,
+  sourceFileMatcher: GeneratedSourceFileMatcher = defaultGeneratedSourceFileMatcher,
+) {
+  return sourceFileMatcher(path);
+}
+
+export async function isFile(path: NormalizedAbsolutePath) {
+  const stats = await safeStat(path);
+  return stats?.isFile() === true;
+}
+
+export async function isDirectory(path: NormalizedAbsolutePath) {
+  const stats = await safeStat(path);
+  return stats?.isDirectory() === true;
+}
+
+export async function safeStat(path: NormalizedAbsolutePath) {
+  try {
+    return await stat(path);
+  } catch {
+    return undefined;
+  }
+}
+
+async function safeReadDir(path: NormalizedAbsolutePath) {
+  try {
+    return await readdir(path, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+export async function listSourceFilesInDirectory(
+  directory: NormalizedAbsolutePath,
+  recursive: boolean,
+  sourceFileMatcher: GeneratedSourceFileMatcher = defaultGeneratedSourceFileMatcher,
+) {
+  const entries = await safeReadDir(directory);
+  const sourceFiles: NormalizedAbsolutePath[] = [];
+
+  for (const entry of entries) {
+    const entryPath = normalizeToAbsolutePath(entry.name, directory);
+    if (!isSafeChildEntryPath(entryPath, directory)) {
+      continue;
+    }
+
+    if (entry.isFile() && isSourceFile(entryPath, sourceFileMatcher)) {
+      sourceFiles.push(entryPath);
+      continue;
+    }
+
+    if (recursive && entry.isDirectory()) {
+      sourceFiles.push(...(await listSourceFilesInDirectory(entryPath, true, sourceFileMatcher)));
+    }
+  }
+
+  return sourceFiles;
+}
+
+/**
+ * Extracts literal flag values from a shell-like script string.
+ * Exported for testing purposes.
+ */
+export function extractFlagValues(script: string, flags: string[]) {
+  const tokens = tokenizeScript(script);
+  if (!tokens) {
+    return [];
+  }
+
+  return extractFlagValuesFromTokens(tokens, flags);
+}
+
+export function extractFlagValuesFromTokens(tokens: readonly string[], flags: string[]) {
+  const values: string[] = [];
+  for (const [index, token] of tokens.entries()) {
+    const value = resolveFlagValue(token, tokens[index + 1], flags);
+    if (value !== undefined) {
+      values.push(value);
+    }
+  }
+
+  return values;
+}
+
+export type ParsedCommandSegment = {
+  commandLine: string;
+  command: string;
+  args: readonly string[];
+};
+
+export function parseDirectCommandSegments(script: string): ParsedCommandSegment[] {
+  const segments: ParsedCommandSegment[] = [];
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+  let segmentStart = 0;
+
+  const flushToken = () => {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = '';
+    }
+  };
+
+  const finalizeSegment = (segmentEnd: number, nextSegmentStart: number) => {
+    flushToken();
+
+    const commandLine = script.slice(segmentStart, segmentEnd).trim();
+    segmentStart = nextSegmentStart;
+
+    if (tokens.length === 0 || commandLine.length === 0) {
+      tokens.length = 0;
+      return;
+    }
+
+    const [command, ...args] = tokens;
+    tokens.length = 0;
+
+    if (!isDirectCommandToken(command)) {
+      return;
+    }
+
+    segments.push({
+      commandLine,
+      command,
+      args,
+    });
+  };
+
+  for (let index = 0; index < script.length; index++) {
+    const char = script[index];
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === '&' && script[index + 1] === '&') {
+      finalizeSegment(index, index + 2);
+      index += 1;
+      continue;
+    }
+
+    if (isWhitespace(char)) {
+      flushToken();
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (quote) {
+    return [];
+  }
+
+  finalizeSegment(script.length, script.length);
+  return segments;
+}
+
+function tokenizeScript(script: string) {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+
+  for (const char of script) {
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (isWhitespace(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (quote) {
+    return undefined;
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+export function matchesCommandToken(token: string, commandName: string) {
+  const lastPathSegment = getLastPathSegment(token);
+  return lastPathSegment === commandName || lastPathSegment.startsWith(`${commandName}.`);
+}
+
+export function isDirectCommandToken(command: string) {
+  return !isShellGeneratedToken(command) && !isEnvironmentAssignment(command);
+}
+
+function resolveFlagValue(token: string, nextToken: string | undefined, flags: string[]) {
+  if (flags.includes(token)) {
+    return nextToken;
+  }
+
+  return resolveEqualsFlagValue(token, flags);
+}
+
+function resolveEqualsFlagValue(token: string, flags: string[]) {
+  for (const flag of flags) {
+    const equalsPrefix = `${flag}=`;
+    if (token.startsWith(equalsPrefix) && token.length > equalsPrefix.length) {
+      return token.slice(equalsPrefix.length);
+    }
+  }
+
+  return undefined;
+}
+
+function isWithinBaseDir(path: NormalizedAbsolutePath, baseDir: NormalizedAbsolutePath) {
+  const relativePath = getRelativeToAncestorPath(path, baseDir);
+  return relativePath !== undefined;
+}
+
+function isSafeChildEntryPath(
+  path: NormalizedAbsolutePath,
+  parentDirectory: NormalizedAbsolutePath,
+) {
+  const relativePath = getRelativeToAncestorPath(path, parentDirectory);
+  return relativePath !== undefined && !hasObviousBuildOrCacheDirectory(relativePath);
+}
+
+function getRelativeToAncestorPath(
+  filePath: NormalizedAbsolutePath,
+  topDir: NormalizedAbsolutePath,
+) {
+  const topDirPrefix = topDir.endsWith('/') ? topDir : `${topDir}/`;
+  if (filePath === topDir) {
+    return '';
+  }
+
+  return filePath.startsWith(topDirPrefix) ? filePath.slice(topDirPrefix.length) : undefined;
+}
+
+function hasObviousBuildOrCacheDirectory(path: string) {
+  return path
+    .split('/')
+    .some(segment => segment.length > 0 && OBVIOUS_BUILD_OR_CACHE_SEGMENTS.has(segment));
+}
+
+// Keep insertion order stable so generated-source maps are deterministic across platforms/runs.
+function comparePathsAlphabetically(left: string, right: string) {
+  return left.localeCompare(right);
+}
+
+function sortPaths<T extends NormalizedAbsolutePath>(paths: Iterable<T>) {
+  return [...paths].sort(comparePathsAlphabetically);
+}
+
+function sortPathEntries<T>(entries: Iterable<[NormalizedAbsolutePath, T]>) {
+  return [...entries].sort(([left], [right]) => comparePathsAlphabetically(left, right));
+}
+
+function getLastPathSegment(path: string) {
+  const separatorIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
+}
+
+function isShellGeneratedToken(token: string) {
+  return token.includes('$') || token.includes('`') || token.includes('$(');
+}
+
+function isEnvironmentAssignment(token: string) {
+  const equalsIndex = token.indexOf('=');
+  if (equalsIndex <= 0) {
+    return false;
+  }
+
+  return /^[A-Za-z_]\w*$/.test(token.slice(0, equalsIndex));
+}
+
+function isWhitespace(char: string) {
+  return /[ \t\n\r\f\v]/.test(char);
+}

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
@@ -61,6 +61,10 @@ const packageJsonTaskInvocationProvider = {
   },
 } satisfies TaskInvocationProvider;
 
+// The package.json script parser intentionally recognizes only simple command chains.
+// Shell preambles such as `NODE_ENV=production tool ...`, command separators other than
+// `&&`, and runner options such as `npx --yes tool ...` are left out until a detector
+// needs that broader shell surface and can justify the parsing rules.
 export const GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS = [
   packageJsonTaskInvocationProvider,
 ] as const satisfies readonly TaskInvocationProvider[];

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
@@ -139,13 +139,10 @@ function normalizePnpmExecTaskInvocation(tokens: InvocationTokens) {
 }
 
 function unwrapNestedCommandTokens(args: readonly string[]): InvocationTokens | undefined {
-  let commandIndex = args[0] === '--' ? 1 : 0;
-  while (isOptionToken(args[commandIndex] ?? '')) {
-    commandIndex += 1;
-  }
+  const commandIndex = args[0] === '--' ? 1 : 0;
   const command = args[commandIndex];
 
-  if (!command || !isDirectCommandToken(command)) {
+  if (!command || !isDirectCommandToken(command) || isOptionToken(command)) {
     return undefined;
   }
 

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
@@ -65,9 +65,9 @@ const packageJsonTaskInvocationProvider = {
 // Shell preambles such as `NODE_ENV=production tool ...`, command separators other than
 // `&&`, and runner options such as `npx --yes tool ...` are left out until a detector
 // needs that broader shell surface and can justify the parsing rules.
-export const GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS = [
+export const GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS: readonly TaskInvocationProvider[] = [
   packageJsonTaskInvocationProvider,
-] as const satisfies readonly TaskInvocationProvider[];
+];
 
 export async function collectGeneratedSourceTaskInvocations(context: {
   baseDir: NormalizedAbsolutePath;

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
@@ -139,10 +139,13 @@ function normalizePnpmExecTaskInvocation(tokens: InvocationTokens) {
 }
 
 function unwrapNestedCommandTokens(args: readonly string[]): InvocationTokens | undefined {
-  const commandIndex = args[0] === '--' ? 1 : 0;
+  let commandIndex = args[0] === '--' ? 1 : 0;
+  while (isOptionToken(args[commandIndex] ?? '')) {
+    commandIndex += 1;
+  }
   const command = args[commandIndex];
 
-  if (!command || !isDirectCommandToken(command) || isOptionToken(command)) {
+  if (!command || !isDirectCommandToken(command)) {
     return undefined;
   }
 

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
@@ -1,0 +1,157 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { PackageJson } from 'type-fest';
+import type { NormalizedAbsolutePath } from '../../../../../../shared/src/helpers/files.js';
+import {
+  isDirectCommandToken,
+  matchesCommandToken,
+  parseDirectCommandSegments,
+  type ParsedCommandSegment,
+} from './shared.js';
+
+export type TaskInvocation = {
+  source: string;
+  taskName: string;
+  commandLine: string;
+  command: string;
+  args: readonly string[];
+};
+
+interface TaskInvocationProvider {
+  readonly kind: string;
+  collect(context: {
+    baseDir: NormalizedAbsolutePath;
+    packageDir: NormalizedAbsolutePath;
+    packageJson: PackageJson;
+  }): Promise<readonly TaskInvocation[]> | readonly TaskInvocation[];
+}
+
+const packageJsonTaskInvocationProvider = {
+  kind: 'package-json-scripts',
+
+  collect({ packageJson }) {
+    return Object.entries(packageJson.scripts ?? {}).flatMap(([taskName, commandLine]) => {
+      if (typeof commandLine !== 'string') {
+        return [];
+      }
+
+      return parseDirectCommandSegments(commandLine).map(
+        segment =>
+          ({
+            source: 'package-json-script',
+            taskName,
+            ...normalizePackageJsonTaskInvocation(segment),
+          }) satisfies TaskInvocation,
+      );
+    });
+  },
+} satisfies TaskInvocationProvider;
+
+export const GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS = [
+  packageJsonTaskInvocationProvider,
+] as const satisfies readonly TaskInvocationProvider[];
+
+export async function collectGeneratedSourceTaskInvocations(context: {
+  baseDir: NormalizedAbsolutePath;
+  packageDir: NormalizedAbsolutePath;
+  packageJson: PackageJson;
+}) {
+  const taskInvocations: TaskInvocation[] = [];
+
+  for (const provider of GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS) {
+    taskInvocations.push(...(await Promise.resolve(provider.collect(context))));
+  }
+
+  return taskInvocations;
+}
+
+export function taskInvocationInvokesCommand(taskInvocation: TaskInvocation, commandName: string) {
+  return matchesCommandToken(taskInvocation.command, commandName);
+}
+
+type InvocationTokens = Pick<TaskInvocation, 'command' | 'args'>;
+type PackageJsonRunnerWrapperNormalizer = (
+  tokens: InvocationTokens,
+) => InvocationTokens | undefined;
+
+// Keep normalization limited to wrappers that unambiguously execute a nested binary.
+// Package-manager shorthands like `yarn <script>` or `npm run <script>` may resolve to
+// user-defined scripts, so they stay raw until we can distinguish them safely.
+const PACKAGE_JSON_RUNNER_WRAPPER_NORMALIZERS = [
+  normalizeNpxTaskInvocation,
+  normalizePnpmExecTaskInvocation,
+] as const satisfies readonly PackageJsonRunnerWrapperNormalizer[];
+
+function normalizePackageJsonTaskInvocation(segment: ParsedCommandSegment): ParsedCommandSegment {
+  let normalized: InvocationTokens = {
+    command: segment.command,
+    args: segment.args,
+  };
+
+  while (true) {
+    const next = unwrapKnownRunnerWrapper(normalized);
+    if (!next) {
+      return {
+        ...segment,
+        ...normalized,
+      };
+    }
+
+    normalized = next;
+  }
+}
+
+function unwrapKnownRunnerWrapper(tokens: InvocationTokens) {
+  for (const normalizeWrapper of PACKAGE_JSON_RUNNER_WRAPPER_NORMALIZERS) {
+    const normalized = normalizeWrapper(tokens);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeNpxTaskInvocation(tokens: InvocationTokens) {
+  return matchesCommandToken(tokens.command, 'npx')
+    ? unwrapNestedCommandTokens(tokens.args)
+    : undefined;
+}
+
+function normalizePnpmExecTaskInvocation(tokens: InvocationTokens) {
+  return matchesCommandToken(tokens.command, 'pnpm') && tokens.args[0] === 'exec'
+    ? unwrapNestedCommandTokens(tokens.args.slice(1))
+    : undefined;
+}
+
+function unwrapNestedCommandTokens(args: readonly string[]): InvocationTokens | undefined {
+  const commandIndex = args[0] === '--' ? 1 : 0;
+  const command = args[commandIndex];
+
+  if (!command || !isDirectCommandToken(command) || isOptionToken(command)) {
+    return undefined;
+  }
+
+  return {
+    command,
+    args: args.slice(commandIndex + 1),
+  };
+}
+
+function isOptionToken(token: string) {
+  return token.startsWith('-') && token !== '-';
+}

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
@@ -77,7 +77,7 @@ export async function collectGeneratedSourceTaskInvocations(context: {
   const taskInvocations: TaskInvocation[] = [];
 
   for (const provider of GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS) {
-    taskInvocations.push(...(await Promise.resolve(provider.collect(context))));
+    taskInvocations.push(...(await provider.collect(context)));
   }
 
   return taskInvocations;

--- a/packages/analysis/tests/dependency-manifests.test.ts
+++ b/packages/analysis/tests/dependency-manifests.test.ts
@@ -798,4 +798,41 @@ describe('files', () => {
     expect(dependenciesCache.size).toEqual(0);
     expect(moduleTypeCache.size).toEqual(0);
   });
+
+  it('should refresh discovered manifests when project-file discovery config changes', async () => {
+    const baseDir = normalizeToAbsolutePath(join(fixtures, 'child-parent-merge'));
+    const subDir = normalizeToAbsolutePath(join(baseDir, 'subdir'));
+
+    let configuration = createConfiguration({ baseDir });
+    await initFileStores(configuration);
+
+    expect(dependencyManifestStore.getPackageJsons().has(baseDir)).toEqual(true);
+    expect(dependencyManifestStore.getPackageJsons().has(subDir)).toEqual(true);
+
+    configuration = createConfiguration({
+      baseDir,
+      jsTsExclusions: ['**/subdir/**'],
+    });
+    await initFileStores(configuration);
+
+    expect(dependencyManifestStore.getPackageJsons().has(baseDir)).toEqual(true);
+    expect(dependencyManifestStore.getPackageJsons().has(subDir)).toEqual(false);
+  });
+
+  it('should keep discovered manifests when only source-file selection changes', async () => {
+    const baseDir = normalizeToAbsolutePath(join(fixtures, 'child-parent-merge'));
+    const subDir = normalizeToAbsolutePath(join(baseDir, 'subdir'));
+
+    let configuration = createConfiguration({ baseDir });
+    await initFileStores(configuration);
+
+    configuration = createConfiguration({
+      baseDir,
+      sources: ['subdir'],
+    });
+    await initFileStores(configuration);
+
+    expect(dependencyManifestStore.getPackageJsons().has(baseDir)).toEqual(true);
+    expect(dependencyManifestStore.getPackageJsons().has(subDir)).toEqual(true);
+  });
 });

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -130,6 +130,7 @@ describe('generated sources project metadata', () => {
           scripts: {
             codegen: 'graphql-codegen --config ./codegen.yml && prettier src/generated',
             wrapped: 'npx graphql-codegen --config ./codegen.yml',
+            wrappedWithFlags: 'npx --yes graphql-codegen --config ./codegen.yml',
             rawYarn: 'yarn graphql-codegen --config ./codegen.yml',
           },
         },
@@ -154,6 +155,13 @@ describe('generated sources project metadata', () => {
           source: 'package-json-script',
           taskName: 'wrapped',
           commandLine: 'npx graphql-codegen --config ./codegen.yml',
+          command: 'graphql-codegen',
+          args: ['--config', './codegen.yml'],
+        },
+        {
+          source: 'package-json-script',
+          taskName: 'wrappedWithFlags',
+          commandLine: 'npx --yes graphql-codegen --config ./codegen.yml',
           command: 'graphql-codegen',
           args: ['--config', './codegen.yml'],
         },

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -262,41 +262,6 @@ describe('generated sources project metadata', () => {
     }
   });
 
-  it('computes detector watched filenames once per filesystem event batch', async () => {
-    const registeredDetectors = GENERATED_SOURCE_DETECTORS as GeneratedSourceDetector[];
-    const originalDetectorCount = registeredDetectors.length;
-    const baseDir = normalizeToAbsolutePath('/generated-sources-watched-filename-batch');
-    let watchedFilenameReads = 0;
-
-    registeredDetectors.push({
-      family: 'graphql-codegen',
-      get watchedFilenames() {
-        watchedFilenameReads++;
-        return ['codegen.yml'];
-      },
-      async detect() {
-        return createDerivedGeneratedSources();
-      },
-    });
-
-    try {
-      let configuration = createConfiguration({ baseDir });
-      generatedSourceStore.setup(configuration);
-      expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
-
-      watchedFilenameReads = 0;
-      configuration = createConfiguration({
-        baseDir,
-        fsEvents: [joinPaths(baseDir, 'src', 'first.ts'), joinPaths(baseDir, 'src', 'second.ts')],
-      });
-
-      expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
-      expect(watchedFilenameReads).toEqual(1);
-    } finally {
-      registeredDetectors.splice(originalDetectorCount);
-    }
-  });
-
   it('exercises the detector foundation helpers through realistic task/config/output flows', async () => {
     const baseDir = await createTempBaseDir();
     const packageDir = joinPaths(baseDir, 'packages', 'app');

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -40,8 +40,8 @@ import {
 import {
   GENERATED_SOURCE_DETECTORS,
   GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS,
-  GENERATED_SOURCE_WATCHED_FILENAMES,
   collectGeneratedSourceTaskInvocations,
+  getGeneratedSourceWatchedFilenames,
 } from '../../../src/jsts/rules/helpers/generated-sources/index.js';
 import {
   addFamilyFiles,
@@ -116,7 +116,7 @@ describe('generated sources project metadata', () => {
     expect(GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS.map(provider => provider.kind)).toEqual([
       'package-json-scripts',
     ]);
-    expect(GENERATED_SOURCE_WATCHED_FILENAMES).toEqual([]);
+    expect(getGeneratedSourceWatchedFilenames()).toEqual([]);
   });
 
   it('collects and normalizes package.json task invocations', async () => {
@@ -230,6 +230,36 @@ describe('generated sources project metadata', () => {
       fsEvents: [generatedFile],
     });
     expect(await generatedSourceStore.isInitialized(configuration)).toBe(false);
+  });
+
+  it('invalidates the generated-source store on detector watched filenames', async () => {
+    const registeredDetectors = GENERATED_SOURCE_DETECTORS as GeneratedSourceDetector[];
+    const originalDetectorCount = registeredDetectors.length;
+    const baseDir = normalizeToAbsolutePath('/generated-sources-watched-filename');
+
+    registeredDetectors.push({
+      family: 'graphql-codegen',
+      watchedFilenames: ['Codegen.yml'],
+      async detect() {
+        return createDerivedGeneratedSources();
+      },
+    });
+
+    try {
+      expect(getGeneratedSourceWatchedFilenames()).toEqual(['codegen.yml']);
+
+      let configuration = createConfiguration({ baseDir });
+      generatedSourceStore.setup(configuration);
+      expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+
+      configuration = createConfiguration({
+        baseDir,
+        fsEvents: [joinPaths(baseDir, 'codegen.yml')],
+      });
+      expect(await generatedSourceStore.isInitialized(configuration)).toBe(false);
+    } finally {
+      registeredDetectors.splice(originalDetectorCount);
+    }
   });
 
   it('exercises the detector foundation helpers through realistic task/config/output flows', async () => {

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -27,6 +27,12 @@ import {
   sourceFileStore,
 } from '../../../src/file-stores/index.js';
 import {
+  hasToolEvidence,
+  resolveConfigPaths,
+  resolveGeneratedOutputsFromLiteralPaths,
+  type ResolvedGeneratedOutputs,
+} from '../../../src/jsts/rules/helpers/generated-sources/detector-api.js';
+import {
   deriveGeneratedSources,
   extractFlagValues,
 } from '../../../src/jsts/rules/helpers/generated-sources/derive.js';
@@ -36,6 +42,16 @@ import {
   GENERATED_SOURCE_WATCHED_FILENAMES,
   collectGeneratedSourceTaskInvocations,
 } from '../../../src/jsts/rules/helpers/generated-sources/index.js';
+import {
+  addFamilyFiles,
+  createDerivedGeneratedSources,
+  isLiteralPathToken,
+} from '../../../src/jsts/rules/helpers/generated-sources/shared.js';
+import {
+  taskInvocationInvokesCommand,
+  type TaskInvocation,
+} from '../../../src/jsts/rules/helpers/generated-sources/task-invocations.js';
+import { createAnalyzableFiles, type AnalyzableFiles } from '../../../src/projectAnalysis.js';
 import {
   joinPaths,
   normalizeToAbsolutePath,
@@ -60,6 +76,31 @@ async function createTempBaseDir() {
 async function writeFixtureFile(filePath: string, content = '') {
   await mkdir(dirname(filePath), { recursive: true });
   await writeFile(filePath, content);
+}
+
+function createObservedInputFiles(filePaths: NormalizedAbsolutePath[]) {
+  const analyzableFiles = createAnalyzableFiles();
+  for (const filePath of filePaths) {
+    analyzableFiles[filePath] = {
+      filePath,
+      fileContent: '',
+      fileType: 'MAIN',
+      fileStatus: 'SAME',
+    };
+  }
+
+  let ownKeysCalls = 0;
+  const observedInputFiles = new Proxy(analyzableFiles, {
+    ownKeys(target) {
+      ownKeysCalls++;
+      return Reflect.ownKeys(target);
+    },
+  }) as AnalyzableFiles;
+
+  return {
+    ownKeysCalls: () => ownKeysCalls,
+    observedInputFiles,
+  };
 }
 
 describe('generated sources project metadata', () => {
@@ -134,6 +175,120 @@ describe('generated sources project metadata', () => {
         '--config',
       ]),
     ).toEqual(['./codegen.yml', './other.yml']);
+  });
+
+  it('filters explicit generated-source families, reuses stable request keys, and resets on discovery-config changes', async () => {
+    let configuration = createConfiguration({
+      baseDir: normalizeToAbsolutePath('/generated-sources-fixture'),
+    });
+    const includedFile = joinPaths(configuration.baseDir, 'src', 'generated', 'graphql.ts');
+    const excludedFile = joinPaths(configuration.baseDir, 'src', 'generated', 'graphql-extra.ts');
+    const state = generatedSourceStore as unknown as {
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+    };
+    const { ownKeysCalls, observedInputFiles } = createObservedInputFiles([includedFile]);
+
+    generatedSourceStore.setup(configuration);
+    state.derivedFamilyByFile = new Map([
+      [includedFile, 'graphql-codegen'],
+      [excludedFile, 'graphql-codegen'],
+    ]);
+
+    await generatedSourceStore.isInitialized(configuration, observedInputFiles);
+    expect(generatedSourceStore.getFamily(includedFile)).toEqual('graphql-codegen');
+    expect(generatedSourceStore.getFamily(excludedFile)).toBeUndefined();
+
+    await generatedSourceStore.isInitialized(configuration, observedInputFiles);
+    expect(ownKeysCalls()).toEqual(1);
+
+    configuration = createConfiguration({
+      baseDir: configuration.baseDir,
+      jsTsExclusions: ['**/dist/**'],
+    });
+    expect(await generatedSourceStore.isInitialized(configuration, observedInputFiles)).toBe(false);
+    expect(generatedSourceStore.getFamily(includedFile)).toBeUndefined();
+  });
+
+  it('exercises the detector foundation helpers through realistic task/config/output flows', async () => {
+    const baseDir = await createTempBaseDir();
+    const packageDir = joinPaths(baseDir, 'packages', 'app');
+    const configPath = joinPaths(packageDir, 'codegen.yml');
+    const outputDirectory = joinPaths(packageDir, 'src', 'generated');
+    const outputFile = joinPaths(outputDirectory, 'graphql.ts');
+    const nestedOutputFile = joinPaths(outputDirectory, 'nested', 'types.ts');
+    const ignoredBuildOutput = joinPaths(outputDirectory, 'dist', 'ignored.ts');
+    const taskInvocations: TaskInvocation[] = [
+      {
+        source: 'package-json-script',
+        taskName: 'codegen',
+        commandLine: 'npx graphql-codegen --config ./codegen.yml',
+        command: 'graphql-codegen',
+        args: ['--config', './codegen.yml'],
+      },
+    ];
+
+    try {
+      await writeFixtureFile(configPath, 'schema: schema.graphql\n');
+      await writeFixtureFile(outputFile, 'export const output = true;\n');
+      await writeFixtureFile(nestedOutputFile, 'export const nested = true;\n');
+      await writeFixtureFile(ignoredBuildOutput, 'export const ignored = true;\n');
+
+      expect(
+        hasToolEvidence({
+          getDependencies: () => new Map([['@graphql-codegen/cli', '5.0.0']]),
+          taskInvocations: [],
+          dependencyName: '@graphql-codegen/cli',
+          matchesTaskInvocation: invocation =>
+            taskInvocationInvokesCommand(invocation, 'graphql-codegen'),
+        }),
+      ).toBe(true);
+      expect(taskInvocationInvokesCommand(taskInvocations[0], 'graphql-codegen')).toBe(true);
+
+      const declaredConfigPaths = await resolveConfigPaths({
+        baseDir,
+        packageDir,
+        taskInvocations,
+        matchesTaskInvocation: invocation =>
+          taskInvocationInvokesCommand(invocation, 'graphql-codegen'),
+        flags: ['--config'],
+        fallbackBasenames: ['fallback-codegen.yml'],
+      });
+      expect([...declaredConfigPaths]).toEqual([configPath]);
+
+      const fallbackConfigPaths = await resolveConfigPaths({
+        baseDir,
+        packageDir,
+        taskInvocations: [],
+        matchesTaskInvocation: invocation =>
+          taskInvocationInvokesCommand(invocation, 'graphql-codegen'),
+        flags: ['--config'],
+        fallbackBasenames: ['codegen.yml'],
+      });
+      expect([...fallbackConfigPaths]).toEqual([configPath]);
+
+      expect(isLiteralPathToken('./src/generated')).toBe(true);
+      expect(isLiteralPathToken('$(pwd)/generated')).toBe(false);
+
+      const resolvedOutputs: ResolvedGeneratedOutputs =
+        await resolveGeneratedOutputsFromLiteralPaths(
+          baseDir,
+          packageDir,
+          ['./src/generated/graphql.ts', './src/generated', '../../../outside.ts'],
+          true,
+        );
+      expect([...resolvedOutputs.filePaths]).toEqual([outputFile, nestedOutputFile]);
+      expect([...resolvedOutputs.outputDirectories]).toEqual([outputDirectory]);
+      expect([...resolvedOutputs.watchedOutputPaths]).toEqual([outputFile, outputDirectory]);
+
+      const derived = createDerivedGeneratedSources();
+      addFamilyFiles('graphql-codegen', [nestedOutputFile, outputFile], derived);
+      expect([...derived.familyByFile.entries()]).toEqual([
+        [outputFile, 'graphql-codegen'],
+        [nestedOutputFile, 'graphql-codegen'],
+      ]);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
   });
 
   it('returns no derived metadata when no detector is registered', async () => {

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -26,7 +26,6 @@ import {
   initFileStores,
   sourceFileStore,
 } from '../../../src/file-stores/index.js';
-import type { GeneratedSourceDetector } from '../../../src/jsts/rules/helpers/generated-sources/contracts.js';
 import {
   hasToolEvidence,
   resolveConfigPaths,
@@ -233,7 +232,7 @@ describe('generated sources project metadata', () => {
   });
 
   it('invalidates the generated-source store on detector watched filenames', async () => {
-    const registeredDetectors = GENERATED_SOURCE_DETECTORS as GeneratedSourceDetector[];
+    const registeredDetectors = GENERATED_SOURCE_DETECTORS;
     const originalDetectorCount = registeredDetectors.length;
     const baseDir = normalizeToAbsolutePath('/generated-sources-watched-filename');
 
@@ -263,7 +262,7 @@ describe('generated sources project metadata', () => {
   });
 
   it('computes detector watched filenames once per filesystem event batch', async () => {
-    const registeredDetectors = GENERATED_SOURCE_DETECTORS as GeneratedSourceDetector[];
+    const registeredDetectors = GENERATED_SOURCE_DETECTORS;
     const originalDetectorCount = registeredDetectors.length;
     const baseDir = normalizeToAbsolutePath('/generated-sources-watched-filename-batch');
     let watchedFilenameReads = 0;
@@ -385,7 +384,7 @@ describe('generated sources project metadata', () => {
     const configPath = joinPaths(packageDir, 'codegen.yml');
     const outputDirectory = joinPaths(packageDir, 'src', 'generated');
     const outputFile = joinPaths(outputDirectory, 'graphql.ts');
-    const registeredDetectors = GENERATED_SOURCE_DETECTORS as GeneratedSourceDetector[];
+    const registeredDetectors = GENERATED_SOURCE_DETECTORS;
     const originalDetectorCount = registeredDetectors.length;
 
     registeredDetectors.push({
@@ -458,7 +457,7 @@ describe('generated sources project metadata', () => {
 
   it('skips package metadata traversal when no detector is registered', async () => {
     const packageJsons = {
-      *[Symbol.iterator](): IterableIterator<[NormalizedAbsolutePath, File]> {
+      [Symbol.iterator](): IterableIterator<[NormalizedAbsolutePath, File]> {
         throw new Error('package.json metadata should not be read without detectors');
       },
     } as ReadonlyMap<NormalizedAbsolutePath, File>;

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -66,6 +66,8 @@ import {
   type NormalizedAbsolutePath,
 } from '../../../../shared/src/helpers/files.js';
 
+const itIfNotWindows = process.platform === 'win32' ? it.skip : it;
+
 function createPackageJsonMap(
   packageDir: NormalizedAbsolutePath,
   packageJson: Record<string, unknown>,
@@ -584,7 +586,7 @@ describe('generated sources project metadata', () => {
     }
   });
 
-  it('ignores resolved outputs that are neither files nor directories', async () => {
+  itIfNotWindows('ignores resolved outputs that are neither files nor directories', async () => {
     const baseDir = await createTempBaseDir();
     const socketPath = joinPaths(baseDir, 'generated.sock');
     const server = createServer();

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -262,6 +262,41 @@ describe('generated sources project metadata', () => {
     }
   });
 
+  it('computes detector watched filenames once per filesystem event batch', async () => {
+    const registeredDetectors = GENERATED_SOURCE_DETECTORS as GeneratedSourceDetector[];
+    const originalDetectorCount = registeredDetectors.length;
+    const baseDir = normalizeToAbsolutePath('/generated-sources-watched-filename-batch');
+    let watchedFilenameReads = 0;
+
+    registeredDetectors.push({
+      family: 'graphql-codegen',
+      get watchedFilenames() {
+        watchedFilenameReads++;
+        return ['codegen.yml'];
+      },
+      async detect() {
+        return createDerivedGeneratedSources();
+      },
+    });
+
+    try {
+      let configuration = createConfiguration({ baseDir });
+      generatedSourceStore.setup(configuration);
+      expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+
+      watchedFilenameReads = 0;
+      configuration = createConfiguration({
+        baseDir,
+        fsEvents: [joinPaths(baseDir, 'src', 'first.ts'), joinPaths(baseDir, 'src', 'second.ts')],
+      });
+
+      expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+      expect(watchedFilenameReads).toEqual(1);
+    } finally {
+      registeredDetectors.splice(originalDetectorCount);
+    }
+  });
+
   it('exercises the detector foundation helpers through realistic task/config/output flows', async () => {
     const baseDir = await createTempBaseDir();
     const packageDir = joinPaths(baseDir, 'packages', 'app');
@@ -419,6 +454,23 @@ describe('generated sources project metadata', () => {
     } finally {
       await rm(baseDir, { recursive: true, force: true });
     }
+  });
+
+  it('skips package metadata traversal when no detector is registered', async () => {
+    const packageJsons = {
+      *[Symbol.iterator](): IterableIterator<[NormalizedAbsolutePath, File]> {
+        throw new Error('package.json metadata should not be read without detectors');
+      },
+    } as ReadonlyMap<NormalizedAbsolutePath, File>;
+
+    const derived = await deriveGeneratedSources(
+      normalizeToAbsolutePath('/generated-sources-no-detectors'),
+      packageJsons,
+    );
+
+    expect(derived.familyByFile).toEqual(new Map());
+    expect(derived.configPaths).toEqual(new Set());
+    expect(derived.watchedOutputPaths).toEqual(new Set());
   });
 
   it('keeps the generated-source store empty when no detector is registered', async () => {

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -262,6 +262,41 @@ describe('generated sources project metadata', () => {
     }
   });
 
+  it('computes detector watched filenames once per filesystem event batch', async () => {
+    const registeredDetectors = GENERATED_SOURCE_DETECTORS as GeneratedSourceDetector[];
+    const originalDetectorCount = registeredDetectors.length;
+    const baseDir = normalizeToAbsolutePath('/generated-sources-watched-filename-batch');
+    let watchedFilenameReads = 0;
+
+    registeredDetectors.push({
+      family: 'graphql-codegen',
+      get watchedFilenames() {
+        watchedFilenameReads++;
+        return ['codegen.yml'];
+      },
+      async detect() {
+        return createDerivedGeneratedSources();
+      },
+    });
+
+    try {
+      let configuration = createConfiguration({ baseDir });
+      generatedSourceStore.setup(configuration);
+      expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+
+      watchedFilenameReads = 0;
+      configuration = createConfiguration({
+        baseDir,
+        fsEvents: [joinPaths(baseDir, 'src', 'first.ts'), joinPaths(baseDir, 'src', 'second.ts')],
+      });
+
+      expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+      expect(watchedFilenameReads).toEqual(1);
+    } finally {
+      registeredDetectors.splice(originalDetectorCount);
+    }
+  });
+
   it('exercises the detector foundation helpers through realistic task/config/output flows', async () => {
     const baseDir = await createTempBaseDir();
     const packageDir = joinPaths(baseDir, 'packages', 'app');

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -1,0 +1,203 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { beforeEach, describe, it } from 'node:test';
+import { expect } from 'expect';
+import { createConfiguration } from '../../../src/common/configuration.js';
+import {
+  dependencyManifestStore,
+  generatedSourceStore,
+  initFileStores,
+  sourceFileStore,
+} from '../../../src/file-stores/index.js';
+import {
+  deriveGeneratedSources,
+  extractFlagValues,
+} from '../../../src/jsts/rules/helpers/generated-sources/derive.js';
+import {
+  GENERATED_SOURCE_DETECTORS,
+  GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS,
+  GENERATED_SOURCE_WATCHED_FILENAMES,
+  collectGeneratedSourceTaskInvocations,
+} from '../../../src/jsts/rules/helpers/generated-sources/index.js';
+import {
+  joinPaths,
+  normalizeToAbsolutePath,
+  type File,
+  type NormalizedAbsolutePath,
+} from '../../../../shared/src/helpers/files.js';
+
+function createPackageJsonMap(
+  packageDir: NormalizedAbsolutePath,
+  packageJson: Record<string, unknown>,
+) {
+  const packageJsonPath = joinPaths(packageDir, 'package.json');
+  return new Map<NormalizedAbsolutePath, File>([
+    [packageDir, { path: packageJsonPath, content: JSON.stringify(packageJson, null, 2) }],
+  ]);
+}
+
+async function createTempBaseDir() {
+  return normalizeToAbsolutePath(await mkdtemp(join(tmpdir(), 'generated-sources-test-')));
+}
+
+async function writeFixtureFile(filePath: string, content = '') {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, content);
+}
+
+describe('generated sources project metadata', () => {
+  beforeEach(() => {
+    dependencyManifestStore.clearCache();
+    generatedSourceStore.clearCache();
+    sourceFileStore.clearCache();
+  });
+
+  it('registers no detector yet through the shared contract', () => {
+    expect(GENERATED_SOURCE_DETECTORS).toEqual([]);
+    expect(GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS.map(provider => provider.kind)).toEqual([
+      'package-json-scripts',
+    ]);
+    expect(GENERATED_SOURCE_WATCHED_FILENAMES).toEqual([]);
+  });
+
+  it('collects and normalizes package.json task invocations', async () => {
+    const baseDir = await createTempBaseDir();
+
+    try {
+      const taskInvocations = await collectGeneratedSourceTaskInvocations({
+        baseDir,
+        packageDir: baseDir,
+        packageJson: {
+          scripts: {
+            codegen: 'graphql-codegen --config ./codegen.yml && prettier src/generated',
+            wrapped: 'npx graphql-codegen --config ./codegen.yml',
+            rawYarn: 'yarn graphql-codegen --config ./codegen.yml',
+          },
+        },
+      });
+
+      expect(taskInvocations).toEqual([
+        {
+          source: 'package-json-script',
+          taskName: 'codegen',
+          commandLine: 'graphql-codegen --config ./codegen.yml',
+          command: 'graphql-codegen',
+          args: ['--config', './codegen.yml'],
+        },
+        {
+          source: 'package-json-script',
+          taskName: 'codegen',
+          commandLine: 'prettier src/generated',
+          command: 'prettier',
+          args: ['src/generated'],
+        },
+        {
+          source: 'package-json-script',
+          taskName: 'wrapped',
+          commandLine: 'npx graphql-codegen --config ./codegen.yml',
+          command: 'graphql-codegen',
+          args: ['--config', './codegen.yml'],
+        },
+        {
+          source: 'package-json-script',
+          taskName: 'rawYarn',
+          commandLine: 'yarn graphql-codegen --config ./codegen.yml',
+          command: 'yarn',
+          args: ['graphql-codegen', '--config', './codegen.yml'],
+        },
+      ]);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('extracts output flag values from separate and equals syntax', () => {
+    expect(
+      extractFlagValues('graphql-codegen --config ./codegen.yml --config=./other.yml', [
+        '--config',
+      ]),
+    ).toEqual(['./codegen.yml', './other.yml']);
+  });
+
+  it('returns no derived metadata when no detector is registered', async () => {
+    const baseDir = await createTempBaseDir();
+
+    try {
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            '@graphql-codegen/cli': '1.0.0',
+          },
+          scripts: {
+            codegen: 'graphql-codegen --config ./codegen.ts',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile).toEqual(new Map());
+      expect(derived.configPaths).toEqual(new Set());
+      expect(derived.watchedOutputPaths).toEqual(new Set());
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the generated-source store empty when no detector is registered', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+
+    try {
+      await writeFixtureFile(
+        join(baseDir, 'package.json'),
+        JSON.stringify(
+          {
+            devDependencies: {
+              '@graphql-codegen/cli': '5.0.0',
+            },
+            scripts: {
+              codegen: 'graphql-codegen --config ./codegen.ts',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFixtureFile(
+        join(baseDir, 'codegen.ts'),
+        `export default {
+  generates: {
+    './src/generated/graphql.ts': {
+      plugins: ['typescript'],
+    },
+  },
+};
+`,
+      );
+      await writeFixtureFile(outputPath, 'export const generated = true;\n');
+
+      await initFileStores(createConfiguration({ baseDir }));
+
+      expect(generatedSourceStore.getFamily(outputPath)).toBeUndefined();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -26,6 +26,7 @@ import {
   initFileStores,
   sourceFileStore,
 } from '../../../src/file-stores/index.js';
+import type { GeneratedSourceDetector } from '../../../src/jsts/rules/helpers/generated-sources/contracts.js';
 import {
   hasToolEvidence,
   resolveConfigPaths,
@@ -209,6 +210,28 @@ describe('generated sources project metadata', () => {
     expect(generatedSourceStore.getFamily(includedFile)).toBeUndefined();
   });
 
+  it('keeps all derived generated-source families in filesystem mode and invalidates on relevant file events', async () => {
+    let configuration = createConfiguration({
+      baseDir: normalizeToAbsolutePath('/generated-sources-all-files'),
+    });
+    const generatedFile = joinPaths(configuration.baseDir, 'src', 'generated', 'graphql.ts');
+    const state = generatedSourceStore as unknown as {
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+    };
+
+    generatedSourceStore.setup(configuration);
+    state.derivedFamilyByFile = new Map([[generatedFile, 'graphql-codegen']]);
+
+    await generatedSourceStore.isInitialized(configuration);
+    expect(generatedSourceStore.getFamily(generatedFile)).toEqual('graphql-codegen');
+
+    configuration = createConfiguration({
+      baseDir: configuration.baseDir,
+      fsEvents: [generatedFile],
+    });
+    expect(await generatedSourceStore.isInitialized(configuration)).toBe(false);
+  });
+
   it('exercises the detector foundation helpers through realistic task/config/output flows', async () => {
     const baseDir = await createTempBaseDir();
     const packageDir = joinPaths(baseDir, 'packages', 'app');
@@ -287,6 +310,59 @@ describe('generated sources project metadata', () => {
         [nestedOutputFile, 'graphql-codegen'],
       ]);
     } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('merges detector output and falls back to raw package dependencies for synthetic manifests', async () => {
+    const baseDir = await createTempBaseDir();
+    const packageDir = joinPaths(baseDir, 'packages', 'fixture');
+    const configPath = joinPaths(packageDir, 'codegen.yml');
+    const outputDirectory = joinPaths(packageDir, 'src', 'generated');
+    const outputFile = joinPaths(outputDirectory, 'graphql.ts');
+    const registeredDetectors = GENERATED_SOURCE_DETECTORS as GeneratedSourceDetector[];
+    const originalDetectorCount = registeredDetectors.length;
+
+    registeredDetectors.push({
+      family: 'graphql-codegen',
+      async detect({ getDependencies, taskInvocations }) {
+        expect(getDependencies().get('@graphql-codegen/cli')).toEqual('5.0.0');
+        expect(taskInvocations).toEqual([
+          {
+            source: 'package-json-script',
+            taskName: 'codegen',
+            commandLine: 'graphql-codegen --config ./codegen.yml',
+            command: 'graphql-codegen',
+            args: ['--config', './codegen.yml'],
+          },
+        ]);
+
+        const derived = createDerivedGeneratedSources();
+        addFamilyFiles('graphql-codegen', [outputFile], derived);
+        derived.configPaths.add(configPath);
+        derived.watchedOutputPaths.add(outputDirectory);
+        return derived;
+      },
+    });
+
+    try {
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(packageDir, {
+          devDependencies: {
+            '@graphql-codegen/cli': '5.0.0',
+          },
+          scripts: {
+            codegen: 'graphql-codegen --config ./codegen.yml',
+          },
+        }),
+      );
+
+      expect([...derived.familyByFile.entries()]).toEqual([[outputFile, 'graphql-codegen']]);
+      expect([...derived.configPaths]).toEqual([configPath]);
+      expect([...derived.watchedOutputPaths]).toEqual([outputDirectory]);
+    } finally {
+      registeredDetectors.splice(originalDetectorCount);
       await rm(baseDir, { recursive: true, force: true });
     }
   });

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -15,6 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { beforeEach, describe, it } from 'node:test';
@@ -45,7 +46,13 @@ import {
 import {
   addFamilyFiles,
   createDerivedGeneratedSources,
+  isDirectory,
+  isFile,
   isLiteralPathToken,
+  listSourceFilesInDirectory,
+  mergeDerivedGeneratedSources,
+  parseDirectCommandSegments,
+  resolveLiteralPath,
 } from '../../../src/jsts/rules/helpers/generated-sources/shared.js';
 import {
   taskInvocationInvokesCommand,
@@ -177,25 +184,102 @@ describe('generated sources project metadata', () => {
     ).toEqual(['./codegen.yml', './other.yml']);
   });
 
+  it('handles generated-source parsing and filesystem edge cases defensively', async () => {
+    const baseDir = await createTempBaseDir();
+
+    try {
+      expect(extractFlagValues('graphql-codegen --config "./codegen.yml"', ['--config'])).toEqual([
+        './codegen.yml',
+      ]);
+      expect(extractFlagValues('graphql-codegen --config "./broken', ['--config'])).toEqual([]);
+
+      expect(
+        parseDirectCommandSegments(
+          'graphql-codegen --config "./codegen.yml" && && NODE_ENV=production graphql-codegen --config ./ignored.yml && prettier src/generated',
+        ),
+      ).toEqual([
+        {
+          commandLine: 'graphql-codegen --config "./codegen.yml"',
+          command: 'graphql-codegen',
+          args: ['--config', './codegen.yml'],
+        },
+        {
+          commandLine: 'prettier src/generated',
+          command: 'prettier',
+          args: ['src/generated'],
+        },
+      ]);
+      expect(parseDirectCommandSegments('graphql-codegen --config "./broken')).toEqual([]);
+
+      expect(resolveLiteralPath('$(pwd)/generated', baseDir, baseDir)).toBeUndefined();
+
+      const missingFile = joinPaths(baseDir, 'missing.ts');
+      const missingDirectory = joinPaths(baseDir, 'missing-directory');
+      expect(await isFile(missingFile)).toBe(false);
+      expect(await isDirectory(missingDirectory)).toBe(false);
+      expect(await listSourceFilesInDirectory(missingDirectory, true)).toEqual([]);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('merges derived generated-source metadata in a deterministic order', () => {
+    const target = createDerivedGeneratedSources();
+    const source = createDerivedGeneratedSources();
+    const aConfigPath = normalizeToAbsolutePath('/generated/a/codegen.yml');
+    const zConfigPath = normalizeToAbsolutePath('/generated/z/codegen.yml');
+    const aFilePath = normalizeToAbsolutePath('/generated/a/output.ts');
+    const zFilePath = normalizeToAbsolutePath('/generated/z/output.ts');
+    const aOutputPath = normalizeToAbsolutePath('/generated/a/output');
+    const zOutputPath = normalizeToAbsolutePath('/generated/z/output');
+
+    source.familyByFile.set(zFilePath, 'graphql-codegen');
+    source.familyByFile.set(aFilePath, 'graphql-codegen');
+    source.configPaths.add(zConfigPath);
+    source.configPaths.add(aConfigPath);
+    source.watchedOutputPaths.add(zOutputPath);
+    source.watchedOutputPaths.add(aOutputPath);
+
+    mergeDerivedGeneratedSources(target, source);
+
+    expect([...target.familyByFile.entries()]).toEqual([
+      [aFilePath, 'graphql-codegen'],
+      [zFilePath, 'graphql-codegen'],
+    ]);
+    expect([...target.configPaths]).toEqual([aConfigPath, zConfigPath]);
+    expect([...target.watchedOutputPaths]).toEqual([aOutputPath, zOutputPath]);
+  });
+
   it('filters explicit generated-source families, reuses stable request keys, and resets on discovery-config changes', async () => {
     let configuration = createConfiguration({
       baseDir: normalizeToAbsolutePath('/generated-sources-fixture'),
     });
     const includedFile = joinPaths(configuration.baseDir, 'src', 'generated', 'graphql.ts');
+    const secondIncludedFile = joinPaths(
+      configuration.baseDir,
+      'src',
+      'generated',
+      'graphql-second.ts',
+    );
     const excludedFile = joinPaths(configuration.baseDir, 'src', 'generated', 'graphql-extra.ts');
     const state = generatedSourceStore as unknown as {
       derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
     };
-    const { ownKeysCalls, observedInputFiles } = createObservedInputFiles([includedFile]);
+    const { ownKeysCalls, observedInputFiles } = createObservedInputFiles([
+      secondIncludedFile,
+      includedFile,
+    ]);
 
     generatedSourceStore.setup(configuration);
     state.derivedFamilyByFile = new Map([
       [includedFile, 'graphql-codegen'],
+      [secondIncludedFile, 'graphql-codegen'],
       [excludedFile, 'graphql-codegen'],
     ]);
 
     await generatedSourceStore.isInitialized(configuration, observedInputFiles);
     expect(generatedSourceStore.getFamily(includedFile)).toEqual('graphql-codegen');
+    expect(generatedSourceStore.getFamily(secondIncludedFile)).toEqual('graphql-codegen');
     expect(generatedSourceStore.getFamily(excludedFile)).toBeUndefined();
 
     await generatedSourceStore.isInitialized(configuration, observedInputFiles);
@@ -296,6 +380,51 @@ describe('generated sources project metadata', () => {
     }
   });
 
+  it('normalizes supported runner wrappers and preserves unsupported script forms', async () => {
+    const baseDir = await createTempBaseDir();
+
+    try {
+      const taskInvocations = await collectGeneratedSourceTaskInvocations({
+        baseDir,
+        packageDir: baseDir,
+        packageJson: {
+          scripts: {
+            ignored: 42 as never,
+            wrappedPnpm: 'pnpm exec graphql-codegen --config ./codegen.yml',
+            wrappedDashDash: 'npx -- graphql-codegen --config ./codegen.yml',
+            rawNpxOption: 'npx --yes graphql-codegen --config ./codegen.yml',
+          },
+        },
+      });
+
+      expect(taskInvocations).toEqual([
+        {
+          source: 'package-json-script',
+          taskName: 'wrappedPnpm',
+          commandLine: 'pnpm exec graphql-codegen --config ./codegen.yml',
+          command: 'graphql-codegen',
+          args: ['--config', './codegen.yml'],
+        },
+        {
+          source: 'package-json-script',
+          taskName: 'wrappedDashDash',
+          commandLine: 'npx -- graphql-codegen --config ./codegen.yml',
+          command: 'graphql-codegen',
+          args: ['--config', './codegen.yml'],
+        },
+        {
+          source: 'package-json-script',
+          taskName: 'rawNpxOption',
+          commandLine: 'npx --yes graphql-codegen --config ./codegen.yml',
+          command: 'npx',
+          args: ['--yes', 'graphql-codegen', '--config', './codegen.yml'],
+        },
+      ]);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   it('exercises the detector foundation helpers through realistic task/config/output flows', async () => {
     const baseDir = await createTempBaseDir();
     const packageDir = joinPaths(baseDir, 'packages', 'app');
@@ -378,6 +507,112 @@ describe('generated sources project metadata', () => {
     }
   });
 
+  it('resolves config and output paths across fallback, duplicate, and unsupported candidates', async () => {
+    const baseDir = await createTempBaseDir();
+    const packageDir = joinPaths(baseDir, 'packages', 'app');
+    const configPath = joinPaths(packageDir, 'codegen.yml');
+    const generatedFile = joinPaths(packageDir, 'src', 'generated', 'graphql.ts');
+    const nonSourceFile = joinPaths(packageDir, 'README.md');
+    const rootOutputFile = joinPaths(baseDir, 'index.ts');
+    const missingOutputPath = joinPaths(packageDir, 'missing.ts');
+    const codegenInvocation: TaskInvocation = {
+      source: 'package-json-script',
+      taskName: 'codegen',
+      commandLine: 'graphql-codegen --config ./codegen.yml',
+      command: 'graphql-codegen',
+      args: ['--config', './codegen.yml'],
+    };
+    const prettierInvocation: TaskInvocation = {
+      source: 'package-json-script',
+      taskName: 'format',
+      commandLine: 'prettier .',
+      command: 'prettier',
+      args: ['.'],
+    };
+
+    try {
+      await writeFixtureFile(configPath, 'schema: schema.graphql\n');
+      await writeFixtureFile(generatedFile, 'export const generated = true;\n');
+      await writeFixtureFile(nonSourceFile, '# generated sources\n');
+      await writeFixtureFile(rootOutputFile, 'export const root = true;\n');
+
+      expect(
+        hasToolEvidence({
+          getDependencies: () => new Map(),
+          taskInvocations: [codegenInvocation],
+          matchesTaskInvocation: invocation =>
+            taskInvocationInvokesCommand(invocation, 'graphql-codegen'),
+        }),
+      ).toBe(true);
+
+      const fallbackConfigPaths = await resolveConfigPaths({
+        baseDir,
+        packageDir,
+        taskInvocations: [prettierInvocation],
+        matchesTaskInvocation: invocation =>
+          taskInvocationInvokesCommand(invocation, 'graphql-codegen'),
+        flags: ['--config'],
+        fallbackBasenames: ['codegen.yml'],
+      });
+      expect([...fallbackConfigPaths]).toEqual([configPath]);
+
+      const resolvedOutputs = await resolveGeneratedOutputsFromLiteralPaths(
+        baseDir,
+        [packageDir, packageDir],
+        ['./README.md', './missing.ts', './src/generated/graphql.ts'],
+        false,
+      );
+      expect([...resolvedOutputs.filePaths]).toEqual([generatedFile]);
+      expect([...resolvedOutputs.outputDirectories]).toEqual([]);
+      expect([...resolvedOutputs.watchedOutputPaths]).toEqual([
+        nonSourceFile,
+        missingOutputPath,
+        generatedFile,
+      ]);
+
+      const baseDirOutputs = await resolveGeneratedOutputsFromLiteralPaths(
+        baseDir,
+        baseDir,
+        ['.'],
+        false,
+      );
+      expect([...baseDirOutputs.filePaths]).toEqual([rootOutputFile]);
+      expect([...baseDirOutputs.outputDirectories]).toEqual([baseDir]);
+      expect([...baseDirOutputs.watchedOutputPaths]).toEqual([baseDir]);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores resolved outputs that are neither files nor directories', async () => {
+    const baseDir = await createTempBaseDir();
+    const socketPath = joinPaths(baseDir, 'generated.sock');
+    const server = createServer();
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(socketPath, () => {
+          server.off('error', reject);
+          resolve();
+        });
+      });
+
+      const resolvedOutputs = await resolveGeneratedOutputsFromLiteralPaths(
+        baseDir,
+        baseDir,
+        ['./generated.sock'],
+        false,
+      );
+      expect([...resolvedOutputs.filePaths]).toEqual([]);
+      expect([...resolvedOutputs.outputDirectories]).toEqual([]);
+      expect([...resolvedOutputs.watchedOutputPaths]).toEqual([socketPath]);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   it('merges detector output and falls back to raw package dependencies for synthetic manifests', async () => {
     const baseDir = await createTempBaseDir();
     const packageDir = joinPaths(baseDir, 'packages', 'fixture');
@@ -425,6 +660,111 @@ describe('generated sources project metadata', () => {
       expect([...derived.familyByFile.entries()]).toEqual([[outputFile, 'graphql-codegen']]);
       expect([...derived.configPaths]).toEqual([configPath]);
       expect([...derived.watchedOutputPaths]).toEqual([outputDirectory]);
+    } finally {
+      registeredDetectors.splice(originalDetectorCount);
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps generated-source store defensive in request-only mode and on stale refresh signals', async () => {
+    const requestOnlyBaseDir = normalizeToAbsolutePath('/generated-sources-request-only');
+    let configuration = createConfiguration({
+      baseDir: requestOnlyBaseDir,
+      canAccessFileSystem: false,
+    });
+
+    generatedSourceStore.setup(configuration);
+    (
+      generatedSourceStore as unknown as {
+        requestFilesKey: string | undefined;
+      }
+    ).requestFilesKey = 'all-files';
+    expect(await generatedSourceStore.isInitialized(configuration)).toBe(false);
+
+    generatedSourceStore.clearCache();
+    await generatedSourceStore.postProcess(configuration);
+
+    const requestOnlyState = generatedSourceStore as unknown as {
+      baseDir: NormalizedAbsolutePath | undefined;
+      canAccessFileSystem: boolean | undefined;
+      familyByFile: Map<NormalizedAbsolutePath, string>;
+    };
+    expect(requestOnlyState.baseDir).toEqual(requestOnlyBaseDir);
+    expect(requestOnlyState.canAccessFileSystem).toBe(false);
+    expect(requestOnlyState.familyByFile).toEqual(new Map());
+
+    const watchedBaseDir = normalizeToAbsolutePath('/generated-sources-watched-output');
+    const generatedFile = joinPaths(watchedBaseDir, 'src', 'generated', 'graphql.ts');
+    const watchedOutputPath = joinPaths(watchedBaseDir, 'src', 'generated');
+
+    configuration = createConfiguration({ baseDir: watchedBaseDir });
+    generatedSourceStore.setup(configuration);
+    const watchedState = generatedSourceStore as unknown as {
+      analyzableFilesConfigKey: string | undefined;
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+      projectFileDiscoveryConfigKey: string | undefined;
+      watchedOutputPaths: Set<NormalizedAbsolutePath>;
+    };
+    watchedState.derivedFamilyByFile = new Map([[generatedFile, 'graphql-codegen']]);
+    watchedState.watchedOutputPaths = new Set([watchedOutputPath]);
+
+    expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+
+    configuration = createConfiguration({
+      baseDir: watchedBaseDir,
+      fsEvents: [joinPaths(watchedOutputPath, 'nested', 'child.ts')],
+    });
+    expect(await generatedSourceStore.isInitialized(configuration)).toBe(false);
+
+    configuration = createConfiguration({ baseDir: watchedBaseDir });
+    generatedSourceStore.setup(configuration);
+    watchedState.projectFileDiscoveryConfigKey = 'stale-discovery-key';
+    expect(await generatedSourceStore.isInitialized(configuration)).toBe(false);
+  });
+
+  it('filters derived generated-source files with the configured source suffix matcher', async () => {
+    const baseDir = await createTempBaseDir();
+    const supportedOutputFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+    const unsupportedOutputFile = joinPaths(baseDir, 'src', 'generated', 'graphql.txt');
+    const registeredDetectors = GENERATED_SOURCE_DETECTORS;
+    const originalDetectorCount = registeredDetectors.length;
+
+    registeredDetectors.push({
+      family: 'graphql-codegen',
+      async detect({ baseDir, packageDir, sourceFileMatcher }) {
+        const derived = createDerivedGeneratedSources();
+        const outputs = await resolveGeneratedOutputsFromLiteralPaths(
+          baseDir,
+          packageDir,
+          ['./src/generated/graphql.ts', './src/generated/graphql.txt'],
+          false,
+          sourceFileMatcher,
+        );
+        addFamilyFiles('graphql-codegen', outputs.filePaths, derived);
+        return derived;
+      },
+    });
+
+    try {
+      await writeFixtureFile(
+        join(baseDir, 'package.json'),
+        JSON.stringify(
+          {
+            scripts: {
+              codegen: 'graphql-codegen --config ./codegen.yml',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFixtureFile(supportedOutputFile, 'export const generated = true;\n');
+      await writeFixtureFile(unsupportedOutputFile, 'generated output\n');
+
+      await initFileStores(createConfiguration({ baseDir }));
+
+      expect(generatedSourceStore.getFamily(supportedOutputFile)).toEqual('graphql-codegen');
+      expect(generatedSourceStore.getFamily(unsupportedOutputFile)).toBeUndefined();
     } finally {
       registeredDetectors.splice(originalDetectorCount);
       await rm(baseDir, { recursive: true, force: true });

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -130,7 +130,6 @@ describe('generated sources project metadata', () => {
           scripts: {
             codegen: 'graphql-codegen --config ./codegen.yml && prettier src/generated',
             wrapped: 'npx graphql-codegen --config ./codegen.yml',
-            wrappedWithFlags: 'npx --yes graphql-codegen --config ./codegen.yml',
             rawYarn: 'yarn graphql-codegen --config ./codegen.yml',
           },
         },
@@ -155,13 +154,6 @@ describe('generated sources project metadata', () => {
           source: 'package-json-script',
           taskName: 'wrapped',
           commandLine: 'npx graphql-codegen --config ./codegen.yml',
-          command: 'graphql-codegen',
-          args: ['--config', './codegen.yml'],
-        },
-        {
-          source: 'package-json-script',
-          taskName: 'wrappedWithFlags',
-          commandLine: 'npx --yes graphql-codegen --config ./codegen.yml',
           command: 'graphql-codegen',
           args: ['--config', './codegen.yml'],
         },

--- a/packages/analysis/tests/source-files.test.ts
+++ b/packages/analysis/tests/source-files.test.ts
@@ -19,6 +19,7 @@ import { expect } from 'expect';
 import { join } from 'node:path/posix';
 import { initFileStores, sourceFileStore } from '../src/file-stores/index.js';
 import { createConfiguration } from '../src/common/configuration.js';
+import { sanitizeRawInputFiles } from '../src/common/input-sanitize.js';
 import { normalizePath, normalizeToAbsolutePath } from '../../shared/src/helpers/files.js';
 import { UNINITIALIZED_ERROR } from '../src/file-stores/source-files.js';
 
@@ -56,5 +57,39 @@ describe('files', () => {
         fileType: 'TEST',
       },
     });
+  });
+
+  it('should rebuild the directory index from input files on each analysis', async () => {
+    const baseDir = normalizeToAbsolutePath('/project');
+    const configuration = createConfiguration({ baseDir, canAccessFileSystem: false });
+
+    const { files: firstInputFiles } = await sanitizeRawInputFiles(
+      {
+        first: {
+          filePath: '/project/src/first.ts',
+          fileContent: 'export const first = true;\n',
+        },
+      },
+      configuration,
+    );
+    await sourceFileStore.isInitialized(configuration, firstInputFiles);
+    expect([
+      ...sourceFileStore.getFilesInDirectory(normalizeToAbsolutePath('/project/src'))!,
+    ]).toEqual(['first.ts']);
+
+    const { files: secondInputFiles } = await sanitizeRawInputFiles(
+      {
+        second: {
+          filePath: '/project/src/second.ts',
+          fileContent: 'export const second = true;\n',
+        },
+      },
+      configuration,
+    );
+    await sourceFileStore.isInitialized(configuration, secondInputFiles);
+
+    expect([
+      ...sourceFileStore.getFilesInDirectory(normalizeToAbsolutePath('/project/src'))!,
+    ]).toEqual(['second.ts']);
   });
 });

--- a/packages/analysis/tests/tsconfigs.test.ts
+++ b/packages/analysis/tests/tsconfigs.test.ts
@@ -89,4 +89,35 @@ describe('tsconfigs', () => {
       `Failed to find any of the provided tsconfig.json files: ${join(fixtures, 'tsconfig.fake.json')}`,
     );
   });
+
+  it('should refresh discovered tsconfigs when project-file discovery config changes', async () => {
+    let configuration = createConfiguration({ baseDir: fixtures });
+    await initFileStores(configuration);
+
+    const excludedTsconfig = normalizeToAbsolutePath(join(fixtures, 'project3', 'tsconfig.json'));
+    expect(tsConfigStore.getTsConfigs()).toContain(excludedTsconfig);
+
+    configuration = createConfiguration({
+      baseDir: fixtures,
+      jsTsExclusions: ['**/project3/**'],
+    });
+    await initFileStores(configuration);
+
+    expect(tsConfigStore.getTsConfigs()).not.toContain(excludedTsconfig);
+  });
+
+  it('should keep discovered tsconfigs when only source-file selection changes', async () => {
+    let configuration = createConfiguration({ baseDir: fixtures });
+    await initFileStores(configuration);
+
+    const retainedTsconfig = normalizeToAbsolutePath(join(fixtures, 'project3', 'tsconfig.json'));
+
+    configuration = createConfiguration({
+      baseDir: fixtures,
+      sources: ['project3'],
+    });
+    await initFileStores(configuration);
+
+    expect(tsConfigStore.getTsConfigs()).toContain(retainedTsconfig);
+  });
 });

--- a/packages/analysis/tests/tsconfigs.test.ts
+++ b/packages/analysis/tests/tsconfigs.test.ts
@@ -90,6 +90,28 @@ describe('tsconfigs', () => {
     );
   });
 
+  it('should keep using provided tsconfig paths after project-file discovery resets the cache', async () => {
+    const providedTsconfig = normalizeToAbsolutePath(join(fixtures, 'project3', 'tsconfig.json'));
+    let configuration = createConfiguration({
+      baseDir: fixtures,
+      tsConfigPaths: [providedTsconfig],
+    });
+    await initFileStores(configuration);
+
+    expect(tsConfigStore.getTsConfigs()).toEqual([providedTsconfig]);
+    expect(tsConfigStore.usingPropertyTsConfigs()).toBe(true);
+
+    configuration = createConfiguration({
+      baseDir: fixtures,
+      tsConfigPaths: [providedTsconfig],
+      jsTsExclusions: ['**/project1/**'],
+    });
+    await initFileStores(configuration);
+
+    expect(tsConfigStore.getTsConfigs()).toEqual([providedTsconfig]);
+    expect(tsConfigStore.usingPropertyTsConfigs()).toBe(true);
+  });
+
   it('should refresh discovered tsconfigs when project-file discovery config changes', async () => {
     let configuration = createConfiguration({ baseDir: fixtures });
     await initFileStores(configuration);

--- a/packages/grpc/src/analyze-project-normalize.ts
+++ b/packages/grpc/src/analyze-project-normalize.ts
@@ -23,6 +23,7 @@ import {
 } from '../../analysis/src/common/configuration.js';
 import {
   dependencyManifestStore,
+  generatedSourceStore,
   initFileStores,
   sourceFileStore,
   tsConfigStore,
@@ -432,5 +433,6 @@ function hasExplicitFiles(
 function resetFileStoresForFileSystemDiscovery() {
   sourceFileStore.clearCache();
   dependencyManifestStore.clearCache();
+  generatedSourceStore.clearCache();
   tsConfigStore.clearCache();
 }

--- a/packages/grpc/tests/analyze-project-normalize.test.ts
+++ b/packages/grpc/tests/analyze-project-normalize.test.ts
@@ -23,6 +23,13 @@ import {
   InvalidAnalyzeProjectRequestError,
   normalizeAnalyzeProjectRequest,
 } from '../src/analyze-project-normalize.js';
+import { createConfiguration } from '../../analysis/src/common/configuration.js';
+import {
+  dependencyManifestStore,
+  generatedSourceStore,
+  sourceFileStore,
+  tsConfigStore,
+} from '../../analysis/src/file-stores/index.js';
 import {
   normalizeToAbsolutePath,
   type NormalizedAbsolutePath,
@@ -37,6 +44,10 @@ afterEach(async () => {
   await Promise.all(
     temporaryDirectories.splice(0).map(path => rm(path, { force: true, recursive: true })),
   );
+  sourceFileStore.clearCache();
+  dependencyManifestStore.clearCache();
+  generatedSourceStore.clearCache();
+  tsConfigStore.clearCache();
 });
 
 async function createBaseDir() {
@@ -206,6 +217,41 @@ describe('normalizeAnalyzeProjectRequest', () => {
     expect(normalized.pathMap.size).toBe(0);
     expect(normalized.configuration.canAccessFileSystem).toBe(true);
     expect(normalized.configuration.maxFileSize).toBe(64);
+  });
+
+  it('should reset the generated-source store before filesystem rediscovery', async () => {
+    const baseDir = await createBaseDir();
+    const staleGeneratedFile = normalizeToAbsolutePath(
+      join(baseDir, 'src', 'generated.ts'),
+      baseDir,
+    );
+    const generatedSourceState = generatedSourceStore as unknown as {
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+      familyByFile: Map<NormalizedAbsolutePath, string>;
+      requestFilesKey: string | undefined;
+    };
+
+    generatedSourceStore.setup(
+      createConfiguration({
+        baseDir,
+        canAccessFileSystem: true,
+      }),
+    );
+    generatedSourceState.derivedFamilyByFile = new Map([[staleGeneratedFile, 'stale-family']]);
+    generatedSourceState.familyByFile = new Map([[staleGeneratedFile, 'stale-family']]);
+    generatedSourceState.requestFilesKey = 'all-files';
+
+    await normalizeAnalyzeProjectRequest({
+      configuration: {
+        baseDir,
+        canAccessFileSystem: true,
+      },
+      rules: [],
+      cssRules: [],
+      bundles: [],
+    });
+
+    expect(generatedSourceStore.getFamily(staleGeneratedFile)).toBeUndefined();
   });
 
   it('should keep empty files explicit when filesystem access is disabled', async () => {


### PR DESCRIPTION
Part of JS-1597

## What
- introduce the generated-source file store and shared detector/task-invocation contracts
- derive generated-source metadata from dependency manifests and normalized package.json task invocations
- wire generated-source awareness into analysis configuration and file-store initialization
- add project-metadata tests for invocation normalization, empty-derivation behavior, and store behavior with no registered detector

## Why
- generated-source detection needs common plumbing before tool-specific detectors can be added safely
- this change establishes the shared APIs, watched-path handling, and store lifecycle for the follow-up PRs in this series

## Impact
- no detector is registered yet, so behavior should remain unchanged for analyzed projects
- follow-up changes can add detectors on top of the same derived metadata and store contract

## Validation
- `npm run bridge:build:fast`
- `npx tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec --test-reporter-destination stdout packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts`

----
## Summary by Gitar

- **Refactored file store lifecycle:**
  - Updated `FileStore` interface to support `postProcess` with optional `analyzableFiles`.
  - Added configuration hashing via `getProjectFileDiscoveryConfigKey` and `getAnalyzableFilesConfigKey` for granular cache invalidation across all stores.
- **New generated-source store:**
  - Added `generatedSourceStore` to coordinate detection, watched paths, and family mappings.
  - Integrated generated-source detection into `analyzeProject` via `isGeneratedSourceFile` to classify files for the linter.
- **Detector foundation:**
  - Implemented `GeneratedSourceDetector` contract and `deriveGeneratedSources` to collect metadata from package manifests and task invocations.

<sub>This will update automatically on new commits.</sub>