### PR TITLE
JS-1650 Move WebSensor to project-level analysis

### DIFF
--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.javascript.TypeScriptLanguage;
 
 public final class SonarScannerIntegrationHelper {
 
-  static final String LITS_VERSION = "0.11.0.2659";
+  static final String LITS_VERSION = "0.12.0.5847";
 
   /**
    * Get the engine version based on the sonar.runtimeVersion system property.

--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.javascript.TypeScriptLanguage;
 
 public final class SonarScannerIntegrationHelper {
 
-  static final String LITS_VERSION = "0.12.0.5847";
+  static final String LITS_VERSION = "0.12.0.5851";
 
   /**
    * Get the engine version based on the sonar.runtimeVersion system property.

--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/WebSensorMultiModuleTest.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/WebSensorMultiModuleTest.java
@@ -92,6 +92,56 @@ class WebSensorMultiModuleTest {
   }
 
   @Test
+  void should_collect_module_glob_paths_and_analyze_matching_tsconfigs() {
+    ScannerInput build = ScannerInput.create(PROJECT_KEY, PROJECT_DIR)
+      .withScmDisabled()
+      .withScannerProperty("sonar.modules", "moduleA,moduleB")
+      .withScannerProperty("sonar.exclusions", "**")
+      .withScannerProperty("moduleA.sonar.projectBaseDir", "moduleA")
+      .withScannerProperty("moduleA.sonar.sources", "src")
+      .withScannerProperty("moduleA.sonar.exclusions", "")
+      .withScannerProperty("moduleA.sonar.typescript.tsconfigPaths", "../tsconfig.module*.json")
+      .withScannerProperty("moduleA.sonar.eslint.reportPaths", "report.json")
+      .withScannerProperty("moduleB.sonar.projectBaseDir", "moduleB")
+      .withScannerProperty("moduleB.sonar.sources", "src")
+      .withScannerProperty("moduleB.sonar.exclusions", "")
+      .withScannerProperty("moduleB.sonar.typescript.tsconfigPaths", "../tsconfig.module*.json")
+      .withScannerProperty("moduleB.sonar.eslint.reportPaths", "report.json")
+      .build();
+
+    var result = ScannerRunner.run(SERVER_CONTEXT, build, ScannerRunnerConfig.builder().build());
+    assertThat(result.logOutput())
+      .extracting(Log::message)
+      .filteredOn(message -> message.startsWith("Found 2 tsconfig.json file(s)"))
+      .hasSize(1);
+    assertThat(result.logOutput())
+      .filteredOn(
+        log ->
+          log.level().equals(Log.Level.INFO) &&
+          log.message().startsWith("Analyzing 1 file(s) from tsconfig")
+      )
+      .hasSize(2);
+
+    var issues = result
+      .scannerOutputReader()
+      .getProject()
+      .getAllIssues()
+      .stream()
+      .filter(TextRangeIssue.class::isInstance)
+      .map(TextRangeIssue.class::cast)
+      .toList();
+
+    assertThat(issues)
+      .extracting(TextRangeIssue::componentPath, TextRangeIssue::ruleKey, TextRangeIssue::line)
+      .containsExactlyInAnyOrder(
+        tuple("moduleA/src/main.ts", "typescript:S3003", 4),
+        tuple("moduleA/src/main.ts", "external_eslint_repo:semi", 4),
+        tuple("moduleB/src/main.ts", "typescript:S3003", 4),
+        tuple("moduleB/src/main.ts", "external_eslint_repo:semi", 4)
+      );
+  }
+
+  @Test
   void should_merge_project_and_module_tsconfig_paths_and_eslint_reports() {
     ScannerInput build = ScannerInput.create(PROJECT_KEY, PROJECT_DIR)
       .withScmDisabled()

--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/WebSensorMultiModuleTest.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/WebSensorMultiModuleTest.java
@@ -1,0 +1,93 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package com.sonar.javascript.it.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.sonarsource.scanner.integrationtester.dsl.Log;
+import com.sonarsource.scanner.integrationtester.dsl.ScannerInput;
+import com.sonarsource.scanner.integrationtester.dsl.SonarServerContext;
+import com.sonarsource.scanner.integrationtester.dsl.issue.TextRangeIssue;
+import com.sonarsource.scanner.integrationtester.runner.ScannerRunner;
+import com.sonarsource.scanner.integrationtester.runner.ScannerRunnerConfig;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.javascript.TypeScriptLanguage;
+
+class WebSensorMultiModuleTest {
+
+  private static final SonarServerContext SERVER_CONTEXT = SonarScannerIntegrationHelper.getContext(
+    List.of(TypeScriptLanguage.KEY),
+    List.of(SonarScannerIntegrationHelper.getJavascriptPlugin()),
+    List.of(Path.of("src", "test", "resources", "typechecker-config-ts.xml"))
+  );
+
+  private static final String PROJECT_KEY = "SonarJS-websensor-multi-module";
+  private static final Path PROJECT_DIR = TestUtils.projectDir("websensor-multi-module");
+
+  @Test
+  void should_collect_module_relative_paths_and_analyze_once() {
+    ScannerInput build = ScannerInput.create(PROJECT_KEY, PROJECT_DIR)
+      .withScmDisabled()
+      .withScannerProperty("sonar.modules", "moduleA,moduleB")
+      .withScannerProperty("sonar.exclusions", "**")
+      .withScannerProperty("moduleA.sonar.projectBaseDir", "moduleA")
+      .withScannerProperty("moduleA.sonar.sources", "src")
+      .withScannerProperty("moduleA.sonar.exclusions", "")
+      .withScannerProperty("moduleA.sonar.typescript.tsconfigPaths", "../tsconfig.shared.json")
+      .withScannerProperty("moduleA.sonar.eslint.reportPaths", "report.json")
+      .withScannerProperty("moduleB.sonar.projectBaseDir", "moduleB")
+      .withScannerProperty("moduleB.sonar.sources", "src")
+      .withScannerProperty("moduleB.sonar.exclusions", "")
+      .withScannerProperty("moduleB.sonar.typescript.tsconfigPaths", "../tsconfig.shared.json")
+      .withScannerProperty("moduleB.sonar.eslint.reportPaths", "report.json")
+      .build();
+
+    var result = ScannerRunner.run(SERVER_CONTEXT, build, ScannerRunnerConfig.builder().build());
+    assertThat(result.logOutput())
+      .extracting(Log::message)
+      .filteredOn(message -> message.startsWith("Found 1 tsconfig.json file(s)"))
+      .hasSize(1);
+    assertThat(result.logOutput())
+      .filteredOn(
+        log ->
+          log.level().equals(Log.Level.INFO) &&
+          log.message().startsWith("Analyzing 2 file(s) from tsconfig")
+      )
+      .hasSize(1);
+
+    var issues = result
+      .scannerOutputReader()
+      .getProject()
+      .getAllIssues()
+      .stream()
+      .filter(TextRangeIssue.class::isInstance)
+      .map(TextRangeIssue.class::cast)
+      .toList();
+
+    assertThat(issues)
+      .extracting(TextRangeIssue::componentPath, TextRangeIssue::ruleKey, TextRangeIssue::line)
+      .containsExactlyInAnyOrder(
+        tuple("moduleA/src/main.ts", "typescript:S3003", 4),
+        tuple("moduleA/src/main.ts", "external_eslint_repo:semi", 4),
+        tuple("moduleB/src/main.ts", "typescript:S3003", 4),
+        tuple("moduleB/src/main.ts", "external_eslint_repo:semi", 4)
+      );
+  }
+}

--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/WebSensorMultiModuleTest.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/WebSensorMultiModuleTest.java
@@ -90,4 +90,54 @@ class WebSensorMultiModuleTest {
         tuple("moduleB/src/main.ts", "external_eslint_repo:semi", 4)
       );
   }
+
+  @Test
+  void should_merge_project_and_module_tsconfig_paths_and_eslint_reports() {
+    ScannerInput build = ScannerInput.create(PROJECT_KEY, PROJECT_DIR)
+      .withScmDisabled()
+      .withScannerProperty("sonar.modules", "moduleA,moduleB")
+      .withScannerProperty("sonar.exclusions", "**")
+      .withScannerProperty("sonar.typescript.tsconfigPaths", "tsconfig.moduleA.json")
+      .withScannerProperty("sonar.eslint.reportPaths", "root-report.json")
+      .withScannerProperty("moduleA.sonar.projectBaseDir", "moduleA")
+      .withScannerProperty("moduleA.sonar.sources", "src")
+      .withScannerProperty("moduleA.sonar.exclusions", "")
+      .withScannerProperty("moduleB.sonar.projectBaseDir", "moduleB")
+      .withScannerProperty("moduleB.sonar.sources", "src")
+      .withScannerProperty("moduleB.sonar.exclusions", "")
+      .withScannerProperty("moduleB.sonar.typescript.tsconfigPaths", "../tsconfig.moduleB.json")
+      .withScannerProperty("moduleB.sonar.eslint.reportPaths", "report.json")
+      .build();
+
+    var result = ScannerRunner.run(SERVER_CONTEXT, build, ScannerRunnerConfig.builder().build());
+    assertThat(result.logOutput())
+      .extracting(Log::message)
+      .filteredOn(message -> message.startsWith("Found 2 tsconfig.json file(s)"))
+      .hasSize(1);
+    assertThat(result.logOutput())
+      .filteredOn(
+        log ->
+          log.level().equals(Log.Level.INFO) &&
+          log.message().startsWith("Analyzing 1 file(s) from tsconfig")
+      )
+      .hasSize(2);
+
+    var issues = result
+      .scannerOutputReader()
+      .getProject()
+      .getAllIssues()
+      .stream()
+      .filter(TextRangeIssue.class::isInstance)
+      .map(TextRangeIssue.class::cast)
+      .toList();
+
+    assertThat(issues)
+      .extracting(TextRangeIssue::componentPath, TextRangeIssue::ruleKey, TextRangeIssue::line)
+      .containsExactlyInAnyOrder(
+        tuple("moduleA/src/main.ts", "typescript:S3003", 4),
+        tuple("moduleA/src/main.ts", "external_eslint_repo:use-isnan", 4),
+        tuple("moduleB/src/main.ts", "typescript:S3003", 4),
+        tuple("moduleB/src/main.ts", "external_eslint_repo:semi", 4)
+      );
+  }
 }

--- a/its/plugin/projects/websensor-multi-module/moduleA/report.json
+++ b/its/plugin/projects/websensor-multi-module/moduleA/report.json
@@ -1,0 +1,15 @@
+[
+  {
+    "filePath": "src/main.ts",
+    "messages": [
+      {
+        "ruleId": "semi",
+        "message": "External issue",
+        "line": 4,
+        "column": 10,
+        "endLine": 4,
+        "endColumn": 15
+      }
+    ]
+  }
+]

--- a/its/plugin/projects/websensor-multi-module/moduleA/src/main.ts
+++ b/its/plugin/projects/websensor-multi-module/moduleA/src/main.ts
@@ -1,0 +1,5 @@
+import { CONSTANT } from "shared/constant";
+
+export function isSmaller(value: string) {
+  return value < CONSTANT; // Noncompliant: S3003
+}

--- a/its/plugin/projects/websensor-multi-module/moduleB/report.json
+++ b/its/plugin/projects/websensor-multi-module/moduleB/report.json
@@ -1,0 +1,15 @@
+[
+  {
+    "filePath": "src/main.ts",
+    "messages": [
+      {
+        "ruleId": "semi",
+        "message": "External issue",
+        "line": 4,
+        "column": 10,
+        "endLine": 4,
+        "endColumn": 15
+      }
+    ]
+  }
+]

--- a/its/plugin/projects/websensor-multi-module/moduleB/src/main.ts
+++ b/its/plugin/projects/websensor-multi-module/moduleB/src/main.ts
@@ -1,0 +1,5 @@
+import { CONSTANT } from "shared/constant";
+
+export function isSmaller(value: string) {
+  return value < CONSTANT; // Noncompliant: S3003
+}

--- a/its/plugin/projects/websensor-multi-module/root-report.json
+++ b/its/plugin/projects/websensor-multi-module/root-report.json
@@ -1,0 +1,15 @@
+[
+  {
+    "filePath": "moduleA/src/main.ts",
+    "messages": [
+      {
+        "ruleId": "use-isnan",
+        "message": "External issue imported from project-level ESLint report",
+        "line": 4,
+        "column": 10,
+        "endLine": 4,
+        "endColumn": 15
+      }
+    ]
+  }
+]

--- a/its/plugin/projects/websensor-multi-module/shared/constant.ts
+++ b/its/plugin/projects/websensor-multi-module/shared/constant.ts
@@ -1,0 +1,1 @@
+export const CONSTANT = "42";

--- a/its/plugin/projects/websensor-multi-module/tsconfig.moduleA.json
+++ b/its/plugin/projects/websensor-multi-module/tsconfig.moduleA.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "strict": true
+  },
+  "include": [
+    "moduleA/src/**/*.ts",
+    "shared/**/*.ts"
+  ]
+}

--- a/its/plugin/projects/websensor-multi-module/tsconfig.moduleB.json
+++ b/its/plugin/projects/websensor-multi-module/tsconfig.moduleB.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "strict": true
+  },
+  "include": [
+    "moduleB/src/**/*.ts",
+    "shared/**/*.ts"
+  ]
+}

--- a/its/plugin/projects/websensor-multi-module/tsconfig.shared.json
+++ b/its/plugin/projects/websensor-multi-module/tsconfig.shared.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "strict": true
+  },
+  "include": [
+    "moduleA/src/**/*.ts",
+    "moduleB/src/**/*.ts",
+    "shared/**/*.ts"
+  ]
+}

--- a/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
@@ -56,7 +56,7 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 class RulingTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RulingTest.class);
-  static final String LITS_VERSION = "0.11.0.2659";
+  static final String LITS_VERSION = "0.12.0.5847";
   static final String SCANNER_VERSION = "5.0.1.3006";
 
   static final String DEFAULT_EXCLUSIONS = "**/.*,**/*.d.ts";
@@ -279,11 +279,15 @@ class RulingTest {
       .setScannerVersion(SCANNER_VERSION)
       .setProperty(
         "sonar.lits.dump.old",
-        FileLocation.of("src/test/expected/" + projectKey).getFile().getAbsolutePath()
+        FileLocation.of("src/test/expected/" + projectKey)
+          .getFile()
+          .getAbsolutePath()
       )
       .setProperty(
         "sonar.lits.dump.new",
-        FileLocation.of("target/actual/" + projectKey).getFile().getAbsolutePath()
+        FileLocation.of("target/actual/" + projectKey)
+          .getFile()
+          .getAbsolutePath()
       )
       .setProperty("sonar.lits.differences", differencesPath.toString())
       .setProperty("sonar.exclusions", actualExclusions)

--- a/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
@@ -56,7 +56,7 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 class RulingTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RulingTest.class);
-  static final String LITS_VERSION = "0.12.0.5847";
+  static final String LITS_VERSION = "0.12.0.5851";
   static final String SCANNER_VERSION = "5.0.1.3006";
 
   static final String DEFAULT_EXCLUSIONS = "**/.*,**/*.d.ts";

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalyzeProjectMessages.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalyzeProjectMessages.java
@@ -25,7 +25,6 @@ import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import java.lang.reflect.Array;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -53,18 +52,6 @@ public final class AnalyzeProjectMessages {
     String baseDir,
     AnalysisConfiguration analysisConfiguration
   ) {
-    return newProjectConfigurationBuilder(
-      baseDir,
-      analysisConfiguration,
-      analysisConfiguration.getTsConfigPaths()
-    );
-  }
-
-  public static ProjectConfiguration.Builder newProjectConfigurationBuilder(
-    String baseDir,
-    AnalysisConfiguration analysisConfiguration,
-    Collection<String> tsConfigPaths
-  ) {
     var builder = ProjectConfiguration.newBuilder()
       .setBaseDir(baseDir)
       .setSonarlint(analysisConfiguration.isSonarLint())
@@ -74,7 +61,7 @@ public final class AnalyzeProjectMessages {
       .setMaxFileSize(analysisConfiguration.getMaxFileSizeProperty())
       .setEnvironments(stringList(analysisConfiguration.getEnvironments()))
       .setGlobals(stringList(analysisConfiguration.getGlobals()))
-      .addAllTsConfigPaths(tsConfigPaths)
+      .addAllTsConfigPaths(analysisConfiguration.getTsConfigPaths())
       .setJsTsExclusions(stringList(analysisConfiguration.getJsTsExcludedPaths()))
       .addAllSources(analysisConfiguration.getSources())
       .addAllInclusions(analysisConfiguration.getInclusions())

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalyzeProjectMessages.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalyzeProjectMessages.java
@@ -25,6 +25,7 @@ import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import java.lang.reflect.Array;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -52,6 +53,18 @@ public final class AnalyzeProjectMessages {
     String baseDir,
     AnalysisConfiguration analysisConfiguration
   ) {
+    return newProjectConfigurationBuilder(
+      baseDir,
+      analysisConfiguration,
+      analysisConfiguration.getTsConfigPaths()
+    );
+  }
+
+  public static ProjectConfiguration.Builder newProjectConfigurationBuilder(
+    String baseDir,
+    AnalysisConfiguration analysisConfiguration,
+    Collection<String> tsConfigPaths
+  ) {
     var builder = ProjectConfiguration.newBuilder()
       .setBaseDir(baseDir)
       .setSonarlint(analysisConfiguration.isSonarLint())
@@ -61,7 +74,7 @@ public final class AnalyzeProjectMessages {
       .setMaxFileSize(analysisConfiguration.getMaxFileSizeProperty())
       .setEnvironments(stringList(analysisConfiguration.getEnvironments()))
       .setGlobals(stringList(analysisConfiguration.getGlobals()))
-      .addAllTsConfigPaths(analysisConfiguration.getTsConfigPaths())
+      .addAllTsConfigPaths(tsConfigPaths)
       .setJsTsExclusions(stringList(analysisConfiguration.getJsTsExcludedPaths()))
       .addAllSources(analysisConfiguration.getSources())
       .addAllInclusions(analysisConfiguration.getInclusions())

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -32,6 +32,8 @@ import org.sonar.plugins.javascript.analysis.AnalysisProcessor;
 import org.sonar.plugins.javascript.analysis.JsTsChecks;
 import org.sonar.plugins.javascript.analysis.JsTsExclusionsFilter;
 import org.sonar.plugins.javascript.analysis.WebSensor;
+import org.sonar.plugins.javascript.analysis.WebSensorModuleConfiguration;
+import org.sonar.plugins.javascript.analysis.WebSensorModuleConfigurationSensor;
 import org.sonar.plugins.javascript.bridge.AnalysisWarningsWrapper;
 import org.sonar.plugins.javascript.bridge.BridgeServerImpl;
 import org.sonar.plugins.javascript.bridge.BundleImpl;
@@ -161,6 +163,8 @@ public class JavaScriptPlugin implements Plugin {
       BridgeServerImpl.class,
       NodeDeprecationWarning.class,
       BundleImpl.class,
+      WebSensorModuleConfiguration.class,
+      WebSensorModuleConfigurationSensor.class,
       WebSensor.class,
       TypeScriptLanguage.class,
       TypeScriptRulesDefinition.class,

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensor.java
@@ -33,9 +33,9 @@ import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.DependedUpon;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.scanner.sensor.ProjectSensor;
 import org.sonar.css.CssLanguage;
 import org.sonar.css.CssRules;
 import org.sonar.plugins.javascript.CancellationException;
@@ -72,7 +72,7 @@ import org.sonar.plugins.javascript.nodejs.NodeCommandException;
 import org.sonar.plugins.javascript.sonarlint.FSListener;
 
 @DependedUpon("js-analysis")
-public class WebSensor implements Sensor {
+public class WebSensor implements ProjectSensor {
 
   private static final Logger LOG = LoggerFactory.getLogger(WebSensor.class);
   private static final String LANG = "JS/TS";
@@ -90,6 +90,7 @@ public class WebSensor implements Sensor {
   private final AnalysisWarningsWrapper analysisWarnings;
   private final CssRules cssRules;
   private final BridgeServer bridgeServer;
+  private final WebSensorModuleConfiguration moduleConfiguration;
   private ProjectConfiguration.Builder configurationBuilder;
   private JsTsContext<?> context;
   FSListener fsListener;
@@ -100,9 +101,19 @@ public class WebSensor implements Sensor {
     AnalysisProcessor analysisProcessor,
     AnalysisWarningsWrapper analysisWarnings,
     AnalysisConsumers consumers,
-    CssRules cssRules
+    CssRules cssRules,
+    WebSensorModuleConfiguration moduleConfiguration
   ) {
-    this(checks, bridgeServer, analysisProcessor, analysisWarnings, consumers, cssRules, null);
+    this(
+      checks,
+      bridgeServer,
+      analysisProcessor,
+      analysisWarnings,
+      consumers,
+      cssRules,
+      null,
+      moduleConfiguration
+    );
   }
 
   public WebSensor(
@@ -112,7 +123,8 @@ public class WebSensor implements Sensor {
     AnalysisWarningsWrapper analysisWarnings,
     AnalysisConsumers consumers,
     CssRules cssRules,
-    @Nullable FSListener fsListener
+    @Nullable FSListener fsListener,
+    WebSensorModuleConfiguration moduleConfiguration
   ) {
     this.checks = checks;
     this.consumers = consumers;
@@ -121,6 +133,7 @@ public class WebSensor implements Sensor {
     this.analysisWarnings = analysisWarnings;
     this.cssRules = cssRules;
     this.bridgeServer = bridgeServer;
+    this.moduleConfiguration = moduleConfiguration;
   }
 
   @Override
@@ -159,7 +172,8 @@ public class WebSensor implements Sensor {
       LOG.debug(msg);
       configurationBuilder = AnalyzeProjectMessages.newProjectConfigurationBuilder(
         sensorContext.fileSystem().baseDir().getAbsolutePath(),
-        context
+        context,
+        moduleConfiguration.tsConfigPaths(context)
       );
       bridgeServer.startServerLazily(BridgeServerConfig.fromSensorContext(sensorContext));
       analyzeFiles(inputFiles);
@@ -189,6 +203,7 @@ public class WebSensor implements Sensor {
       LOG.error("Failure during analysis", e);
       throw new IllegalStateException("Analysis of " + LANG + " files failed", e);
     } finally {
+      moduleConfiguration.clear();
       CacheStrategies.logReport();
     }
   }
@@ -232,7 +247,10 @@ public class WebSensor implements Sensor {
 
   private void analyzeFiles(List<InputFile> inputFiles) {
     var eslintImporter = new EslintReportImporter();
-    var externalIssues = eslintImporter.execute(context);
+    var externalIssues = eslintImporter.execute(
+      context,
+      moduleConfiguration.eslintReports(context.getSensorContext())
+    );
     try {
       var handler = new AnalyzeProjectHandler(context, inputFiles, externalIssues);
       bridgeServer.analyzeProject(handler);

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensor.java
@@ -172,8 +172,7 @@ public class WebSensor implements ProjectSensor {
       LOG.debug(msg);
       configurationBuilder = AnalyzeProjectMessages.newProjectConfigurationBuilder(
         sensorContext.fileSystem().baseDir().getAbsolutePath(),
-        context,
-        moduleConfiguration.tsConfigPaths(context)
+        contextWithCollectedTsConfigPaths(sensorContext)
       );
       bridgeServer.startServerLazily(BridgeServerConfig.fromSensorContext(sensorContext));
       analyzeFiles(inputFiles);
@@ -206,6 +205,19 @@ public class WebSensor implements ProjectSensor {
       moduleConfiguration.clear();
       CacheStrategies.logReport();
     }
+  }
+
+  private JsTsContext<SensorContext> contextWithCollectedTsConfigPaths(
+    SensorContext sensorContext
+  ) {
+    var baseContext = new JsTsContext<>(sensorContext);
+    Set<String> collectedTsConfigPaths = moduleConfiguration.tsConfigPaths(baseContext);
+    return new JsTsContext<>(sensorContext) {
+      @Override
+      public Set<String> getTsConfigPaths() {
+        return collectedTsConfigPaths;
+      }
+    };
   }
 
   private List<InputFile> getInputFiles() {

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensorModuleConfiguration.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensorModuleConfiguration.java
@@ -1,0 +1,94 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.javascript.analysis;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.sonar.api.batch.InstantiationStrategy;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.scanner.ScannerSide;
+import org.sonar.plugins.javascript.external.EslintReportImporter;
+
+@ScannerSide
+@InstantiationStrategy(InstantiationStrategy.PER_BATCH)
+public class WebSensorModuleConfiguration {
+
+  private final Set<String> collectedTsConfigPaths = new LinkedHashSet<>();
+  private final Map<String, EslintReportImporter.PreparedReport> collectedEslintReports =
+    new LinkedHashMap<>();
+  private final EslintReportImporter eslintReportImporter = new EslintReportImporter();
+
+  public synchronized void clear() {
+    collectedTsConfigPaths.clear();
+    collectedEslintReports.clear();
+  }
+
+  public synchronized void collect(SensorContext sensorContext) {
+    collectedTsConfigPaths.addAll(resolveTsConfigPaths(new JsTsContext<>(sensorContext)));
+    addReports(collectedEslintReports, eslintReportImporter.prepareReports(sensorContext));
+  }
+
+  public synchronized Set<String> tsConfigPaths(JsTsContext<?> context) {
+    var resolvedPaths = resolveTsConfigPaths(context);
+    resolvedPaths.addAll(collectedTsConfigPaths);
+    return resolvedPaths;
+  }
+
+  public synchronized List<EslintReportImporter.PreparedReport> eslintReports(
+    SensorContext sensorContext
+  ) {
+    var mergedReports = new LinkedHashMap<String, EslintReportImporter.PreparedReport>();
+    addReports(mergedReports, eslintReportImporter.prepareReports(sensorContext));
+    addReports(mergedReports, collectedEslintReports.values());
+    return List.copyOf(mergedReports.values());
+  }
+
+  private static LinkedHashSet<String> resolveTsConfigPaths(JsTsContext<?> context) {
+    var baseDir = context.getSensorContext().fileSystem().baseDir().toPath();
+    var resolvedPaths = new LinkedHashSet<String>();
+    for (String tsConfigPath : context.getTsConfigPaths()) {
+      resolvedPaths.add(resolvePath(baseDir, tsConfigPath));
+    }
+    return resolvedPaths;
+  }
+
+  private static void addReports(
+    Map<String, EslintReportImporter.PreparedReport> target,
+    Iterable<EslintReportImporter.PreparedReport> reports
+  ) {
+    for (var report : reports) {
+      target.putIfAbsent(normalize(report.reportFile()), report);
+    }
+  }
+
+  private static String resolvePath(Path baseDir, String path) {
+    Path resolvedPath = Path.of(path);
+    if (!resolvedPath.isAbsolute()) {
+      resolvedPath = baseDir.resolve(path);
+    }
+    return normalize(resolvedPath.toFile());
+  }
+
+  private static String normalize(File file) {
+    return file.toPath().toAbsolutePath().normalize().toString();
+  }
+}

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensorModuleConfiguration.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensorModuleConfiguration.java
@@ -81,14 +81,14 @@ public class WebSensorModuleConfiguration {
   }
 
   private static String resolvePath(Path baseDir, String path) {
-    Path resolvedPath = Path.of(path);
-    if (!resolvedPath.isAbsolute()) {
-      resolvedPath = baseDir.resolve(path);
+    File resolvedFile = new File(path);
+    if (!resolvedFile.isAbsolute()) {
+      resolvedFile = new File(baseDir.toFile(), path);
     }
-    return normalize(resolvedPath.toFile());
+    return normalize(resolvedFile);
   }
 
   private static String normalize(File file) {
-    return file.toPath().toAbsolutePath().normalize().toString();
+    return new File(file.toURI().normalize()).getPath();
   }
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensorModuleConfiguration.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensorModuleConfiguration.java
@@ -23,13 +23,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.sonar.api.batch.InstantiationStrategy;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.scanner.ScannerSide;
 import org.sonar.plugins.javascript.external.EslintReportImporter;
+import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @ScannerSide
-@InstantiationStrategy(InstantiationStrategy.PER_BATCH)
+@SonarLintSide
 public class WebSensorModuleConfiguration {
 
   private final Set<String> collectedTsConfigPaths = new LinkedHashSet<>();

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensorModuleConfigurationSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensorModuleConfigurationSensor.java
@@ -1,0 +1,62 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.javascript.analysis;
+
+import static org.sonar.plugins.javascript.JavaScriptPlugin.ESLINT_REPORT_PATHS;
+import static org.sonar.plugins.javascript.JavaScriptPlugin.TSCONFIG_PATHS;
+import static org.sonar.plugins.javascript.JavaScriptPlugin.TSCONFIG_PATHS_ALIAS;
+
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.css.CssLanguage;
+import org.sonar.plugins.javascript.JavaScriptFilePredicate;
+import org.sonar.plugins.javascript.JavaScriptLanguage;
+import org.sonar.plugins.javascript.TypeScriptLanguage;
+
+public class WebSensorModuleConfigurationSensor implements Sensor {
+
+  private final WebSensorModuleConfiguration moduleConfiguration;
+
+  public WebSensorModuleConfigurationSensor(WebSensorModuleConfiguration moduleConfiguration) {
+    this.moduleConfiguration = moduleConfiguration;
+  }
+
+  @Override
+  public void describe(SensorDescriptor descriptor) {
+    descriptor
+      .onlyOnLanguages(
+        JavaScriptLanguage.KEY,
+        TypeScriptLanguage.KEY,
+        CssLanguage.KEY,
+        JavaScriptFilePredicate.YAML_LANGUAGE,
+        JavaScriptFilePredicate.WEB_LANGUAGE
+      )
+      .onlyWhenConfiguration(
+        conf ->
+          conf.hasKey(TSCONFIG_PATHS) ||
+          conf.hasKey(TSCONFIG_PATHS_ALIAS) ||
+          conf.hasKey(ESLINT_REPORT_PATHS)
+      )
+      .name("JavaScript/TypeScript module configuration");
+  }
+
+  @Override
+  public void execute(SensorContext sensorContext) {
+    moduleConfiguration.collect(sensorContext);
+  }
+}

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/EslintReportImporter.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/external/EslintReportImporter.java
@@ -25,10 +25,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicates;
@@ -54,9 +56,19 @@ public class EslintReportImporter {
   }
 
   InputFile getInputFile(JsTsContext<?> context, String fileName) {
+    return getInputFile(context, fileName, context.getSensorContext().fileSystem().baseDir());
+  }
+
+  InputFile getInputFile(JsTsContext<?> context, String fileName, @Nullable File pathBaseDir) {
     var fileSystem = context.getSensorContext().fileSystem();
     FilePredicates predicates = fileSystem.predicates();
-    InputFile inputFile = fileSystem.inputFile(predicates.hasPath(fileName));
+    InputFile inputFile = null;
+    if (pathBaseDir != null) {
+      inputFile = inputFileByResolvedPath(fileSystem, predicates, pathBaseDir.toPath(), fileName);
+    }
+    if (inputFile == null) {
+      inputFile = fileSystem.inputFile(predicates.hasPath(fileName));
+    }
     if (inputFile == null) {
       LOG.warn(
         "No input file found for {}. No {} issues will be imported on this file.",
@@ -72,26 +84,51 @@ public class EslintReportImporter {
    * Execute the importer, and return the list of external issues found.
    */
   public Map<String, List<ExternalIssue>> execute(JsTsContext<?> context) {
-    var results = new HashMap<String, List<ExternalIssue>>();
+    return execute(context, prepareReports(context.getSensorContext()));
+  }
 
-    List<File> reportFiles = ExternalReportProvider.getReportFiles(
-      context.getSensorContext(),
-      reportsPropertyName()
-    );
-    reportFiles.forEach(report -> results.putAll(importReportByFilePath(report, context)));
+  public Map<String, List<ExternalIssue>> execute(
+    JsTsContext<?> context,
+    List<PreparedReport> reports
+  ) {
+    var results = new HashMap<String, List<ExternalIssue>>();
+    reports.forEach(report -> results.putAll(importReportByFilePath(report, context)));
 
     return results;
   }
 
+  public List<PreparedReport> prepareReports(
+    org.sonar.api.batch.sensor.SensorContext sensorContext
+  ) {
+    File baseDir = normalize(sensorContext.fileSystem().baseDir());
+    return ExternalReportProvider.getReportFiles(sensorContext, reportsPropertyName())
+      .stream()
+      .map(report -> new PreparedReport(normalize(report), baseDir))
+      .toList();
+  }
+
   Map<String, List<ExternalIssue>> importReportByFilePath(File report, JsTsContext<?> context) {
-    LOG.info("Importing external issues from: {}", report.getAbsoluteFile());
+    return importReportByFilePath(
+      new PreparedReport(
+        normalize(report),
+        normalize(context.getSensorContext().fileSystem().baseDir())
+      ),
+      context
+    );
+  }
+
+  Map<String, List<ExternalIssue>> importReportByFilePath(
+    PreparedReport report,
+    JsTsContext<?> context
+  ) {
+    LOG.info("Importing external issues from: {}", report.reportFile().getAbsoluteFile());
 
     var results = new HashMap<String, List<ExternalIssue>>();
     var serializer = new Gson();
 
     try (
       InputStreamReader inputStreamReader = new InputStreamReader(
-        new FileInputStream(report),
+        new FileInputStream(report.reportFile()),
         StandardCharsets.UTF_8
       )
     ) {
@@ -101,7 +138,7 @@ public class EslintReportImporter {
       );
 
       for (FileWithMessages fileWithMessages : filesWithMessages) {
-        InputFile inputFile = getInputFile(context, fileWithMessages.filePath);
+        InputFile inputFile = getInputFile(context, fileWithMessages.filePath, report.baseDir());
         if (inputFile != null) {
           var externalIssuesForFile = new ArrayList<ExternalIssue>();
           for (EslintError eslintError : fileWithMessages.messages) {
@@ -124,6 +161,28 @@ public class EslintReportImporter {
     }
 
     return results;
+  }
+
+  private static InputFile inputFileByResolvedPath(
+    org.sonar.api.batch.fs.FileSystem fileSystem,
+    FilePredicates predicates,
+    Path pathBaseDir,
+    String fileName
+  ) {
+    Path resolvedPath = Path.of(fileName);
+    if (!resolvedPath.isAbsolute()) {
+      resolvedPath = pathBaseDir.resolve(fileName);
+    }
+    String absolutePath = resolvedPath.toAbsolutePath().normalize().toString();
+    InputFile inputFile = fileSystem.inputFile(predicates.hasAbsolutePath(absolutePath));
+    if (inputFile == null) {
+      inputFile = fileSystem.inputFile(predicates.hasPath(absolutePath));
+    }
+    return inputFile;
+  }
+
+  private static File normalize(File file) {
+    return file.toPath().toAbsolutePath().normalize().toFile();
   }
 
   private static ExternalIssue createIssue(EslintError eslintError, InputFile inputFile) {
@@ -182,4 +241,6 @@ public class EslintReportImporter {
       return line == endLine && column == endColumn;
     }
   }
+
+  public record PreparedReport(File reportFile, File baseDir) {}
 }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
@@ -33,6 +33,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -608,6 +609,46 @@ class WebSensorTest {
       .normalize()
       .toString();
     assertThat(configuration.getTsConfigPathsList()).containsExactly(expectedPath);
+  }
+
+  @Test
+  void should_preserve_wildcard_module_tsconfig_paths() throws IOException {
+    var moduleConfiguration = new WebSensorModuleConfiguration();
+    var collector = new WebSensorModuleConfigurationSensor(moduleConfiguration);
+
+    var projectContext = createSensorContext(baseDir);
+    setSonarQubeRuntime(projectContext);
+    projectContext.setSettings(
+      new MapSettings().setProperty(
+        JavaScriptPlugin.TSCONFIG_PATHS,
+        "tsconfig.json,**/custom.tsconfig.json"
+      )
+    );
+    createInputFile(projectContext, "file.ts", StandardCharsets.UTF_8, baseDir);
+
+    collector.execute(projectContext);
+
+    var configuration = executeSensorAndCaptureHandler(
+      createSensor(moduleConfiguration),
+      projectContext
+    )
+      .getRequest()
+      .getConfiguration();
+    var expectedGlobPath = new File(
+      new File(projectContext.fileSystem().baseDir(), "**/custom.tsconfig.json").toURI().normalize()
+    ).getPath();
+
+    assertThat(configuration.getTsConfigPathsList()).containsExactly(
+      projectContext
+        .fileSystem()
+        .baseDir()
+        .toPath()
+        .resolve("tsconfig.json")
+        .toAbsolutePath()
+        .normalize()
+        .toString(),
+      expectedGlobPath
+    );
   }
 
   @Test

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
@@ -36,6 +36,7 @@ import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -421,7 +422,12 @@ class WebSensorTest {
       }
     );
     executeSensorMockingResponse(
-      createSensor(checks("S3923", "S1451"), new AnalysisConsumers(), null),
+      createSensor(
+        checks("S3923", "S1451"),
+        new AnalysisConsumers(),
+        null,
+        new WebSensorModuleConfiguration()
+      ),
       expectedResponse
     );
     Collection<Issue> issues = context.allIssues();
@@ -559,6 +565,43 @@ class WebSensorTest {
         .getConfiguration()
         .getSkipNodeModuleLookupOutsideBaseDir()
     ).isTrue();
+  }
+
+  @Test
+  void should_send_collected_module_tsconfig_paths_to_bridge_configuration() throws IOException {
+    Files.writeString(baseDir.resolve("tsconfig.shared.json"), "{}");
+    Files.createDirectories(baseDir.resolve("moduleA"));
+    Files.createDirectories(baseDir.resolve("moduleB"));
+
+    var moduleConfiguration = new WebSensorModuleConfiguration();
+    var collector = new WebSensorModuleConfigurationSensor(moduleConfiguration);
+
+    var projectContext = createSensorContext(baseDir);
+    setSonarQubeRuntime(projectContext);
+    createInputFile(projectContext, "moduleA/src/main.ts", StandardCharsets.UTF_8, baseDir);
+    createInputFile(projectContext, "moduleB/src/main.ts", StandardCharsets.UTF_8, baseDir);
+
+    var moduleAContext = createSensorContext(baseDir.resolve("moduleA"));
+    moduleAContext.setSettings(
+      new MapSettings().setProperty(JavaScriptPlugin.TSCONFIG_PATHS, "../tsconfig.shared.json")
+    );
+    collector.execute(moduleAContext);
+
+    var moduleBContext = createSensorContext(baseDir.resolve("moduleB"));
+    moduleBContext.setSettings(
+      new MapSettings().setProperty(JavaScriptPlugin.TSCONFIG_PATHS, "../tsconfig.shared.json")
+    );
+    collector.execute(moduleBContext);
+
+    var configuration = executeSensorAndCaptureHandler(
+      createSensor(moduleConfiguration),
+      projectContext
+    )
+      .getRequest()
+      .getConfiguration();
+    assertThat(configuration.getTsConfigPathsList()).containsExactly(
+      baseDir.resolve("tsconfig.shared.json").toAbsolutePath().normalize().toString()
+    );
   }
 
   @Test
@@ -1636,26 +1679,43 @@ class WebSensorTest {
     return createSensor(
       checks("S3923", "S2260", "S1451"),
       new AnalysisConsumers(List.of(consumer)),
-      null
+      null,
+      new WebSensorModuleConfiguration()
     );
   }
 
   private WebSensor createSensor() {
-    return createSensor(checks("S3923", "S2260", "S1451"), new AnalysisConsumers(), null);
+    return createSensor(
+      checks("S3923", "S2260", "S1451"),
+      new AnalysisConsumers(),
+      null,
+      new WebSensorModuleConfiguration()
+    );
+  }
+
+  private WebSensor createSensor(WebSensorModuleConfiguration moduleConfiguration) {
+    return createSensor(
+      checks("S3923", "S2260", "S1451"),
+      new AnalysisConsumers(),
+      null,
+      moduleConfiguration
+    );
   }
 
   private WebSensor createSonarLintSensor() {
     return createSensor(
       checks("S3923", "S2260", "S1451"),
       new AnalysisConsumers(),
-      new FSListenerImpl()
+      new FSListenerImpl(),
+      new WebSensorModuleConfiguration()
     );
   }
 
   private WebSensor createSensor(
     JsTsChecks checks,
     AnalysisConsumers consumers,
-    @Nullable FSListener fsListener
+    @Nullable FSListener fsListener,
+    WebSensorModuleConfiguration moduleConfiguration
   ) {
     return new WebSensor(
       checks,
@@ -1664,7 +1724,8 @@ class WebSensorTest {
       analysisWarnings,
       consumers,
       mock(CssRules.class),
-      fsListener
+      fsListener,
+      moduleConfiguration
     );
   }
 
@@ -2168,6 +2229,16 @@ class WebSensorTest {
 
   private void setSonarLintRuntime(SensorContextTester context) {
     context.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(8, 9)));
+  }
+
+  private void setSonarQubeRuntime(SensorContextTester context) {
+    context.setRuntime(
+      SonarRuntimeImpl.forSonarQube(
+        Version.create(9, 3),
+        SonarQubeSide.SCANNER,
+        SonarEdition.COMMUNITY
+      )
+    );
   }
 
   private boolean isWindows() {

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
@@ -599,9 +599,15 @@ class WebSensorTest {
     )
       .getRequest()
       .getConfiguration();
-    assertThat(configuration.getTsConfigPathsList()).containsExactly(
-      baseDir.resolve("tsconfig.shared.json").toAbsolutePath().normalize().toString()
-    );
+    var expectedPath = projectContext
+      .fileSystem()
+      .baseDir()
+      .toPath()
+      .resolve("tsconfig.shared.json")
+      .toAbsolutePath()
+      .normalize()
+      .toString();
+    assertThat(configuration.getTsConfigPathsList()).containsExactly(expectedPath);
   }
 
   @Test

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/EslintReportImporterTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/EslintReportImporterTest.java
@@ -20,9 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.plugins.javascript.TestUtils.createInputFile;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.DefaultTextPointer;
@@ -36,6 +40,9 @@ import org.sonar.plugins.javascript.JavaScriptPlugin;
 import org.sonar.plugins.javascript.analysis.JsTsContext;
 
 class EslintReportImporterTest {
+
+  @TempDir
+  Path tempDir;
 
   @RegisterExtension
   public final LogTesterJUnit5 logTester = new LogTesterJUnit5();
@@ -127,6 +134,44 @@ class EslintReportImporterTest {
     assertThat(logTester.logs(Level.WARN)).contains(
       "No issues information will be saved as the report file can't be read."
     );
+  }
+
+  @Test
+  void should_resolve_module_relative_paths_when_importing_from_project_context() throws Exception {
+    Path moduleDir = Files.createDirectories(tempDir.resolve("module"));
+    Path report = moduleDir.resolve("report.json");
+    Files.writeString(
+      report,
+      """
+      [
+        {
+          "filePath": "src/file.ts",
+          "messages": [
+            {
+              "ruleId": "semi",
+              "message": "External issue",
+              "line": 1,
+              "column": 1,
+              "endLine": 1,
+              "endColumn": 2
+            }
+          ]
+        }
+      ]
+      """
+    );
+
+    var projectContext = SensorContextTester.create(tempDir.toFile());
+    var inputFile = createInputFile(projectContext, CONTENT, "module/src/file.ts", "ts");
+
+    var issues = eslintReportImporter.execute(
+      new JsTsContext<SensorContext>(projectContext),
+      List.of(new EslintReportImporter.PreparedReport(report.toFile(), moduleDir.toFile()))
+    );
+
+    assertThat(issues).containsOnlyKeys(inputFile.absolutePath());
+    assertThat(issues.get(inputFile.absolutePath())).hasSize(1);
+    assertThat(issues.get(inputFile.absolutePath()).get(0).file()).isEqualTo(inputFile);
   }
 
   private void setEslintReport(String reportFileName) {


### PR DESCRIPTION
Part of JS-1650

## Summary
- migrate `WebSensor` to project-level analysis
- collect per-module web sensor configuration so module-relative `tsconfig` paths still resolve correctly
- preserve module-based ESLint report imports and cover the behavior with unit and multi-module integration tests

## Verification
- `mvn -pl sonar-plugin/sonar-javascript-plugin -am -DskipTests clean package`
- `mvn -pl its/plugin/tests -am "-DskipTests=false" "-Dtest=CoverageTest#LCOV_report_outside_module" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- `mvn -pl sonar-plugin/sonar-javascript-plugin -am "-Dtest=WebSensorTest,EslintReportImporterTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- `mvn -pl its/plugin/fast-tests -am "-DskipTests=false" "-Dtest=WebSensorMultiModuleTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`

## Note
- `sonar.javascript.lcov.reportPaths` is intentionally not part of the new module property collection.
- JS-1650 only collects module-scoped properties now needed by the project-level `WebSensor`: `tsconfig` paths and ESLint report paths.
- LCOV import still runs in `CoverageSensor`, which remains module-scoped and reads `sonar.javascript.lcov.reportPaths` directly from its own `SensorContext`.
- If LCOV import moves to project-level later, it will need the same kind of module property aggregation.