### PR TITLE
JS-1811 Move functions into helpers

### DIFF
--- a/packages/analysis/src/jsts/rules/S6767/custom-superclass-forwarding.ts
+++ b/packages/analysis/src/jsts/rules/S6767/custom-superclass-forwarding.ts
@@ -17,6 +17,7 @@
 
 import type estree from 'estree';
 import { isIdentifier } from '../helpers/ast.js';
+import { isBuiltinReactSuperclass } from '../helpers/react/component-analysis.js';
 
 /**
  * False-positive remediation escape:
@@ -38,17 +39,6 @@ export function hasOwnCustomSuperclassPropsForwarding(componentNode: estree.Node
       member.type === 'MethodDefinition' &&
       member.kind === 'constructor' &&
       member.value.body?.body.some(isWholePropsSuperCallStatement) === true,
-  );
-}
-
-function isBuiltinReactSuperclass(superClass: estree.Expression): boolean {
-  return (
-    isIdentifier(superClass, 'Component') ||
-    isIdentifier(superClass, 'PureComponent') ||
-    (superClass.type === 'MemberExpression' &&
-      isIdentifier(superClass.object, 'React') &&
-      (isIdentifier(superClass.property, 'Component') ||
-        isIdentifier(superClass.property, 'PureComponent')))
   );
 }
 

--- a/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
@@ -33,7 +33,7 @@ import { areSameTypeDeclarations, getTypeFromTreeNode } from '../helpers/type.js
 import {
   isNamedPropExpressionOrAlias,
   isWholePropsExpressionOrAlias,
-} from './helpers/prop-alias-resolution.js';
+} from '../helpers/react/prop-alias-resolution.js';
 import { isSupportedWholePropsUsage } from './whole-props-usage.js';
 
 /**

--- a/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/decorator-indirect-prop-usage.ts
@@ -18,7 +18,12 @@
 import type { Rule, Scope, SourceCode } from 'eslint';
 import type estree from 'estree';
 import { getNodeParent } from '../helpers/ancestor.js';
-import { getVariableFromName, isFunctionNode, isIdentifier } from '../helpers/ast.js';
+import {
+  collectReferences,
+  getVariableFromName,
+  isFunctionNode,
+  isIdentifier,
+} from '../helpers/ast.js';
 import { isRequiredParserServices } from '../helpers/parser-services.js';
 import {
   getComponentIdentifier,
@@ -26,10 +31,9 @@ import {
 } from '../helpers/react/component-analysis.js';
 import { areSameTypeDeclarations, getTypeFromTreeNode } from '../helpers/type.js';
 import {
-  collectReferences,
   isNamedPropExpressionOrAlias,
   isWholePropsExpressionOrAlias,
-} from './prop-alias-resolution.js';
+} from './helpers/prop-alias-resolution.js';
 import { isSupportedWholePropsUsage } from './whole-props-usage.js';
 
 /**

--- a/packages/analysis/src/jsts/rules/S6767/forward-ref-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/forward-ref-indirect-prop-usage.ts
@@ -18,17 +18,14 @@
 import type { Rule, Scope } from 'eslint';
 import type estree from 'estree';
 import { getNodeParent } from '../helpers/ancestor.js';
-import { getVariableFromName, isFunctionNode, isIdentifier } from '../helpers/ast.js';
-import { collectReferences, isNamedPropExpressionOrAlias } from './prop-alias-resolution.js';
-
-/** Composable callee checkers for forwardRef call detection. */
-const forwardRefCalleePatterns: Array<(callee: estree.Expression | estree.Super) => boolean> = [
-  callee => isIdentifier(callee, 'forwardRef'),
-  callee =>
-    callee.type === 'MemberExpression' &&
-    isIdentifier(callee.object, 'React') &&
-    isIdentifier(callee.property, 'forwardRef'),
-];
+import {
+  collectReferences,
+  getVariableFromName,
+  isFunctionNode,
+  isIdentifier,
+} from '../helpers/ast.js';
+import { isForwardRefCallee } from '../helpers/react/component-analysis.js';
+import { isNamedPropExpressionOrAlias } from './helpers/prop-alias-resolution.js';
 
 /**
  * False-positive remediation escape:
@@ -105,10 +102,7 @@ function isPropReferenceInForwardRefCallback(
   while (current) {
     if (current.type === 'CallExpression') {
       const call = current;
-      if (
-        forwardRefCalleePatterns.some(pattern => pattern(call.callee)) &&
-        call.arguments[0] === prev
-      ) {
+      if (isForwardRefCallee(call.callee) && call.arguments[0] === prev) {
         return true;
       }
     }

--- a/packages/analysis/src/jsts/rules/S6767/forward-ref-indirect-prop-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/forward-ref-indirect-prop-usage.ts
@@ -25,7 +25,7 @@ import {
   isIdentifier,
 } from '../helpers/ast.js';
 import { isForwardRefCallee } from '../helpers/react/component-analysis.js';
-import { isNamedPropExpressionOrAlias } from './helpers/prop-alias-resolution.js';
+import { isNamedPropExpressionOrAlias } from '../helpers/react/prop-alias-resolution.js';
 
 /**
  * False-positive remediation escape:

--- a/packages/analysis/src/jsts/rules/S6767/helpers/prop-alias-resolution.ts
+++ b/packages/analysis/src/jsts/rules/S6767/helpers/prop-alias-resolution.ts
@@ -16,7 +16,7 @@
  */
 import type { Rule, Scope } from 'eslint';
 import type estree from 'estree';
-import { getUniqueWriteReference, getVariableFromName, isIdentifier } from '../helpers/ast.js';
+import { getUniqueWriteReference, getVariableFromName, isIdentifier } from '../../helpers/ast.js';
 
 function isObjectPatternBinding(variable: Scope.Variable) {
   return variable.defs.some(
@@ -25,24 +25,6 @@ function isObjectPatternBinding(variable: Scope.Variable) {
       definition.node.type === 'VariableDeclarator' &&
       definition.node.id.type === 'ObjectPattern',
   );
-}
-
-/**
- * Returns all read references reachable from `scope`, including nested scopes.
- *
- * Pseudo code:
- *   function outer() {
- *     props.label; // included
- *     function inner() {
- *       props.title; // included
- *     }
- *   }
- */
-export function collectReferences(scope: Scope.Scope): Scope.Reference[] {
-  return [
-    ...scope.references.filter(reference => reference.isRead()),
-    ...scope.childScopes.flatMap(collectReferences),
-  ];
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
@@ -19,7 +19,7 @@ import type { Rule, Scope, SourceCode } from 'eslint';
 import type estree from 'estree';
 import { childrenOf } from '../helpers/ancestor.js';
 import { getVariableFromName, isFunctionNode, isIdentifier } from '../helpers/ast.js';
-import { isWholePropsExpressionOrAlias } from './helpers/prop-alias-resolution.js';
+import { isWholePropsExpressionOrAlias } from '../helpers/react/prop-alias-resolution.js';
 
 /**
  * False-positive remediation escape:

--- a/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
+++ b/packages/analysis/src/jsts/rules/S6767/whole-props-usage.ts
@@ -19,7 +19,7 @@ import type { Rule, Scope, SourceCode } from 'eslint';
 import type estree from 'estree';
 import { childrenOf } from '../helpers/ancestor.js';
 import { getVariableFromName, isFunctionNode, isIdentifier } from '../helpers/ast.js';
-import { isWholePropsExpressionOrAlias } from './prop-alias-resolution.js';
+import { isWholePropsExpressionOrAlias } from './helpers/prop-alias-resolution.js';
 
 /**
  * False-positive remediation escape:

--- a/packages/analysis/src/jsts/rules/helpers/ast.ts
+++ b/packages/analysis/src/jsts/rules/helpers/ast.ts
@@ -311,6 +311,16 @@ export function getUniqueWriteReference(
   return undefined;
 }
 
+/**
+ * Returns all read references reachable from `scope`, including nested scopes.
+ */
+export function collectReferences(scope: Scope.Scope): Scope.Reference[] {
+  return [
+    ...scope.references.filter(reference => reference.isRead()),
+    ...scope.childScopes.flatMap(collectReferences),
+  ];
+}
+
 export function getUniqueWriteUsageOrNode(
   context: Rule.RuleContext,
   node: estree.Node,

--- a/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/component-analysis.ts
@@ -122,6 +122,18 @@ function isReactComponentWrapperCallee(callee: estree.Expression | estree.Super)
   );
 }
 
+/**
+ * Returns true when `callee` is a call to `forwardRef` or `React.forwardRef`.
+ */
+export function isForwardRefCallee(callee: estree.Expression | estree.Super): boolean {
+  return (
+    isIdentifier(callee, 'forwardRef') ||
+    (callee.type === 'MemberExpression' &&
+      isIdentifier(callee.object, 'React') &&
+      isIdentifier(callee.property, 'forwardRef'))
+  );
+}
+
 function isWrappedInReactComponentCall(
   node: estree.Node,
   parent: estree.Node | undefined,
@@ -295,7 +307,7 @@ function isQualifiedReactClassSuper(objectName: string | undefined, propertyName
     : objectName === 'React' && isReactClassSuperName(propertyName);
 }
 
-function isBuiltinReactSuperclass(superClass: estree.Expression): boolean {
+export function isBuiltinReactSuperclass(superClass: estree.Expression): boolean {
   return (
     (superClass.type === 'Identifier' && isQualifiedReactClassSuper(undefined, superClass.name)) ||
     (superClass.type === 'MemberExpression' &&

--- a/packages/analysis/src/jsts/rules/helpers/react/prop-alias-resolution.ts
+++ b/packages/analysis/src/jsts/rules/helpers/react/prop-alias-resolution.ts
@@ -16,7 +16,7 @@
  */
 import type { Rule, Scope } from 'eslint';
 import type estree from 'estree';
-import { getUniqueWriteReference, getVariableFromName, isIdentifier } from '../../helpers/ast.js';
+import { getUniqueWriteReference, getVariableFromName, isIdentifier } from '../ast.js';
 
 function isObjectPatternBinding(variable: Scope.Variable) {
   return variable.defs.some(


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored helpers:**
  - Moved `prop-alias-resolution.ts` into a dedicated `helpers/` directory within `S6767`.
  - Centralized `collectReferences` into the global `ast.ts` utility file.
- **React analysis improvements:**
  - Added `isForwardRefCallee` to `component-analysis.ts` and updated `forward-ref-indirect-prop-usage.ts` to use it.
  - Exported `isBuiltinReactSuperclass` from `component-analysis.ts` to allow reuse in `custom-superclass-forwarding.ts`.


<sub>This will update automatically on new commits.</sub>