### PR TITLE
JS-1597 add proto-loader generated-source detector

### DIFF
--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -17,10 +17,12 @@
 import type { GeneratedSourceDetector } from '../contracts.js';
 import { graphqlCodegenDetector } from './graphql-codegen.js';
 import { openApiGeneratorDetector } from './openapi-generator.js';
+import { protoLoaderGenTypesDetector } from './proto-loader-gen-types.js';
 
 export const GENERATED_SOURCE_DETECTORS: readonly GeneratedSourceDetector[] = [
   graphqlCodegenDetector,
   openApiGeneratorDetector,
+  protoLoaderGenTypesDetector,
 ];
 
 export function getGeneratedSourceWatchedFilenames(

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/proto-loader-gen-types.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/proto-loader-gen-types.ts
@@ -1,0 +1,82 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { GeneratedSourceDetector } from '../contracts.js';
+import { resolveGeneratedOutputsFromLiteralPaths } from '../detector-api.js';
+import {
+  addFamilyFiles,
+  createDerivedGeneratedSources,
+  extractFlagValuesFromTokens,
+  resolveLiteralPath,
+} from '../shared.js';
+import { taskInvocationInvokesCommand, type TaskInvocation } from '../task-invocations.js';
+
+const PROTO_LOADER_GEN_TYPES_FAMILY = 'proto-loader-gen-types';
+const PROTO_LOADER_OUTPUT_FLAGS = ['-O', '--outDir'];
+const PROTO_LOADER_GENERATED_DIRECTORY_SEGMENT_PATTERN =
+  /^(generated|generated[-_].+|.+[-_]generated)$/;
+
+function isGeneratedLikeProtoLoaderDirectory(outputPath: string) {
+  return outputPath
+    .replaceAll('\\', '/')
+    .split('/')
+    .some(segment => PROTO_LOADER_GENERATED_DIRECTORY_SEGMENT_PATTERN.test(segment));
+}
+
+export const protoLoaderGenTypesDetector = {
+  family: PROTO_LOADER_GEN_TYPES_FAMILY,
+
+  async detect({ baseDir, packageDir, taskInvocations, sourceFileMatcher }) {
+    const matchesTaskInvocation = (taskInvocation: TaskInvocation) =>
+      taskInvocationInvokesCommand(taskInvocation, PROTO_LOADER_GEN_TYPES_FAMILY);
+    const matchingInvocations = taskInvocations.filter(matchesTaskInvocation);
+    if (matchingInvocations.length === 0) {
+      return createDerivedGeneratedSources();
+    }
+
+    const outputPaths = matchingInvocations.flatMap(taskInvocation =>
+      extractFlagValuesFromTokens(taskInvocation.args, PROTO_LOADER_OUTPUT_FLAGS),
+    );
+    const derived = createDerivedGeneratedSources();
+    const recursiveOutputPaths = outputPaths.filter(isGeneratedLikeProtoLoaderDirectory);
+    if (recursiveOutputPaths.length > 0) {
+      const resolvedOutputs = await resolveGeneratedOutputsFromLiteralPaths(
+        baseDir,
+        packageDir,
+        recursiveOutputPaths,
+        true,
+        sourceFileMatcher,
+      );
+      addFamilyFiles(PROTO_LOADER_GEN_TYPES_FAMILY, resolvedOutputs.filePaths, derived);
+      for (const watchedOutputPath of resolvedOutputs.watchedOutputPaths) {
+        derived.watchedOutputPaths.add(watchedOutputPath);
+      }
+    }
+
+    for (const outputPath of outputPaths) {
+      if (isGeneratedLikeProtoLoaderDirectory(outputPath)) {
+        continue;
+      }
+
+      const resolvedPath = resolveLiteralPath(outputPath, packageDir, baseDir);
+      if (resolvedPath) {
+        derived.watchedOutputPaths.add(resolvedPath);
+      }
+    }
+
+    return derived;
+  },
+} satisfies GeneratedSourceDetector;

--- a/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/proto-loader/build/generated/ignored.ts
+++ b/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/proto-loader/build/generated/ignored.ts
@@ -1,0 +1,1 @@
+export const ignored = true;

--- a/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/proto-loader/package.json
+++ b/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/proto-loader/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "proto-loader-fixture",
+  "scripts": {
+    "codegen": "proto-loader-gen-types -O ./src/generated ./proto/service.proto",
+    "dynamic": "proto-loader-gen-types -O $PROTO_OUT ./proto/service.proto",
+    "build-output": "proto-loader-gen-types -O ./build/generated ./proto/service.proto"
+  }
+}

--- a/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/proto-loader/src/generated/service.ts
+++ b/packages/analysis/tests/jsts/project-metadata/fixtures/generated-sources/proto-loader/src/generated/service.ts
@@ -1,0 +1,3 @@
+export type ProtoFixture = {
+  service: string;
+};

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -52,6 +52,7 @@ const fixtures = joinPaths(
 );
 const GRAPHQL_CODEGEN_FAMILY = '@graphql-codegen/cli';
 const OPENAPI_GENERATOR_FAMILY = '@openapitools/openapi-generator-cli';
+const PROTO_LOADER_GEN_TYPES_FAMILY = 'proto-loader-gen-types';
 
 function createPackageJsonMap(
   packageDir: NormalizedAbsolutePath,
@@ -73,7 +74,10 @@ async function writeFixtureFile(filePath: string, content = '') {
 }
 
 async function writeOpenApiFilesManifest(outputDir: string, filePaths: string[]) {
-  await writeFixtureFile(join(outputDir, '.openapi-generator', 'FILES'), `${filePaths.join('\n')}\n`);
+  await writeFixtureFile(
+    join(outputDir, '.openapi-generator', 'FILES'),
+    `${filePaths.join('\n')}\n`,
+  );
 }
 
 describe('generated sources project metadata', () => {
@@ -83,10 +87,11 @@ describe('generated sources project metadata', () => {
     sourceFileStore.clearCache();
   });
 
-  it('registers the GraphQL and OpenAPI detectors through the shared contract', () => {
+  it('registers the GraphQL, OpenAPI, and proto-loader detectors through the shared contract', () => {
     expect(GENERATED_SOURCE_DETECTORS.map(detector => detector.family)).toEqual([
       GRAPHQL_CODEGEN_FAMILY,
       OPENAPI_GENERATOR_FAMILY,
+      PROTO_LOADER_GEN_TYPES_FAMILY,
     ]);
     expect(GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS.map(provider => provider.kind)).toEqual([
       'package-json-scripts',
@@ -1073,7 +1078,9 @@ export default config;
     expect(
       generatedSourceStore.getFamily(joinPaths(baseDir, 'build', 'api', 'ignored.ts')),
     ).toEqual(OPENAPI_GENERATOR_FAMILY);
-    expect(generatedSourceStore.getFamily(joinPaths(baseDir, 'src', 'api', 'manual.ts'))).toBeUndefined();
+    expect(
+      generatedSourceStore.getFamily(joinPaths(baseDir, 'src', 'api', 'manual.ts')),
+    ).toBeUndefined();
   });
 
   it('derives OpenAPI outputs from an output flag using equals syntax', async () => {
@@ -2183,6 +2190,138 @@ plugins = [
 
       expect(derived.configPaths).toEqual(new Set());
       expect(derived.familyByFile.get(outputPath)).toBeUndefined();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives proto-loader outputs from the standard fixture', async () => {
+    const baseDir = joinPaths(fixtures, 'proto-loader');
+    await initFileStores(createConfiguration({ baseDir }));
+
+    expect(
+      generatedSourceStore.getFamily(joinPaths(baseDir, 'src', 'generated', 'service.ts')),
+    ).toEqual(PROTO_LOADER_GEN_TYPES_FAMILY);
+    expect(
+      generatedSourceStore.getFamily(joinPaths(baseDir, 'build', 'generated', 'ignored.ts')),
+    ).toEqual(PROTO_LOADER_GEN_TYPES_FAMILY);
+  });
+
+  it('derives recursive proto-loader outputs rooted under dist while pruning nested build/cache folders', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'dist', 'generated', 'nested', 'service.ts');
+    const ignoredBuildFile = joinPaths(baseDir, 'dist', 'generated', 'build', 'ignored.ts');
+    const ignoredCacheFile = joinPaths(baseDir, 'dist', 'generated', '.cache', 'ignored.ts');
+
+    try {
+      await writeFixtureFile(outputPath, 'export const service = true;\n');
+      await writeFixtureFile(ignoredBuildFile, 'export const ignored = true;\n');
+      await writeFixtureFile(ignoredCacheFile, 'export const ignored = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          scripts: {
+            codegen: 'proto-loader-gen-types -O=./dist/generated ./proto/service.proto',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toEqual(PROTO_LOADER_GEN_TYPES_FAMILY);
+      expect(derived.familyByFile.get(ignoredBuildFile)).toBeUndefined();
+      expect(derived.familyByFile.get(ignoredCacheFile)).toBeUndefined();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives proto-loader outputs from generated-like directory names with separator variants', async () => {
+    const cases = [
+      {
+        outputDirFlag: './src/generated-types',
+        outputPathSegments: ['src', 'generated-types', 'service.ts'],
+      },
+      {
+        outputDirFlag: './src/generated_types',
+        outputPathSegments: ['src', 'generated_types', 'service.ts'],
+      },
+      {
+        outputDirFlag: './src/types-generated',
+        outputPathSegments: ['src', 'types-generated', 'service.ts'],
+      },
+      {
+        outputDirFlag: './src/types_generated',
+        outputPathSegments: ['src', 'types_generated', 'service.ts'],
+      },
+    ] satisfies ReadonlyArray<{
+      outputDirFlag: string;
+      outputPathSegments: readonly string[];
+    }>;
+
+    for (const testCase of cases) {
+      const baseDir = await createTempBaseDir();
+      const outputPath = joinPaths(baseDir, ...testCase.outputPathSegments);
+
+      try {
+        await writeFixtureFile(outputPath, 'export const service = true;\n');
+
+        const derived = await deriveGeneratedSources(
+          baseDir,
+          createPackageJsonMap(baseDir, {
+            scripts: {
+              codegen: `proto-loader-gen-types -O=${testCase.outputDirFlag} ./proto/service.proto`,
+            },
+          }),
+        );
+
+        expect(derived.familyByFile.get(outputPath)).toEqual(PROTO_LOADER_GEN_TYPES_FAMILY);
+      } finally {
+        await rm(baseDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('derives proto-loader outputs from the --outDir long flag', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputPath = joinPaths(baseDir, 'src', 'generated', 'service.ts');
+
+    try {
+      await writeFixtureFile(outputPath, 'export const service = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          scripts: {
+            codegen: 'proto-loader-gen-types --outDir=./src/generated ./proto/service.proto',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toEqual(PROTO_LOADER_GEN_TYPES_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not derive proto-loader outputs from arbitrary directory names', async () => {
+    const baseDir = await createTempBaseDir();
+    const outputDirectory = joinPaths(baseDir, 'src', 'types');
+    const outputPath = joinPaths(outputDirectory, 'service.ts');
+
+    try {
+      await writeFixtureFile(outputPath, 'export const service = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          scripts: {
+            codegen: 'proto-loader-gen-types -O=./src/types ./proto/service.proto',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
+      expect(derived.watchedOutputPaths).toEqual(new Set([outputDirectory]));
     } finally {
       await rm(baseDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add generated-source detection for `proto-loader-gen-types`
- recurse only for proto-loader output directories whose path segments match `generated`, `generated-*`, `*-generated`, `generated_*`, or `*_generated`
- cover the proto-loader heuristics in project-metadata tests

## Why
- generated JS/TS files emitted by `proto-loader-gen-types` should not be analyzed as handwritten source
- peachee-js projects place supported proto-loader outputs under generated-style directories, so the heuristic stays intentionally narrow to avoid tagging arbitrary output folders as generated

## Impact
- proto-loader outputs are tagged as generated sources for both `-O` and `--outDir` when the output directory follows the supported generated-style naming
- non-matching output directories are still watched for refresh, but they are not scanned recursively as generated code

## Root Cause
- generated-source detection did not yet recognize the committed `proto-loader-gen-types` task patterns used in peachee-js projects
- recursive inclusion of every declared proto-loader output directory would risk misidentifying handwritten files as generated

## Validation
- `npx tsx --tsconfig packages/tsconfig.test.json --test --test-concurrency=4 --test-reporter=spec --test-reporter-destination stdout packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts`
