### PR TITLE
JS-1650 Use promoted LITS build on current master

### DIFF
--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.javascript.TypeScriptLanguage;
 
 public final class SonarScannerIntegrationHelper {
 
-  static final String LITS_VERSION = "0.11.0.2659";
+  static final String LITS_VERSION = "0.12.0.5847";
 
   /**
    * Get the engine version based on the sonar.runtimeVersion system property.

--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.javascript.TypeScriptLanguage;
 
 public final class SonarScannerIntegrationHelper {
 
-  static final String LITS_VERSION = "0.12.0.5847";
+  static final String LITS_VERSION = "0.12.0.5851";
 
   /**
    * Get the engine version based on the sonar.runtimeVersion system property.

--- a/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
@@ -56,7 +56,7 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 class RulingTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RulingTest.class);
-  static final String LITS_VERSION = "0.11.0.2659";
+  static final String LITS_VERSION = "0.12.0.5847";
   static final String SCANNER_VERSION = "5.0.1.3006";
 
   static final String DEFAULT_EXCLUSIONS = "**/.*,**/*.d.ts";
@@ -279,11 +279,15 @@ class RulingTest {
       .setScannerVersion(SCANNER_VERSION)
       .setProperty(
         "sonar.lits.dump.old",
-        FileLocation.of("src/test/expected/" + projectKey).getFile().getAbsolutePath()
+        FileLocation.of("src/test/expected/" + projectKey)
+          .getFile()
+          .getAbsolutePath()
       )
       .setProperty(
         "sonar.lits.dump.new",
-        FileLocation.of("target/actual/" + projectKey).getFile().getAbsolutePath()
+        FileLocation.of("target/actual/" + projectKey)
+          .getFile()
+          .getAbsolutePath()
       )
       .setProperty("sonar.lits.differences", differencesPath.toString())
       .setProperty("sonar.exclusions", actualExclusions)

--- a/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
@@ -56,7 +56,7 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 class RulingTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RulingTest.class);
-  static final String LITS_VERSION = "0.12.0.5847";
+  static final String LITS_VERSION = "0.12.0.5851";
   static final String SCANNER_VERSION = "5.0.1.3006";
 
   static final String DEFAULT_EXCLUSIONS = "**/.*,**/*.d.ts";


### PR DESCRIPTION
Part of JS-1650

## Summary
- bump the LITS version used by ruling and plugin integration tests from `0.11.0.2659` to `0.12.0.5851`
- use the same promoted `sonar-lits-plugin` build as [#7158](https://github.com/SonarSource/SonarJS/pull/7158)
- keep this on current `master`, which still uses the module-sensor path, as a draft smoke PR with no analyzer changes

## Verification
- not run locally for this draft PR