### PR TITLE
JS-1812 Add SonarJS telemetry dashboard

### DIFF
--- a/.github/workflows/telemetry-dashboard.yml
+++ b/.github/workflows/telemetry-dashboard.yml
@@ -1,0 +1,62 @@
+name: Refresh Telemetry Dashboard
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: telemetry-dashboard
+  cancel-in-progress: false
+
+jobs:
+  fetch-and-deploy:
+    runs-on: sonar-xs
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: jdx/mise-action@v4.0.1
+        with:
+          version: 2025.11.2
+          mise_toml: |
+            [tools]
+            node = "24.11.0"
+
+      - name: Configure npm
+        uses: SonarSource/ci-github-actions/config-npm@v1
+
+      - name: Install telemetry dashboard dependencies
+        run: npm --prefix telemetry-dashboard ci
+
+      - name: Validate Redshift role configuration
+        run: |
+          if [ -z "${{ vars.TELEMETRY_DASHBOARD_REDSHIFT_ROLE_ARN }}" ]; then
+            echo "Missing repository variable TELEMETRY_DASHBOARD_REDSHIFT_ROLE_ARN"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials for Redshift
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ vars.TELEMETRY_DASHBOARD_REDSHIFT_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Fetch telemetry snapshot
+        run: npm --prefix telemetry-dashboard run fetch:redshift
+
+      - name: Build static site
+        run: npm --prefix telemetry-dashboard run build
+
+      - name: Deploy to GitHub Pages
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          npm --prefix telemetry-dashboard run deploy

--- a/.github/workflows/telemetry-dashboard.yml
+++ b/.github/workflows/telemetry-dashboard.yml
@@ -1,8 +1,9 @@
-name: Refresh Telemetry Dashboard
+name: Publish Telemetry Dashboard
 
 on:
-  schedule:
-    - cron: '0 10 * * *'
+  push:
+    branches:
+      - codex/telemetry-static-site
   workflow_dispatch:
 
 concurrency:
@@ -10,11 +11,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  fetch-and-deploy:
+  build-and-deploy:
     runs-on: sonar-xs
     permissions:
       contents: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -34,15 +34,6 @@ jobs:
 
       - name: Install telemetry dashboard dependencies
         run: npm --prefix telemetry-dashboard ci
-
-      - name: Configure AWS credentials for Redshift
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: arn:aws:iam::478507623792:role/deploymentroles/SonarJSTelemetryDashboardRedshiftRole
-          aws-region: eu-west-1
-
-      - name: Fetch telemetry snapshot
-        run: npm --prefix telemetry-dashboard run fetch:redshift
 
       - name: Build static site
         run: npm --prefix telemetry-dashboard run build

--- a/.github/workflows/telemetry-dashboard.yml
+++ b/.github/workflows/telemetry-dashboard.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: sonar-xs
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/telemetry-dashboard.yml
+++ b/.github/workflows/telemetry-dashboard.yml
@@ -35,17 +35,10 @@ jobs:
       - name: Install telemetry dashboard dependencies
         run: npm --prefix telemetry-dashboard ci
 
-      - name: Validate Redshift role configuration
-        run: |
-          if [ -z "${{ vars.TELEMETRY_DASHBOARD_REDSHIFT_ROLE_ARN }}" ]; then
-            echo "Missing repository variable TELEMETRY_DASHBOARD_REDSHIFT_ROLE_ARN"
-            exit 1
-          fi
-
       - name: Configure AWS credentials for Redshift
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: ${{ vars.TELEMETRY_DASHBOARD_REDSHIFT_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::478507623792:role/deploymentroles/SonarJSTelemetryDashboardRedshiftRole
           aws-region: eu-west-1
 
       - name: Fetch telemetry snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ lcov.info
 .codex/*
 !.codex/skills/
 .mcp.json
+telemetry-dashboard/.cache/
+telemetry-dashboard/data/*.json
+telemetry-dashboard/dist/

--- a/telemetry-dashboard/.gitignore
+++ b/telemetry-dashboard/.gitignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+.cache/
+data/latest.json
+data/*.json

--- a/telemetry-dashboard/README.md
+++ b/telemetry-dashboard/README.md
@@ -1,0 +1,53 @@
+# SonarJS Telemetry Dashboard
+
+Static site for exploring SonarJS analyzer telemetry from Redshift.
+
+## What it does
+
+- Discovers telemetry columns directly from the SonarJS adhoc warehouse views
+- Deduplicates to the latest analysis per `project_uuid` over a configurable window
+- Builds a static dashboard that renders new telemetry fields automatically
+- Uses untracked local snapshots or CI-fetched snapshots instead of committed telemetry data
+
+## Local usage
+
+```bash
+cd telemetry-dashboard
+npm ci
+npm run build
+```
+
+This writes the static site to `telemetry-dashboard/dist`.
+
+If `data/latest.json` is not present yet, the build still succeeds and emits an empty placeholder snapshot with instructions in the UI.
+
+To fetch fresh data from Redshift first:
+
+```bash
+npm run fetch:redshift
+npm run build
+```
+
+The fetch script follows the same Redshift auth pattern as `issue-feedback-dashboard`:
+
+- In CI, it uses `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`
+- Locally, it can fall back to the JumpCloud SAML login flow and cached Redshift credentials
+
+Useful environment variables:
+
+- `TELEMETRY_WINDOW_DAYS`: rolling dedup window, defaults to `21`
+- `TELEMETRY_TOP_VALUES_LIMIT`: max distinct values stored per field, defaults to `24`
+
+## Deployment
+
+The GitHub Actions workflow is expected to:
+
+1. Configure Node and install `telemetry-dashboard` dependencies
+2. Assume the Redshift CI role
+3. Run `npm --prefix telemetry-dashboard run fetch:redshift`
+4. Run `npm --prefix telemetry-dashboard run build`
+5. Deploy `telemetry-dashboard/dist` to `gh_pages`
+
+The workflow uses a repository variable for the Redshift role ARN:
+
+- `TELEMETRY_DASHBOARD_REDSHIFT_ROLE_ARN`

--- a/telemetry-dashboard/README.md
+++ b/telemetry-dashboard/README.md
@@ -43,10 +43,8 @@ Useful environment variables:
 The GitHub Actions workflow is expected to:
 
 1. Configure Node and install `telemetry-dashboard` dependencies
-2. Assume the Redshift CI role
-3. Run `npm --prefix telemetry-dashboard run fetch:redshift`
-4. Run `npm --prefix telemetry-dashboard run build`
-5. Deploy `telemetry-dashboard/dist` to `gh_pages`
+2. Run `npm --prefix telemetry-dashboard run build`
+3. Deploy `telemetry-dashboard/dist` to `gh_pages`
 
-The workflow assumes `SonarJSTelemetryDashboardRedshiftRole` from the Data Team prod account
-through GitHub OIDC, following the same deployment model as `issue-feedback-dashboard`.
+The workflow currently publishes the static site without fetching Redshift data. This keeps the
+GitHub Pages deployment path testable before Redshift access is enabled.

--- a/telemetry-dashboard/README.md
+++ b/telemetry-dashboard/README.md
@@ -48,6 +48,5 @@ The GitHub Actions workflow is expected to:
 4. Run `npm --prefix telemetry-dashboard run build`
 5. Deploy `telemetry-dashboard/dist` to `gh_pages`
 
-The workflow uses a repository variable for the Redshift role ARN:
-
-- `TELEMETRY_DASHBOARD_REDSHIFT_ROLE_ARN`
+The workflow assumes `SonarJSTelemetryDashboardRedshiftRole` from the Data Team prod account
+through GitHub OIDC, following the same deployment model as `issue-feedback-dashboard`.

--- a/telemetry-dashboard/data/.gitignore
+++ b/telemetry-dashboard/data/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!.gitignore

--- a/telemetry-dashboard/package-lock.json
+++ b/telemetry-dashboard/package-lock.json
@@ -1,0 +1,2418 @@
+{
+  "name": "sonarjs-telemetry-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sonarjs-telemetry-dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aws-sdk/client-redshift": "3.975.0",
+        "@aws-sdk/client-sts": "3.975.0",
+        "pg": "8.17.2"
+      },
+      "devDependencies": {
+        "@types/node": "24.12.4",
+        "@types/pg": "8.16.0",
+        "esbuild": "0.28.0",
+        "gh-pages": "6.3.0",
+        "tsx": "4.22.3",
+        "typescript": "6.0.3"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift": {
+      "version": "3.975.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/client-redshift/-/client-redshift-3.975.0.tgz",
+      "integrity": "sha512-CBRoQBXhbId9Pb3tstKgFI/vuYVsSUlmRwTODuQx36voWSPazJHmAA1lNw66rAIhyVHjwtOkTRClE12NAuuPQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.1",
+        "@aws-sdk/credential-provider-node": "^3.972.1",
+        "@aws-sdk/middleware-host-header": "^3.972.1",
+        "@aws-sdk/middleware-logger": "^3.972.1",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.2",
+        "@aws-sdk/region-config-resolver": "^3.972.1",
+        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/util-endpoints": "3.972.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.1",
+        "@aws-sdk/util-user-agent-node": "^3.972.1",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.21.1",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.11",
+        "@smithy/middleware-retry": "^4.4.27",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.10.12",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.26",
+        "@smithy/util-defaults-mode-node": "^4.2.29",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.975.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/client-sts/-/client-sts-3.975.0.tgz",
+      "integrity": "sha512-09uQiFTXZb0M2Vms2TtpPXZHAuySAEq66I7q4G2saJBNZyXFXmtTqtl3LGR+Y967RVl9UNOwvSR6hYiCHjDrYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.1",
+        "@aws-sdk/credential-provider-node": "^3.972.1",
+        "@aws-sdk/middleware-host-header": "^3.972.1",
+        "@aws-sdk/middleware-logger": "^3.972.1",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.2",
+        "@aws-sdk/region-config-resolver": "^3.972.1",
+        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/util-endpoints": "3.972.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.1",
+        "@aws-sdk/util-user-agent-node": "^3.972.1",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.21.1",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.11",
+        "@smithy/middleware-retry": "^4.4.27",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.10.12",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.26",
+        "@smithy/util-defaults-mode-node": "^4.2.29",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/core/-/core-3.974.15.tgz",
+      "integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.5",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.41",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
+      "integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.43",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
+      "integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.46",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.46.tgz",
+      "integrity": "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-login": "^3.972.45",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.45",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
+      "integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.48",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.48.tgz",
+      "integrity": "sha512-QIbtJP0olSLZ2ImEu636pP+7JJbPfaL3xSJIFXhu472CWuondCc4bGOa8OeyhOFet8z4H1D/ZFKXc39FboWwYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-ini": "^3.972.46",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.41",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
+      "integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.45",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
+      "integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/token-providers": "3.1056.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.45",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
+      "integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.16",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.16.tgz",
+      "integrity": "sha512-DcDXAl32I/YZnJ9LyX/XpRXOtoTYIwgmYxoNMGkyvtomdjPpkXPGhz93VJyzKFFNffz/SZwEkoAuWOkeOzo90Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/middleware-logger/-/middleware-logger-3.972.15.tgz",
+      "integrity": "sha512-4Org8yUew+Y1+buTcH5A39unAdkVRnQxcOp3XexvFAVctbtznDytk3UKbkXq8FYWEVdz1ycxnAqHaKHePyGQEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.17",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.17.tgz",
+      "integrity": "sha512-T/FpIr0OcR1kad/u5ZTDE2ziFG7QM6pq1MN8atHBmyyOJgqWjGez9TQ0W2WCixS7EE9fsUQKWn70l5M+e+O/qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.45",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.45.tgz",
+      "integrity": "sha512-sWd7bGH+thMsNGYdqPdLuH7SDEkpplWCDKSCWhjkMPXwz3o/9BK3ZNrd5JGUB8y+cPbs3rXIe3Ah7iSlKXj5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.13",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
+      "integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.19",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.19.tgz",
+      "integrity": "sha512-ol9yhY2nzPTrQoKX9WZ8cps2JABcDt0Dlhr59FRYYW/2S5h07PFrhfZZzD8sXZ8XpYfObTIJ+evmbcz41m1SJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.30",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
+      "integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1056.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
+      "integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.9",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/types/-/types-3.973.9.tgz",
+      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.972.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/util-endpoints/-/util-endpoints-3.972.0.tgz",
+      "integrity": "sha512-6JHsl1V/a1ZW8D8AFfd4R52fwZPnZ5H4U6DS8m/bWT8qad72NvbOFAC7U2cDtFs2TShqUO3TEiX/EJibtY3ijg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.972.0",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
+      "version": "3.972.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/types/-/types-3.972.0.tgz",
+      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.16",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.16.tgz",
+      "integrity": "sha512-h4VTGl6lxJkM/odeRPzXB5YZbkxVr5FnJ2Bwv78+IY9Ah7QsXSBhefvvz1CQDoQNzOLYsNMQ3PhMQM7i6tpoPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.31",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.31.tgz",
+      "integrity": "sha512-hYTWRlhOnhs2tYCYgNK30jaQKyl4FvXQl0AK9tKRZq8sunS9ygi+USYiG6LCb7DuqT0Gl3jONP9jtb4D4NYhHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.26",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
+      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.5.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/config-resolver/-/config-resolver-4.5.6.tgz",
+      "integrity": "sha512-AXbvUX9aNY2qCLOMCikpl1Df5w2CNFEqbEb6XafG81FJbAbB8avIT7BOx1KDqiO86J/38qKQ3YuakfAfY3iBkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.7",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.7.tgz",
+      "integrity": "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/hash-node/-/hash-node-4.3.6.tgz",
+      "integrity": "sha512-lIZyQ7gDxURrnfkjalM0lKmDnfZYuPzNBYlkza3czPTQNVYsg4e0o90Zx/RpxhamKKOGsQGCsopp0ULsJqltNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/invalid-dependency/-/invalid-dependency-4.3.6.tgz",
+      "integrity": "sha512-jUH1Eth7Sgn4KPBX5OKYDRpNjzul7AzsIhxKXT1rHXPTSfY00/7Kb9RtNil5SDAlPPsxaUiesR/rql2wjackmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/middleware-content-length/-/middleware-content-length-4.3.6.tgz",
+      "integrity": "sha512-nfpYCrzSFAgfIXmIHFTjOGNeTV3DVF5E5rfi3ZuNfsOjKSpePBOJF3rjyXlWYND0anvxVoqioIwClWCNdKt4Og==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.5.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.6.tgz",
+      "integrity": "sha512-zdG5bJZOiM2PRgL2lwcgui6uwZ+s5y6Qsk/rk05Q69sZJT6oi1x+v8Kn++V/q9VY94EgOtEe5kivpu+eGau0wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.6.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/middleware-retry/-/middleware-retry-4.6.6.tgz",
+      "integrity": "sha512-MWppaYUlc+W4cU2JZnYuMFeOxCWbKO4A57BWti6aCb7hRBK3+CL6llADGpX084hjImsqr3EvCGewArOj7G81eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/middleware-serde/-/middleware-serde-4.3.6.tgz",
+      "integrity": "sha512-I3fPVYKKEog3a3qdqt1nttP1NBuQOAlNoQxEp6j5pMogSx0HHfid63difhcDgslV6p1XsTXG6D6ieTe13ycJtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/middleware-stack/-/middleware-stack-4.3.6.tgz",
+      "integrity": "sha512-QhNiWfg47Kl4SJHmuQvnlzCtlD1eX1J7d/vuuttIE17Ra2YUKp9Srv5lCwa3OvoYaSNWMKYn0PjGIsfCLMJsEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.4.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/node-config-provider/-/node-config-provider-4.4.6.tgz",
+      "integrity": "sha512-M+gG6eQ0y073mSmNB+erRXJvwpsqsN72ol2w6vcd8FEKeG7pqYK0JvzfVqONkPj2ElBB2pg+cU13I850b//Wag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/node-http-handler/-/node-http-handler-4.7.6.tgz",
+      "integrity": "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.4.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/protocol-http/-/protocol-http-5.4.6.tgz",
+      "integrity": "sha512-H6S7NyaaL+7qO8kIL7VQ7KyrGnKXdllGzJqvtp3hvDen25UOydKV51qGDVK0UciW125jV3CoLJQy/ihc0OEC6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.13.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/smithy-client/-/smithy-client-4.13.6.tgz",
+      "integrity": "sha512-tAf35/JW/DvMlACcazcoIOKOV0JBqyOvxjPTEME9W+m9wLcE0G1rwADc7Ntu38rY5C9OH8jZjpo4tbtjmIjEBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/url-parser/-/url-parser-4.3.6.tgz",
+      "integrity": "sha512-9MRJzwUrlswwHogOR7raDcykuzojZn74qGdQdbEQLVaixlvJuMiIT0g/CejKcmAIgrUVs8brBrnGtmYmBc0iuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.4.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-base64/-/util-base64-4.4.6.tgz",
+      "integrity": "sha512-V6ApAGvCQnb7Wy1Sy60AQc+7UOEaNQxvAXBLdMi5Zzm66cmX0srvfAxDmg7BGuJ+9H9ez0PPWS/AeFgWxwGavA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-body-length-browser/-/util-body-length-browser-4.3.6.tgz",
+      "integrity": "sha512-+3vGcNHuvzuFLVWL9/wJgucOuQWufhuGhb3oxVDj9SWFGtwkOmtC2nFUwVC2IJoPe45uhs6TAb8bgE4IXDSPzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-body-length-node/-/util-body-length-node-4.3.6.tgz",
+      "integrity": "sha512-T15zTQJ/xKYdS0/3CFckhz1QBbhxmhk/xjL6FKvHKgkJPN4E985If2FI9CcV2kh2v0sfiWMfXVEOKFbqgw4m4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.4.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.4.6.tgz",
+      "integrity": "sha512-dRCZKu05AL7KQWrVuRJPotfjCRnvGkCjV56XNP067CRfyTtvgi/Ygu44qrBKb814Hsa52bWwDJ+Vt3pd04BjPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.3.6.tgz",
+      "integrity": "sha512-tTR8tayMoa0WeRhtMH7j3WpHUtggBXjh7rBdf7j6POYI69R85gpWBW6B32kaJRnlQU8+0gOGAzJj50S7SU1Egw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.5.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-endpoints/-/util-endpoints-3.5.6.tgz",
+      "integrity": "sha512-kaB41eVUYC7ajVWUsZRqagxwRaa3VupjQ/Z2Z2v/Vffh/gJ/fFOS25s6mTyR2Lw1FrnBbRWo1iShR9BhekpPeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-middleware/-/util-middleware-4.3.6.tgz",
+      "integrity": "sha512-TrAgOcL63TRi7G92arTzq0n+VDrmZifwP1I1T9y2xU3lJpybsHdm33S2d3xaFfG0c8zJNIF9yYRqLSe6rbhH/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.4.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-retry/-/util-retry-4.4.6.tgz",
+      "integrity": "sha512-E/kFnvWQL6rIPr0Ucjk8oDgJSkKx2bv0nJkJ/cB3ywys7xCqeL1AXP9liHjgYONdQ+MKw/xT06IQK3vgbtu2Ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.3.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-utf8/-/util-utf8-4.3.6.tgz",
+      "integrity": "sha512-tAa4sePYB7mlJzdYbdBqdv37KwFKWixmM/r3ihcI0HFOVjf+a5oGvtcLXcGm4S1bY4DFsLAIOHgjubtp+oRufw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.4.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@smithy/util-waiter/-/util-waiter-4.4.6.tgz",
+      "integrity": "sha512-oTt3OP9NcJkrySCSCCdSbP6XLSMNgOmt/ulaiYtb0Ng6tfEWtXQ1mwfyqmLd+GapmDUjbU2mgkf7QIq9H4ij/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.16.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gh-pages": {
+      "version": "6.3.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/gh-pages/-/gh-pages-6.3.0.tgz",
+      "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.4",
+        "commander": "^13.0.0",
+        "email-addresses": "^5.0.0",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^11.1.1",
+        "globby": "^11.1.0"
+      },
+      "bin": {
+        "gh-pages": "bin/gh-pages.js",
+        "gh-pages-clean": "bin/gh-pages-clean.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.17.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pg/-/pg-8.17.2.tgz",
+      "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.10.1",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/telemetry-dashboard/package.json
+++ b/telemetry-dashboard/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "sonarjs-telemetry-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Static site for exploring SonarJS analyzer telemetry",
+  "type": "module",
+  "scripts": {
+    "build": "tsx scripts/build.ts",
+    "deploy": "gh-pages -d dist -b gh_pages --dotfiles",
+    "fetch:redshift": "tsx scripts/fetch-redshift.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@aws-sdk/client-redshift": "3.975.0",
+    "@aws-sdk/client-sts": "3.975.0",
+    "pg": "8.17.2"
+  },
+  "devDependencies": {
+    "@types/node": "24.12.4",
+    "@types/pg": "8.16.0",
+    "esbuild": "0.28.0",
+    "gh-pages": "6.3.0",
+    "tsx": "4.22.3",
+    "typescript": "6.0.3"
+  }
+}

--- a/telemetry-dashboard/scripts/build.ts
+++ b/telemetry-dashboard/scripts/build.ts
@@ -1,0 +1,75 @@
+import { build } from 'esbuild';
+import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const DIST_DIR = path.join(ROOT, 'dist');
+const DIST_DATA_DIR = path.join(DIST_DIR, 'data');
+const latestSnapshot = path.join(ROOT, 'data', 'latest.json');
+const WINDOW_DAYS = Number.parseInt(process.env.TELEMETRY_WINDOW_DAYS ?? '21', 10) || 21;
+
+function createEmptySnapshot() {
+  const now = new Date();
+  return {
+    generatedAt: now.toISOString(),
+    source: 'empty',
+    windowDays: WINDOW_DAYS,
+    windowStart: new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString(),
+    notes: [
+      'No local telemetry snapshot was found at data/latest.json.',
+      'Run npm run fetch:redshift locally or let CI refresh the dashboard before publishing.',
+    ],
+    platforms: {
+      sq: {
+        id: 'sq',
+        label: 'SonarQube Server',
+        shortLabel: 'SQS',
+        view: 'measures.sq_analysis_javascript_adhoc',
+        latestProjectCount: 0,
+        fieldCount: 0,
+        fields: {},
+      },
+      sc: {
+        id: 'sc',
+        label: 'SonarQube Cloud',
+        shortLabel: 'SQC',
+        view: 'measures.sc_analysis_javascript_adhoc',
+        latestProjectCount: 0,
+        fieldCount: 0,
+        fields: {},
+      },
+    },
+    catalog: [],
+    overview: {
+      moduleType: {},
+    },
+  };
+}
+
+rmSync(DIST_DIR, { recursive: true, force: true });
+mkdirSync(DIST_DATA_DIR, { recursive: true });
+
+console.log('Bundling frontend...');
+await build({
+  bundle: true,
+  entryPoints: [path.join(ROOT, 'src', 'main.ts')],
+  format: 'esm',
+  outfile: path.join(DIST_DIR, 'main.js'),
+  platform: 'browser',
+  target: ['es2022'],
+});
+
+console.log('Copying static assets...');
+cpSync(path.join(ROOT, 'src', 'index.html'), path.join(DIST_DIR, 'index.html'));
+cpSync(path.join(ROOT, 'src', 'styles.css'), path.join(DIST_DIR, 'styles.css'));
+
+if (existsSync(latestSnapshot)) {
+  cpSync(latestSnapshot, path.join(DIST_DATA_DIR, 'snapshot.json'));
+  console.log(`Using ${path.relative(ROOT, latestSnapshot)} as snapshot source`);
+} else {
+  writeFileSync(path.join(DIST_DATA_DIR, 'snapshot.json'), `${JSON.stringify(createEmptySnapshot(), null, 2)}\n`);
+  console.log('No data/latest.json found, emitted an empty placeholder snapshot');
+}
+
+writeFileSync(path.join(DIST_DIR, '.nojekyll'), '');
+console.log(`Build complete: ${DIST_DIR}`);

--- a/telemetry-dashboard/scripts/fetch-redshift.ts
+++ b/telemetry-dashboard/scripts/fetch-redshift.ts
@@ -1,0 +1,1121 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Client } from 'pg';
+import type {
+  CatalogField,
+  DistributionValue,
+  FieldSemanticType,
+  FieldSummary,
+  FieldValueType,
+  ModuleTypeOverview,
+  PlatformTimelineOverview,
+  PlatformId,
+  PlatformSnapshot,
+  ProgramCreationOverview,
+  ProgramCreationVersionOverview,
+  TelemetrySnapshot,
+  VersionTimeline,
+} from '../src/types.js';
+import { createClient } from './lib/redshift.js';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const DATA_DIR = path.join(ROOT, 'data');
+const OUTPUT_FILE = path.join(DATA_DIR, 'latest.json');
+const WINDOW_DAYS = parsePositiveInt(process.env.TELEMETRY_WINDOW_DAYS, 21);
+const TIMELINE_WEEKS = parsePositiveInt(process.env.TELEMETRY_TIMELINE_WEEKS, 12);
+const TOP_VALUES_LIMIT = parsePositiveInt(process.env.TELEMETRY_TOP_VALUES_LIMIT, 24);
+const TOKEN_VALUES_LIMIT = 16;
+const TIMELINE_SPLIT_LIMIT = parsePositiveInt(process.env.TELEMETRY_TIMELINE_SPLIT_LIMIT, 16);
+const VERSION_COLLATOR = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+const PLATFORMS = [
+  {
+    id: 'sq',
+    label: 'SonarQube Server',
+    shortLabel: 'SQS',
+    tableName: 'sq_analysis_javascript_adhoc',
+    view: 'measures.sq_analysis_javascript_adhoc',
+  },
+  {
+    id: 'sc',
+    label: 'SonarQube Cloud',
+    shortLabel: 'SQC',
+    tableName: 'sc_analysis_javascript_adhoc',
+    view: 'measures.sc_analysis_javascript_adhoc',
+  },
+] as const satisfies ReadonlyArray<{
+  id: PlatformId;
+  label: string;
+  shortLabel: string;
+  tableName: string;
+  view: string;
+}>;
+
+interface ColumnRow {
+  column_name: string;
+  data_type: string;
+  ordinal_position: string | number;
+}
+
+interface ColumnMeta {
+  columnName: string;
+  redshiftType: string;
+  ordinalPosition: number;
+}
+
+interface AggregateRow extends Record<string, string | number | null> {
+  total_rows: string | number;
+}
+
+interface DistributionRow {
+  value: string;
+  row_count: string | number;
+}
+
+interface ModuleTypeRow {
+  projects_with_telemetry: string | number | null;
+  total_esm_files: string | number | null;
+  total_cjs_files: string | number | null;
+  esm_only_projects: string | number | null;
+  cjs_only_projects: string | number | null;
+  both_projects: string | number | null;
+  neither_projects: string | number | null;
+}
+
+interface ProgramCreationRow {
+  typescript_versions: string | null;
+  attempted_count: string | number | null;
+  succeeded_count: string | number | null;
+  failed_count: string | number | null;
+}
+
+interface TimelineSeriesRow {
+  week_start: string;
+  value: string;
+  project_count: string | number;
+}
+
+interface TimelineWeekRow {
+  week_start: string;
+  project_count: string | number;
+}
+
+interface PlatformFetchResult {
+  snapshot: PlatformSnapshot;
+  moduleTypeOverview?: ModuleTypeOverview;
+  programCreationOverview?: ProgramCreationOverview;
+  timelineOverview?: PlatformTimelineOverview;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function quoteIdentifier(name: string): string {
+  return `"${name.replaceAll('"', '""')}"`;
+}
+
+function toTextExpression(column: ColumnMeta): string {
+  const identifier = quoteIdentifier(column.columnName);
+  if (column.redshiftType.toLowerCase().includes('boolean')) {
+    return `CASE WHEN ${identifier} IS TRUE THEN 'true' WHEN ${identifier} IS FALSE THEN 'false' ELSE NULL END`;
+  }
+  return `CAST(${identifier} AS VARCHAR(1024))`;
+}
+
+function latestSubquery(view: string): string {
+  return `
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY project_uuid ORDER BY partition_timestamp DESC) AS rn
+    FROM ${view}
+    WHERE partition_timestamp >= DATEADD(day, -${WINDOW_DAYS}, GETDATE())
+  `;
+}
+
+function timelineWindowStartExpression(): string {
+  return `DATE_TRUNC('week', DATEADD(week, -${Math.max(TIMELINE_WEEKS - 1, 0)}, GETDATE()))`;
+}
+
+function weeklyLatestSubquery(platformView: string, valueExpression: string): string {
+  return `
+    SELECT
+      project_uuid,
+      DATE_TRUNC('week', partition_timestamp) AS week_start,
+      ${valueExpression} AS value,
+      ROW_NUMBER() OVER (
+        PARTITION BY project_uuid, DATE_TRUNC('week', partition_timestamp)
+        ORDER BY partition_timestamp DESC
+      ) AS rn
+    FROM ${platformView}
+    WHERE partition_timestamp >= ${timelineWindowStartExpression()}
+  `;
+}
+
+function toNumber(value: string | number | null | undefined): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return Number(value);
+  }
+  return 0;
+}
+
+function round(value: number, digits = 2): number {
+  return Number(value.toFixed(digits));
+}
+
+function columnNameToKey(columnName: string): string {
+  return `javascript.${columnName.replaceAll('_', '.')}`;
+}
+
+function getCategory(pathSegments: string[]): string {
+  if (pathSegments[1] === 'runtime') {
+    return 'runtime';
+  }
+  if (pathSegments[1] !== 'telemetry') {
+    return 'other';
+  }
+  if (pathSegments[2] === 'typescript' && pathSegments[3] === 'compiler-options') {
+    return 'compiler-options';
+  }
+  if (pathSegments[2] === 'typescript') {
+    return 'typescript';
+  }
+  if (pathSegments[2] === 'ecmascript') {
+    return 'ecmascript';
+  }
+  if (pathSegments[2] === 'module-type') {
+    return 'module-type';
+  }
+  return 'other';
+}
+
+function humanizeToken(token: string): string {
+  const known = new Map<string, string>([
+    ['allowarbitraryextensions', 'Allow Arbitrary Extensions'],
+    ['allowimportingtsextensions', 'Allow Importing TS Extensions'],
+    ['allowjs', 'Allow JS'],
+    ['allowsyntheticdefaultimports', 'Allow Synthetic Default Imports'],
+    ['alwaysstrict', 'Always Strict'],
+    ['checkjs', 'Check JS'],
+    ['cjs', 'CJS'],
+    ['ecmascript', 'ECMAScript'],
+    ['esm', 'ESM'],
+    ['esmoduleinterop', 'ES Module Interop'],
+    ['exactoptionalpropertytypes', 'Exact Optional Property Types'],
+    ['isolatedmodules', 'Isolated Modules'],
+    ['jsx', 'JSX'],
+    ['lib', 'Lib'],
+    ['major-version', 'Major Version'],
+    ['moduledetection', 'Module Detection'],
+    ['module', 'Module'],
+    ['moduleresolution', 'Module Resolution'],
+    ['native-preview', 'Native Preview'],
+    ['noimplicitany', 'No Implicit Any'],
+    ['noimplicitthis', 'No Implicit This'],
+    ['nouncheckedindexedaccess', 'No Unchecked Indexed Access'],
+    ['resolvejsonmodule', 'Resolve JSON Module'],
+    ['resolvepackagejsonexports', 'Resolve Package JSON Exports'],
+    ['resolvepackagejsonimports', 'Resolve Package JSON Imports'],
+    ['sonarqube', 'SonarQube'],
+    ['strict', 'Strict'],
+    ['strictbindcallapply', 'Strict Bind Call Apply'],
+    ['strictbuiltiniteratorreturn', 'Strict Builtin Iterator Return'],
+    ['strictfunctiontypes', 'Strict Function Types'],
+    ['strictnullchecks', 'Strict Null Checks'],
+    ['strictpropertyinitialization', 'Strict Property Initialization'],
+    ['target', 'Target'],
+    ['typescript', 'TypeScript'],
+    ['usedefineforclassfields', 'Use Define For Class Fields'],
+    ['useunknownincatchvariables', 'Use Unknown In Catch Variables'],
+    ['verbatimmodulesyntax', 'Verbatim Module Syntax'],
+  ]);
+
+  const lower = token.toLowerCase();
+  if (known.has(lower)) {
+    return known.get(lower)!;
+  }
+
+  return token
+    .replaceAll('-', ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, letter => letter.toUpperCase());
+}
+
+function getDisplayName(pathSegments: string[]): string {
+  return humanizeToken(pathSegments[pathSegments.length - 1] ?? 'Field');
+}
+
+function buildFieldMeta(columnName: string) {
+  const key = columnNameToKey(columnName);
+  const pathSegments = key.split('.');
+
+  return {
+    key,
+    pathSegments,
+    category: getCategory(pathSegments),
+    displayName: getDisplayName(pathSegments),
+  };
+}
+
+function inferSemanticTypeFromKey(key: string): FieldSemanticType | undefined {
+  const lastSegment = key.split('.').at(-1) ?? '';
+  const isCountField =
+    /(^|-)count$/.test(lastSegment) ||
+    (key.includes('.program-creation.') &&
+      (lastSegment === 'attempted' || lastSegment === 'failed' || lastSegment === 'succeeded'));
+
+  if (isCountField) {
+    return 'count';
+  }
+
+  if (key.endsWith('.major-version') || key.endsWith('.versions')) {
+    return 'version';
+  }
+
+  return undefined;
+}
+
+function inferFieldSemanticType(key: string, valueType: FieldValueType): FieldSemanticType {
+  if (valueType === 'boolean') {
+    return 'boolean';
+  }
+
+  return inferSemanticTypeFromKey(key) ?? (valueType === 'number' ? 'metric' : 'dimension');
+}
+
+function inferValueType(
+  nonNullRows: number,
+  numericRows: number,
+  topValues: DistributionValue[],
+): FieldValueType {
+  if (nonNullRows === 0) {
+    return 'unknown';
+  }
+
+  const normalized = new Set(topValues.map(entry => entry.value.toLowerCase()));
+  if (normalized.size > 0 && [...normalized].every(value => value === 'true' || value === 'false')) {
+    return 'boolean';
+  }
+
+  if (numericRows === nonNullRows) {
+    return 'number';
+  }
+
+  if (numericRows > 0) {
+    return 'mixed';
+  }
+
+  return 'string';
+}
+
+function buildTokenValues(values: DistributionValue[], nonNullRows: number): DistributionValue[] | undefined {
+  const counts = new Map<string, number>();
+  let sawSplitValue = false;
+
+  for (const value of values) {
+    const parts = value.value
+      .split(',')
+      .map(part => part.trim())
+      .filter(Boolean);
+
+    if (parts.length > 1) {
+      sawSplitValue = true;
+    }
+
+    for (const part of parts) {
+      counts.set(part, (counts.get(part) ?? 0) + value.count);
+    }
+  }
+
+  if (!sawSplitValue || counts.size === 0 || nonNullRows === 0) {
+    return undefined;
+  }
+
+  return [...counts.entries()]
+    .map(([value, count]) => ({
+      value,
+      count,
+      percent: round((count / nonNullRows) * 100, 1),
+    }))
+    .sort((left, right) => right.count - left.count || left.value.localeCompare(right.value))
+    .slice(0, TOKEN_VALUES_LIMIT);
+}
+
+function parseTelemetryTokens(
+  value: string | null | undefined,
+  fallback = 'not-detected',
+): string[] {
+  if (typeof value !== 'string') {
+    return [fallback];
+  }
+
+  const tokens = [...new Set(value.split(',').map(part => part.trim()).filter(Boolean))];
+  return tokens.length > 0 ? tokens : [fallback];
+}
+
+function isComparableVersionLabel(value: string): boolean {
+  return value !== 'not-detected' && /\d/.test(value);
+}
+
+function compareVersionLabels(left: string, right: string): number {
+  const leftComparable = isComparableVersionLabel(left);
+  const rightComparable = isComparableVersionLabel(right);
+
+  if (leftComparable !== rightComparable) {
+    return leftComparable ? -1 : 1;
+  }
+
+  return VERSION_COLLATOR.compare(left, right);
+}
+
+function getHighestComparableVersion(versions: string[]): string | undefined {
+  let highest: string | undefined;
+
+  for (const version of versions) {
+    if (!isComparableVersionLabel(version)) {
+      continue;
+    }
+
+    if (!highest || compareVersionLabels(version, highest) > 0) {
+      highest = version;
+    }
+  }
+
+  return highest;
+}
+
+function sortProgramCreationEntries(
+  entries: ProgramCreationVersionOverview[],
+): ProgramCreationVersionOverview[] {
+  return [...entries].sort(
+    (left, right) =>
+      right.failed - left.failed ||
+      right.projectsWithFailures - left.projectsWithFailures ||
+      right.projects - left.projects ||
+      compareVersionLabels(left.version, right.version),
+  );
+}
+
+function buildCatalog(platforms: Record<PlatformId, PlatformSnapshot>): CatalogField[] {
+  const catalog = new Map<string, CatalogField>();
+
+  for (const platformId of Object.keys(platforms) as PlatformId[]) {
+    for (const field of Object.values(platforms[platformId].fields)) {
+      const existing =
+        catalog.get(field.key) ??
+        {
+          key: field.key,
+          columnName: field.columnName,
+          displayName: field.displayName,
+          path: field.path,
+          category: field.category,
+          availability: { sq: false, sc: false },
+          redshiftTypes: {},
+        };
+
+      existing.availability[platformId] = true;
+      existing.redshiftTypes[platformId] = field.redshiftType;
+      catalog.set(field.key, existing);
+    }
+  }
+
+  return [...catalog.values()].sort(
+    (left, right) =>
+      left.category.localeCompare(right.category) ||
+      left.displayName.localeCompare(right.displayName) ||
+      left.key.localeCompare(right.key),
+  );
+}
+
+function buildSingleValueTimelineSeriesQuery(
+  platformView: string,
+  columnName: string,
+): string {
+  const valueExpression = `CAST(${quoteIdentifier(columnName)} AS VARCHAR(1024))`;
+
+  return `
+    WITH latest AS (
+      ${weeklyLatestSubquery(platformView, valueExpression)}
+    )
+    SELECT
+      TO_CHAR(week_start, 'YYYY-MM-DD') AS week_start,
+      value,
+      COUNT(*) AS project_count
+    FROM latest
+    WHERE rn = 1
+      AND value IS NOT NULL
+    GROUP BY 1, 2
+    ORDER BY 1, 3 DESC, 2
+  `;
+}
+
+function buildSingleValueTimelineWeeksQuery(
+  platformView: string,
+  columnName: string,
+): string {
+  const valueExpression = `CAST(${quoteIdentifier(columnName)} AS VARCHAR(1024))`;
+
+  return `
+    WITH latest AS (
+      ${weeklyLatestSubquery(platformView, valueExpression)}
+    )
+    SELECT
+      TO_CHAR(week_start, 'YYYY-MM-DD') AS week_start,
+      COUNT(*) AS project_count
+    FROM latest
+    WHERE rn = 1
+      AND value IS NOT NULL
+    GROUP BY 1
+    ORDER BY 1
+  `;
+}
+
+function buildSplitValueTimelineSeriesQuery(
+  platformView: string,
+  columnName: string,
+): string {
+  const valueExpression = `CAST(${quoteIdentifier(columnName)} AS VARCHAR(4096))`;
+
+  return `
+    WITH RECURSIVE token_indexes(index_value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT index_value + 1
+      FROM token_indexes
+      WHERE index_value < ${TIMELINE_SPLIT_LIMIT}
+    ),
+    latest AS (
+      ${weeklyLatestSubquery(platformView, valueExpression)}
+    ),
+    exploded AS (
+      SELECT
+        week_start,
+        project_uuid,
+        COALESCE(
+          NULLIF(TRIM(SPLIT_PART(COALESCE(value, 'not-detected'), ',', index_value)), ''),
+          'not-detected'
+        ) AS value
+      FROM latest
+      JOIN token_indexes
+        ON index_value <= CASE
+          WHEN value IS NULL OR TRIM(value) = '' THEN 1
+          ELSE LEAST(REGEXP_COUNT(value, ',') + 1, ${TIMELINE_SPLIT_LIMIT})
+        END
+      WHERE rn = 1
+    ),
+    deduplicated AS (
+      SELECT DISTINCT
+        week_start,
+        project_uuid,
+        value
+      FROM exploded
+    )
+    SELECT
+      TO_CHAR(week_start, 'YYYY-MM-DD') AS week_start,
+      value,
+      COUNT(*) AS project_count
+    FROM deduplicated
+    GROUP BY 1, 2
+    ORDER BY 1, 3 DESC, 2
+  `;
+}
+
+function buildSplitValueTimelineWeeksQuery(
+  platformView: string,
+  columnName: string,
+): string {
+  const valueExpression = `CAST(${quoteIdentifier(columnName)} AS VARCHAR(4096))`;
+
+  return `
+    WITH latest AS (
+      ${weeklyLatestSubquery(platformView, valueExpression)}
+    )
+    SELECT
+      TO_CHAR(week_start, 'YYYY-MM-DD') AS week_start,
+      COUNT(*) AS project_count
+    FROM latest
+    WHERE rn = 1
+    GROUP BY 1
+    ORDER BY 1
+  `;
+}
+
+function buildVersionTimeline(
+  weekRows: TimelineWeekRow[],
+  seriesRows: TimelineSeriesRow[],
+): VersionTimeline | undefined {
+  if (weekRows.length === 0) {
+    return undefined;
+  }
+
+  const weeks = weekRows
+    .map(row => ({
+      weekStart: row.week_start,
+      projects: toNumber(row.project_count),
+    }))
+    .sort((left, right) => left.weekStart.localeCompare(right.weekStart));
+  const countsByValue = new Map<string, Map<string, number>>();
+
+  for (const row of seriesRows) {
+    const weeklyCounts = countsByValue.get(row.value) ?? new Map<string, number>();
+    weeklyCounts.set(row.week_start, toNumber(row.project_count));
+    countsByValue.set(row.value, weeklyCounts);
+  }
+
+  const series = [...countsByValue.entries()]
+    .map(([value, weeklyCounts]) => {
+      const weekly = weeks.map(week => ({
+        weekStart: week.weekStart,
+        projects: weeklyCounts.get(week.weekStart) ?? 0,
+      }));
+
+      return {
+        value,
+        totalProjects: weekly.reduce((sum, point) => sum + point.projects, 0),
+        weekly,
+      };
+    })
+    .sort(
+      (left, right) =>
+        right.totalProjects - left.totalProjects || left.value.localeCompare(right.value),
+    );
+
+  return {
+    weeks,
+    series,
+  };
+}
+
+function buildAggregateQuery(platformView: string, columns: ColumnMeta[]): string {
+  const expressions = columns.flatMap((column, index) => {
+    const identifier = quoteIdentifier(column.columnName);
+    const valueExpr = toTextExpression(column);
+    const numericExpr = `TRY_CAST(${valueExpr} AS DOUBLE PRECISION)`;
+    const alias = `c${index}`;
+
+    return [
+      `SUM(CASE WHEN ${identifier} IS NOT NULL THEN 1 ELSE 0 END) AS ${alias}_non_null`,
+      `COUNT(DISTINCT CASE WHEN ${identifier} IS NOT NULL THEN ${valueExpr} END) AS ${alias}_distinct`,
+      `SUM(CASE WHEN ${numericExpr} IS NOT NULL THEN 1 ELSE 0 END) AS ${alias}_numeric_rows`,
+      `SUM(CASE WHEN ${numericExpr} = 0 THEN 1 ELSE 0 END) AS ${alias}_zero_rows`,
+      `SUM(CASE WHEN ${numericExpr} > 0 THEN 1 ELSE 0 END) AS ${alias}_positive_rows`,
+      `MIN(${numericExpr}) AS ${alias}_min`,
+      `MAX(${numericExpr}) AS ${alias}_max`,
+      `AVG(${numericExpr}) AS ${alias}_avg`,
+      `SUM(${numericExpr}) AS ${alias}_sum`,
+    ];
+  });
+
+  return `
+    SELECT
+      COUNT(*) AS total_rows,
+      ${expressions.join(',\n      ')}
+    FROM (
+      ${latestSubquery(platformView)}
+    ) latest
+    WHERE rn = 1
+  `;
+}
+
+async function getTelemetryColumns(
+  client: Client,
+  tableName: string,
+): Promise<ColumnMeta[]> {
+  const result = await client.query<ColumnRow>(`
+    SELECT column_name, data_type, ordinal_position
+    FROM svv_columns
+    WHERE table_schema = 'measures'
+      AND table_name = '${tableName}'
+    ORDER BY ordinal_position
+  `);
+
+  return result.rows
+    .filter(row => row.column_name.startsWith('runtime_') || row.column_name.startsWith('telemetry_'))
+    .map(row => ({
+      columnName: row.column_name,
+      redshiftType: row.data_type,
+      ordinalPosition: toNumber(row.ordinal_position),
+    }));
+}
+
+async function getTopValues(
+  client: Client,
+  platformView: string,
+  column: ColumnMeta,
+  latestProjectCount: number,
+): Promise<DistributionValue[]> {
+  const identifier = quoteIdentifier(column.columnName);
+  const valueExpr = toTextExpression(column);
+  const result = await client.query<DistributionRow>(`
+    SELECT
+      ${valueExpr} AS value,
+      COUNT(*) AS row_count
+    FROM (
+      ${latestSubquery(platformView)}
+    ) latest
+    WHERE rn = 1
+      AND ${identifier} IS NOT NULL
+    GROUP BY 1
+    ORDER BY 2 DESC, 1
+    LIMIT ${TOP_VALUES_LIMIT}
+  `);
+
+  return result.rows.map(row => {
+    const count = toNumber(row.row_count);
+    return {
+      value: row.value,
+      count,
+      percent: latestProjectCount === 0 ? 0 : round((count / latestProjectCount) * 100, 1),
+    };
+  });
+}
+
+async function getModuleTypeOverview(
+  client: Client,
+  platformView: string,
+): Promise<ModuleTypeOverview | undefined> {
+  const esmColumn = quoteIdentifier('telemetry_module-type_esm-file-count');
+  const cjsColumn = quoteIdentifier('telemetry_module-type_cjs-file-count');
+  const esmExpr = `COALESCE(TRY_CAST(CAST(${esmColumn} AS VARCHAR(1024)) AS BIGINT), 0)`;
+  const cjsExpr = `COALESCE(TRY_CAST(CAST(${cjsColumn} AS VARCHAR(1024)) AS BIGINT), 0)`;
+
+  const result = await client.query<ModuleTypeRow>(`
+    SELECT
+      COUNT(*) AS projects_with_telemetry,
+      COALESCE(SUM(${esmExpr}), 0) AS total_esm_files,
+      COALESCE(SUM(${cjsExpr}), 0) AS total_cjs_files,
+      SUM(CASE WHEN ${esmExpr} > 0 AND ${cjsExpr} = 0 THEN 1 ELSE 0 END) AS esm_only_projects,
+      SUM(CASE WHEN ${cjsExpr} > 0 AND ${esmExpr} = 0 THEN 1 ELSE 0 END) AS cjs_only_projects,
+      SUM(CASE WHEN ${esmExpr} > 0 AND ${cjsExpr} > 0 THEN 1 ELSE 0 END) AS both_projects,
+      SUM(CASE WHEN ${esmExpr} = 0 AND ${cjsExpr} = 0 THEN 1 ELSE 0 END) AS neither_projects
+    FROM (
+      ${latestSubquery(platformView)}
+    ) latest
+    WHERE rn = 1
+      AND (${esmColumn} IS NOT NULL OR ${cjsColumn} IS NOT NULL)
+  `);
+
+  const row = result.rows[0];
+  if (!row) {
+    return undefined;
+  }
+
+  return {
+    projectsWithTelemetry: toNumber(row.projects_with_telemetry),
+    totalEsmFiles: toNumber(row.total_esm_files),
+    totalCjsFiles: toNumber(row.total_cjs_files),
+    esmOnlyProjects: toNumber(row.esm_only_projects),
+    cjsOnlyProjects: toNumber(row.cjs_only_projects),
+    bothProjects: toNumber(row.both_projects),
+    neitherProjects: toNumber(row.neither_projects),
+  };
+}
+
+async function getProgramCreationOverview(
+  client: Client,
+  platformView: string,
+  hasTypeScriptVersionColumn: boolean,
+): Promise<ProgramCreationOverview | undefined> {
+  const versionsColumn = quoteIdentifier('telemetry_typescript_versions');
+  const attemptedColumn = quoteIdentifier('telemetry_typescript_program-creation_attempted');
+  const succeededColumn = quoteIdentifier('telemetry_typescript_program-creation_succeeded');
+  const failedColumn = quoteIdentifier('telemetry_typescript_program-creation_failed');
+  const attemptedExpr = `COALESCE(TRY_CAST(CAST(${attemptedColumn} AS VARCHAR(1024)) AS BIGINT), 0)`;
+  const succeededExpr = `COALESCE(TRY_CAST(CAST(${succeededColumn} AS VARCHAR(1024)) AS BIGINT), 0)`;
+  const failedExpr = `COALESCE(TRY_CAST(CAST(${failedColumn} AS VARCHAR(1024)) AS BIGINT), 0)`;
+  const versionsExpr = hasTypeScriptVersionColumn
+    ? `CAST(${versionsColumn} AS VARCHAR(4096))`
+    : 'NULL::VARCHAR(4096)';
+  const result = await client.query<ProgramCreationRow>(`
+    SELECT
+      ${versionsExpr} AS typescript_versions,
+      ${attemptedExpr} AS attempted_count,
+      ${succeededExpr} AS succeeded_count,
+      ${failedExpr} AS failed_count
+    FROM (
+      ${latestSubquery(platformView)}
+    ) latest
+    WHERE rn = 1
+      AND (
+        ${attemptedColumn} IS NOT NULL
+        OR ${succeededColumn} IS NOT NULL
+        OR ${failedColumn} IS NOT NULL
+      )
+  `);
+
+  if (result.rows.length === 0) {
+    return undefined;
+  }
+
+  const byVersion = new Map<string, ProgramCreationVersionOverview>();
+  const preparedRows: Array<{
+    attempts: number;
+    succeeded: number;
+    failed: number;
+    versions: string[];
+  }> = [];
+  const overview: ProgramCreationOverview = {
+    projects: 0,
+    projectsWithFailures: 0,
+    attempts: 0,
+    succeeded: 0,
+    failed: 0,
+    byVersion: [],
+    atOrAboveVersion: [],
+  };
+
+  for (const row of result.rows) {
+    const attempts = toNumber(row.attempted_count);
+    const succeeded = toNumber(row.succeeded_count);
+    const failed = toNumber(row.failed_count);
+    const versions = parseTelemetryTokens(row.typescript_versions);
+    preparedRows.push({ attempts, succeeded, failed, versions });
+
+    overview.projects += 1;
+    overview.attempts += attempts;
+    overview.succeeded += succeeded;
+    overview.failed += failed;
+
+    if (failed > 0) {
+      overview.projectsWithFailures += 1;
+    }
+
+    for (const version of versions) {
+      const entry =
+        byVersion.get(version) ??
+        {
+          version,
+          projects: 0,
+          projectsWithFailures: 0,
+          attempts: 0,
+          succeeded: 0,
+          failed: 0,
+        };
+
+      entry.projects += 1;
+      entry.attempts += attempts;
+      entry.succeeded += succeeded;
+      entry.failed += failed;
+
+      if (failed > 0) {
+        entry.projectsWithFailures += 1;
+      }
+
+      byVersion.set(version, entry);
+    }
+  }
+
+  const comparableVersions = [...new Set(preparedRows.flatMap(row => row.versions))]
+    .filter(isComparableVersionLabel)
+    .sort(compareVersionLabels);
+
+  if (comparableVersions.length > 0) {
+    const versionIndex = new Map(comparableVersions.map((version, index) => [version, index]));
+    const projectsDiff = new Array(comparableVersions.length + 1).fill(0);
+    const projectsWithFailuresDiff = new Array(comparableVersions.length + 1).fill(0);
+    const attemptsDiff = new Array(comparableVersions.length + 1).fill(0);
+    const succeededDiff = new Array(comparableVersions.length + 1).fill(0);
+    const failedDiff = new Array(comparableVersions.length + 1).fill(0);
+
+    for (const row of preparedRows) {
+      const highestVersion = getHighestComparableVersion(row.versions);
+      if (!highestVersion) {
+        continue;
+      }
+
+      const maxIndex = versionIndex.get(highestVersion);
+      if (maxIndex === undefined) {
+        continue;
+      }
+
+      projectsDiff[0] += 1;
+      projectsDiff[maxIndex + 1] -= 1;
+      attemptsDiff[0] += row.attempts;
+      attemptsDiff[maxIndex + 1] -= row.attempts;
+      succeededDiff[0] += row.succeeded;
+      succeededDiff[maxIndex + 1] -= row.succeeded;
+      failedDiff[0] += row.failed;
+      failedDiff[maxIndex + 1] -= row.failed;
+
+      if (row.failed > 0) {
+        projectsWithFailuresDiff[0] += 1;
+        projectsWithFailuresDiff[maxIndex + 1] -= 1;
+      }
+    }
+
+    let projects = 0;
+    let projectsWithFailures = 0;
+    let attempts = 0;
+    let succeeded = 0;
+    let failed = 0;
+
+    overview.atOrAboveVersion = comparableVersions.map((version, index) => {
+      projects += projectsDiff[index]!;
+      projectsWithFailures += projectsWithFailuresDiff[index]!;
+      attempts += attemptsDiff[index]!;
+      succeeded += succeededDiff[index]!;
+      failed += failedDiff[index]!;
+
+      return {
+        version,
+        projects,
+        projectsWithFailures,
+        attempts,
+        succeeded,
+        failed,
+      };
+    });
+  }
+
+  overview.byVersion = sortProgramCreationEntries([...byVersion.values()]);
+
+  return overview;
+}
+
+async function getSingleValueVersionTimeline(
+  client: Client,
+  platformView: string,
+  columnName: string,
+): Promise<VersionTimeline | undefined> {
+  const weekResult = await client.query<TimelineWeekRow>(
+    buildSingleValueTimelineWeeksQuery(platformView, columnName),
+  );
+  const seriesResult = await client.query<TimelineSeriesRow>(
+    buildSingleValueTimelineSeriesQuery(platformView, columnName),
+  );
+
+  return buildVersionTimeline(weekResult.rows, seriesResult.rows);
+}
+
+async function getSplitValueVersionTimeline(
+  client: Client,
+  platformView: string,
+  columnName: string,
+): Promise<VersionTimeline | undefined> {
+  const weekResult = await client.query<TimelineWeekRow>(
+    buildSplitValueTimelineWeeksQuery(platformView, columnName),
+  );
+  const seriesResult = await client.query<TimelineSeriesRow>(
+    buildSplitValueTimelineSeriesQuery(platformView, columnName),
+  );
+
+  return buildVersionTimeline(weekResult.rows, seriesResult.rows);
+}
+
+async function fetchPlatformSnapshot(
+  client: Client,
+  platform: (typeof PLATFORMS)[number],
+): Promise<PlatformFetchResult> {
+  console.log(`Inspecting ${platform.view}`);
+  const columns = await getTelemetryColumns(client, platform.tableName);
+  console.log(`Discovered ${columns.length} telemetry columns for ${platform.shortLabel}`);
+
+  if (columns.length === 0) {
+    return {
+      snapshot: {
+        id: platform.id,
+        label: platform.label,
+        shortLabel: platform.shortLabel,
+        view: platform.view,
+        latestProjectCount: 0,
+        fieldCount: 0,
+        fields: {},
+      },
+    };
+  }
+
+  console.log(`Aggregating coverage and numeric summaries for ${platform.shortLabel}...`);
+  const aggregateResult = await client.query<AggregateRow>(buildAggregateQuery(platform.view, columns));
+  const aggregateRow = aggregateResult.rows[0];
+  const latestProjectCount = toNumber(aggregateRow?.total_rows);
+  console.log(`Latest deduplicated projects for ${platform.shortLabel}: ${latestProjectCount}`);
+  const fields: Record<string, FieldSummary> = {};
+
+  for (const [index, column] of columns.entries()) {
+    const alias = `c${index}`;
+    const meta = buildFieldMeta(column.columnName);
+    const semanticHint = inferSemanticTypeFromKey(meta.key);
+    if (semanticHint !== 'count') {
+      console.log(
+        `Fetching top values for ${platform.shortLabel} field ${index + 1}/${columns.length}: ${column.columnName}`,
+      );
+    }
+    const topValues =
+      semanticHint === 'count'
+        ? []
+        : await getTopValues(client, platform.view, column, latestProjectCount);
+    const nonNullRows = toNumber(aggregateRow?.[`${alias}_non_null`]);
+    const distinctValues = toNumber(aggregateRow?.[`${alias}_distinct`]);
+    const numericRows = toNumber(aggregateRow?.[`${alias}_numeric_rows`]);
+    const valueType = inferValueType(nonNullRows, numericRows, topValues);
+    const semanticType = inferFieldSemanticType(meta.key, valueType);
+
+    const numeric =
+      numericRows > 0
+        ? {
+            numericRows,
+            zeroRows: toNumber(aggregateRow?.[`${alias}_zero_rows`]),
+            positiveRows: toNumber(aggregateRow?.[`${alias}_positive_rows`]),
+            min: round(toNumber(aggregateRow?.[`${alias}_min`])),
+            max: round(toNumber(aggregateRow?.[`${alias}_max`])),
+            avg: round(toNumber(aggregateRow?.[`${alias}_avg`])),
+            sum: round(toNumber(aggregateRow?.[`${alias}_sum`])),
+          }
+        : undefined;
+
+    fields[meta.key] = {
+      key: meta.key,
+      columnName: column.columnName,
+      displayName: meta.displayName,
+      path: meta.pathSegments,
+      category: meta.category,
+      valueType,
+      semanticType,
+      redshiftType: column.redshiftType,
+      coverage: {
+        total: latestProjectCount,
+        nonNull: nonNullRows,
+        percent: latestProjectCount === 0 ? 0 : round((nonNullRows / latestProjectCount) * 100, 1),
+        distinct: distinctValues,
+      },
+      topValues,
+      tokenValues: topValues.length > 0 ? buildTokenValues(topValues, nonNullRows) : undefined,
+      valueListTruncated: topValues.length > 0 ? distinctValues > topValues.length : false,
+      numeric,
+    };
+  }
+
+  const hasModuleColumns =
+    fields['javascript.telemetry.module-type.esm-file-count'] &&
+    fields['javascript.telemetry.module-type.cjs-file-count'];
+  const hasProgramCreationColumns =
+    fields['javascript.telemetry.typescript.program-creation.attempted'] &&
+    fields['javascript.telemetry.typescript.program-creation.succeeded'] &&
+    fields['javascript.telemetry.typescript.program-creation.failed'];
+  const hasTypeScriptVersionColumn = Boolean(fields['javascript.telemetry.typescript.versions']);
+  const timelineOverview: PlatformTimelineOverview = {};
+
+  if (fields['javascript.runtime.major-version']) {
+    timelineOverview.nodeMajorVersion = await getSingleValueVersionTimeline(
+      client,
+      platform.view,
+      'runtime_major-version',
+    );
+  }
+
+  if (hasTypeScriptVersionColumn) {
+    timelineOverview.typescriptVersion = await getSplitValueVersionTimeline(
+      client,
+      platform.view,
+      'telemetry_typescript_versions',
+    );
+  }
+
+  return {
+    snapshot: {
+      id: platform.id,
+      label: platform.label,
+      shortLabel: platform.shortLabel,
+      view: platform.view,
+      latestProjectCount,
+      fieldCount: columns.length,
+      fields,
+    },
+    moduleTypeOverview: hasModuleColumns ? await getModuleTypeOverview(client, platform.view) : undefined,
+    programCreationOverview: hasProgramCreationColumns
+      ? await getProgramCreationOverview(client, platform.view, hasTypeScriptVersionColumn)
+      : undefined,
+    timelineOverview:
+      timelineOverview.nodeMajorVersion || timelineOverview.typescriptVersion
+        ? timelineOverview
+        : undefined,
+  };
+}
+
+async function main(): Promise<void> {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+  const client = await createClient();
+
+  try {
+    const platforms = {
+      sq: {
+        id: 'sq',
+        label: 'SonarQube Server',
+        shortLabel: 'SQS',
+        view: 'measures.sq_analysis_javascript_adhoc',
+        latestProjectCount: 0,
+        fieldCount: 0,
+        fields: {},
+      },
+      sc: {
+        id: 'sc',
+        label: 'SonarQube Cloud',
+        shortLabel: 'SQC',
+        view: 'measures.sc_analysis_javascript_adhoc',
+        latestProjectCount: 0,
+        fieldCount: 0,
+        fields: {},
+      },
+    } as Record<PlatformId, PlatformSnapshot>;
+    const moduleTypeOverview: Partial<Record<PlatformId, ModuleTypeOverview>> = {};
+    const programCreationOverview: Partial<Record<PlatformId, ProgramCreationOverview>> = {};
+    const timelineOverview: Partial<Record<PlatformId, PlatformTimelineOverview>> = {};
+
+    console.log(`Fetching telemetry for platforms: ${PLATFORMS.map(platform => platform.shortLabel).join(', ')}`);
+
+    for (const platform of PLATFORMS) {
+      const result = await fetchPlatformSnapshot(client, platform);
+      platforms[platform.id] = result.snapshot;
+
+      if (result.moduleTypeOverview) {
+        moduleTypeOverview[platform.id] = result.moduleTypeOverview;
+      }
+
+      if (result.programCreationOverview) {
+        programCreationOverview[platform.id] = result.programCreationOverview;
+      }
+
+      if (result.timelineOverview) {
+        timelineOverview[platform.id] = result.timelineOverview;
+      }
+    }
+
+    const snapshot: TelemetrySnapshot = {
+      generatedAt: new Date().toISOString(),
+      source: 'redshift',
+      windowDays: WINDOW_DAYS,
+      windowStart: new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString(),
+      notes: [
+        `Latest analysis per project_uuid over the last ${WINDOW_DAYS} days.`,
+        'Telemetry fields are discovered from adhoc Redshift columns with runtime_ or telemetry_ prefixes.',
+        'SQC is known to omit some compiler option columns that still exist on SQS.',
+        'Program creation version buckets split comma-separated TypeScript version lists, so a single project can contribute to multiple version rows.',
+        'The program creation >= filter counts a project once when any emitted TypeScript version meets the selected threshold.',
+        `Weekly adoption timelines are aggregated in Redshift over the last ${TIMELINE_WEEKS} calendar weeks.`,
+      ],
+      platforms,
+      catalog: buildCatalog(platforms),
+      overview: {
+        moduleType: moduleTypeOverview,
+        programCreation: programCreationOverview,
+        timelines: timelineOverview,
+      },
+    };
+
+    fs.writeFileSync(OUTPUT_FILE, `${JSON.stringify(snapshot, null, 2)}\n`);
+    console.log(`Wrote snapshot with ${snapshot.catalog.length} fields to ${OUTPUT_FILE}`);
+  } finally {
+    await client.end();
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/telemetry-dashboard/scripts/fetch-redshift.ts
+++ b/telemetry-dashboard/scripts/fetch-redshift.ts
@@ -16,7 +16,7 @@ import type {
   TelemetrySnapshot,
   VersionTimeline,
 } from '../src/types.js';
-import { createClient } from './lib/redshift.js';
+import { createClient } from './redshift.js';
 
 const ROOT = path.resolve(import.meta.dirname, '..');
 const DATA_DIR = path.join(ROOT, 'data');
@@ -297,7 +297,10 @@ function inferValueType(
   }
 
   const normalized = new Set(topValues.map(entry => entry.value.toLowerCase()));
-  if (normalized.size > 0 && [...normalized].every(value => value === 'true' || value === 'false')) {
+  if (
+    normalized.size > 0 &&
+    [...normalized].every(value => value === 'true' || value === 'false')
+  ) {
     return 'boolean';
   }
 
@@ -312,7 +315,10 @@ function inferValueType(
   return 'string';
 }
 
-function buildTokenValues(values: DistributionValue[], nonNullRows: number): DistributionValue[] | undefined {
+function buildTokenValues(
+  values: DistributionValue[],
+  nonNullRows: number,
+): DistributionValue[] | undefined {
   const counts = new Map<string, number>();
   let sawSplitValue = false;
 
@@ -353,7 +359,14 @@ function parseTelemetryTokens(
     return [fallback];
   }
 
-  const tokens = [...new Set(value.split(',').map(part => part.trim()).filter(Boolean))];
+  const tokens = [
+    ...new Set(
+      value
+        .split(',')
+        .map(part => part.trim())
+        .filter(Boolean),
+    ),
+  ];
   return tokens.length > 0 ? tokens : [fallback];
 }
 
@@ -405,17 +418,15 @@ function buildCatalog(platforms: Record<PlatformId, PlatformSnapshot>): CatalogF
 
   for (const platformId of Object.keys(platforms) as PlatformId[]) {
     for (const field of Object.values(platforms[platformId].fields)) {
-      const existing =
-        catalog.get(field.key) ??
-        {
-          key: field.key,
-          columnName: field.columnName,
-          displayName: field.displayName,
-          path: field.path,
-          category: field.category,
-          availability: { sq: false, sc: false },
-          redshiftTypes: {},
-        };
+      const existing = catalog.get(field.key) ?? {
+        key: field.key,
+        columnName: field.columnName,
+        displayName: field.displayName,
+        path: field.path,
+        category: field.category,
+        availability: { sq: false, sc: false },
+        redshiftTypes: {},
+      };
 
       existing.availability[platformId] = true;
       existing.redshiftTypes[platformId] = field.redshiftType;
@@ -431,10 +442,7 @@ function buildCatalog(platforms: Record<PlatformId, PlatformSnapshot>): CatalogF
   );
 }
 
-function buildSingleValueTimelineSeriesQuery(
-  platformView: string,
-  columnName: string,
-): string {
+function buildSingleValueTimelineSeriesQuery(platformView: string, columnName: string): string {
   const valueExpression = `CAST(${quoteIdentifier(columnName)} AS VARCHAR(1024))`;
 
   return `
@@ -453,10 +461,7 @@ function buildSingleValueTimelineSeriesQuery(
   `;
 }
 
-function buildSingleValueTimelineWeeksQuery(
-  platformView: string,
-  columnName: string,
-): string {
+function buildSingleValueTimelineWeeksQuery(platformView: string, columnName: string): string {
   const valueExpression = `CAST(${quoteIdentifier(columnName)} AS VARCHAR(1024))`;
 
   return `
@@ -474,10 +479,7 @@ function buildSingleValueTimelineWeeksQuery(
   `;
 }
 
-function buildSplitValueTimelineSeriesQuery(
-  platformView: string,
-  columnName: string,
-): string {
+function buildSplitValueTimelineSeriesQuery(platformView: string, columnName: string): string {
   const valueExpression = `CAST(${quoteIdentifier(columnName)} AS VARCHAR(4096))`;
 
   return `
@@ -524,10 +526,7 @@ function buildSplitValueTimelineSeriesQuery(
   `;
 }
 
-function buildSplitValueTimelineWeeksQuery(
-  platformView: string,
-  columnName: string,
-): string {
+function buildSplitValueTimelineWeeksQuery(platformView: string, columnName: string): string {
   const valueExpression = `CAST(${quoteIdentifier(columnName)} AS VARCHAR(4096))`;
 
   return `
@@ -621,10 +620,7 @@ function buildAggregateQuery(platformView: string, columns: ColumnMeta[]): strin
   `;
 }
 
-async function getTelemetryColumns(
-  client: Client,
-  tableName: string,
-): Promise<ColumnMeta[]> {
+async function getTelemetryColumns(client: Client, tableName: string): Promise<ColumnMeta[]> {
   const result = await client.query<ColumnRow>(`
     SELECT column_name, data_type, ordinal_position
     FROM svv_columns
@@ -634,7 +630,9 @@ async function getTelemetryColumns(
   `);
 
   return result.rows
-    .filter(row => row.column_name.startsWith('runtime_') || row.column_name.startsWith('telemetry_'))
+    .filter(
+      row => row.column_name.startsWith('runtime_') || row.column_name.startsWith('telemetry_'),
+    )
     .map(row => ({
       columnName: row.column_name,
       redshiftType: row.data_type,
@@ -785,16 +783,14 @@ async function getProgramCreationOverview(
     }
 
     for (const version of versions) {
-      const entry =
-        byVersion.get(version) ??
-        {
-          version,
-          projects: 0,
-          projectsWithFailures: 0,
-          attempts: 0,
-          succeeded: 0,
-          failed: 0,
-        };
+      const entry = byVersion.get(version) ?? {
+        version,
+        projects: 0,
+        projectsWithFailures: 0,
+        attempts: 0,
+        succeeded: 0,
+        failed: 0,
+      };
 
       entry.projects += 1;
       entry.attempts += attempts;
@@ -929,7 +925,9 @@ async function fetchPlatformSnapshot(
   }
 
   console.log(`Aggregating coverage and numeric summaries for ${platform.shortLabel}...`);
-  const aggregateResult = await client.query<AggregateRow>(buildAggregateQuery(platform.view, columns));
+  const aggregateResult = await client.query<AggregateRow>(
+    buildAggregateQuery(platform.view, columns),
+  );
   const aggregateRow = aggregateResult.rows[0];
   const latestProjectCount = toNumber(aggregateRow?.total_rows);
   console.log(`Latest deduplicated projects for ${platform.shortLabel}: ${latestProjectCount}`);
@@ -1025,7 +1023,9 @@ async function fetchPlatformSnapshot(
       fieldCount: columns.length,
       fields,
     },
-    moduleTypeOverview: hasModuleColumns ? await getModuleTypeOverview(client, platform.view) : undefined,
+    moduleTypeOverview: hasModuleColumns
+      ? await getModuleTypeOverview(client, platform.view)
+      : undefined,
     programCreationOverview: hasProgramCreationColumns
       ? await getProgramCreationOverview(client, platform.view, hasTypeScriptVersionColumn)
       : undefined,
@@ -1065,7 +1065,9 @@ async function main(): Promise<void> {
     const programCreationOverview: Partial<Record<PlatformId, ProgramCreationOverview>> = {};
     const timelineOverview: Partial<Record<PlatformId, PlatformTimelineOverview>> = {};
 
-    console.log(`Fetching telemetry for platforms: ${PLATFORMS.map(platform => platform.shortLabel).join(', ')}`);
+    console.log(
+      `Fetching telemetry for platforms: ${PLATFORMS.map(platform => platform.shortLabel).join(', ')}`,
+    );
 
     for (const platform of PLATFORMS) {
       const result = await fetchPlatformSnapshot(client, platform);

--- a/telemetry-dashboard/scripts/redshift.ts
+++ b/telemetry-dashboard/scripts/redshift.ts
@@ -1,0 +1,367 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { RedshiftClient, GetClusterCredentialsCommand } from '@aws-sdk/client-redshift';
+import { STSClient, AssumeRoleWithSAMLCommand } from '@aws-sdk/client-sts';
+import pg from 'pg';
+
+const CONFIG = {
+  region: 'eu-west-1',
+  clusterIdentifier: 'sonarsource-warehouse-prod',
+  database: 'sonarsource',
+  host: 'redshift.aws-prd.sonarsource.com',
+  port: 5439,
+  loginUrl: 'https://sso.jumpcloud.com/saml2/awsredshift',
+  callbackPort: 7890,
+  idpResponseTimeout: 60000,
+  dbGroup: 'App-Redshift-ProductDevelopment',
+};
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const CACHE_DIR = path.join(ROOT, '.cache');
+const CACHE_FILE = path.join(CACHE_DIR, 'redshift-credentials.json');
+const DB_CACHE_FILE = path.join(CACHE_DIR, 'redshift-db-credentials.json');
+const EXPIRATION_BUFFER_MS = 5 * 60 * 1000;
+
+const elapsed = (start: number) => ((Date.now() - start) / 1000).toFixed(1);
+
+interface AWSCredentials {
+  AccessKeyId: string;
+  SecretAccessKey: string;
+  SessionToken: string;
+  Expiration: Date;
+  AssumedRoleUser?: {
+    Arn?: string;
+    AssumedRoleId?: string;
+  };
+}
+
+interface CachedCredentials {
+  AccessKeyId: string;
+  SecretAccessKey: string;
+  SessionToken: string;
+  Expiration: string;
+  AssumedRoleUser?: {
+    Arn?: string;
+    AssumedRoleId?: string;
+  };
+}
+
+interface DbCredentials {
+  user: string;
+  password: string;
+  expiration: Date | undefined;
+}
+
+interface CachedDbCredentials {
+  user: string;
+  password: string;
+  expiration: string;
+}
+
+function getEnvironmentCredentials(): AWSCredentials | null {
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const sessionToken = process.env.AWS_SESSION_TOKEN;
+
+  if (accessKeyId && secretAccessKey && sessionToken) {
+    console.error('Using AWS credentials from environment variables');
+
+    return {
+      AccessKeyId: accessKeyId,
+      SecretAccessKey: secretAccessKey,
+      SessionToken: sessionToken,
+      Expiration: new Date(Date.now() + 60 * 60 * 1000),
+    };
+  }
+
+  return null;
+}
+
+function getDbUser(awsCredentials: AWSCredentials): string {
+  const arnSession = awsCredentials.AssumedRoleUser?.Arn?.split('/').pop();
+  if (arnSession) {
+    return arnSession.replace(/@sonarsource\.com$/, '');
+  }
+
+  const assumedRoleId = awsCredentials.AssumedRoleUser?.AssumedRoleId?.split(':').pop();
+  if (assumedRoleId) {
+    return assumedRoleId.replace(/@sonarsource\.com$/, '');
+  }
+
+  return 'cicd-web-redshift';
+}
+
+function loadCachedCredentials(): AWSCredentials | null {
+  try {
+    if (!fs.existsSync(CACHE_FILE)) {
+      return null;
+    }
+
+    const cached: CachedCredentials = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8'));
+    const expiration = new Date(cached.Expiration).getTime();
+
+    if (expiration - Date.now() > EXPIRATION_BUFFER_MS) {
+      console.error(`Cached credentials valid until ${cached.Expiration}`);
+      return { ...cached, Expiration: new Date(cached.Expiration) };
+    }
+
+    console.error('Cached credentials expired');
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function saveCachedCredentials(credentials: AWSCredentials): void {
+  fs.mkdirSync(CACHE_DIR, { recursive: true, mode: 0o700 });
+
+  const data: CachedCredentials = {
+    ...credentials,
+    Expiration: credentials.Expiration.toISOString(),
+  };
+
+  fs.writeFileSync(CACHE_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
+  console.error(`Credentials cached until ${data.Expiration}`);
+}
+
+function loadCachedDbCredentials(): DbCredentials | null {
+  try {
+    if (!fs.existsSync(DB_CACHE_FILE)) {
+      return null;
+    }
+
+    const cached: CachedDbCredentials = JSON.parse(fs.readFileSync(DB_CACHE_FILE, 'utf-8'));
+    const expiration = new Date(cached.expiration);
+
+    if (expiration.getTime() - Date.now() > EXPIRATION_BUFFER_MS) {
+      console.error(`Cached DB credentials valid until ${cached.expiration}`);
+      return { user: cached.user, password: cached.password, expiration };
+    }
+
+    console.error('Cached DB credentials expired');
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function saveCachedDbCredentials(credentials: DbCredentials): void {
+  fs.mkdirSync(CACHE_DIR, { recursive: true, mode: 0o700 });
+
+  const expiration = credentials.expiration ?? new Date(Date.now() + 3600 * 1000);
+  const data: CachedDbCredentials = {
+    user: credentials.user,
+    password: credentials.password,
+    expiration: expiration.toISOString(),
+  };
+
+  fs.writeFileSync(DB_CACHE_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
+  console.error(`DB credentials cached until ${data.expiration}`);
+}
+
+async function exchangeSAMLForCredentials(samlResponse: string): Promise<AWSCredentials> {
+  const samlXml = Buffer.from(samlResponse, 'base64').toString('utf-8');
+
+  const roleMatch = samlXml.match(/arn:aws:iam::\d+:role\/[^<,]+/);
+  const principalMatch = samlXml.match(/arn:aws:iam::\d+:saml-provider\/[^<,]+/);
+
+  if (!roleMatch || !principalMatch) {
+    throw new Error('Could not extract role/principal ARN from SAML assertion');
+  }
+
+  const sts = new STSClient({ region: CONFIG.region });
+  try {
+    const response = await sts.send(
+      new AssumeRoleWithSAMLCommand({
+        RoleArn: roleMatch[0],
+        PrincipalArn: principalMatch[0],
+        SAMLAssertion: samlResponse,
+      }),
+    );
+
+    if (!response.Credentials) {
+      throw new Error('No credentials returned from STS');
+    }
+
+    return {
+      AccessKeyId: response.Credentials.AccessKeyId!,
+      SecretAccessKey: response.Credentials.SecretAccessKey!,
+      SessionToken: response.Credentials.SessionToken!,
+      Expiration: response.Credentials.Expiration!,
+      AssumedRoleUser: response.AssumedRoleUser,
+    };
+  } finally {
+    sts.destroy();
+  }
+}
+
+function authenticateWithSAML(): Promise<AWSCredentials> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      server.close();
+      reject(new Error('SAML authentication timed out'));
+    }, CONFIG.idpResponseTimeout);
+
+    const server = http.createServer((req, res) => {
+      if (req.method !== 'POST') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><body><p>Waiting for SAML response...</p></body></html>');
+        return;
+      }
+
+      let body = '';
+      req.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on('end', async () => {
+        try {
+          const samlResponse = new URLSearchParams(body).get('SAMLResponse');
+          if (!samlResponse) {
+            throw new Error('No SAMLResponse in callback');
+          }
+
+          const credentials = await exchangeSAMLForCredentials(samlResponse);
+
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end(
+            '<html><body><h1>Authentication successful!</h1><p>You can close this window.</p></body></html>',
+          );
+
+          clearTimeout(timeout);
+          server.close();
+          resolve(credentials);
+        } catch (err: any) {
+          res.writeHead(500, { 'Content-Type': 'text/html' });
+          res.end(`<html><body><h1>Error</h1><p>${err.message}</p></body></html>`);
+          clearTimeout(timeout);
+          server.close();
+          reject(err);
+        }
+      });
+    });
+
+    server.listen(CONFIG.callbackPort, () => {
+      console.error(`Listening on port ${CONFIG.callbackPort}, opening browser...`);
+      execSync(`open "${CONFIG.loginUrl}"`);
+    });
+  });
+}
+
+async function getDbCredentials(awsCredentials: AWSCredentials): Promise<DbCredentials> {
+  const cached = loadCachedDbCredentials();
+  if (cached) {
+    return cached;
+  }
+
+  const redshift = new RedshiftClient({
+    region: CONFIG.region,
+    credentials: {
+      accessKeyId: awsCredentials.AccessKeyId,
+      secretAccessKey: awsCredentials.SecretAccessKey,
+      sessionToken: awsCredentials.SessionToken,
+    },
+  });
+
+  try {
+    const dbUser = getDbUser(awsCredentials);
+    const response = await redshift.send(
+      new GetClusterCredentialsCommand({
+        ClusterIdentifier: CONFIG.clusterIdentifier,
+        DbName: CONFIG.database,
+        DbUser: dbUser,
+        DbGroups: [CONFIG.dbGroup],
+        AutoCreate: false,
+        DurationSeconds: 3600,
+      }),
+    );
+
+    const credentials: DbCredentials = {
+      user: response.DbUser!,
+      password: response.DbPassword!,
+      expiration: response.Expiration,
+    };
+
+    saveCachedDbCredentials(credentials);
+    return credentials;
+  } finally {
+    redshift.destroy();
+  }
+}
+
+export async function getCredentials(): Promise<AWSCredentials> {
+  const envCredentials = getEnvironmentCredentials();
+  if (envCredentials) {
+    return envCredentials;
+  }
+
+  let awsCredentials = loadCachedCredentials();
+
+  if (!awsCredentials) {
+    console.error('No valid cached credentials, initiating SAML authentication...');
+    awsCredentials = await authenticateWithSAML();
+    saveCachedCredentials(awsCredentials);
+  }
+
+  return awsCredentials;
+}
+
+export async function createClient(): Promise<pg.Client> {
+  const awsCredentials = await getCredentials();
+  const dbCredentials = await getDbCredentials(awsCredentials);
+  const client = new pg.Client({
+    host: CONFIG.host,
+    port: CONFIG.port,
+    database: CONFIG.database,
+    user: dbCredentials.user,
+    password: dbCredentials.password,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 120000,
+  });
+
+  client.on('error', error => {
+    console.error(`Redshift client error: ${error.message}`);
+  });
+
+  await client.connect();
+  return client;
+}
+
+export async function query<T = Record<string, unknown>>(sql: string): Promise<T[]> {
+  const client = await createClient();
+
+  try {
+    const start = Date.now();
+    const { rows } = await client.query(sql);
+
+    console.error(`${rows.length} rows in ${elapsed(start)}s`);
+    return rows as T[];
+  } finally {
+    await client.end();
+  }
+}
+
+async function main() {
+  const sqlFile = process.argv[2];
+  const sql =
+    sqlFile && !sqlFile.startsWith('-')
+      ? fs.readFileSync(sqlFile, 'utf-8')
+      : 'SELECT current_user, current_database()';
+
+  if (sqlFile && !sqlFile.startsWith('-')) {
+    console.error(`Executing ${sqlFile}`);
+  }
+
+  const rows = await query(sql);
+  console.log(JSON.stringify(rows, null, 2));
+}
+
+if (process.argv[1]?.endsWith('/scripts/redshift.ts')) {
+  try {
+    await main();
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}

--- a/telemetry-dashboard/src/index.html
+++ b/telemetry-dashboard/src/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SonarJS Telemetry Dashboard</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app" class="app-shell">
+      <div class="loading">
+        <p>Loading telemetry snapshot…</p>
+      </div>
+    </div>
+    <script type="module" src="./main.js"></script>
+  </body>
+  </html>

--- a/telemetry-dashboard/src/main.ts
+++ b/telemetry-dashboard/src/main.ts
@@ -1,0 +1,1486 @@
+import type {
+  CatalogField,
+  DistributionValue,
+  FieldSemanticType,
+  FieldSummary,
+  FieldValueType,
+  ModuleTypeOverview,
+  NumericSummary,
+  PlatformId,
+  PlatformTimelineOverview,
+  ProgramCreationOverview,
+  ProgramCreationVersionOverview,
+  TelemetrySnapshot,
+  VersionTimeline,
+} from './types.js';
+
+type SortKey = 'coverage' | 'alphabetical' | 'sparsest';
+
+interface AppState {
+  snapshot: TelemetrySnapshot;
+  selectedPlatforms: Set<PlatformId>;
+  selectedProgramCreationVersion: string;
+  search: string;
+  sort: SortKey;
+}
+
+interface AggregatedField {
+  meta: CatalogField;
+  coverage: {
+    total: number;
+    nonNull: number;
+    percent: number;
+  };
+  topValues: DistributionValue[];
+  tokenValues?: DistributionValue[];
+  valueType: FieldValueType;
+  semanticType: FieldSemanticType;
+  numeric?: NumericSummary;
+  valueListTruncated: boolean;
+  platformDetails: Array<{
+    id: PlatformId;
+    label: string;
+    shortLabel: string;
+    summary: FieldSummary;
+  }>;
+}
+
+const CATEGORY_ORDER = ['runtime', 'typescript', 'compiler-options', 'ecmascript', 'module-type', 'other'];
+const CATEGORY_COPY: Record<string, string> = {
+  runtime: 'Runtime telemetry emitted by the bridge server.',
+  typescript: 'TypeScript-specific telemetry fields and counters.',
+  'compiler-options': 'Compiler option coverage and value distributions.',
+  ecmascript: 'ECMAScript versions observed in analyzed projects.',
+  'module-type': 'Module type counters and mixed ESM/CJS usage.',
+  other: 'Telemetry fields that do not fit the main curated sections.',
+};
+
+const appRoot = document.querySelector<HTMLElement>('#app');
+
+if (!appRoot) {
+  throw new Error('Missing #app root');
+}
+
+const app: HTMLElement = appRoot;
+
+let state: AppState | undefined;
+
+app.addEventListener('input', handleControls);
+app.addEventListener('change', handleControls);
+
+void loadSnapshot();
+
+async function loadSnapshot(): Promise<void> {
+  try {
+    const response = await fetch('./data/snapshot.json', { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Unable to load snapshot: ${response.status} ${response.statusText}`);
+    }
+
+    const snapshot = (await response.json()) as TelemetrySnapshot;
+    state = {
+      snapshot,
+      selectedPlatforms: new Set<PlatformId>(['sq', 'sc']),
+      selectedProgramCreationVersion: '',
+      search: '',
+      sort: 'coverage',
+    };
+
+    document.title = `SonarJS Telemetry Dashboard • ${getSourceLabel(snapshot.source)}`;
+    render();
+  } catch (error) {
+    renderError(error);
+  }
+}
+
+function handleControls(event: Event): void {
+  if (!state) {
+    return;
+  }
+
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  if (target instanceof HTMLInputElement && target.name === 'platform') {
+    if (target.checked) {
+      state.selectedPlatforms.add(target.value as PlatformId);
+    } else {
+      state.selectedPlatforms.delete(target.value as PlatformId);
+      if (state.selectedPlatforms.size === 0) {
+        state.selectedPlatforms.add(target.value as PlatformId);
+      }
+    }
+    render();
+    return;
+  }
+
+  if (target instanceof HTMLInputElement && target.name === 'search') {
+    state.search = target.value;
+    render();
+    return;
+  }
+
+  if (target instanceof HTMLSelectElement && target.name === 'sort') {
+    state.sort = target.value as SortKey;
+    render();
+    return;
+  }
+
+  if (target instanceof HTMLSelectElement && target.name === 'programCreationVersion') {
+    state.selectedProgramCreationVersion = target.value;
+    render();
+  }
+}
+
+function render(): void {
+  if (!state) {
+    return;
+  }
+
+  const currentState = state;
+  const selectedPlatforms = getSelectedPlatforms(currentState);
+  const programCreationOverview = getAggregatedProgramCreationOverview(
+    currentState.snapshot,
+    selectedPlatforms,
+  );
+  if (
+    currentState.selectedProgramCreationVersion &&
+    !programCreationOverview?.byVersion.some(
+      entry => entry.version === currentState.selectedProgramCreationVersion,
+    )
+  ) {
+    currentState.selectedProgramCreationVersion = '';
+  }
+
+  const nodeTimeline = getAggregatedVersionTimeline(
+    currentState.snapshot,
+    selectedPlatforms,
+    'nodeMajorVersion',
+  );
+  const typeScriptTimeline = getAggregatedVersionTimeline(
+    currentState.snapshot,
+    selectedPlatforms,
+    'typescriptVersion',
+  );
+  const visibleCatalog = getVisibleCatalog(
+    currentState.snapshot,
+    selectedPlatforms,
+    currentState.search,
+    currentState.sort,
+  );
+  const visibleFields = visibleCatalog
+    .map(field => aggregateField(field, currentState.snapshot, selectedPlatforms))
+    .filter((field): field is AggregatedField => field !== undefined);
+
+  const latestProjects = selectedPlatforms.reduce(
+    (sum, platformId) => sum + currentState.snapshot.platforms[platformId].latestProjectCount,
+    0,
+  );
+  const fieldsWithData = visibleFields.filter(field => field.coverage.nonNull > 0).length;
+  const highCoverageFields = visibleFields.filter(field => field.coverage.percent >= 50).length;
+  const compilerFields = visibleFields
+    .filter(field => field.meta.category === 'compiler-options')
+    .sort((left, right) => right.coverage.nonNull - left.coverage.nonNull);
+  const groupedFields = groupFields(visibleFields);
+
+  const overviewCards = [
+    renderDistributionCard(
+      'Node.js Major Version',
+      'javascript.runtime.major-version',
+      'Which Node major versions appear in the latest analyses.',
+      selectedPlatforms,
+      8,
+    ),
+    renderDistributionCard(
+      'Node Executable Origin',
+      'javascript.runtime.node-executable-origin',
+      'Embedded vs host Node resolution across selected platforms.',
+      selectedPlatforms,
+      6,
+    ),
+    renderDistributionCard(
+      'TypeScript Versions',
+      'javascript.telemetry.typescript.versions',
+      'Most common TypeScript versions seen in project telemetry.',
+      selectedPlatforms,
+      12,
+    ),
+    renderDistributionCard(
+      'ECMAScript Versions',
+      'javascript.telemetry.ecmascript.versions',
+      'Reported ECMAScript versions from the deduplicated latest analyses.',
+      selectedPlatforms,
+      12,
+    ),
+    renderBooleanCard(
+      'TypeScript Native Preview',
+      'javascript.telemetry.typescript.native-preview',
+      'Adoption of TypeScript native preview in the selected platforms.',
+      selectedPlatforms,
+    ),
+    renderTimelineCard(
+      'Node.js Adoption Timeline',
+      'Weekly share of Node major versions using the latest project analysis in each calendar week.',
+      nodeTimeline,
+      { limit: 6 },
+    ),
+    renderTimelineCard(
+      'TypeScript Adoption Timeline',
+      'Weekly share of TypeScript versions. When the program-creation filter is set, this chart focuses on that version.',
+      typeScriptTimeline,
+      {
+        limit: 6,
+        focusValue: state.selectedProgramCreationVersion,
+        note: 'Projects that report multiple TypeScript versions can contribute to multiple series in the same week.',
+      },
+    ),
+    renderCompilerCoverageCard(compilerFields),
+    renderModuleTypeCard(currentState.snapshot, selectedPlatforms),
+    renderProgramCreationCard(programCreationOverview, currentState.selectedProgramCreationVersion),
+  ]
+    .filter(Boolean)
+    .join('');
+
+  app.innerHTML = `
+    <main class="page">
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>SonarJS Telemetry Dashboard</h1>
+            <p>
+              Schema-driven explorer for the SonarJS analyzer telemetry stored in the warehouse.
+              The curated overview highlights the current hotspots, while the field explorer below
+              renders new telemetry columns automatically as they land in Redshift.
+            </p>
+          </div>
+          <aside class="meta-panel">
+            <div class="meta-grid">
+              <div class="meta-block">
+                <div class="meta-label">Snapshot</div>
+                <div class="meta-value">${escapeHtml(getSourceDescription(currentState.snapshot.source))}</div>
+              </div>
+              <div class="meta-block">
+                <div class="meta-label">Generated</div>
+                <div class="meta-value">${escapeHtml(formatDateTime(currentState.snapshot.generatedAt))}</div>
+              </div>
+              <div class="meta-block">
+                <div class="meta-label">Window</div>
+                <div class="meta-value">Last ${currentState.snapshot.windowDays} days</div>
+              </div>
+              <div class="meta-block">
+                <div class="meta-label">Platforms</div>
+                <div class="meta-value">${selectedPlatforms
+                  .map(platformId => currentState.snapshot.platforms[platformId].shortLabel)
+                  .join(' + ')}</div>
+              </div>
+            </div>
+            <ol class="notes">
+              ${currentState.snapshot.notes.map(note => `<li>${escapeHtml(note)}</li>`).join('')}
+            </ol>
+          </aside>
+        </div>
+      </section>
+
+      <section class="controls">
+        <div class="control-group">
+          <span class="control-label">Platforms</span>
+          ${renderPlatformToggle(
+            'sq',
+            currentState.snapshot.platforms.sq,
+            currentState.selectedPlatforms.has('sq'),
+          )}
+          ${renderPlatformToggle(
+            'sc',
+            currentState.snapshot.platforms.sc,
+            currentState.selectedPlatforms.has('sc'),
+          )}
+        </div>
+        <div class="control-group">
+          <span class="control-label">Search</span>
+          <input
+            class="search-input"
+            type="search"
+            name="search"
+            value="${escapeAttribute(currentState.search)}"
+            placeholder="Search by field name, key, or column"
+          />
+        </div>
+        <div class="control-group">
+          <span class="control-label">Sort</span>
+          <select class="sort-select" name="sort">
+            ${renderSortOption('coverage', currentState.sort, 'Coverage first')}
+            ${renderSortOption('alphabetical', currentState.sort, 'Alphabetical')}
+            ${renderSortOption('sparsest', currentState.sort, 'Lowest coverage')}
+          </select>
+        </div>
+      </section>
+
+      <section class="kpi-grid">
+        <article class="kpi-card">
+          <div class="kpi-label">Latest Projects</div>
+          <div class="kpi-value">${formatNumber(latestProjects)}</div>
+          <div class="kpi-sub">Deduplicated latest analyses in the selected ${selectedPlatforms.length === 1 ? 'platform' : 'platforms'}.</div>
+        </article>
+        <article class="kpi-card">
+          <div class="kpi-label">Visible Fields</div>
+          <div class="kpi-value">${formatNumber(visibleFields.length)}</div>
+          <div class="kpi-sub">${formatNumber(fieldsWithData)} currently have non-null values.</div>
+        </article>
+        <article class="kpi-card">
+          <div class="kpi-label">High Coverage</div>
+          <div class="kpi-value">${formatNumber(highCoverageFields)}</div>
+          <div class="kpi-sub">Fields present in at least half of the selected latest analyses.</div>
+        </article>
+        <article class="kpi-card">
+          <div class="kpi-label">Compiler Options</div>
+          <div class="kpi-value">${formatNumber(compilerFields.length)}</div>
+          <div class="kpi-sub">Auto-discovered compiler option columns across the selected platforms.</div>
+        </article>
+      </section>
+
+      <section class="overview-grid">
+        ${overviewCards}
+      </section>
+
+      ${
+        visibleFields.length === 0
+          ? `
+            <section class="empty-state">
+              <div class="empty-card">
+                <h2>${
+                  currentState.snapshot.source === 'empty'
+                    ? 'No local telemetry snapshot yet'
+                    : 'No matching telemetry fields'
+                }</h2>
+                <p>${
+                  currentState.snapshot.source === 'empty'
+                    ? 'Run `npm --prefix telemetry-dashboard run fetch:redshift` locally or let CI refresh the dashboard, then build again.'
+                    : 'Adjust the search or platform filters to bring fields back into view.'
+                }</p>
+              </div>
+            </section>
+          `
+          : CATEGORY_ORDER.map(category => renderGroupSection(category, groupedFields.get(category) ?? [])).join('')
+      }
+    </main>
+  `;
+}
+
+function renderPlatformToggle(
+  platformId: PlatformId,
+  platform: TelemetrySnapshot['platforms'][PlatformId],
+  checked: boolean,
+): string {
+  return `
+    <label class="pill-toggle">
+      <input type="checkbox" name="platform" value="${platformId}" ${checked ? 'checked' : ''} />
+      <span>${escapeHtml(platform.label)}</span>
+      <span class="tag"><strong>${platform.shortLabel}</strong> ${formatNumber(platform.latestProjectCount)}</span>
+    </label>
+  `;
+}
+
+function renderSortOption(value: SortKey, selected: SortKey, label: string): string {
+  return `<option value="${value}" ${value === selected ? 'selected' : ''}>${escapeHtml(label)}</option>`;
+}
+
+function renderProgramVersionOption(value: string, selectedValue: string): string {
+  return `<option value="${escapeAttribute(value)}" ${value === selectedValue ? 'selected' : ''}>${escapeHtml(value)}</option>`;
+}
+
+function renderDistributionCard(
+  title: string,
+  fieldKey: string,
+  description: string,
+  selectedPlatforms: PlatformId[],
+  limit: number,
+): string {
+  if (!state) {
+    return '';
+  }
+
+  const field = getAggregatedField(fieldKey, state.snapshot, selectedPlatforms);
+  if (!field || field.coverage.nonNull === 0) {
+    return '';
+  }
+
+  const distribution = field.tokenValues?.length ? field.tokenValues : field.topValues;
+  const denominator = field.tokenValues?.length ? field.coverage.nonNull : field.coverage.total;
+
+  return `
+    <article class="overview-card">
+      <h2>${escapeHtml(title)}</h2>
+      <p>${escapeHtml(description)}</p>
+      <div class="tag-row" style="margin-top: 12px">
+        <span class="tag"><strong>Coverage</strong> ${formatPercent(field.coverage.percent)}</span>
+        <span class="tag"><strong>Non-null</strong> ${formatNumber(field.coverage.nonNull)}</span>
+      </div>
+      <div style="margin-top: 14px">
+        ${renderDistributionList(distribution.slice(0, limit), distribution, denominator)}
+      </div>
+      ${
+        field.tokenValues?.length
+          ? '<p class="dist-note">Comma-separated values are split before the distribution is aggregated.</p>'
+          : ''
+      }
+    </article>
+  `;
+}
+
+function renderBooleanCard(
+  title: string,
+  fieldKey: string,
+  description: string,
+  selectedPlatforms: PlatformId[],
+): string {
+  if (!state) {
+    return '';
+  }
+
+  const field = getAggregatedField(fieldKey, state.snapshot, selectedPlatforms);
+  if (!field || field.coverage.nonNull === 0) {
+    return '';
+  }
+
+  return `
+    <article class="overview-card">
+      <h2>${escapeHtml(title)}</h2>
+      <p>${escapeHtml(description)}</p>
+      <div class="tag-row" style="margin-top: 12px">
+        <span class="tag"><strong>Coverage</strong> ${formatPercent(field.coverage.percent)}</span>
+        <span class="tag"><strong>Rows</strong> ${formatNumber(field.coverage.nonNull)}</span>
+      </div>
+      <div style="margin-top: 14px">
+        ${renderDistributionList(field.topValues, field.topValues, field.coverage.nonNull)}
+      </div>
+    </article>
+  `;
+}
+
+function renderCompilerCoverageCard(fields: AggregatedField[]): string {
+  if (fields.length === 0) {
+    return '';
+  }
+
+  const coverageValues = fields.slice(0, 10).map(field => ({
+    value: field.meta.displayName,
+    count: field.coverage.nonNull,
+    percent: field.coverage.percent,
+  }));
+
+  return `
+    <article class="overview-card">
+      <h2>Compiler Option Coverage</h2>
+      <p>Which compiler option columns currently show up most often in the deduplicated latest analyses.</p>
+      <div style="margin-top: 14px">
+        ${renderDistributionList(coverageValues, coverageValues, fields[0]?.coverage.total ?? 0)}
+      </div>
+      <p class="dist-note">New compiler option fields appear automatically when new columns land in Redshift.</p>
+    </article>
+  `;
+}
+
+function renderModuleTypeCard(snapshot: TelemetrySnapshot, selectedPlatforms: PlatformId[]): string {
+  const entries = selectedPlatforms
+    .map(platformId => snapshot.overview?.moduleType?.[platformId])
+    .filter((entry): entry is ModuleTypeOverview => entry !== undefined);
+
+  if (entries.length === 0) {
+    return '';
+  }
+
+  const aggregate = entries.reduce<ModuleTypeOverview>(
+    (sum, entry) => ({
+      projectsWithTelemetry: sum.projectsWithTelemetry + entry.projectsWithTelemetry,
+      totalEsmFiles: sum.totalEsmFiles + entry.totalEsmFiles,
+      totalCjsFiles: sum.totalCjsFiles + entry.totalCjsFiles,
+      esmOnlyProjects: sum.esmOnlyProjects + entry.esmOnlyProjects,
+      cjsOnlyProjects: sum.cjsOnlyProjects + entry.cjsOnlyProjects,
+      bothProjects: sum.bothProjects + entry.bothProjects,
+      neitherProjects: sum.neitherProjects + entry.neitherProjects,
+    }),
+    {
+      projectsWithTelemetry: 0,
+      totalEsmFiles: 0,
+      totalCjsFiles: 0,
+      esmOnlyProjects: 0,
+      cjsOnlyProjects: 0,
+      bothProjects: 0,
+      neitherProjects: 0,
+    },
+  );
+
+  const projectMix: DistributionValue[] = [
+    { value: 'CJS only', count: aggregate.cjsOnlyProjects, percent: 0 },
+    { value: 'ESM only', count: aggregate.esmOnlyProjects, percent: 0 },
+    { value: 'Both ESM and CJS', count: aggregate.bothProjects, percent: 0 },
+    { value: 'Both counts are 0', count: aggregate.neitherProjects, percent: 0 },
+  ]
+    .filter(entry => entry.count > 0)
+    .map(entry => ({
+      ...entry,
+      percent:
+        aggregate.projectsWithTelemetry === 0
+          ? 0
+          : round((entry.count / aggregate.projectsWithTelemetry) * 100, 1),
+    }))
+    .sort((left, right) => right.count - left.count);
+
+  return `
+    <article class="overview-card">
+      <h2>Module Type Breakdown</h2>
+      <p>Built from the ESM and CJS file count fields, limited to projects that emitted module telemetry.</p>
+      <div class="stat-grid" style="margin-top: 14px">
+        <div class="stat">
+          <div class="stat-label">Projects With Telemetry</div>
+          <div class="stat-value">${formatNumber(aggregate.projectsWithTelemetry)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Total ESM Files</div>
+          <div class="stat-value">${formatNumber(aggregate.totalEsmFiles)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Total CJS Files</div>
+          <div class="stat-value">${formatNumber(aggregate.totalCjsFiles)}</div>
+        </div>
+      </div>
+      <div style="margin-top: 14px">
+        ${renderDistributionList(projectMix, projectMix, aggregate.projectsWithTelemetry)}
+      </div>
+      <p class="dist-note">“Both counts are 0” means the project emitted module telemetry, but both counters were zero in that latest analysis.</p>
+    </article>
+  `;
+}
+
+function renderProgramCreationCard(
+  overview: ProgramCreationOverview | undefined,
+  selectedTypeScriptVersion: string,
+): string {
+  if (!overview) {
+    return '';
+  }
+
+  const selectedVersion = selectedTypeScriptVersion.trim();
+  const selectedEntry = selectedVersion
+    ? overview.byVersion.find(entry => entry.version === selectedVersion)
+    : undefined;
+  const scope = selectedEntry ?? overview;
+  const failureRate = scope.attempts === 0 ? 0 : round((scope.failed / scope.attempts) * 100, 1);
+  const failingVersions = overview.byVersion.filter(entry => entry.failed > 0);
+  const breakdownEntries = selectedEntry
+    ? selectedEntry.failed > 0
+      ? [selectedEntry]
+      : []
+    : failingVersions.slice(0, 12);
+  const failureDistribution = breakdownEntries.map(entry => ({
+    value: entry.version,
+    count: entry.failed,
+    percent: overview.failed === 0 ? 0 : round((entry.failed / overview.failed) * 100, 1),
+  }));
+
+  return `
+    <article class="overview-card overview-card-wide">
+      <div class="section-header">
+        <div>
+          <h2>Program Creation Failures</h2>
+          <p>Grouped by TypeScript version using the versions emitted by each latest project analysis.</p>
+        </div>
+        <label class="control-group inline-filter">
+          <span class="control-label">TS Version</span>
+          <select class="sort-select" name="programCreationVersion">
+            <option value="" ${selectedVersion === '' ? 'selected' : ''}>All versions</option>
+            ${overview.byVersion
+              .map(entry => renderProgramVersionOption(entry.version, selectedVersion))
+              .join('')}
+          </select>
+        </label>
+      </div>
+      <div class="tag-row">
+        <span class="tag"><strong>Scope</strong> ${escapeHtml(selectedEntry?.version ?? 'All versions')}</span>
+        <span class="tag"><strong>Projects</strong> ${formatNumber(scope.projects)}</span>
+        <span class="tag"><strong>Projects With Failures</strong> ${formatNumber(scope.projectsWithFailures)}</span>
+        <span class="tag"><strong>Version Buckets</strong> ${formatNumber(overview.byVersion.length)}</span>
+      </div>
+      <div class="stat-grid" style="margin-top: 14px">
+        <div class="stat">
+          <div class="stat-label">Attempted</div>
+          <div class="stat-value">${formatNumber(scope.attempts)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Succeeded</div>
+          <div class="stat-value">${formatNumber(scope.succeeded)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Failed</div>
+          <div class="stat-value">${formatNumber(scope.failed)}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Failure Rate</div>
+          <div class="stat-value">${formatPercent(failureRate)}</div>
+        </div>
+      </div>
+      <div style="margin-top: 14px">
+        <div class="muted-copy">${selectedEntry ? 'Selected version failure share' : 'Top failure buckets'}</div>
+        ${
+          failureDistribution.length > 0
+            ? renderDistributionList(failureDistribution, failureDistribution, overview.failed)
+            : '<div class="empty-copy">No program creation failures in the current selection.</div>'
+        }
+      </div>
+      <p class="dist-note">Rows that report multiple TypeScript versions contribute to every matching version bucket.</p>
+    </article>
+  `;
+}
+
+function renderTimelineCard(
+  title: string,
+  description: string,
+  timeline: VersionTimeline | undefined,
+  options: {
+    limit: number;
+    focusValue?: string;
+    note?: string;
+  },
+): string {
+  if (!timeline || timeline.weeks.length === 0 || timeline.series.length === 0) {
+    return '';
+  }
+
+  const focusedSeries = options.focusValue
+    ? timeline.series.find(series => series.value === options.focusValue)
+    : undefined;
+  const visibleSeries = focusedSeries ? [focusedSeries] : timeline.series.slice(0, options.limit);
+  const latestWeek = timeline.weeks.at(-1);
+
+  if (!latestWeek || visibleSeries.length === 0) {
+    return '';
+  }
+
+  return `
+    <article class="overview-card overview-card-wide">
+      <div class="section-header">
+        <div>
+          <h2>${escapeHtml(title)}</h2>
+          <p>${escapeHtml(description)}</p>
+        </div>
+        <div class="tag-row">
+          <span class="tag"><strong>Weeks</strong> ${formatNumber(timeline.weeks.length)}</span>
+          <span class="tag"><strong>Latest Week</strong> ${escapeHtml(formatWeekLabel(latestWeek.weekStart))}</span>
+          <span class="tag"><strong>Projects</strong> ${formatNumber(latestWeek.projects)}</span>
+          <span class="tag"><strong>Series Shown</strong> ${formatNumber(visibleSeries.length)}</span>
+        </div>
+      </div>
+      ${renderTimelineChart(timeline, visibleSeries)}
+      <div class="timeline-legend">
+        ${visibleSeries
+          .map((series, index) => {
+            const color = getTimelineColor(index);
+            const latestPoint = series.weekly.at(-1);
+            const latestShare =
+              !latestPoint || latestWeek.projects === 0
+                ? 0
+                : round((latestPoint.projects / latestWeek.projects) * 100, 1);
+
+            return `
+              <div class="timeline-legend-item">
+                <span class="timeline-swatch" style="--timeline-color: ${color}"></span>
+                <div>
+                  <div class="dist-label">${escapeHtml(series.value)}</div>
+                  <div class="dist-note">${formatNumber(series.totalProjects)} project-weeks · ${formatPercent(latestShare)} in the latest week</div>
+                </div>
+              </div>
+            `;
+          })
+          .join('')}
+      </div>
+      ${options.note ? `<p class="dist-note">${escapeHtml(options.note)}</p>` : ''}
+    </article>
+  `;
+}
+
+function renderTimelineChart(
+  timeline: VersionTimeline,
+  visibleSeries: VersionTimeline['series'],
+): string {
+  const viewWidth = 560;
+  const viewHeight = 220;
+  const leftPad = 42;
+  const rightPad = 12;
+  const topPad = 16;
+  const bottomPad = 30;
+  const chartWidth = viewWidth - leftPad - rightPad;
+  const chartHeight = viewHeight - topPad - bottomPad;
+  const weeksByStart = new Map(timeline.weeks.map(week => [week.weekStart, week.projects]));
+  const maxShare = Math.max(
+    ...visibleSeries.flatMap(series =>
+      series.weekly.map(point => {
+        const totalProjects = weeksByStart.get(point.weekStart) ?? 0;
+        return totalProjects === 0 ? 0 : (point.projects / totalProjects) * 100;
+      }),
+    ),
+    0,
+  );
+  const axisMax = Math.max(5, Math.ceil(maxShare / 5) * 5);
+  const divisor = Math.max(timeline.weeks.length - 1, 1);
+  const yTicks = [axisMax, axisMax / 2, 0];
+  const xLabelIndexes =
+    timeline.weeks.length === 1
+      ? [0]
+      : [...new Set([0, Math.floor((timeline.weeks.length - 1) / 2), timeline.weeks.length - 1])];
+
+  const gridLines = yTicks
+    .map(tick => {
+      const y = topPad + chartHeight - (tick / axisMax) * chartHeight;
+      return `
+        <line x1="${leftPad}" y1="${y}" x2="${viewWidth - rightPad}" y2="${y}" class="timeline-grid-line" />
+        <text x="${leftPad - 8}" y="${y + 4}" class="timeline-axis-label">${formatPercent(tick)}</text>
+      `;
+    })
+    .join('');
+
+  const xLabels = xLabelIndexes
+    .map(index => {
+      const x = leftPad + (index / divisor) * chartWidth;
+      return `<text x="${x}" y="${viewHeight - 8}" text-anchor="middle" class="timeline-axis-label">${escapeHtml(
+        formatWeekLabel(timeline.weeks[index]!.weekStart),
+      )}</text>`;
+    })
+    .join('');
+
+  const seriesPaths = visibleSeries
+    .map((series, index) => {
+      const color = getTimelineColor(index);
+      const points = series.weekly
+        .map((point, pointIndex) => {
+          const x = leftPad + (pointIndex / divisor) * chartWidth;
+          const totalProjects = weeksByStart.get(point.weekStart) ?? 0;
+          const share = totalProjects === 0 ? 0 : (point.projects / totalProjects) * 100;
+          const y = topPad + chartHeight - (share / axisMax) * chartHeight;
+          return `${round(x, 2)},${round(y, 2)}`;
+        })
+        .join(' ');
+      const latestPoint = series.weekly.at(-1);
+      const latestShare =
+        !latestPoint || latestWeekProjects(timeline) === 0
+          ? 0
+          : (latestPoint.projects / latestWeekProjects(timeline)) * 100;
+      const latestX = leftPad + ((series.weekly.length - 1) / divisor) * chartWidth;
+      const latestY = topPad + chartHeight - (latestShare / axisMax) * chartHeight;
+
+      return `
+        <polyline points="${points}" fill="none" stroke="${color}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+        <circle cx="${round(latestX, 2)}" cy="${round(latestY, 2)}" r="4" fill="${color}" />
+      `;
+    })
+    .join('');
+
+  return `
+    <div class="timeline-chart">
+      <svg viewBox="0 0 ${viewWidth} ${viewHeight}" role="img" aria-label="Weekly adoption timeline">
+        ${gridLines}
+        ${seriesPaths}
+        ${xLabels}
+      </svg>
+    </div>
+  `;
+}
+
+function renderGroupSection(category: string, fields: AggregatedField[]): string {
+  if (fields.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="group-section">
+      <div class="section-header">
+        <div>
+          <h2>${escapeHtml(humanizeCategory(category))}</h2>
+          <p>${escapeHtml(CATEGORY_COPY[category] ?? CATEGORY_COPY.other)}</p>
+        </div>
+        <div class="tag-row">
+          <span class="tag"><strong>Fields</strong> ${formatNumber(fields.length)}</span>
+        </div>
+      </div>
+      <div class="field-grid">
+        ${fields.map(renderFieldCard).join('')}
+      </div>
+    </section>
+  `;
+}
+
+function renderFieldCard(field: AggregatedField): string {
+  const platformTags = field.platformDetails.map(platform => {
+    const typeLabel = platform.summary.redshiftType;
+    return `
+      <span class="tag">
+        <strong>${escapeHtml(platform.shortLabel)}</strong>
+        ${escapeHtml(typeLabel)} · ${formatPercent(platform.summary.coverage.percent)}
+      </span>
+    `;
+  });
+
+  const primaryDistribution =
+    field.semanticType === 'count'
+      ? ''
+      : field.semanticType === 'version'
+        ? (field.tokenValues?.length ? field.tokenValues : field.topValues).length > 0
+          ? `
+              <div>
+                <div class="muted-copy">Top versions</div>
+                ${renderDistributionList(
+                  (field.tokenValues?.length ? field.tokenValues : field.topValues).slice(0, 8),
+                  field.tokenValues?.length ? field.tokenValues : field.topValues,
+                  field.tokenValues?.length ? field.coverage.nonNull : field.coverage.total,
+                )}
+              </div>
+            `
+          : '<div class="empty-copy">No version distribution available.</div>'
+        : field.topValues.length > 0
+          ? `
+              <div>
+                <div class="muted-copy">Top exact values</div>
+                ${renderDistributionList(field.topValues.slice(0, 8), field.topValues, field.coverage.total)}
+              </div>
+            `
+          : '<div class="empty-copy">No exact-value distribution available.</div>';
+
+  const secondaryDistribution =
+    field.semanticType === 'count' || field.semanticType === 'version' || !field.tokenValues?.length
+      ? ''
+      : `
+          <div>
+            <div class="muted-copy">Top split tokens</div>
+            ${renderDistributionList(field.tokenValues.slice(0, 8), field.tokenValues, field.coverage.nonNull)}
+          </div>
+        `;
+
+  const numericStats = field.numeric
+    ? field.semanticType === 'version'
+      ? ''
+      : field.semanticType === 'count'
+        ? `
+            <div class="stat-grid">
+              <div class="stat">
+                <div class="stat-label">Rows &gt; 0</div>
+                <div class="stat-value">${formatNumber(field.numeric.positiveRows)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Rows = 0</div>
+                <div class="stat-value">${formatNumber(field.numeric.zeroRows)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Average / Row</div>
+                <div class="stat-value">${formatCompact(field.numeric.avg)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Max</div>
+                <div class="stat-value">${formatCompact(field.numeric.max)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Total</div>
+                <div class="stat-value">${formatCompact(field.numeric.sum)}</div>
+              </div>
+            </div>
+          `
+        : `
+            <div class="stat-grid">
+              <div class="stat">
+                <div class="stat-label">Min</div>
+                <div class="stat-value">${formatCompact(field.numeric.min)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Max</div>
+                <div class="stat-value">${formatCompact(field.numeric.max)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Average</div>
+                <div class="stat-value">${formatCompact(field.numeric.avg)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Sum</div>
+                <div class="stat-value">${formatCompact(field.numeric.sum)}</div>
+              </div>
+            </div>
+          `
+    : '';
+
+  const distributionGrid =
+    primaryDistribution || secondaryDistribution
+      ? `
+          <div class="duo-grid">
+            ${primaryDistribution}
+            ${secondaryDistribution}
+          </div>
+        `
+      : '';
+
+  return `
+    <article class="field-card">
+      <div class="field-header">
+        <div>
+          <h3>${escapeHtml(field.meta.displayName)}</h3>
+          <p class="field-subtitle">${escapeHtml(field.meta.key)}<br />${escapeHtml(field.meta.columnName)}</p>
+        </div>
+        <span class="chip ${field.valueListTruncated ? 'warn' : ''}">
+          ${escapeHtml(humanizeFieldSemantic(field.semanticType, field.valueType))}
+          ${field.valueListTruncated ? ' · truncated' : ''}
+        </span>
+      </div>
+
+      <div class="platform-row">
+        ${platformTags.join('')}
+      </div>
+
+      <div class="coverage">
+        <div class="coverage-line">
+          <span>Coverage</span>
+          <span>${formatNumber(field.coverage.nonNull)} / ${formatNumber(field.coverage.total)} (${formatPercent(
+            field.coverage.percent,
+          )})</span>
+        </div>
+        <div class="meter"><div class="meter-fill" style="width: ${field.coverage.percent}%"></div></div>
+      </div>
+
+      ${numericStats}
+
+      ${distributionGrid}
+
+      ${
+        field.valueListTruncated
+          ? '<div class="dist-note">Only the most frequent distinct values are stored in the snapshot for this field.</div>'
+          : ''
+      }
+    </article>
+  `;
+}
+
+function renderDistributionList(
+  items: DistributionValue[],
+  fullList: DistributionValue[],
+  denominator: number,
+): string {
+  if (items.length === 0) {
+    return '<div class="empty-copy">No values in the current selection.</div>';
+  }
+
+  const maxCount = Math.max(...fullList.map(item => item.count), 1);
+  return `
+    <div class="dist-list">
+      ${items
+        .map(item => {
+          const percent = denominator === 0 ? 0 : round((item.count / denominator) * 100, 1);
+          const width = round((item.count / maxCount) * 100, 1);
+
+          return `
+            <div class="dist-row">
+              <div class="dist-label-row">
+                <div class="dist-label">${escapeHtml(item.value)}</div>
+                <div class="dist-meta">${formatNumber(item.count)} · ${formatPercent(percent)}</div>
+              </div>
+              <div class="dist-bar">
+                <div class="dist-bar-fill" style="width: ${width}%"></div>
+              </div>
+            </div>
+          `;
+        })
+        .join('')}
+    </div>
+  `;
+}
+
+function getVisibleCatalog(
+  snapshot: TelemetrySnapshot,
+  selectedPlatforms: PlatformId[],
+  search: string,
+  sort: SortKey,
+): CatalogField[] {
+  const normalizedSearch = search.trim().toLowerCase();
+  const filtered = snapshot.catalog.filter(field => {
+    if (!selectedPlatforms.some(platformId => field.availability[platformId])) {
+      return false;
+    }
+
+    if (normalizedSearch.length === 0) {
+      return true;
+    }
+
+    const haystack = [field.displayName, field.key, field.columnName, field.category]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(normalizedSearch);
+  });
+
+  return filtered.sort((left, right) => {
+    const leftField = aggregateField(left, snapshot, selectedPlatforms);
+    const rightField = aggregateField(right, snapshot, selectedPlatforms);
+    const leftCoverage = leftField?.coverage.percent ?? 0;
+    const rightCoverage = rightField?.coverage.percent ?? 0;
+
+    if (sort === 'alphabetical') {
+      return left.displayName.localeCompare(right.displayName) || left.key.localeCompare(right.key);
+    }
+
+    if (sort === 'sparsest') {
+      return leftCoverage - rightCoverage || left.displayName.localeCompare(right.displayName);
+    }
+
+    return rightCoverage - leftCoverage || left.displayName.localeCompare(right.displayName);
+  });
+}
+
+function groupFields(fields: AggregatedField[]): Map<string, AggregatedField[]> {
+  const grouped = new Map<string, AggregatedField[]>();
+
+  for (const field of fields) {
+    const list = grouped.get(field.meta.category) ?? [];
+    list.push(field);
+    grouped.set(field.meta.category, list);
+  }
+
+  return grouped;
+}
+
+function getSelectedPlatforms(currentState: AppState): PlatformId[] {
+  return (['sq', 'sc'] as PlatformId[]).filter(platformId =>
+    currentState.selectedPlatforms.has(platformId),
+  );
+}
+
+function getAggregatedProgramCreationOverview(
+  snapshot: TelemetrySnapshot,
+  selectedPlatforms: PlatformId[],
+): ProgramCreationOverview | undefined {
+  const overviews = selectedPlatforms
+    .map(platformId => snapshot.overview?.programCreation?.[platformId])
+    .filter((overview): overview is ProgramCreationOverview => overview !== undefined);
+
+  if (overviews.length === 0) {
+    return undefined;
+  }
+
+  const byVersion = new Map<string, ProgramCreationVersionOverview>();
+  const atOrAboveVersion = new Map<string, ProgramCreationVersionOverview>();
+  const aggregate: ProgramCreationOverview = {
+    projects: 0,
+    projectsWithFailures: 0,
+    attempts: 0,
+    succeeded: 0,
+    failed: 0,
+    byVersion: [],
+    atOrAboveVersion: [],
+  };
+
+  for (const overview of overviews) {
+    aggregate.projects += overview.projects;
+    aggregate.projectsWithFailures += overview.projectsWithFailures;
+    aggregate.attempts += overview.attempts;
+    aggregate.succeeded += overview.succeeded;
+    aggregate.failed += overview.failed;
+
+    for (const entry of overview.byVersion) {
+      const merged =
+        byVersion.get(entry.version) ??
+        {
+          version: entry.version,
+          projects: 0,
+          projectsWithFailures: 0,
+          attempts: 0,
+          succeeded: 0,
+          failed: 0,
+        };
+
+      merged.projects += entry.projects;
+      merged.projectsWithFailures += entry.projectsWithFailures;
+      merged.attempts += entry.attempts;
+      merged.succeeded += entry.succeeded;
+      merged.failed += entry.failed;
+      byVersion.set(entry.version, merged);
+    }
+
+    for (const entry of overview.atOrAboveVersion) {
+      const merged =
+        atOrAboveVersion.get(entry.version) ??
+        {
+          version: entry.version,
+          projects: 0,
+          projectsWithFailures: 0,
+          attempts: 0,
+          succeeded: 0,
+          failed: 0,
+        };
+
+      merged.projects += entry.projects;
+      merged.projectsWithFailures += entry.projectsWithFailures;
+      merged.attempts += entry.attempts;
+      merged.succeeded += entry.succeeded;
+      merged.failed += entry.failed;
+      atOrAboveVersion.set(entry.version, merged);
+    }
+  }
+
+  aggregate.byVersion = [...byVersion.values()].sort(
+    (left, right) =>
+      right.failed - left.failed ||
+      right.projectsWithFailures - left.projectsWithFailures ||
+      right.projects - left.projects ||
+      left.version.localeCompare(right.version),
+  );
+  aggregate.atOrAboveVersion = [...atOrAboveVersion.values()].sort(
+    (left, right) => left.version.localeCompare(right.version),
+  );
+
+  return aggregate;
+}
+
+function getAggregatedVersionTimeline(
+  snapshot: TelemetrySnapshot,
+  selectedPlatforms: PlatformId[],
+  key: keyof PlatformTimelineOverview,
+): VersionTimeline | undefined {
+  const timelines = selectedPlatforms
+    .map(platformId => snapshot.overview?.timelines?.[platformId]?.[key])
+    .filter((timeline): timeline is VersionTimeline => timeline !== undefined);
+
+  if (timelines.length === 0) {
+    return undefined;
+  }
+
+  const weeks = new Map<string, number>();
+  const seriesCounts = new Map<string, Map<string, number>>();
+
+  for (const timeline of timelines) {
+    for (const week of timeline.weeks) {
+      weeks.set(week.weekStart, (weeks.get(week.weekStart) ?? 0) + week.projects);
+    }
+
+    for (const series of timeline.series) {
+      const weeklyCounts = seriesCounts.get(series.value) ?? new Map<string, number>();
+
+      for (const point of series.weekly) {
+        weeklyCounts.set(point.weekStart, (weeklyCounts.get(point.weekStart) ?? 0) + point.projects);
+      }
+
+      seriesCounts.set(series.value, weeklyCounts);
+    }
+  }
+
+  const mergedWeeks = [...weeks.entries()]
+    .map(([weekStart, projects]) => ({ weekStart, projects }))
+    .sort((left, right) => left.weekStart.localeCompare(right.weekStart));
+
+  const mergedSeries = [...seriesCounts.entries()]
+    .map(([value, weeklyCounts]) => {
+      const weekly = mergedWeeks.map(week => ({
+        weekStart: week.weekStart,
+        projects: weeklyCounts.get(week.weekStart) ?? 0,
+      }));
+
+      return {
+        value,
+        totalProjects: weekly.reduce((sum, point) => sum + point.projects, 0),
+        weekly,
+      };
+    })
+    .sort(
+      (left, right) =>
+        right.totalProjects - left.totalProjects || left.value.localeCompare(right.value),
+    );
+
+  return {
+    weeks: mergedWeeks,
+    series: mergedSeries,
+  };
+}
+
+function aggregateField(
+  field: CatalogField,
+  snapshot: TelemetrySnapshot,
+  selectedPlatforms: PlatformId[],
+): AggregatedField | undefined {
+  const platformDetails = selectedPlatforms
+    .map(platformId => {
+      const summary = snapshot.platforms[platformId].fields[field.key];
+      if (!summary) {
+        return undefined;
+      }
+
+      return {
+        id: platformId,
+        label: snapshot.platforms[platformId].label,
+        shortLabel: snapshot.platforms[platformId].shortLabel,
+        summary,
+      };
+    })
+    .filter((entry): entry is AggregatedField['platformDetails'][number] => entry !== undefined);
+
+  if (platformDetails.length === 0) {
+    return undefined;
+  }
+
+  const coverage = platformDetails.reduce(
+    (sum, platform) => ({
+      total: sum.total + platform.summary.coverage.total,
+      nonNull: sum.nonNull + platform.summary.coverage.nonNull,
+      percent: 0,
+    }),
+    { total: 0, nonNull: 0, percent: 0 },
+  );
+
+  coverage.percent = coverage.total === 0 ? 0 : round((coverage.nonNull / coverage.total) * 100, 1);
+
+  const topValues = mergeDistributions(
+    platformDetails.map(platform => platform.summary.topValues),
+    coverage.total,
+    16,
+  );
+  const tokenValues = mergeDistributions(
+    platformDetails
+      .map(platform => platform.summary.tokenValues ?? [])
+      .filter(values => values.length > 0),
+    coverage.nonNull,
+    16,
+  );
+
+  const numericSummaries = platformDetails
+    .map(platform => platform.summary.numeric)
+    .filter((summary): summary is NumericSummary => summary !== undefined);
+
+  const numeric =
+    numericSummaries.length > 0
+      ? {
+          numericRows: numericSummaries.reduce((sum, summary) => sum + summary.numericRows, 0),
+          zeroRows: numericSummaries.reduce((sum, summary) => sum + summary.zeroRows, 0),
+          positiveRows: numericSummaries.reduce((sum, summary) => sum + summary.positiveRows, 0),
+          min: Math.min(...numericSummaries.map(summary => summary.min)),
+          max: Math.max(...numericSummaries.map(summary => summary.max)),
+          avg: 0,
+          sum: numericSummaries.reduce((sum, summary) => sum + summary.sum, 0),
+        }
+      : undefined;
+
+  if (numeric) {
+    numeric.avg = numeric.numericRows === 0 ? 0 : round(numeric.sum / numeric.numericRows);
+  }
+
+  const valueType = collapseValueTypes(platformDetails.map(platform => platform.summary.valueType));
+  const semanticType = collapseSemanticTypes(
+    platformDetails.map(platform => platform.summary.semanticType),
+  );
+
+  return {
+    meta: field,
+    coverage,
+    topValues,
+    tokenValues: tokenValues.length > 0 ? tokenValues : undefined,
+    valueType,
+    semanticType,
+    numeric,
+    valueListTruncated: platformDetails.some(platform => platform.summary.valueListTruncated),
+    platformDetails,
+  };
+}
+
+function mergeDistributions(
+  lists: DistributionValue[][],
+  denominator: number,
+  limit: number,
+): DistributionValue[] {
+  const counts = new Map<string, number>();
+
+  for (const list of lists) {
+    for (const entry of list) {
+      counts.set(entry.value, (counts.get(entry.value) ?? 0) + entry.count);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([value, count]) => ({
+      value,
+      count,
+      percent: denominator === 0 ? 0 : round((count / denominator) * 100, 1),
+    }))
+    .sort((left, right) => right.count - left.count || left.value.localeCompare(right.value))
+    .slice(0, limit);
+}
+
+function collapseValueTypes(types: FieldValueType[]): FieldValueType {
+  const filtered = [...new Set(types.filter(type => type !== 'unknown'))];
+  if (filtered.length === 0) {
+    return 'unknown';
+  }
+  if (filtered.length === 1) {
+    return filtered[0];
+  }
+  return 'mixed';
+}
+
+function collapseSemanticTypes(types: FieldSemanticType[]): FieldSemanticType {
+  const uniqueTypes = [...new Set(types)];
+  if (uniqueTypes.length === 1) {
+    return uniqueTypes[0]!;
+  }
+  if (uniqueTypes.includes('count')) {
+    return 'count';
+  }
+  if (uniqueTypes.includes('version')) {
+    return 'version';
+  }
+  if (uniqueTypes.includes('boolean')) {
+    return 'boolean';
+  }
+  if (uniqueTypes.includes('metric')) {
+    return 'metric';
+  }
+  return 'dimension';
+}
+
+function getAggregatedField(
+  fieldKey: string,
+  snapshot: TelemetrySnapshot,
+  selectedPlatforms: PlatformId[],
+): AggregatedField | undefined {
+  const catalogField = snapshot.catalog.find(field => field.key === fieldKey);
+  if (!catalogField) {
+    return undefined;
+  }
+
+  return aggregateField(catalogField, snapshot, selectedPlatforms);
+}
+
+function humanizeCategory(category: string): string {
+  return category
+    .split('-')
+    .map(token => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+function humanizeValueType(type: FieldValueType): string {
+  switch (type) {
+    case 'boolean':
+      return 'Boolean';
+    case 'mixed':
+      return 'Mixed';
+    case 'number':
+      return 'Numeric';
+    case 'string':
+      return 'Text';
+    default:
+      return 'Unknown';
+  }
+}
+
+function humanizeFieldSemantic(
+  semanticType: FieldSemanticType,
+  valueType: FieldValueType,
+): string {
+  switch (semanticType) {
+    case 'boolean':
+      return 'Boolean';
+    case 'count':
+      return 'Count';
+    case 'metric':
+      return 'Measure';
+    case 'version':
+      return 'Version';
+    default:
+      return humanizeValueType(valueType);
+  }
+}
+
+function getSourceLabel(source: TelemetrySnapshot['source']): string {
+  switch (source) {
+    case 'redshift':
+      return 'Live warehouse data';
+    case 'sample':
+      return 'Sample data';
+    default:
+      return 'No local data';
+  }
+}
+
+function getSourceDescription(source: TelemetrySnapshot['source']): string {
+  switch (source) {
+    case 'redshift':
+      return 'Live warehouse snapshot';
+    case 'sample':
+      return 'Committed sample snapshot';
+    default:
+      return 'Empty placeholder snapshot';
+  }
+}
+
+function renderError(error: unknown): void {
+  app.innerHTML = `
+    <section class="error-state">
+      <div class="error-card">
+        <h1>Failed to load telemetry snapshot</h1>
+        <p>${escapeHtml(error instanceof Error ? error.message : String(error))}</p>
+      </div>
+    </section>
+  `;
+}
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function formatWeekLabel(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatCompact(value: number): string {
+  if (Math.abs(value) >= 1000) {
+    return new Intl.NumberFormat(undefined, {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(value);
+  }
+
+  if (Number.isInteger(value)) {
+    return formatNumber(value);
+  }
+
+  return value.toFixed(2);
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function round(value: number, digits = 1): number {
+  return Number(value.toFixed(digits));
+}
+
+function latestWeekProjects(timeline: VersionTimeline): number {
+  return timeline.weeks.at(-1)?.projects ?? 0;
+}
+
+function getTimelineColor(index: number): string {
+  const colors = ['#0a7c66', '#f2a65a', '#2159a8', '#cf7a00', '#7a3e00', '#698f2a'];
+  return colors[index % colors.length]!;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value);
+}

--- a/telemetry-dashboard/src/styles.css
+++ b/telemetry-dashboard/src/styles.css
@@ -1,0 +1,571 @@
+:root {
+  color-scheme: light;
+  --bg: #eef3ef;
+  --bg-strong: #d9e8dd;
+  --surface: rgba(255, 255, 255, 0.88);
+  --surface-strong: rgba(255, 255, 255, 0.97);
+  --surface-border: rgba(16, 47, 34, 0.12);
+  --text: #102f22;
+  --text-soft: #4a685a;
+  --muted: #6d8579;
+  --accent: #0a7c66;
+  --accent-soft: rgba(10, 124, 102, 0.14);
+  --accent-strong: #0b6654;
+  --highlight: #f2a65a;
+  --warning: #cf7a00;
+  --shadow: 0 26px 60px rgba(16, 47, 34, 0.12);
+  --shadow-soft: 0 10px 30px rgba(16, 47, 34, 0.08);
+  --radius-xl: 28px;
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 999px;
+  --mono: 'SFMono-Regular', 'JetBrains Mono', 'SF Mono', Consolas, monospace;
+  --sans: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(242, 166, 90, 0.22), transparent 38%),
+    radial-gradient(circle at top right, rgba(10, 124, 102, 0.24), transparent 36%),
+    linear-gradient(180deg, #f9fbf8 0%, var(--bg) 58%, #e7f0ea 100%);
+  color: var(--text);
+  font-family: var(--sans);
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(16, 47, 34, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(16, 47, 34, 0.03) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.25), transparent 88%);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+}
+
+.page {
+  width: min(1480px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 28px 0 64px;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 20px;
+  padding: 36px;
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-xl);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(245, 250, 247, 0.82)),
+    rgba(255, 255, 255, 0.8);
+  box-shadow: var(--shadow);
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  right: -120px;
+  top: -80px;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(242, 166, 90, 0.38), transparent 68%);
+  transform: rotate(12deg);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 22px;
+  grid-template-columns: minmax(0, 1.7fr) minmax(320px, 0.9fr);
+}
+
+.hero h1 {
+  margin: 0 0 10px;
+  font-size: clamp(2.2rem, 3vw, 3.6rem);
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+}
+
+.hero p {
+  margin: 0;
+  max-width: 72ch;
+  color: var(--text-soft);
+  line-height: 1.55;
+}
+
+.meta-panel,
+.controls,
+.kpi-card,
+.overview-card,
+.field-card,
+.group-section {
+  border: 1px solid var(--surface-border);
+  background: var(--surface);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow-soft);
+}
+
+.meta-panel {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 20px;
+  border-radius: var(--radius-lg);
+}
+
+.meta-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.meta-block {
+  padding: 14px;
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+}
+
+.meta-label {
+  margin-bottom: 4px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.meta-value {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.notes {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-soft);
+  line-height: 1.45;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 18px;
+  padding: 16px;
+  border-radius: var(--radius-lg);
+}
+
+.control-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.inline-filter {
+  justify-content: flex-end;
+}
+
+.control-label {
+  color: var(--muted);
+  font-size: 0.88rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.pill-toggle,
+.chip,
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.pill-toggle {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(16, 47, 34, 0.08);
+}
+
+.pill-toggle input {
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+.search-input,
+.sort-select {
+  min-height: 44px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(16, 47, 34, 0.12);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text);
+}
+
+.search-input {
+  min-width: min(360px, 100%);
+  padding: 0 16px;
+}
+
+.sort-select {
+  padding: 0 14px;
+}
+
+.kpi-grid {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.kpi-card {
+  padding: 18px;
+  border-radius: var(--radius-lg);
+}
+
+.kpi-label {
+  margin-bottom: 10px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.kpi-value {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.kpi-sub {
+  margin-top: 10px;
+  color: var(--text-soft);
+  font-size: 0.94rem;
+}
+
+.overview-grid {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.overview-card,
+.group-section {
+  border-radius: var(--radius-lg);
+}
+
+.overview-card {
+  padding: 20px;
+}
+
+.overview-card-wide {
+  grid-column: span 2;
+}
+
+.group-section {
+  margin-top: 18px;
+  padding: 18px;
+}
+
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.section-header h2,
+.overview-card h2,
+.field-card h3 {
+  margin: 0;
+  letter-spacing: -0.03em;
+}
+
+.section-header p,
+.overview-card p {
+  margin: 4px 0 0;
+  color: var(--text-soft);
+}
+
+.field-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.field-card {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+}
+
+.field-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.field-subtitle {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.chip {
+  padding: 7px 11px;
+  background: rgba(10, 124, 102, 0.08);
+  color: var(--accent-strong);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.chip.warn {
+  background: rgba(242, 166, 90, 0.18);
+  color: #8b4f07;
+}
+
+.platform-row,
+.tag-row,
+.stat-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag {
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(16, 47, 34, 0.1);
+  color: var(--text-soft);
+  font-size: 0.82rem;
+}
+
+.tag strong {
+  color: var(--text);
+}
+
+.coverage {
+  display: grid;
+  gap: 8px;
+}
+
+.coverage-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text-soft);
+  font-size: 0.88rem;
+}
+
+.meter {
+  overflow: hidden;
+  height: 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(16, 47, 34, 0.08);
+}
+
+.meter-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), #2db892);
+}
+
+.dist-list {
+  display: grid;
+  gap: 10px;
+}
+
+.dist-row {
+  display: grid;
+  gap: 6px;
+}
+
+.dist-label-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.dist-label {
+  min-width: 0;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.dist-meta {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+}
+
+.dist-bar {
+  overflow: hidden;
+  height: 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(16, 47, 34, 0.07);
+}
+
+.dist-bar-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--highlight), #f7c57d);
+}
+
+.dist-note,
+.empty-copy,
+.muted-copy {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.timeline-chart {
+  margin-top: 16px;
+  padding: 12px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.timeline-chart svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.timeline-grid-line {
+  stroke: rgba(16, 47, 34, 0.12);
+  stroke-width: 1;
+}
+
+.timeline-axis-label {
+  fill: var(--muted);
+  font-size: 10px;
+}
+
+.timeline-legend {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.timeline-legend-item {
+  display: flex;
+  gap: 10px;
+  align-items: start;
+}
+
+.timeline-swatch {
+  width: 12px;
+  height: 12px;
+  margin-top: 4px;
+  border-radius: 999px;
+  background: var(--timeline-color);
+  flex: 0 0 auto;
+}
+
+.stat-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+}
+
+.stat {
+  padding: 12px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.stat-label {
+  color: var(--muted);
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.stat-value {
+  margin-top: 6px;
+  font-size: 1.08rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.duo-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.loading,
+.error-state,
+.empty-state {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 24px;
+  color: var(--text-soft);
+}
+
+.error-card,
+.empty-card {
+  max-width: 600px;
+  padding: 24px;
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shadow);
+}
+
+.mono {
+  font-family: var(--mono);
+}
+
+@media (max-width: 980px) {
+  .page {
+    width: min(100vw - 20px, 100%);
+    padding: 14px 0 40px;
+  }
+
+  .hero {
+    padding: 22px;
+  }
+
+  .hero-content {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-card-wide {
+    grid-column: span 1;
+  }
+}

--- a/telemetry-dashboard/src/types.ts
+++ b/telemetry-dashboard/src/types.ts
@@ -1,0 +1,130 @@
+export type PlatformId = 'sq' | 'sc';
+export type FieldValueType = 'string' | 'number' | 'boolean' | 'mixed' | 'unknown';
+export type FieldSemanticType = 'dimension' | 'version' | 'count' | 'metric' | 'boolean';
+export type SnapshotSource = 'empty' | 'sample' | 'redshift';
+
+export interface DistributionValue {
+  value: string;
+  count: number;
+  percent: number;
+}
+
+export interface NumericSummary {
+  numericRows: number;
+  zeroRows: number;
+  positiveRows: number;
+  min: number;
+  max: number;
+  avg: number;
+  sum: number;
+}
+
+export interface FieldCoverage {
+  total: number;
+  nonNull: number;
+  percent: number;
+  distinct: number;
+}
+
+export interface FieldSummary {
+  key: string;
+  columnName: string;
+  displayName: string;
+  path: string[];
+  category: string;
+  valueType: FieldValueType;
+  semanticType: FieldSemanticType;
+  redshiftType: string;
+  coverage: FieldCoverage;
+  topValues: DistributionValue[];
+  tokenValues?: DistributionValue[];
+  valueListTruncated: boolean;
+  numeric?: NumericSummary;
+}
+
+export interface CatalogField {
+  key: string;
+  columnName: string;
+  displayName: string;
+  path: string[];
+  category: string;
+  availability: Record<PlatformId, boolean>;
+  redshiftTypes: Partial<Record<PlatformId, string>>;
+}
+
+export interface ModuleTypeOverview {
+  projectsWithTelemetry: number;
+  totalEsmFiles: number;
+  totalCjsFiles: number;
+  esmOnlyProjects: number;
+  cjsOnlyProjects: number;
+  bothProjects: number;
+  neitherProjects: number;
+}
+
+export interface ProgramCreationVersionOverview {
+  version: string;
+  projects: number;
+  projectsWithFailures: number;
+  attempts: number;
+  succeeded: number;
+  failed: number;
+}
+
+export interface ProgramCreationOverview {
+  projects: number;
+  projectsWithFailures: number;
+  attempts: number;
+  succeeded: number;
+  failed: number;
+  byVersion: ProgramCreationVersionOverview[];
+  atOrAboveVersion: ProgramCreationVersionOverview[];
+}
+
+export interface TimelinePoint {
+  weekStart: string;
+  projects: number;
+}
+
+export interface VersionTimelineSeries {
+  value: string;
+  totalProjects: number;
+  weekly: TimelinePoint[];
+}
+
+export interface VersionTimeline {
+  weeks: TimelinePoint[];
+  series: VersionTimelineSeries[];
+}
+
+export interface PlatformTimelineOverview {
+  nodeMajorVersion?: VersionTimeline;
+  typescriptVersion?: VersionTimeline;
+}
+
+export interface SnapshotOverview {
+  moduleType?: Partial<Record<PlatformId, ModuleTypeOverview>>;
+  programCreation?: Partial<Record<PlatformId, ProgramCreationOverview>>;
+  timelines?: Partial<Record<PlatformId, PlatformTimelineOverview>>;
+}
+
+export interface PlatformSnapshot {
+  id: PlatformId;
+  label: string;
+  shortLabel: string;
+  view: string;
+  latestProjectCount: number;
+  fieldCount: number;
+  fields: Record<string, FieldSummary>;
+}
+
+export interface TelemetrySnapshot {
+  generatedAt: string;
+  source: SnapshotSource;
+  windowDays: number;
+  windowStart: string;
+  notes: string[];
+  platforms: Record<PlatformId, PlatformSnapshot>;
+  catalog: CatalogField[];
+  overview?: SnapshotOverview;
+}

--- a/telemetry-dashboard/tsconfig.json
+++ b/telemetry-dashboard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["DOM", "ES2023"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add the SonarJS telemetry dashboard static site
- temporarily publish the static build to gh_pages without fetching Redshift data
- keep the Redshift fetch code in place for the next step, once access is ready
- keep the deployment model aligned with issue-feedback-dashboard and the existing SonarJS Pages config in re-service-config

## Related
- SonarSource/sonarsource-iam#2170

## Validation
- npm --prefix telemetry-dashboard run typecheck
- npm --prefix telemetry-dashboard run build
- git diff --check