### PR TITLE
JS-1597 wire generated-source analysis plumbing

### DIFF
--- a/packages/analysis/src/analyzeProject.ts
+++ b/packages/analysis/src/analyzeProject.ts
@@ -36,7 +36,11 @@ import type { WsIncrementalResult } from './incremental-result.js';
 import { setSourceFilesContext } from './jsts/program/cache/sourceFileCache.js';
 import { generatedSourceStore, sourceFileStore } from './file-stores/index.js';
 import type { NormalizedAbsolutePath } from '../../shared/src/helpers/files.js';
-import { getProjectAnalysisTelemetry, resetProjectAnalysisTelemetry } from './telemetry.js';
+import {
+  getProjectAnalysisTelemetry,
+  getProjectAnalysisTelemetryCollector,
+  resetProjectAnalysisTelemetry,
+} from './telemetry.js';
 
 const analysisStatus = {
   cancelled: false,
@@ -79,6 +83,9 @@ export async function analyzeProject(
   };
   const { baseDir, environments, globals, sonarlint, canAccessFileSystem } = configuration;
   resetProjectAnalysisTelemetry();
+  getProjectAnalysisTelemetryCollector().recordGeneratedSources(
+    generatedSourceStore.getObservabilityTelemetry(),
+  );
   const jsTsConfigFields = getJsTsConfigFields(configuration);
   setSourceFilesContext(filesToAnalyze);
   const { testFileExtensions } = getFilterPathParams(configuration);
@@ -88,6 +95,7 @@ export async function analyzeProject(
     globals,
     bundles,
     baseDir,
+    detectGeneratedCode: configuration.detectGeneratedCode,
     isGeneratedSourceFile: filePath => generatedSourceStore.getFamily(filePath) !== undefined,
     rulesWorkdir,
     testFileExtensions,

--- a/packages/analysis/src/common/configuration.ts
+++ b/packages/analysis/src/common/configuration.ts
@@ -196,6 +196,25 @@ const DEFAULT_GLOBALS = [
   'sap',
 ];
 
+type RawConfiguration = Record<string, unknown>;
+
+function getRequiredBaseDir(raw: RawConfiguration) {
+  const { baseDir } = raw;
+  if (!isString(baseDir)) {
+    throw new Error('baseDir is required and must be a string');
+  }
+  return baseDir;
+}
+
+function getOptionalValue<T>(
+  raw: RawConfiguration,
+  key: keyof ConfigurationInput,
+  predicate: (value: unknown) => value is T,
+) {
+  const value = raw[key];
+  return predicate(value) ? value : undefined;
+}
+
 /**
  * Creates a new Configuration instance from raw input.
  * Validates and normalizes the input without mutating any global state.
@@ -217,58 +236,50 @@ export function createConfiguration(raw: unknown): Configuration {
   if (!isObject(raw)) {
     throw new Error('Invalid configuration: expected object');
   }
-  if (!isString(raw.baseDir)) {
-    throw new Error('baseDir is required and must be a string');
-  }
+  const baseDir = getRequiredBaseDir(raw);
   return createConfigurationFromInput({
-    baseDir: raw.baseDir,
-    canAccessFileSystem: isBoolean(raw.canAccessFileSystem) ? raw.canAccessFileSystem : undefined,
-    sonarlint: isBoolean(raw.sonarlint) ? raw.sonarlint : undefined,
-    clearDependenciesCache: isBoolean(raw.clearDependenciesCache)
-      ? raw.clearDependenciesCache
-      : undefined,
-    clearTsConfigCache: isBoolean(raw.clearTsConfigCache) ? raw.clearTsConfigCache : undefined,
+    baseDir,
+    canAccessFileSystem: getOptionalValue(raw, 'canAccessFileSystem', isBoolean),
+    sonarlint: getOptionalValue(raw, 'sonarlint', isBoolean),
+    clearDependenciesCache: getOptionalValue(raw, 'clearDependenciesCache', isBoolean),
+    clearTsConfigCache: getOptionalValue(raw, 'clearTsConfigCache', isBoolean),
     fsEvents: sanitizeFsEvents(raw.fsEvents),
-    allowTsParserJsFiles: isBoolean(raw.allowTsParserJsFiles)
-      ? raw.allowTsParserJsFiles
-      : undefined,
-    analysisMode: isAnalysisMode(raw.analysisMode) ? raw.analysisMode : undefined,
-    skipAst: isBoolean(raw.skipAst) ? raw.skipAst : undefined,
-    ignoreHeaderComments: isBoolean(raw.ignoreHeaderComments)
-      ? raw.ignoreHeaderComments
-      : undefined,
-    maxFileSize: isNumber(raw.maxFileSize) ? raw.maxFileSize : undefined,
-    environments: isStringArray(raw.environments) ? raw.environments : undefined,
-    globals: isStringArray(raw.globals) ? raw.globals : undefined,
-    tsSuffixes: isStringArray(raw.tsSuffixes) ? raw.tsSuffixes : undefined,
-    jsSuffixes: isStringArray(raw.jsSuffixes) ? raw.jsSuffixes : undefined,
-    cssSuffixes: isStringArray(raw.cssSuffixes) ? raw.cssSuffixes : undefined,
-    htmlSuffixes: isStringArray(raw.htmlSuffixes) ? raw.htmlSuffixes : undefined,
-    yamlSuffixes: isStringArray(raw.yamlSuffixes) ? raw.yamlSuffixes : undefined,
-    cssAdditionalSuffixes: isStringArray(raw.cssAdditionalSuffixes)
-      ? raw.cssAdditionalSuffixes
-      : undefined,
-    tsConfigPaths: isStringArray(raw.tsConfigPaths) ? raw.tsConfigPaths : undefined,
-    jsTsExclusions: isStringArray(raw.jsTsExclusions) ? raw.jsTsExclusions : undefined,
-    sources: isStringArray(raw.sources) ? raw.sources : undefined,
-    inclusions: isStringArray(raw.inclusions) ? raw.inclusions : undefined,
-    exclusions: isStringArray(raw.exclusions) ? raw.exclusions : undefined,
-    tests: isStringArray(raw.tests) ? raw.tests : undefined,
-    testInclusions: isStringArray(raw.testInclusions) ? raw.testInclusions : undefined,
-    testExclusions: isStringArray(raw.testExclusions) ? raw.testExclusions : undefined,
-    detectBundles: isBoolean(raw.detectBundles) ? raw.detectBundles : undefined,
-    detectGeneratedCode: isBoolean(raw.detectGeneratedCode) ? raw.detectGeneratedCode : undefined,
-    createTSProgramForOrphanFiles: isBoolean(raw.createTSProgramForOrphanFiles)
-      ? raw.createTSProgramForOrphanFiles
-      : undefined,
-    disableTypeChecking: isBoolean(raw.disableTypeChecking) ? raw.disableTypeChecking : undefined,
-    skipNodeModuleLookupOutsideBaseDir: isBoolean(raw.skipNodeModuleLookupOutsideBaseDir)
-      ? raw.skipNodeModuleLookupOutsideBaseDir
-      : undefined,
-    ecmaScriptVersion: isString(raw.ecmaScriptVersion) ? raw.ecmaScriptVersion : undefined,
-    reportNclocForTestFiles: isBoolean(raw.reportNclocForTestFiles)
-      ? raw.reportNclocForTestFiles
-      : undefined,
+    allowTsParserJsFiles: getOptionalValue(raw, 'allowTsParserJsFiles', isBoolean),
+    analysisMode: getOptionalValue(raw, 'analysisMode', isAnalysisMode),
+    skipAst: getOptionalValue(raw, 'skipAst', isBoolean),
+    ignoreHeaderComments: getOptionalValue(raw, 'ignoreHeaderComments', isBoolean),
+    maxFileSize: getOptionalValue(raw, 'maxFileSize', isNumber),
+    environments: getOptionalValue(raw, 'environments', isStringArray),
+    globals: getOptionalValue(raw, 'globals', isStringArray),
+    tsSuffixes: getOptionalValue(raw, 'tsSuffixes', isStringArray),
+    jsSuffixes: getOptionalValue(raw, 'jsSuffixes', isStringArray),
+    cssSuffixes: getOptionalValue(raw, 'cssSuffixes', isStringArray),
+    htmlSuffixes: getOptionalValue(raw, 'htmlSuffixes', isStringArray),
+    yamlSuffixes: getOptionalValue(raw, 'yamlSuffixes', isStringArray),
+    cssAdditionalSuffixes: getOptionalValue(raw, 'cssAdditionalSuffixes', isStringArray),
+    tsConfigPaths: getOptionalValue(raw, 'tsConfigPaths', isStringArray),
+    jsTsExclusions: getOptionalValue(raw, 'jsTsExclusions', isStringArray),
+    sources: getOptionalValue(raw, 'sources', isStringArray),
+    inclusions: getOptionalValue(raw, 'inclusions', isStringArray),
+    exclusions: getOptionalValue(raw, 'exclusions', isStringArray),
+    tests: getOptionalValue(raw, 'tests', isStringArray),
+    testInclusions: getOptionalValue(raw, 'testInclusions', isStringArray),
+    testExclusions: getOptionalValue(raw, 'testExclusions', isStringArray),
+    detectBundles: getOptionalValue(raw, 'detectBundles', isBoolean),
+    detectGeneratedCode: getOptionalValue(raw, 'detectGeneratedCode', isBoolean),
+    createTSProgramForOrphanFiles: getOptionalValue(
+      raw,
+      'createTSProgramForOrphanFiles',
+      isBoolean,
+    ),
+    disableTypeChecking: getOptionalValue(raw, 'disableTypeChecking', isBoolean),
+    skipNodeModuleLookupOutsideBaseDir: getOptionalValue(
+      raw,
+      'skipNodeModuleLookupOutsideBaseDir',
+      isBoolean,
+    ),
+    ecmaScriptVersion: getOptionalValue(raw, 'ecmaScriptVersion', isString),
+    reportNclocForTestFiles: getOptionalValue(raw, 'reportNclocForTestFiles', isBoolean),
   });
 }
 

--- a/packages/analysis/src/common/configuration.ts
+++ b/packages/analysis/src/common/configuration.ts
@@ -431,6 +431,16 @@ function serializeMinimatchPatterns(patterns: Minimatch[]) {
 }
 
 /**
+ * Returns a stable cache key for configuration fields that decide which project-level
+ * helper files can be discovered during the file-system walk.
+ */
+export function getProjectFileDiscoveryConfigKey(configuration: Configuration) {
+  return JSON.stringify({
+    jsTsExclusions: serializeMinimatchPatterns(configuration.jsTsExclusions),
+  });
+}
+
+/**
  * Returns a stable cache key for the configuration fields that decide which files
  * are discovered, kept, and classified for analysis.
  */

--- a/packages/analysis/src/common/configuration.ts
+++ b/packages/analysis/src/common/configuration.ts
@@ -29,7 +29,6 @@ import {
   isStringArray,
   isObject,
 } from '../../../shared/src/helpers/sanitize.js';
-import { JAVASCRIPT_CODE_FILE_EXTENSIONS, TYPESCRIPT_CODE_FILE_EXTENSIONS } from './file-kinds.js';
 
 /**
  * A discriminator between JavaScript and TypeScript languages. This is used
@@ -82,6 +81,7 @@ export type Configuration = {
   testInclusions: Minimatch[] /* sonar.test.inclusions - WILDCARD to narrow down sonar.tests */;
   testExclusions: Minimatch[] /* sonar.test.exclusions - WILDCARD to narrow down sonar.tests */;
   detectBundles: boolean /* sonar.javascript.detectBundles - whether files looking like bundled code should be ignored */;
+  detectGeneratedCode: boolean /* sonar.javascript.detectGeneratedCode - whether generated-source detection should affect analysis behavior */;
   createTSProgramForOrphanFiles: boolean /* sonar.javascript.createTSProgramForOrphanFiles - whether to create a TS program for orphan files */;
   disableTypeChecking: boolean /* sonar.javascript.disableTypeChecking - whether to completely disable TypeScript type checking */;
   skipNodeModuleLookupOutsideBaseDir: boolean /* sonar.internal.analysis.skipNodeModuleLookupOutsideBaseDir - whether to skip node_modules lookups outside baseDir in TS compiler host */;
@@ -118,6 +118,7 @@ export type ConfigurationInput = {
   testInclusions?: string[];
   testExclusions?: string[];
   detectBundles?: boolean;
+  detectGeneratedCode?: boolean;
   createTSProgramForOrphanFiles?: boolean;
   disableTypeChecking?: boolean;
   skipNodeModuleLookupOutsideBaseDir?: boolean;
@@ -128,8 +129,8 @@ export type ConfigurationInput = {
 // Patterns enforced to be ignored no matter what the user configures on sonar.properties
 const IGNORED_PATTERNS = ['.scannerwork'];
 
-const DEFAULT_JS_EXTENSIONS = [...JAVASCRIPT_CODE_FILE_EXTENSIONS, '.vue'];
-const DEFAULT_TS_EXTENSIONS = TYPESCRIPT_CODE_FILE_EXTENSIONS.slice();
+const DEFAULT_JS_EXTENSIONS = ['.js', '.mjs', '.cjs', '.jsx', '.vue'];
+const DEFAULT_TS_EXTENSIONS = ['.ts', '.mts', '.cts', '.tsx'];
 const DEFAULT_CSS_EXTENSIONS = ['.css', '.less', '.scss', '.sass'];
 const DEFAULT_HTML_EXTENSIONS = ['.html', '.htm', '.xhtml'];
 const DEFAULT_YAML_EXTENSIONS = ['.yml', '.yaml'];
@@ -256,6 +257,7 @@ export function createConfiguration(raw: unknown): Configuration {
     testInclusions: isStringArray(raw.testInclusions) ? raw.testInclusions : undefined,
     testExclusions: isStringArray(raw.testExclusions) ? raw.testExclusions : undefined,
     detectBundles: isBoolean(raw.detectBundles) ? raw.detectBundles : undefined,
+    detectGeneratedCode: isBoolean(raw.detectGeneratedCode) ? raw.detectGeneratedCode : undefined,
     createTSProgramForOrphanFiles: isBoolean(raw.createTSProgramForOrphanFiles)
       ? raw.createTSProgramForOrphanFiles
       : undefined,
@@ -308,6 +310,7 @@ export function createConfigurationFromInput(input: ConfigurationInput): Configu
     testInclusions: normalizeGlobs(input.testInclusions, baseDir),
     testExclusions: normalizeGlobs(input.testExclusions, baseDir),
     detectBundles: input.detectBundles ?? true,
+    detectGeneratedCode: input.detectGeneratedCode ?? true,
     createTSProgramForOrphanFiles: input.createTSProgramForOrphanFiles ?? true,
     disableTypeChecking: input.disableTypeChecking ?? false,
     skipNodeModuleLookupOutsideBaseDir: input.skipNodeModuleLookupOutsideBaseDir ?? false,
@@ -425,16 +428,6 @@ export function getFilterPathParams(configuration: Configuration): FilterPathPar
 
 function serializeMinimatchPatterns(patterns: Minimatch[]) {
   return patterns.map(({ pattern }) => pattern);
-}
-
-/**
- * Returns a stable cache key for configuration fields that decide which project-level
- * helper files can be discovered during the file-system walk.
- */
-export function getProjectFileDiscoveryConfigKey(configuration: Configuration) {
-  return JSON.stringify({
-    jsTsExclusions: serializeMinimatchPatterns(configuration.jsTsExclusions),
-  });
 }
 
 /**

--- a/packages/analysis/src/common/file-kinds.ts
+++ b/packages/analysis/src/common/file-kinds.ts
@@ -17,8 +17,8 @@
 import { extname } from 'node:path/posix';
 import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
 
-export const JAVASCRIPT_CODE_FILE_EXTENSIONS = ['.js', '.mjs', '.cjs', '.jsx'] as const;
-export const TYPESCRIPT_CODE_FILE_EXTENSIONS = ['.ts', '.mts', '.cts', '.tsx'] as const;
+const JAVASCRIPT_CODE_FILE_EXTENSIONS = ['.js', '.mjs', '.cjs', '.jsx'] as const;
+const TYPESCRIPT_CODE_FILE_EXTENSIONS = ['.ts', '.mts', '.cts', '.tsx'] as const;
 const JS_TS_CODE_FILE_EXTENSIONS = [
   ...JAVASCRIPT_CODE_FILE_EXTENSIONS,
   ...TYPESCRIPT_CODE_FILE_EXTENSIONS,

--- a/packages/analysis/src/common/filter/filter-path.ts
+++ b/packages/analysis/src/common/filter/filter-path.ts
@@ -21,6 +21,14 @@ import type { FileType } from '../../contracts/file.js';
 import { type FilterPathParams } from '../configuration.js';
 import { isTestRelatedFile } from '../../jsts/rules/helpers/test-file-pattern.js';
 
+type CandidateClassification = 'MATCH' | 'EXCLUDED' | 'OUT_OF_SCOPE' | 'NO_MATCH';
+
+type FilePathClassification =
+  | { status: 'MAIN'; fileType: 'MAIN' }
+  | { status: 'TEST'; fileType: 'TEST' }
+  | { status: 'EXCLUDED' }
+  | { status: 'OUT_OF_SCOPE' };
+
 /**
  * Checks whether a given file path is excluded based on JavaScript/TypeScript exclusion
  * properties sonar.typescript.exclusions and sonar.javascript.exclusions wildcards.
@@ -62,21 +70,55 @@ export function filterPathAndGetFileType(
   filePath: NormalizedAbsolutePath,
   params: FilterPathParams,
 ): FileType | undefined {
-  if (fileIsTest(filePath, params)) {
-    return 'TEST';
-  }
-
-  if (fileIsMain(filePath, params)) {
-    return 'MAIN';
+  const classification = classifyFilePathInternal(filePath, params, true);
+  if (classification.status === 'TEST' || classification.status === 'MAIN') {
+    return classification.fileType;
   }
   debug(`File ignored due to analysis scope filters: ${filePath}`);
+}
+
+export function classifyFilePath(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+): FilePathClassification {
+  return classifyFilePathInternal(filePath, params, false);
 }
 
 function fileIsUnder(filePath: NormalizedAbsolutePath, paths: NormalizedAbsolutePath[]): boolean {
   return paths.some(path => filePath === path || filePath.startsWith(`${path}/`));
 }
 
-function fileIsTest(filePath: NormalizedAbsolutePath, params: FilterPathParams): boolean {
+function classifyFilePathInternal(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+  logHeuristicTestDetection: boolean,
+): FilePathClassification {
+  const testClassification = classifyTestPath(filePath, params, logHeuristicTestDetection);
+  if (testClassification === 'MATCH') {
+    return { status: 'TEST', fileType: 'TEST' };
+  }
+
+  const mainClassification = classifyMainPath(filePath, params);
+  if (mainClassification === 'MATCH') {
+    return { status: 'MAIN', fileType: 'MAIN' };
+  }
+
+  if (mainClassification === 'EXCLUDED' || testClassification === 'EXCLUDED') {
+    return { status: 'EXCLUDED' };
+  }
+
+  if (mainClassification === 'OUT_OF_SCOPE' || testClassification === 'OUT_OF_SCOPE') {
+    return { status: 'OUT_OF_SCOPE' };
+  }
+
+  return { status: 'OUT_OF_SCOPE' };
+}
+
+function classifyTestPath(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+  logHeuristicTestDetection: boolean,
+): CandidateClassification {
   const {
     testPaths,
     testExclusions,
@@ -95,41 +137,44 @@ function fileIsTest(filePath: NormalizedAbsolutePath, params: FilterPathParams):
       fileIsUnder(filePath, sourcesPaths) &&
       inclusions.some(inclusion => inclusion.match(filePath))
     ) {
-      return false;
+      return 'NO_MATCH';
     }
     const doesLookLikeTestFile = isTestRelatedFile(filePath, testFileExtensions);
-    if (doesLookLikeTestFile) {
+    if (doesLookLikeTestFile && logHeuristicTestDetection) {
       debug(
         `Test file detected: ${filePath}. If this file should not be treated as a test, please configure sonar.tests or adjust your sonar.sources/sonar.inclusions to explicitly include it as MAIN.`,
       );
     }
-    return doesLookLikeTestFile;
+    return doesLookLikeTestFile ? 'MATCH' : 'NO_MATCH';
   }
 
   if (!fileIsUnder(filePath, testPaths)) {
-    return false;
+    return 'NO_MATCH';
   }
   if (testExclusions?.some(exclusion => exclusion.match(filePath))) {
-    return false;
+    return 'EXCLUDED';
   }
   if (testInclusions?.length) {
-    return testInclusions.some(inclusion => inclusion.match(filePath));
+    return testInclusions.some(inclusion => inclusion.match(filePath)) ? 'MATCH' : 'OUT_OF_SCOPE';
   }
-  return true;
+  return 'MATCH';
 }
 
-function fileIsMain(filePath: NormalizedAbsolutePath, params: FilterPathParams): boolean {
+function classifyMainPath(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+): CandidateClassification {
   const { sourcesPaths, exclusions, inclusions } = params;
   if (!fileIsUnder(filePath, sourcesPaths)) {
-    return false;
+    return 'NO_MATCH';
   }
 
   if (exclusions?.some(exclusion => exclusion.match(filePath))) {
-    return false;
+    return 'EXCLUDED';
   }
 
   if (inclusions?.length) {
-    return inclusions.some(inclusion => inclusion.match(filePath));
+    return inclusions.some(inclusion => inclusion.match(filePath)) ? 'MATCH' : 'OUT_OF_SCOPE';
   }
-  return true;
+  return 'MATCH';
 }

--- a/packages/analysis/src/file-stores/dependency-manifests.ts
+++ b/packages/analysis/src/file-stores/dependency-manifests.ts
@@ -32,7 +32,6 @@ import {
   type PreloadableDependencyManifestName,
   isPreloadableDependencyManifestPath,
 } from '../jsts/rules/helpers/dependency-manifests/index.js';
-import { getProjectFileDiscoveryConfigKey } from '../common/configuration.js';
 
 export const UNINITIALIZED_ERROR =
   'dependency manifest cache has not been initialized. Call loadFiles() first.';
@@ -52,7 +51,6 @@ class DependencyManifestStore implements FileStore {
   private readonly manifestsByName = createManifestFilesByName();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
-  private projectFileDiscoveryConfigKey: string | undefined = undefined;
   private readonly dirnameToParent: Map<
     NormalizedAbsolutePath,
     NormalizedAbsolutePath | undefined
@@ -72,11 +70,7 @@ class DependencyManifestStore implements FileStore {
 
   dirtyCachesIfNeeded(configuration: Configuration) {
     const { baseDir, canAccessFileSystem, fsEvents } = configuration;
-    if (
-      baseDir !== this.baseDir ||
-      canAccessFileSystem !== this.canAccessFileSystem ||
-      getProjectFileDiscoveryConfigKey(configuration) !== this.projectFileDiscoveryConfigKey
-    ) {
+    if (baseDir !== this.baseDir || canAccessFileSystem !== this.canAccessFileSystem) {
       this.clearCache();
       return;
     }
@@ -91,7 +85,6 @@ class DependencyManifestStore implements FileStore {
   clearCache() {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
-    this.projectFileDiscoveryConfigKey = undefined;
     for (const manifestFiles of Object.values(this.manifestsByName)) {
       manifestFiles.clear();
     }
@@ -103,7 +96,6 @@ class DependencyManifestStore implements FileStore {
   setup(configuration: Configuration) {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
-    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     this.dirnameToParent.set(configuration.baseDir, undefined);
   }
 

--- a/packages/analysis/src/file-stores/dependency-manifests.ts
+++ b/packages/analysis/src/file-stores/dependency-manifests.ts
@@ -22,7 +22,10 @@ import {
   type NormalizedAbsolutePath,
   dirnamePath,
 } from '../../../shared/src/helpers/files.js';
-import type { Configuration } from '../common/configuration.js';
+import {
+  getProjectFileDiscoveryConfigKey,
+  type Configuration,
+} from '../common/configuration.js';
 import {
   clearDependenciesCache,
   getPreloadableDependencyManifestName,
@@ -51,6 +54,7 @@ class DependencyManifestStore implements FileStore {
   private readonly manifestsByName = createManifestFilesByName();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
+  private projectFileDiscoveryConfigKey: string | undefined = undefined;
   private readonly dirnameToParent: Map<
     NormalizedAbsolutePath,
     NormalizedAbsolutePath | undefined
@@ -74,6 +78,12 @@ class DependencyManifestStore implements FileStore {
       this.clearCache();
       return;
     }
+
+    if (getProjectFileDiscoveryConfigKey(configuration) !== this.projectFileDiscoveryConfigKey) {
+      this.clearCache();
+      return;
+    }
+
     for (const filename of fsEvents) {
       if (isPreloadableDependencyManifestPath(filename)) {
         this.clearCache();
@@ -85,6 +95,7 @@ class DependencyManifestStore implements FileStore {
   clearCache() {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
+    this.projectFileDiscoveryConfigKey = undefined;
     for (const manifestFiles of Object.values(this.manifestsByName)) {
       manifestFiles.clear();
     }
@@ -96,6 +107,7 @@ class DependencyManifestStore implements FileStore {
   setup(configuration: Configuration) {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
+    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     this.dirnameToParent.set(configuration.baseDir, undefined);
   }
 

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -31,6 +31,7 @@ import { classifyFilePath } from '../common/filter/filter-path.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
 import { GENERATED_SOURCE_WATCHED_FILENAMES } from '../jsts/rules/helpers/generated-sources/index.js';
+import type { GeneratedSourceFamily } from '../jsts/rules/helpers/generated-sources/contracts.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
 import { relativeToAncestorPath } from '../jsts/rules/helpers/files.js';
 import { deriveGeneratedSources } from '../jsts/rules/helpers/generated-sources/derive.js';
@@ -69,8 +70,8 @@ class GeneratedSourceStore implements FileStore {
   private analyzableFilesConfigKey: string | undefined = undefined;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
-  private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
-  private familyByFile = new Map<NormalizedAbsolutePath, string>();
+  private derivedFamilyByFile = new Map<NormalizedAbsolutePath, GeneratedSourceFamily>();
+  private familyByFile = new Map<NormalizedAbsolutePath, GeneratedSourceFamily>();
   private resolvedFiles = new Set<NormalizedAbsolutePath>();
   private configPaths = new Set<NormalizedAbsolutePath>();
   private watchedOutputPaths = new Set<NormalizedAbsolutePath>();
@@ -96,7 +97,7 @@ class GeneratedSourceStore implements FileStore {
     return true;
   }
 
-  getFamily(filePath: NormalizedAbsolutePath): string | undefined {
+  getFamily(filePath: NormalizedAbsolutePath): GeneratedSourceFamily | undefined {
     return this.familyByFile.get(filePath);
   }
 
@@ -242,14 +243,14 @@ class GeneratedSourceStore implements FileStore {
 }
 
 function filterAnalyzableGeneratedFiles(
-  familyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
+  familyByFile: ReadonlyMap<NormalizedAbsolutePath, GeneratedSourceFamily>,
   analyzableFiles: AnalyzableFiles | undefined,
 ) {
   if (!analyzableFiles) {
     return new Map(familyByFile);
   }
 
-  const filtered = new Map<NormalizedAbsolutePath, string>();
+  const filtered = new Map<NormalizedAbsolutePath, GeneratedSourceFamily>();
   for (const [filePath, family] of familyByFile) {
     if (Object.hasOwn(analyzableFiles, filePath)) {
       filtered.set(filePath, family);

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -31,7 +31,6 @@ import { classifyFilePath } from '../common/filter/filter-path.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
 import { GENERATED_SOURCE_WATCHED_FILENAMES } from '../jsts/rules/helpers/generated-sources/index.js';
-import type { GeneratedSourceFamily } from '../jsts/rules/helpers/generated-sources/contracts.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
 import { relativeToAncestorPath } from '../jsts/rules/helpers/files.js';
 import { deriveGeneratedSources } from '../jsts/rules/helpers/generated-sources/derive.js';
@@ -59,7 +58,7 @@ type GeneratedSourceObservability = {
   telemetry: GeneratedSourcesTelemetry;
   families: GeneratedSourceFamilyObservability[];
   ignoredDefaultDtsFamilies: Array<{
-    family: GeneratedSourceFamily;
+    family: string;
     filePaths: NormalizedAbsolutePath[];
   }>;
 };
@@ -70,8 +69,9 @@ class GeneratedSourceStore implements FileStore {
   private analyzableFilesConfigKey: string | undefined = undefined;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
-  private derivedFamilyByFile = new Map<NormalizedAbsolutePath, GeneratedSourceFamily>();
-  private familyByFile = new Map<NormalizedAbsolutePath, GeneratedSourceFamily>();
+  private readonly explicitRequestFilesKeys = new WeakMap<AnalyzableFiles, string>();
+  private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
+  private familyByFile = new Map<NormalizedAbsolutePath, string>();
   private resolvedFiles = new Set<NormalizedAbsolutePath>();
   private configPaths = new Set<NormalizedAbsolutePath>();
   private watchedOutputPaths = new Set<NormalizedAbsolutePath>();
@@ -79,7 +79,7 @@ class GeneratedSourceStore implements FileStore {
 
   async isInitialized(configuration: Configuration, inputFiles?: AnalyzableFiles) {
     this.dirtyCachesIfNeeded(configuration);
-    const requestFilesKey = getRequestFilesKey(configuration.canAccessFileSystem, inputFiles);
+    const requestFilesKey = this.getRequestFilesKey(configuration.canAccessFileSystem, inputFiles);
     this.activeRequestFilesKey = requestFilesKey;
     if (this.baseDir === undefined) {
       return false;
@@ -97,7 +97,7 @@ class GeneratedSourceStore implements FileStore {
     return true;
   }
 
-  getFamily(filePath: NormalizedAbsolutePath): GeneratedSourceFamily | undefined {
+  getFamily(filePath: NormalizedAbsolutePath): string | undefined {
     return this.familyByFile.get(filePath);
   }
 
@@ -179,7 +179,7 @@ class GeneratedSourceStore implements FileStore {
     this.refreshFilteredState(
       configuration,
       analyzableFiles,
-      this.activeRequestFilesKey ?? getRequestFilesKey(canAccessFileSystem, analyzableFiles),
+      this.activeRequestFilesKey ?? this.getRequestFilesKey(canAccessFileSystem, analyzableFiles),
     );
   }
 
@@ -219,6 +219,31 @@ class GeneratedSourceStore implements FileStore {
     this.observabilityTelemetry = createEmptyGeneratedSourcesTelemetry();
   }
 
+  private getRequestFilesKey(
+    canAccessFileSystem: boolean,
+    analyzableFiles?: AnalyzableFiles,
+  ): RequestFilesKey {
+    if (!analyzableFiles) {
+      return canAccessFileSystem ? ALL_FILES_REQUEST_KEY : undefined;
+    }
+
+    const cachedKey = this.explicitRequestFilesKeys.get(analyzableFiles);
+    if (cachedKey) {
+      return cachedKey;
+    }
+
+    const filePaths = Object.keys(analyzableFiles).sort((left, right) => left.localeCompare(right));
+    const hash = createHash('sha256');
+    for (const filePath of filePaths) {
+      hash.update(filePath);
+      hash.update('\0');
+    }
+
+    const requestFilesKey = `${EXPLICIT_FILE_SET_REQUEST_KEY_PREFIX}:${filePaths.length}:${hash.digest('hex')}`;
+    this.explicitRequestFilesKeys.set(analyzableFiles, requestFilesKey);
+    return requestFilesKey;
+  }
+
   private refreshFilteredState(
     configuration: Configuration,
     analyzableFiles: AnalyzableFiles | undefined,
@@ -243,38 +268,20 @@ class GeneratedSourceStore implements FileStore {
 }
 
 function filterAnalyzableGeneratedFiles(
-  familyByFile: ReadonlyMap<NormalizedAbsolutePath, GeneratedSourceFamily>,
+  familyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
   analyzableFiles: AnalyzableFiles | undefined,
 ) {
   if (!analyzableFiles) {
     return new Map(familyByFile);
   }
 
-  const filtered = new Map<NormalizedAbsolutePath, GeneratedSourceFamily>();
+  const filtered = new Map<NormalizedAbsolutePath, string>();
   for (const [filePath, family] of familyByFile) {
     if (Object.hasOwn(analyzableFiles, filePath)) {
       filtered.set(filePath, family);
     }
   }
   return filtered;
-}
-
-function getRequestFilesKey(
-  canAccessFileSystem: boolean,
-  analyzableFiles?: AnalyzableFiles,
-): RequestFilesKey {
-  if (!analyzableFiles) {
-    return canAccessFileSystem ? ALL_FILES_REQUEST_KEY : undefined;
-  }
-
-  const filePaths = Object.keys(analyzableFiles).sort((left, right) => left.localeCompare(right));
-  const hash = createHash('sha256');
-  for (const filePath of filePaths) {
-    hash.update(filePath);
-    hash.update('\0');
-  }
-
-  return `${EXPLICIT_FILE_SET_REQUEST_KEY_PREFIX}:${filePaths.length}:${hash.digest('hex')}`;
 }
 
 function createConfiguredGeneratedSourceFileMatcher(configuration: Configuration) {
@@ -290,12 +297,12 @@ function createConfiguredGeneratedSourceFileMatcher(configuration: Configuration
 export const generatedSourceStore = new GeneratedSourceStore();
 
 function buildGeneratedSourceObservability(
-  resolvedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, GeneratedSourceFamily>,
-  taggedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, GeneratedSourceFamily>,
+  resolvedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
+  taggedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
   configuration: Configuration,
 ): GeneratedSourceObservability {
   const filterPathParams = getFilterPathParams(configuration);
-  const pathsByFamily = new Map<GeneratedSourceFamily, NormalizedAbsolutePath[]>();
+  const pathsByFamily = new Map<string, NormalizedAbsolutePath[]>();
 
   for (const [filePath, family] of sortPathEntries(resolvedFamilyByFile.entries())) {
     let familyPaths = pathsByFamily.get(family);
@@ -386,7 +393,7 @@ function buildGeneratedSourceObservability(
 
 function shouldIgnoreDefaultDtsFamily(
   filePaths: readonly NormalizedAbsolutePath[],
-  taggedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, GeneratedSourceFamily>,
+  taggedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
   configuration: Configuration,
   filterPathParams: ReturnType<typeof getFilterPathParams>,
 ) {
@@ -415,9 +422,11 @@ function logGeneratedSourceObservability(
   baseDir: NormalizedAbsolutePath,
   observability: GeneratedSourceObservability,
 ) {
-  info(
-    `Generated source observability: families=${observability.telemetry.familyCount}, resolvedFiles=${observability.telemetry.resolvedFileCount}, taggedFiles=${observability.telemetry.taggedFileCount}, outOfScopeFiles=${observability.telemetry.outOfScopeFileCount}, excludedFiles=${observability.telemetry.excludedFileCount}`,
-  );
+  if (observability.telemetry.familyCount > 0) {
+    info(
+      `Generated source observability: families=${observability.telemetry.familyCount}, resolvedFiles=${observability.telemetry.resolvedFileCount}, taggedFiles=${observability.telemetry.taggedFileCount}, outOfScopeFiles=${observability.telemetry.outOfScopeFileCount}, excludedFiles=${observability.telemetry.excludedFileCount}`,
+    );
+  }
 
   for (const family of observability.families) {
     info(

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -17,29 +17,56 @@
 import { createHash } from 'node:crypto';
 import { basename, extname } from 'node:path/posix';
 import type { FileStore } from './store-type.js';
-import type { Configuration } from '../common/configuration.js';
-import type { AnalyzableFiles } from '../projectAnalysis.js';
-import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
+import {
+  normalizeToAbsolutePath,
+  type NormalizedAbsolutePath,
+} from '../../../shared/src/helpers/files.js';
+import { debug, info } from '../../../shared/src/helpers/logging.js';
 import {
   getAnalyzableFilesConfigKey,
-  getProjectFileDiscoveryConfigKey,
+  getFilterPathParams,
+  type Configuration,
 } from '../common/configuration.js';
+import { classifyFilePath } from '../common/filter/filter-path.js';
+import type { AnalyzableFiles } from '../projectAnalysis.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
-import { getGeneratedSourceWatchedFilenames } from '../jsts/rules/helpers/generated-sources/index.js';
+import { GENERATED_SOURCE_WATCHED_FILENAMES } from '../jsts/rules/helpers/generated-sources/index.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
+import { relativeToAncestorPath } from '../jsts/rules/helpers/files.js';
 import { deriveGeneratedSources } from '../jsts/rules/helpers/generated-sources/derive.js';
+import { sortPathEntries } from '../jsts/rules/helpers/generated-sources/shared.js';
+import {
+  cloneGeneratedSourcesTelemetry,
+  createEmptyGeneratedSourcesTelemetry,
+  type GeneratedSourceFamilyTelemetry,
+  type GeneratedSourcesTelemetry,
+} from '../telemetry.js';
 
+const DEFAULT_DTS_EXCLUSION_PATTERN = '**/*.d.ts';
+const OBSERVABILITY_SAMPLE_LIMIT = 3;
 const ALL_FILES_REQUEST_KEY = 'all-files';
 const EXPLICIT_FILE_SET_REQUEST_KEY_PREFIX = 'explicit';
 
 type RequestFilesKey = string | undefined;
 
+type GeneratedSourceFamilyObservability = GeneratedSourceFamilyTelemetry & {
+  excludedPaths: NormalizedAbsolutePath[];
+  outOfScopePaths: NormalizedAbsolutePath[];
+};
+
+type GeneratedSourceObservability = {
+  telemetry: GeneratedSourcesTelemetry;
+  families: GeneratedSourceFamilyObservability[];
+  ignoredDefaultDtsFamilies: Array<{
+    family: GeneratedSourceFamily;
+    filePaths: NormalizedAbsolutePath[];
+  }>;
+};
+
 class GeneratedSourceStore implements FileStore {
-  private readonly explicitRequestFilesKeys = new WeakMap<AnalyzableFiles, string>();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
-  private projectFileDiscoveryConfigKey: string | undefined = undefined;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
   private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
@@ -47,10 +74,11 @@ class GeneratedSourceStore implements FileStore {
   private resolvedFiles = new Set<NormalizedAbsolutePath>();
   private configPaths = new Set<NormalizedAbsolutePath>();
   private watchedOutputPaths = new Set<NormalizedAbsolutePath>();
+  private observabilityTelemetry = createEmptyGeneratedSourcesTelemetry();
 
   async isInitialized(configuration: Configuration, inputFiles?: AnalyzableFiles) {
     this.dirtyCachesIfNeeded(configuration);
-    const requestFilesKey = this.getRequestFilesKey(configuration.canAccessFileSystem, inputFiles);
+    const requestFilesKey = getRequestFilesKey(configuration.canAccessFileSystem, inputFiles);
     this.activeRequestFilesKey = requestFilesKey;
     if (this.baseDir === undefined) {
       return false;
@@ -64,12 +92,16 @@ class GeneratedSourceStore implements FileStore {
       return false;
     }
 
-    this.refreshFilteredState(inputFiles, requestFilesKey);
+    this.refreshFilteredState(configuration, inputFiles, requestFilesKey);
     return true;
   }
 
   getFamily(filePath: NormalizedAbsolutePath): string | undefined {
     return this.familyByFile.get(filePath);
+  }
+
+  getObservabilityTelemetry(): GeneratedSourcesTelemetry {
+    return cloneGeneratedSourcesTelemetry(this.observabilityTelemetry);
   }
 
   dirtyCachesIfNeeded(configuration: Configuration) {
@@ -84,14 +116,8 @@ class GeneratedSourceStore implements FileStore {
       return;
     }
 
-    if (getProjectFileDiscoveryConfigKey(configuration) !== this.projectFileDiscoveryConfigKey) {
-      this.clearCache();
-      return;
-    }
-
-    const generatedSourceWatchedFilenames = getGeneratedSourceWatchedFilenames();
     for (const filename of fsEvents) {
-      if (this.isRelevantEvent(filename, generatedSourceWatchedFilenames)) {
+      if (this.isRelevantEvent(filename)) {
         this.clearCache();
         return;
       }
@@ -102,7 +128,6 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
     this.analyzableFilesConfigKey = undefined;
-    this.projectFileDiscoveryConfigKey = undefined;
     this.activeRequestFilesKey = undefined;
     this.clearDerivedState();
   }
@@ -111,7 +136,6 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
     this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
-    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     this.clearDerivedState();
   }
 
@@ -123,6 +147,8 @@ class GeneratedSourceStore implements FileStore {
   }
 
   async postProcess(configuration: Configuration, analyzableFiles?: AnalyzableFiles) {
+    // `postProcess` may run after a cache clear, so restore the current config identity first
+    // without routing through `setup()`, which also clears derived state for a fresh scan.
     if (
       this.baseDir === undefined ||
       this.canAccessFileSystem === undefined ||
@@ -131,7 +157,6 @@ class GeneratedSourceStore implements FileStore {
       this.baseDir = configuration.baseDir;
       this.canAccessFileSystem = configuration.canAccessFileSystem;
       this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
-      this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     }
 
     const { baseDir, canAccessFileSystem } = this;
@@ -151,19 +176,17 @@ class GeneratedSourceStore implements FileStore {
     this.configPaths = derived.configPaths;
     this.watchedOutputPaths = derived.watchedOutputPaths;
     this.refreshFilteredState(
+      configuration,
       analyzableFiles,
-      this.activeRequestFilesKey ?? this.getRequestFilesKey(canAccessFileSystem, analyzableFiles),
+      this.activeRequestFilesKey ?? getRequestFilesKey(canAccessFileSystem, analyzableFiles),
     );
   }
 
-  private isRelevantEvent(
-    filename: NormalizedAbsolutePath,
-    generatedSourceWatchedFilenames: readonly string[],
-  ) {
+  private isRelevantEvent(filename: NormalizedAbsolutePath) {
     const eventBaseName = basename(filename).toLowerCase();
     if (
       isPreloadableDependencyManifestPath(filename) ||
-      generatedSourceWatchedFilenames.includes(eventBaseName)
+      GENERATED_SOURCE_WATCHED_FILENAMES.includes(eventBaseName)
     ) {
       return true;
     }
@@ -192,32 +215,29 @@ class GeneratedSourceStore implements FileStore {
     this.resolvedFiles = new Set();
     this.configPaths = new Set();
     this.watchedOutputPaths = new Set();
-  }
-
-  private getRequestFilesKey(
-    canAccessFileSystem: boolean,
-    analyzableFiles?: AnalyzableFiles,
-  ): RequestFilesKey {
-    if (!analyzableFiles) {
-      return canAccessFileSystem ? ALL_FILES_REQUEST_KEY : undefined;
-    }
-
-    const cachedRequestFilesKey = this.explicitRequestFilesKeys.get(analyzableFiles);
-    if (cachedRequestFilesKey !== undefined) {
-      return cachedRequestFilesKey;
-    }
-
-    const requestFilesKey = createExplicitRequestFilesKey(analyzableFiles);
-    this.explicitRequestFilesKeys.set(analyzableFiles, requestFilesKey);
-    return requestFilesKey;
+    this.observabilityTelemetry = createEmptyGeneratedSourcesTelemetry();
   }
 
   private refreshFilteredState(
+    configuration: Configuration,
     analyzableFiles: AnalyzableFiles | undefined,
     requestFilesKey: RequestFilesKey,
   ) {
+    if (!this.baseDir) {
+      return;
+    }
+
     this.requestFilesKey = requestFilesKey;
+    // Generated-source tagging must stay aligned with the analyzer's real file scope
+    // so configurable suffixes and exclusions win over detector-local heuristics.
     this.familyByFile = filterAnalyzableGeneratedFiles(this.derivedFamilyByFile, analyzableFiles);
+    const observability = buildGeneratedSourceObservability(
+      this.derivedFamilyByFile,
+      this.familyByFile,
+      configuration,
+    );
+    this.observabilityTelemetry = observability.telemetry;
+    logGeneratedSourceObservability(this.baseDir, observability);
   }
 }
 
@@ -238,7 +258,14 @@ function filterAnalyzableGeneratedFiles(
   return filtered;
 }
 
-function createExplicitRequestFilesKey(analyzableFiles: AnalyzableFiles) {
+function getRequestFilesKey(
+  canAccessFileSystem: boolean,
+  analyzableFiles?: AnalyzableFiles,
+): RequestFilesKey {
+  if (!analyzableFiles) {
+    return canAccessFileSystem ? ALL_FILES_REQUEST_KEY : undefined;
+  }
+
   const filePaths = Object.keys(analyzableFiles).sort((left, right) => left.localeCompare(right));
   const hash = createHash('sha256');
   for (const filePath of filePaths) {
@@ -260,3 +287,169 @@ function createConfiguredGeneratedSourceFileMatcher(configuration: Configuration
 }
 
 export const generatedSourceStore = new GeneratedSourceStore();
+
+function buildGeneratedSourceObservability(
+  resolvedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, GeneratedSourceFamily>,
+  taggedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, GeneratedSourceFamily>,
+  configuration: Configuration,
+): GeneratedSourceObservability {
+  const filterPathParams = getFilterPathParams(configuration);
+  const pathsByFamily = new Map<GeneratedSourceFamily, NormalizedAbsolutePath[]>();
+
+  for (const [filePath, family] of sortPathEntries(resolvedFamilyByFile.entries())) {
+    let familyPaths = pathsByFamily.get(family);
+    if (!familyPaths) {
+      familyPaths = [];
+      pathsByFamily.set(family, familyPaths);
+    }
+    familyPaths.push(filePath);
+  }
+
+  const families: GeneratedSourceFamilyObservability[] = [];
+  const ignoredDefaultDtsFamilies: GeneratedSourceObservability['ignoredDefaultDtsFamilies'] = [];
+
+  for (const family of [...pathsByFamily.keys()].sort((left, right) => left.localeCompare(right))) {
+    const filePaths = pathsByFamily.get(family) ?? [];
+    if (
+      shouldIgnoreDefaultDtsFamily(filePaths, taggedFamilyByFile, configuration, filterPathParams)
+    ) {
+      ignoredDefaultDtsFamilies.push({
+        family,
+        filePaths,
+      });
+      continue;
+    }
+
+    const familySummary: GeneratedSourceFamilyObservability = {
+      family,
+      resolvedFileCount: filePaths.length,
+      taggedFileCount: 0,
+      outOfScopeFileCount: 0,
+      excludedFileCount: 0,
+      excludedPaths: [],
+      outOfScopePaths: [],
+    };
+
+    for (const filePath of filePaths) {
+      if (taggedFamilyByFile.get(filePath) === family) {
+        familySummary.taggedFileCount += 1;
+        continue;
+      }
+
+      const pathClassification = classifyFilePath(filePath, filterPathParams);
+      if (pathClassification.status === 'OUT_OF_SCOPE') {
+        familySummary.outOfScopeFileCount += 1;
+        familySummary.outOfScopePaths.push(filePath);
+      } else {
+        familySummary.excludedFileCount += 1;
+        familySummary.excludedPaths.push(filePath);
+      }
+    }
+
+    families.push(familySummary);
+  }
+
+  const telemetryFamilies: GeneratedSourceFamilyTelemetry[] = families.map(family => ({
+    family: family.family,
+    resolvedFileCount: family.resolvedFileCount,
+    taggedFileCount: family.taggedFileCount,
+    outOfScopeFileCount: family.outOfScopeFileCount,
+    excludedFileCount: family.excludedFileCount,
+  }));
+
+  return {
+    telemetry: {
+      familyCount: telemetryFamilies.length,
+      resolvedFileCount: telemetryFamilies.reduce(
+        (count, family) => count + family.resolvedFileCount,
+        0,
+      ),
+      taggedFileCount: telemetryFamilies.reduce(
+        (count, family) => count + family.taggedFileCount,
+        0,
+      ),
+      outOfScopeFileCount: telemetryFamilies.reduce(
+        (count, family) => count + family.outOfScopeFileCount,
+        0,
+      ),
+      excludedFileCount: telemetryFamilies.reduce(
+        (count, family) => count + family.excludedFileCount,
+        0,
+      ),
+      families: telemetryFamilies,
+    },
+    families,
+    ignoredDefaultDtsFamilies,
+  };
+}
+
+function shouldIgnoreDefaultDtsFamily(
+  filePaths: readonly NormalizedAbsolutePath[],
+  taggedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, GeneratedSourceFamily>,
+  configuration: Configuration,
+  filterPathParams: ReturnType<typeof getFilterPathParams>,
+) {
+  if (
+    filePaths.length === 0 ||
+    !configuration.jsTsExclusions.some(
+      exclusion =>
+        exclusion.pattern ===
+        normalizeToAbsolutePath(DEFAULT_DTS_EXCLUSION_PATTERN, configuration.baseDir),
+    )
+  ) {
+    return false;
+  }
+
+  return filePaths.every(filePath => {
+    if (!filePath.endsWith('.d.ts') || taggedFamilyByFile.has(filePath)) {
+      return false;
+    }
+
+    const pathClassification = classifyFilePath(filePath, filterPathParams);
+    return pathClassification.status === 'MAIN' || pathClassification.status === 'TEST';
+  });
+}
+
+function logGeneratedSourceObservability(
+  baseDir: NormalizedAbsolutePath,
+  observability: GeneratedSourceObservability,
+) {
+  info(
+    `Generated source observability: families=${observability.telemetry.familyCount}, resolvedFiles=${observability.telemetry.resolvedFileCount}, taggedFiles=${observability.telemetry.taggedFileCount}, outOfScopeFiles=${observability.telemetry.outOfScopeFileCount}, excludedFiles=${observability.telemetry.excludedFileCount}`,
+  );
+
+  for (const family of observability.families) {
+    info(
+      `Generated source family=${family.family} resolvedFiles=${family.resolvedFileCount} taggedFiles=${family.taggedFileCount} outOfScopeFiles=${family.outOfScopeFileCount} excludedFiles=${family.excludedFileCount}`,
+    );
+
+    if (family.outOfScopePaths.length > 0) {
+      debug(
+        `Generated source family=${family.family} outOfScope sample=${formatSamplePaths(baseDir, family.outOfScopePaths)}`,
+      );
+    }
+
+    if (family.excludedPaths.length > 0) {
+      debug(
+        `Generated source family=${family.family} excluded sample=${formatSamplePaths(baseDir, family.excludedPaths)}`,
+      );
+    }
+  }
+
+  for (const ignoredFamily of observability.ignoredDefaultDtsFamilies) {
+    debug(
+      `Generated source family=${ignoredFamily.family} ignored for observability because all resolved outputs are declaration files excluded by default ${DEFAULT_DTS_EXCLUSION_PATTERN}: ${formatSamplePaths(baseDir, ignoredFamily.filePaths)}`,
+    );
+  }
+}
+
+function formatSamplePaths(
+  baseDir: NormalizedAbsolutePath,
+  filePaths: readonly NormalizedAbsolutePath[],
+) {
+  const samplePaths = filePaths
+    .slice(0, OBSERVABILITY_SAMPLE_LIMIT)
+    .map(filePath => relativeToAncestorPath(filePath, baseDir) ?? filePath);
+  const moreCount = filePaths.length - samplePaths.length;
+  return moreCount > 0 ? `${samplePaths.join(', ')} (+${moreCount} more)` : samplePaths.join(', ');
+}

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/contracts.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/contracts.ts
@@ -21,14 +21,13 @@ import type { TaskInvocation } from './task-invocations.js';
 export const GRAPHQL_CODEGEN_FAMILY = '@graphql-codegen/cli';
 export const OPENAPI_GENERATOR_FAMILY = '@openapitools/openapi-generator-cli';
 export const PROTO_LOADER_GEN_TYPES_FAMILY = 'proto-loader-gen-types';
-// Keep the family contract open-ended so later detector PRs can add new families
-// without modifying the shared detector/store API.
-export type GeneratedSourceFamily = string;
+// Family values stay open-ended so later detector PRs can add new strings without modifying
+// the shared detector/store API.
 
 export type GeneratedSourceFileMatcher = (filePath: NormalizedAbsolutePath) => boolean;
 
 export type DerivedGeneratedSources = {
-  familyByFile: Map<NormalizedAbsolutePath, GeneratedSourceFamily>;
+  familyByFile: Map<NormalizedAbsolutePath, string>;
   configPaths: Set<NormalizedAbsolutePath>;
   watchedOutputPaths: Set<NormalizedAbsolutePath>;
 };
@@ -42,7 +41,7 @@ export type DerivedGeneratedSources = {
  * - reporting any config files and declared output paths it inferred so the store can refresh on change
  */
 export interface GeneratedSourceDetector {
-  readonly family: GeneratedSourceFamily;
+  readonly family: string;
   readonly watchedFilenames?: readonly string[];
   detect(context: {
     baseDir: NormalizedAbsolutePath;

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/contracts.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/contracts.ts
@@ -18,10 +18,17 @@ import type { NormalizedAbsolutePath } from '../../../../../../shared/src/helper
 import type { DependenciesList } from '../dependency-manifests/resolvers/types.js';
 import type { TaskInvocation } from './task-invocations.js';
 
+export const GRAPHQL_CODEGEN_FAMILY = '@graphql-codegen/cli';
+export const OPENAPI_GENERATOR_FAMILY = '@openapitools/openapi-generator-cli';
+export const PROTO_LOADER_GEN_TYPES_FAMILY = 'proto-loader-gen-types';
+// Keep the family contract open-ended so later detector PRs can add new families
+// without modifying the shared detector/store API.
+export type GeneratedSourceFamily = string;
+
 export type GeneratedSourceFileMatcher = (filePath: NormalizedAbsolutePath) => boolean;
 
 export type DerivedGeneratedSources = {
-  familyByFile: Map<NormalizedAbsolutePath, string>;
+  familyByFile: Map<NormalizedAbsolutePath, GeneratedSourceFamily>;
   configPaths: Set<NormalizedAbsolutePath>;
   watchedOutputPaths: Set<NormalizedAbsolutePath>;
 };
@@ -35,12 +42,11 @@ export type DerivedGeneratedSources = {
  * - reporting any config files and declared output paths it inferred so the store can refresh on change
  */
 export interface GeneratedSourceDetector {
-  readonly family: string;
+  readonly family: GeneratedSourceFamily;
   readonly watchedFilenames?: readonly string[];
   detect(context: {
     baseDir: NormalizedAbsolutePath;
     packageDir: NormalizedAbsolutePath;
-    hasDependency?: (dependencyName: string) => boolean;
     getDependencies: () => DependenciesList;
     taskInvocations: readonly TaskInvocation[];
     sourceFileMatcher?: GeneratedSourceFileMatcher;

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/derive.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/derive.ts
@@ -20,7 +20,6 @@ import {
 } from '../../../../../../shared/src/helpers/files.js';
 import type { PackageJson } from 'type-fest';
 import { getDependencies } from '../dependency-manifests/dependencies.js';
-import { getPackageJsonManifests } from '../dependency-manifests/all-in-parent-dirs.js';
 import { parsePackageJson } from '../dependency-manifests/parsed-dependency-files.js';
 import type { DependenciesList } from '../dependency-manifests/resolvers/types.js';
 import type { DerivedGeneratedSources, GeneratedSourceFileMatcher } from './contracts.js';
@@ -36,10 +35,6 @@ export async function deriveGeneratedSources(
   },
 ): Promise<DerivedGeneratedSources> {
   const derived = createDerivedGeneratedSources();
-  if (GENERATED_SOURCE_DETECTORS.length === 0) {
-    return derived;
-  }
-
   const { sourceFileMatcher } = options ?? {};
 
   for (const [packageDir, file] of packageJsons) {
@@ -53,12 +48,7 @@ export async function deriveGeneratedSources(
       packageDir,
       packageJson,
     });
-    let dependencyNames: Set<string> | undefined;
     let dependencies: DependenciesList | undefined;
-    const hasGeneratedSourceDependency = (dependencyName: string) => {
-      dependencyNames ??= collectGeneratedSourceDependencyNames(packageDir, baseDir, packageJson);
-      return dependencyNames.has(dependencyName);
-    };
     const getGeneratedSourceDependencies = () => {
       dependencies ??= resolveGeneratedSourceDependencies(packageDir, baseDir, packageJson);
       return dependencies;
@@ -69,7 +59,6 @@ export async function deriveGeneratedSources(
         await detector.detect({
           baseDir,
           packageDir,
-          hasDependency: hasGeneratedSourceDependency,
           getDependencies: getGeneratedSourceDependencies,
           taskInvocations,
           sourceFileMatcher,
@@ -81,21 +70,6 @@ export async function deriveGeneratedSources(
   return derived;
 }
 
-function collectGeneratedSourceDependencyNames(
-  packageDir: NormalizedAbsolutePath,
-  baseDir: NormalizedAbsolutePath,
-  packageJson: PackageJson,
-) {
-  const dependencyNames = new Set<string>();
-  const packageJsons = getPackageJsonManifests(packageDir, baseDir);
-
-  for (const packageJsonManifest of packageJsons.length > 0 ? packageJsons : [packageJson]) {
-    addPackageJsonDependencyNames(dependencyNames, packageJsonManifest);
-  }
-
-  return dependencyNames;
-}
-
 function resolveGeneratedSourceDependencies(
   packageDir: NormalizedAbsolutePath,
   baseDir: NormalizedAbsolutePath,
@@ -103,8 +77,8 @@ function resolveGeneratedSourceDependencies(
 ): DependenciesList {
   const dependencies = getDependencies(packageDir, baseDir);
 
-  // Support in-memory package.json fixtures that do not populate the manifest caches.
-  // When raw dependency sections are still present, derive the dependency list from them.
+  // Some unit tests call deriveGeneratedSources with synthetic package.json maps
+  // without initializing the manifest store or writing manifests to disk.
   return dependencies.size > 0 || !hasRawDependencySections(packageJson)
     ? dependencies
     : createFallbackDependencies(packageJson);
@@ -138,23 +112,6 @@ function createFallbackDependencies(packageJson: PackageJson): DependenciesList 
   }
 
   return dependencies;
-}
-
-function addPackageJsonDependencyNames(dependencyNames: Set<string>, packageJson: PackageJson) {
-  for (const section of [
-    packageJson.dependencies,
-    packageJson.devDependencies,
-    packageJson.peerDependencies,
-    packageJson.optionalDependencies,
-  ]) {
-    if (!section) {
-      continue;
-    }
-
-    for (const dependencyName of Object.keys(section)) {
-      dependencyNames.add(dependencyName);
-    }
-  }
 }
 
 export { extractFlagValues } from './shared.js';

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detector-api.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detector-api.ts
@@ -40,8 +40,7 @@ type TaskInvocationMatcher = (taskInvocation: TaskInvocation) => boolean;
 type ExistingPathKind = 'file' | 'directory';
 
 type ToolEvidenceOptions = {
-  hasDependency?: (dependencyName: string) => boolean;
-  getDependencies?: () => DependenciesList;
+  getDependencies: () => DependenciesList;
   taskInvocations: readonly TaskInvocation[];
   dependencyName?: string;
   matchesTaskInvocation: TaskInvocationMatcher;
@@ -53,6 +52,7 @@ type ResolvePathsFromTaskInvocationsOptions = {
   taskInvocations: readonly TaskInvocation[];
   matchesTaskInvocation: TaskInvocationMatcher;
   flags: string[];
+  kind: ExistingPathKind;
 };
 
 type ResolveConfigPathsOptions = {
@@ -65,7 +65,6 @@ type ResolveConfigPathsOptions = {
 };
 
 export function hasToolEvidence({
-  hasDependency,
   getDependencies,
   taskInvocations,
   dependencyName,
@@ -75,15 +74,7 @@ export function hasToolEvidence({
     return true;
   }
 
-  if (!dependencyName) {
-    return false;
-  }
-
-  if (hasDependency) {
-    return hasDependency(dependencyName);
-  }
-
-  return getDependencies ? getDependencies().has(dependencyName) : false;
+  return dependencyName ? getDependencies().has(dependencyName) : false;
 }
 
 export async function resolveConfigPaths({
@@ -160,7 +151,7 @@ async function addResolvedGeneratedOutput(
   }
 
   if (stats.isFile()) {
-    if (isSourceFile(resolvedPath, sourceFileMatcher)) {
+    if (isAcceptedGeneratedFile(resolvedPath, sourceFileMatcher)) {
       resolvedOutputs.filePaths.add(resolvedPath);
       return true;
     }
@@ -172,11 +163,30 @@ async function addResolvedGeneratedOutput(
   }
 
   resolvedOutputs.outputDirectories.add(resolvedPath);
-  const childFiles = await listSourceFilesInDirectory(resolvedPath, recursive, sourceFileMatcher);
+  const childFiles = await listAcceptedGeneratedFilesInDirectory(
+    resolvedPath,
+    recursive,
+    sourceFileMatcher,
+  );
   for (const childFile of childFiles) {
     resolvedOutputs.filePaths.add(childFile);
   }
   return childFiles.length > 0;
+}
+
+function isAcceptedGeneratedFile(
+  filePath: NormalizedAbsolutePath,
+  sourceFileMatcher?: GeneratedSourceFileMatcher,
+) {
+  return isSourceFile(filePath, sourceFileMatcher);
+}
+
+async function listAcceptedGeneratedFilesInDirectory(
+  outputDirectory: NormalizedAbsolutePath,
+  recursive: boolean,
+  sourceFileMatcher?: GeneratedSourceFileMatcher,
+) {
+  return listSourceFilesInDirectory(outputDirectory, recursive, sourceFileMatcher);
 }
 
 function resolveDeclaredPathsFromTaskInvocations({
@@ -213,10 +223,14 @@ async function resolveExistingSiblingPaths(
 
   for (const basename of basenames) {
     const resolvedPath = normalizeToAbsolutePath(basename, packageDir);
-    if (kind === 'file' ? await isFile(resolvedPath) : await isDirectory(resolvedPath)) {
+    if (await matchesExistingPathKind(resolvedPath, kind)) {
       resolvedPaths.add(resolvedPath);
     }
   }
 
   return resolvedPaths;
+}
+
+async function matchesExistingPathKind(path: NormalizedAbsolutePath, kind: ExistingPathKind) {
+  return kind === 'file' ? isFile(path) : isDirectory(path);
 }

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/graphql-codegen.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/graphql-codegen.ts
@@ -15,11 +15,11 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { readFile } from 'node:fs/promises';
-import { basename, extname } from 'node:path/posix';
+import { extname } from 'node:path/posix';
 import ts from 'typescript';
 import yaml from 'yaml';
 import { type NormalizedAbsolutePath } from '../../../../../../../shared/src/helpers/files.js';
-import { type GeneratedSourceDetector } from '../contracts.js';
+import { type GeneratedSourceDetector, GRAPHQL_CODEGEN_FAMILY } from '../contracts.js';
 import {
   hasToolEvidence,
   resolveConfigPaths,
@@ -36,36 +36,11 @@ import {
 } from '../shared.js';
 
 const AUTO_DISCOVERED_GRAPHQL_CONFIGS = [
-  'package.json',
-  '.graphqlrc',
-  '.graphqlrc.cjs',
-  '.graphqlrc.cts',
-  '.graphqlrc.js',
-  '.graphqlrc.json',
-  '.graphqlrc.mjs',
-  '.graphqlrc.mts',
-  '.graphqlrc.ts',
-  '.graphqlrc.yaml',
-  '.graphqlrc.yml',
-  '.graphqlconfig',
-  '.graphqlconfig.json',
-  '.graphqlconfig.yaml',
-  '.graphqlconfig.yml',
-  'graphql.config.cjs',
-  'graphql.config.cts',
-  'graphql.config.js',
-  'graphql.config.json',
-  'graphql.config.mjs',
-  'graphql.config.mts',
-  'graphql.config.ts',
-  'graphql.config.yaml',
-  'graphql.config.yml',
   '.codegenrc.js',
   '.codegenrc.json',
   '.codegenrc.ts',
   '.codegenrc.yaml',
   '.codegenrc.yml',
-  'codegen.config.js',
   'codegen.yml',
   'codegen.yaml',
   'codegen.json',
@@ -77,24 +52,18 @@ const AUTO_DISCOVERED_GRAPHQL_CONFIGS = [
 const EXPLICIT_GRAPHQL_CONFIGS = [
   'codegen.config.cjs',
   'codegen.config.cts',
+  'codegen.config.js',
   'codegen.config.mjs',
   'codegen.config.mts',
   'codegen.config.ts',
-  'codegen.cts',
-  'codegen.mts',
 ] as const;
 const WATCHED_GRAPHQL_CONFIGS = [
   ...AUTO_DISCOVERED_GRAPHQL_CONFIGS,
   ...EXPLICIT_GRAPHQL_CONFIGS,
 ] as const;
-const GRAPHQL_YAML_CONFIG_BASENAMES = new Set(['.graphqlrc', '.graphqlconfig']);
-const GRAPHQL_STRUCTURED_CONFIG_EXTENSIONS = new Set(['.json', '.yaml', '.yml']);
-const GRAPHQL_SOURCE_CONFIG_EXTENSIONS = new Set(['.cjs', '.cts', '.js', '.mjs', '.mts', '.ts']);
-const PACKAGE_JSON_BASENAME = 'package.json';
 const GRAPHQL_CONFIG_FLAGS = ['--config', '-c'];
 const DEFAULT_NEAR_OPERATION_FILE_EXTENSION = '.generated.ts';
 const GRAPHQL_GENERATED_DIRECTORY_SEGMENTS = new Set(['generated', '__generated__', 'gql']);
-const GRAPHQL_CODEGEN_FAMILY = '@graphql-codegen/cli';
 
 type GraphqlGenerateTarget = {
   outputPath: string;
@@ -106,39 +75,29 @@ export const graphqlCodegenDetector = {
   family: GRAPHQL_CODEGEN_FAMILY,
   watchedFilenames: WATCHED_GRAPHQL_CONFIGS,
 
-  async detect({
-    baseDir,
-    packageDir,
-    hasDependency,
-    getDependencies,
-    taskInvocations,
-    sourceFileMatcher,
-  }) {
+  async detect({ baseDir, packageDir, getDependencies, taskInvocations, sourceFileMatcher }) {
     const matchesTaskInvocation = (taskInvocation: TaskInvocation) =>
       taskInvocationInvokesCommand(taskInvocation, 'graphql-codegen');
+    const configPaths = await resolveConfigPaths({
+      baseDir,
+      packageDir,
+      taskInvocations,
+      matchesTaskInvocation,
+      flags: GRAPHQL_CONFIG_FLAGS,
+      fallbackBasenames: AUTO_DISCOVERED_GRAPHQL_CONFIGS,
+    });
+    if (configPaths.size === 0) {
+      return createDerivedGeneratedSources();
+    }
+
     if (
       !hasToolEvidence({
-        hasDependency,
         getDependencies,
         taskInvocations,
         dependencyName: GRAPHQL_CODEGEN_FAMILY,
         matchesTaskInvocation,
       })
     ) {
-      return createDerivedGeneratedSources();
-    }
-
-    const configPaths = await filterGraphqlConfigPaths(
-      await resolveConfigPaths({
-        baseDir,
-        packageDir,
-        taskInvocations,
-        matchesTaskInvocation,
-        flags: GRAPHQL_CONFIG_FLAGS,
-        fallbackBasenames: AUTO_DISCOVERED_GRAPHQL_CONFIGS,
-      }),
-    );
-    if (configPaths.size === 0) {
       return createDerivedGeneratedSources();
     }
 
@@ -160,41 +119,6 @@ export const graphqlCodegenDetector = {
     return derived;
   },
 } satisfies GeneratedSourceDetector;
-
-async function filterGraphqlConfigPaths(configPaths: Set<NormalizedAbsolutePath>) {
-  const filteredConfigPaths = new Set<NormalizedAbsolutePath>();
-
-  for (const configPath of configPaths) {
-    if (!isSupportedGraphqlConfigPath(configPath)) {
-      continue;
-    }
-
-    if (
-      basename(configPath).toLowerCase() !== PACKAGE_JSON_BASENAME ||
-      (await parseGraphqlGenerates(configPath)).length > 0
-    ) {
-      filteredConfigPaths.add(configPath);
-    }
-  }
-
-  return filteredConfigPaths;
-}
-
-function isSupportedGraphqlConfigPath(configPath: NormalizedAbsolutePath) {
-  const configBasename = basename(configPath).toLowerCase();
-  if (
-    configBasename === PACKAGE_JSON_BASENAME ||
-    GRAPHQL_YAML_CONFIG_BASENAMES.has(configBasename)
-  ) {
-    return true;
-  }
-
-  const configExtension = extname(configPath).toLowerCase();
-  return (
-    GRAPHQL_STRUCTURED_CONFIG_EXTENSIONS.has(configExtension) ||
-    GRAPHQL_SOURCE_CONFIG_EXTENSIONS.has(configExtension)
-  );
-}
 
 async function resolveGraphqlOutputs(
   baseDir: NormalizedAbsolutePath,
@@ -229,19 +153,10 @@ async function resolveGraphqlOutputs(
 async function parseGraphqlGenerates(configPath: NormalizedAbsolutePath) {
   try {
     const configContents = await readFile(configPath, 'utf8');
-    const configBasename = basename(configPath).toLowerCase();
     const configExtension = extname(configPath).toLowerCase();
 
-    if (configBasename === PACKAGE_JSON_BASENAME) {
-      return getGenerateTargetsFromPackageJson(JSON.parse(configContents) as unknown);
-    }
-
-    if (GRAPHQL_YAML_CONFIG_BASENAMES.has(configBasename)) {
-      return parseGraphqlYamlConfig(configContents);
-    }
-
     if (configExtension === '.yml' || configExtension === '.yaml') {
-      return parseGraphqlYamlConfig(configContents);
+      return getGenerateTargetsFromObject(yaml.parse(configContents));
     }
 
     if (configExtension === '.json') {
@@ -266,68 +181,16 @@ async function parseGraphqlGenerates(configPath: NormalizedAbsolutePath) {
   return [];
 }
 
-function parseGraphqlYamlConfig(configContents: string) {
-  return getGenerateTargetsFromObject(yaml.parse(configContents, { merge: true }));
-}
-
 function getGenerateTargetsFromObject(config: unknown) {
-  return collectGenerateTargets([
-    getGenerateTargetsFromGeneratesRecord(getNestedValue(config, ['generates'])),
-    ...getGenerateTargetsFromGraphqlConfigObject(config),
-  ]);
-}
-
-function getGenerateTargetsFromPackageJson(config: unknown) {
-  return collectGenerateTargets([
-    getGenerateTargetsFromGeneratesRecord(getNestedValue(config, ['codegen', 'generates'])),
-    ...getGenerateTargetsFromGraphqlConfigObject(getNestedValue(config, ['graphql'])),
-  ]);
-}
-
-function getGenerateTargetsFromGeneratesRecord(generates: unknown) {
-  if (!isRecord(generates)) {
+  if (!isRecord(config) || !isRecord(config.generates)) {
     return [];
   }
 
-  return Object.entries(generates).flatMap(([outputPath, generateConfig]) => {
+  return Object.entries(config.generates).flatMap(([outputPath, generateConfig]) => {
     return isLiteralPathToken(outputPath)
       ? [createGraphqlGenerateTarget(outputPath, generateConfig)]
       : [];
   });
-}
-
-function getGenerateTargetsFromGraphqlConfigObject(config: unknown) {
-  return [
-    getGenerateTargetsFromGeneratesRecord(
-      getNestedValue(config, ['extensions', 'codegen', 'generates']),
-    ),
-    ...getGenerateTargetsFromGraphqlProjectConfigs(config),
-  ];
-}
-
-function getGenerateTargetsFromGraphqlProjectConfigs(config: unknown) {
-  const projects = getNestedValue(config, ['projects']);
-  if (!isRecord(projects)) {
-    return [];
-  }
-
-  return Object.values(projects).map(project =>
-    getGenerateTargetsFromGeneratesRecord(
-      getNestedValue(project, ['extensions', 'codegen', 'generates']),
-    ),
-  );
-}
-
-function collectGenerateTargets(generateTargetsGroups: GraphqlGenerateTarget[][]) {
-  const generateTargets = new Map<string, GraphqlGenerateTarget>();
-
-  for (const generateTargetsGroup of generateTargetsGroups) {
-    for (const generateTarget of generateTargetsGroup) {
-      generateTargets.set(generateTarget.outputPath, generateTarget);
-    }
-  }
-
-  return [...generateTargets.values()];
 }
 
 function getGenerateTargetsFromSource(
@@ -340,72 +203,23 @@ function getGenerateTargetsFromSource(
     return [];
   }
 
-  return collectGenerateTargets([
-    getGenerateTargetsFromGeneratesObjectLiteral(
-      resolveNamedObjectLiteralPath(configObject, ['generates'], sourceFile),
-      sourceFile,
-    ),
-    ...getGenerateTargetsFromGraphqlConfigSourceObject(configObject, sourceFile),
-  ]);
-}
-
-function getGenerateTargetsFromGraphqlConfigSourceObject(
-  configObject: ts.ObjectLiteralExpression,
-  sourceFile: ts.SourceFile,
-) {
-  return [
-    getGenerateTargetsFromGeneratesObjectLiteral(
-      resolveNamedObjectLiteralPath(
-        configObject,
-        ['extensions', 'codegen', 'generates'],
-        sourceFile,
-      ),
-      sourceFile,
-    ),
-    ...getGenerateTargetsFromGraphqlProjectSourceObject(configObject, sourceFile),
-  ];
-}
-
-function getGenerateTargetsFromGraphqlProjectSourceObject(
-  configObject: ts.ObjectLiteralExpression,
-  sourceFile: ts.SourceFile,
-) {
-  const projectsObject = resolveNamedObjectLiteralPath(configObject, ['projects'], sourceFile);
-  if (!projectsObject) {
-    return [];
-  }
-
-  return projectsObject.properties.flatMap(property => {
-    if (!ts.isPropertyAssignment(property) || ts.isComputedPropertyName(property.name)) {
-      return [];
-    }
-
-    const projectObject = resolveObjectLiteral(property.initializer, sourceFile);
-
-    return projectObject
-      ? [
-          getGenerateTargetsFromGeneratesObjectLiteral(
-            resolveNamedObjectLiteralPath(
-              projectObject,
-              ['extensions', 'codegen', 'generates'],
-              sourceFile,
-            ),
-            sourceFile,
-          ),
-        ]
-      : [];
+  const generatesProperty = configObject.properties.find(property => {
+    return (
+      ts.isPropertyAssignment(property) &&
+      !ts.isComputedPropertyName(property.name) &&
+      getPropertyName(property.name) === 'generates'
+    );
   });
-}
 
-function getGenerateTargetsFromGeneratesObjectLiteral(
-  generatesObject: ts.ObjectLiteralExpression | undefined,
-  sourceFile: ts.SourceFile,
-) {
-  if (!generatesObject) {
+  if (
+    !generatesProperty ||
+    !ts.isPropertyAssignment(generatesProperty) ||
+    !ts.isObjectLiteralExpression(generatesProperty.initializer)
+  ) {
     return [];
   }
 
-  return generatesObject.properties.flatMap(property => {
+  return generatesProperty.initializer.properties.flatMap(property => {
     if (
       !ts.isPropertyAssignment(property) ||
       ts.isComputedPropertyName(property.name) ||
@@ -619,18 +433,17 @@ function extractExportedObjectLiteral(
 function resolveObjectLiteral(
   expression: ts.Expression,
   sourceFile: ts.SourceFile,
-  visitedIdentifiers: Set<string> = new Set(),
 ): ts.ObjectLiteralExpression | undefined {
   if (ts.isParenthesizedExpression(expression)) {
-    return resolveObjectLiteral(expression.expression, sourceFile, visitedIdentifiers);
+    return resolveObjectLiteral(expression.expression, sourceFile);
   }
 
   if (ts.isAsExpression(expression) || ts.isSatisfiesExpression(expression)) {
-    return resolveObjectLiteral(expression.expression, sourceFile, visitedIdentifiers);
+    return resolveObjectLiteral(expression.expression, sourceFile);
   }
 
   if (ts.isTypeAssertionExpression(expression)) {
-    return resolveObjectLiteral(expression.expression, sourceFile, visitedIdentifiers);
+    return resolveObjectLiteral(expression.expression, sourceFile);
   }
 
   if (ts.isObjectLiteralExpression(expression)) {
@@ -638,12 +451,7 @@ function resolveObjectLiteral(
   }
 
   if (ts.isIdentifier(expression)) {
-    if (visitedIdentifiers.has(expression.text)) {
-      return undefined;
-    }
-
-    visitedIdentifiers.add(expression.text);
-    return resolveTopLevelIdentifierObject(expression.text, sourceFile, visitedIdentifiers);
+    return resolveTopLevelIdentifierObject(expression.text, sourceFile);
   }
 
   return undefined;
@@ -652,7 +460,6 @@ function resolveObjectLiteral(
 function resolveTopLevelIdentifierObject(
   identifierName: string,
   sourceFile: ts.SourceFile,
-  visitedIdentifiers: Set<string>,
 ): ts.ObjectLiteralExpression | undefined {
   for (const statement of sourceFile.statements) {
     if (!ts.isVariableStatement(statement)) {
@@ -668,11 +475,7 @@ function resolveTopLevelIdentifierObject(
         continue;
       }
 
-      const objectLiteral = resolveObjectLiteral(
-        declaration.initializer,
-        sourceFile,
-        visitedIdentifiers,
-      );
+      const objectLiteral = resolveObjectLiteral(declaration.initializer, sourceFile);
       if (objectLiteral) {
         return objectLiteral;
       }
@@ -717,27 +520,6 @@ function getNamedObjectPropertyInitializer(
   return property.initializer;
 }
 
-function resolveNamedObjectLiteralPath(
-  objectLiteral: ts.ObjectLiteralExpression,
-  path: string[],
-  sourceFile: ts.SourceFile,
-): ts.ObjectLiteralExpression | undefined {
-  let currentObject: ts.ObjectLiteralExpression | undefined = objectLiteral;
-
-  for (const propertyName of path) {
-    const initializer = currentObject
-      ? getNamedObjectPropertyInitializer(currentObject, propertyName)
-      : undefined;
-    if (!initializer) {
-      return undefined;
-    }
-
-    currentObject = resolveObjectLiteral(initializer, sourceFile);
-  }
-
-  return currentObject;
-}
-
 function getNamedStringPropertyValue(
   objectLiteral: ts.ObjectLiteralExpression,
   propertyName: string,
@@ -746,19 +528,6 @@ function getNamedStringPropertyValue(
   return initializer && ts.isStringLiteralLike(initializer) ? initializer.text : undefined;
 }
 
-function getNestedValue(value: unknown, path: string[]) {
-  let current: unknown = value;
-
-  for (const pathSegment of path) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[pathSegment];
-  }
-
-  return current;
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  return typeof value === 'object' && value !== null;
 }

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/index.ts
@@ -25,14 +25,6 @@ export const GENERATED_SOURCE_DETECTORS: readonly GeneratedSourceDetector[] = [
   protoLoaderGenTypesDetector,
 ];
 
-export function getGeneratedSourceWatchedFilenames(
-  detectors: readonly GeneratedSourceDetector[] = GENERATED_SOURCE_DETECTORS,
-) {
-  return [
-    ...new Set(
-      detectors.flatMap(detector =>
-        (detector.watchedFilenames ?? []).map(filename => filename.toLowerCase()),
-      ),
-    ),
-  ].sort((left, right) => left.localeCompare(right));
-}
+export const GENERATED_SOURCE_WATCHED_FILENAMES = [
+  ...new Set(GENERATED_SOURCE_DETECTORS.flatMap(detector => detector.watchedFilenames ?? [])),
+].sort((left, right) => left.localeCompare(right));

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/openapi-generator.ts
@@ -14,32 +14,18 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { readFile } from 'node:fs/promises';
-import {
-  normalizeToAbsolutePath,
-  type NormalizedAbsolutePath,
-} from '../../../../../../../shared/src/helpers/files.js';
-import type { GeneratedSourceDetector } from '../contracts.js';
-import { type ResolvedGeneratedOutputs } from '../detector-api.js';
-import {
-  addFamilyFiles,
-  createDerivedGeneratedSources,
-  extractFlagValuesFromTokens,
-  isSourceFile,
-  resolveLiteralPath,
-  safeStat,
-} from '../shared.js';
+import { type GeneratedSourceDetector, OPENAPI_GENERATOR_FAMILY } from '../contracts.js';
+import { addFamilyFiles, createDerivedGeneratedSources, extractFlagValuesFromTokens } from '../shared.js';
+import { resolveGeneratedOutputsFromLiteralPaths } from '../detector-api.js';
 import { taskInvocationInvokesCommand, type TaskInvocation } from '../task-invocations.js';
 
-const OPENAPI_GENERATOR_FAMILY = '@openapitools/openapi-generator-cli';
-const OPENAPI_GENERATOR_FILES_MANIFEST = '.openapi-generator/FILES';
 const JS_TS_OPENAPI_GENERATORS = new Set([
-  'graphql-nodejs-express-server',
   'k6',
   'nodejs-express-server',
+  'graphql-nodejs-express-server',
 ]);
+
 const OPENAPI_GENERATOR_NAME_FLAGS = ['-g', '--generator-name'];
-const OPENAPI_OUTPUT_FLAGS = ['-o', '--output'];
 
 export const openApiGeneratorDetector = {
   family: OPENAPI_GENERATOR_FAMILY,
@@ -51,18 +37,22 @@ export const openApiGeneratorDetector = {
       extractFlagValuesFromTokens(taskInvocation.args, OPENAPI_GENERATOR_NAME_FLAGS).some(
         isJsTsOpenApiGenerator,
       );
-    const matchingInvocations = taskInvocations.filter(matchesTaskInvocation);
-    if (matchingInvocations.length === 0) {
+    if (!taskInvocations.some(matchesTaskInvocation)) {
       return createDerivedGeneratedSources();
     }
 
-    const outputPaths = matchingInvocations.flatMap(taskInvocation =>
-      extractFlagValuesFromTokens(taskInvocation.args, OPENAPI_OUTPUT_FLAGS),
-    );
-    const resolvedOutputs = await resolveOpenApiOutputsFromFilesManifests(
+    const outputPaths = taskInvocations.flatMap(taskInvocation => {
+      if (!matchesTaskInvocation(taskInvocation)) {
+        return [];
+      }
+
+      return extractFlagValuesFromTokens(taskInvocation.args, ['-o', '--output']);
+    });
+    const resolvedOutputs = await resolveGeneratedOutputsFromLiteralPaths(
       baseDir,
       packageDir,
       outputPaths,
+      false,
       sourceFileMatcher,
     );
     const derived = createDerivedGeneratedSources();
@@ -80,79 +70,4 @@ function isJsTsOpenApiGenerator(generatorName: string) {
     generatorName.startsWith('typescript') ||
     JS_TS_OPENAPI_GENERATORS.has(generatorName)
   );
-}
-
-async function resolveOpenApiOutputsFromFilesManifests(
-  baseDir: NormalizedAbsolutePath,
-  packageDir: NormalizedAbsolutePath,
-  outputPaths: Iterable<string>,
-  sourceFileMatcher?: (filePath: NormalizedAbsolutePath) => boolean,
-): Promise<ResolvedGeneratedOutputs> {
-  const resolvedOutputs: ResolvedGeneratedOutputs = {
-    filePaths: new Set(),
-    outputDirectories: new Set(),
-    watchedOutputPaths: new Set(),
-  };
-
-  for (const outputPath of outputPaths) {
-    const resolvedOutputPath = resolveLiteralPath(outputPath, packageDir, baseDir);
-    if (!resolvedOutputPath || resolvedOutputs.watchedOutputPaths.has(resolvedOutputPath)) {
-      continue;
-    }
-
-    await addOpenApiManifestFiles(
-      resolvedOutputs,
-      baseDir,
-      resolvedOutputPath,
-      sourceFileMatcher,
-    );
-  }
-
-  return resolvedOutputs;
-}
-
-async function addOpenApiManifestFiles(
-  resolvedOutputs: ResolvedGeneratedOutputs,
-  baseDir: NormalizedAbsolutePath,
-  outputPath: NormalizedAbsolutePath,
-  sourceFileMatcher?: (filePath: NormalizedAbsolutePath) => boolean,
-) {
-  resolvedOutputs.watchedOutputPaths.add(outputPath);
-
-  const stats = await safeStat(outputPath);
-  if (!stats?.isDirectory()) {
-    return;
-  }
-
-  resolvedOutputs.outputDirectories.add(outputPath);
-  const manifestEntries = await readOpenApiFilesManifest(outputPath);
-  if (!manifestEntries) {
-    return;
-  }
-
-  for (const manifestEntry of manifestEntries) {
-    const resolvedFilePath = resolveLiteralPath(manifestEntry, outputPath, baseDir);
-    if (!resolvedFilePath || !isSourceFile(resolvedFilePath, sourceFileMatcher)) {
-      continue;
-    }
-
-    const fileStats = await safeStat(resolvedFilePath);
-    if (fileStats?.isFile()) {
-      resolvedOutputs.filePaths.add(resolvedFilePath);
-    }
-  }
-}
-
-async function readOpenApiFilesManifest(outputPath: NormalizedAbsolutePath) {
-  const manifestPath = normalizeToAbsolutePath(OPENAPI_GENERATOR_FILES_MANIFEST, outputPath);
-
-  try {
-    const manifestContents = await readFile(manifestPath, 'utf8');
-    return manifestContents
-      .split(/\r?\n/u)
-      .map(line => line.trim())
-      .filter(line => line.length > 0);
-  } catch {
-    return undefined;
-  }
 }

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/proto-loader-gen-types.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/proto-loader-gen-types.ts
@@ -15,12 +15,25 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { type GeneratedSourceDetector, PROTO_LOADER_GEN_TYPES_FAMILY } from '../contracts.js';
-import { createDerivedGeneratedSources } from '../shared.js';
+import { resolveGeneratedOutputsFromLiteralPaths } from '../detector-api.js';
 import {
-  deriveSourcesFromOutputDirectories,
-  resolveOutputDirectoriesFromTaskInvocations,
-} from '../detector-api.js';
+  addFamilyFiles,
+  createDerivedGeneratedSources,
+  extractFlagValuesFromTokens,
+  resolveLiteralPath,
+} from '../shared.js';
 import { taskInvocationInvokesCommand, type TaskInvocation } from '../task-invocations.js';
+
+const PROTO_LOADER_OUTPUT_FLAGS = ['-O', '--outDir'];
+const PROTO_LOADER_GENERATED_DIRECTORY_SEGMENT_PATTERN =
+  /^(generated|generated[-_].+|.+[-_]generated)$/;
+
+function isGeneratedLikeProtoLoaderDirectory(outputPath: string) {
+  return outputPath
+    .replaceAll('\\', '/')
+    .split('/')
+    .some(segment => PROTO_LOADER_GENERATED_DIRECTORY_SEGMENT_PATTERN.test(segment));
+}
 
 export const protoLoaderGenTypesDetector = {
   family: PROTO_LOADER_GEN_TYPES_FAMILY,
@@ -28,22 +41,41 @@ export const protoLoaderGenTypesDetector = {
   async detect({ baseDir, packageDir, taskInvocations, sourceFileMatcher }) {
     const matchesTaskInvocation = (taskInvocation: TaskInvocation) =>
       taskInvocationInvokesCommand(taskInvocation, PROTO_LOADER_GEN_TYPES_FAMILY);
-    if (!taskInvocations.some(matchesTaskInvocation)) {
+    const matchingInvocations = taskInvocations.filter(matchesTaskInvocation);
+    if (matchingInvocations.length === 0) {
       return createDerivedGeneratedSources();
     }
 
-    const outputDirectories = await resolveOutputDirectoriesFromTaskInvocations({
-      baseDir,
-      packageDir,
-      taskInvocations,
-      matchesTaskInvocation,
-      flags: ['-O'],
-    });
-    return deriveSourcesFromOutputDirectories(
-      PROTO_LOADER_GEN_TYPES_FAMILY,
-      outputDirectories,
-      true,
-      sourceFileMatcher,
+    const outputPaths = matchingInvocations.flatMap(taskInvocation =>
+      extractFlagValuesFromTokens(taskInvocation.args, PROTO_LOADER_OUTPUT_FLAGS),
     );
+    const derived = createDerivedGeneratedSources();
+    const recursiveOutputPaths = outputPaths.filter(isGeneratedLikeProtoLoaderDirectory);
+    if (recursiveOutputPaths.length > 0) {
+      const resolvedOutputs = await resolveGeneratedOutputsFromLiteralPaths(
+        baseDir,
+        packageDir,
+        recursiveOutputPaths,
+        true,
+        sourceFileMatcher,
+      );
+      addFamilyFiles(PROTO_LOADER_GEN_TYPES_FAMILY, resolvedOutputs.filePaths, derived);
+      for (const watchedOutputPath of resolvedOutputs.watchedOutputPaths) {
+        derived.watchedOutputPaths.add(watchedOutputPath);
+      }
+    }
+
+    for (const outputPath of outputPaths) {
+      if (isGeneratedLikeProtoLoaderDirectory(outputPath)) {
+        continue;
+      }
+
+      const resolvedPath = resolveLiteralPath(outputPath, packageDir, baseDir);
+      if (resolvedPath) {
+        derived.watchedOutputPaths.add(resolvedPath);
+      }
+    }
+
+    return derived;
   },
 } satisfies GeneratedSourceDetector;

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/proto-loader-gen-types.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/detectors/proto-loader-gen-types.ts
@@ -14,27 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import type { GeneratedSourceDetector } from '../contracts.js';
-import { resolveGeneratedOutputsFromLiteralPaths } from '../detector-api.js';
+import { type GeneratedSourceDetector, PROTO_LOADER_GEN_TYPES_FAMILY } from '../contracts.js';
+import { createDerivedGeneratedSources } from '../shared.js';
 import {
-  addFamilyFiles,
-  createDerivedGeneratedSources,
-  extractFlagValuesFromTokens,
-  resolveLiteralPath,
-} from '../shared.js';
+  deriveSourcesFromOutputDirectories,
+  resolveOutputDirectoriesFromTaskInvocations,
+} from '../detector-api.js';
 import { taskInvocationInvokesCommand, type TaskInvocation } from '../task-invocations.js';
-
-const PROTO_LOADER_GEN_TYPES_FAMILY = 'proto-loader-gen-types';
-const PROTO_LOADER_OUTPUT_FLAGS = ['-O', '--outDir'];
-const PROTO_LOADER_GENERATED_DIRECTORY_SEGMENT_PATTERN =
-  /^(generated|generated[-_].+|.+[-_]generated)$/;
-
-function isGeneratedLikeProtoLoaderDirectory(outputPath: string) {
-  return outputPath
-    .replaceAll('\\', '/')
-    .split('/')
-    .some(segment => PROTO_LOADER_GENERATED_DIRECTORY_SEGMENT_PATTERN.test(segment));
-}
 
 export const protoLoaderGenTypesDetector = {
   family: PROTO_LOADER_GEN_TYPES_FAMILY,
@@ -42,41 +28,22 @@ export const protoLoaderGenTypesDetector = {
   async detect({ baseDir, packageDir, taskInvocations, sourceFileMatcher }) {
     const matchesTaskInvocation = (taskInvocation: TaskInvocation) =>
       taskInvocationInvokesCommand(taskInvocation, PROTO_LOADER_GEN_TYPES_FAMILY);
-    const matchingInvocations = taskInvocations.filter(matchesTaskInvocation);
-    if (matchingInvocations.length === 0) {
+    if (!taskInvocations.some(matchesTaskInvocation)) {
       return createDerivedGeneratedSources();
     }
 
-    const outputPaths = matchingInvocations.flatMap(taskInvocation =>
-      extractFlagValuesFromTokens(taskInvocation.args, PROTO_LOADER_OUTPUT_FLAGS),
+    const outputDirectories = await resolveOutputDirectoriesFromTaskInvocations({
+      baseDir,
+      packageDir,
+      taskInvocations,
+      matchesTaskInvocation,
+      flags: ['-O'],
+    });
+    return deriveSourcesFromOutputDirectories(
+      PROTO_LOADER_GEN_TYPES_FAMILY,
+      outputDirectories,
+      true,
+      sourceFileMatcher,
     );
-    const derived = createDerivedGeneratedSources();
-    const recursiveOutputPaths = outputPaths.filter(isGeneratedLikeProtoLoaderDirectory);
-    if (recursiveOutputPaths.length > 0) {
-      const resolvedOutputs = await resolveGeneratedOutputsFromLiteralPaths(
-        baseDir,
-        packageDir,
-        recursiveOutputPaths,
-        true,
-        sourceFileMatcher,
-      );
-      addFamilyFiles(PROTO_LOADER_GEN_TYPES_FAMILY, resolvedOutputs.filePaths, derived);
-      for (const watchedOutputPath of resolvedOutputs.watchedOutputPaths) {
-        derived.watchedOutputPaths.add(watchedOutputPath);
-      }
-    }
-
-    for (const outputPath of outputPaths) {
-      if (isGeneratedLikeProtoLoaderDirectory(outputPath)) {
-        continue;
-      }
-
-      const resolvedPath = resolveLiteralPath(outputPath, packageDir, baseDir);
-      if (resolvedPath) {
-        derived.watchedOutputPaths.add(resolvedPath);
-      }
-    }
-
-    return derived;
   },
 } satisfies GeneratedSourceDetector;

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -15,8 +15,14 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 export {
+  GRAPHQL_CODEGEN_FAMILY,
+  OPENAPI_GENERATOR_FAMILY,
+  PROTO_LOADER_GEN_TYPES_FAMILY,
+  type GeneratedSourceFamily,
+} from './contracts.js';
+export {
   GENERATED_SOURCE_DETECTORS,
-  getGeneratedSourceWatchedFilenames,
+  GENERATED_SOURCE_WATCHED_FILENAMES,
 } from './detectors/index.js';
 export {
   GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS,

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -14,7 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-export { GRAPHQL_CODEGEN_FAMILY } from './contracts.js';
+export {
+  GRAPHQL_CODEGEN_FAMILY,
+  OPENAPI_GENERATOR_FAMILY,
+  type GeneratedSourceFamily,
+} from './contracts.js';
 export {
   GRAPHQL_CODEGEN_FAMILY,
   OPENAPI_GENERATOR_FAMILY,

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -18,7 +18,6 @@ export {
   GRAPHQL_CODEGEN_FAMILY,
   OPENAPI_GENERATOR_FAMILY,
   PROTO_LOADER_GEN_TYPES_FAMILY,
-  type GeneratedSourceFamily,
 } from './contracts.js';
 export {
   GENERATED_SOURCE_DETECTORS,

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -17,6 +17,7 @@
 export {
   GRAPHQL_CODEGEN_FAMILY,
   OPENAPI_GENERATOR_FAMILY,
+  PROTO_LOADER_GEN_TYPES_FAMILY,
   type GeneratedSourceFamily,
 } from './contracts.js';
 export {

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -21,12 +21,6 @@ export {
   type GeneratedSourceFamily,
 } from './contracts.js';
 export {
-  GRAPHQL_CODEGEN_FAMILY,
-  OPENAPI_GENERATOR_FAMILY,
-  PROTO_LOADER_GEN_TYPES_FAMILY,
-  type GeneratedSourceFamily,
-} from './contracts.js';
-export {
   GENERATED_SOURCE_DETECTORS,
   GENERATED_SOURCE_WATCHED_FILENAMES,
 } from './detectors/index.js';

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/index.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
+export { GRAPHQL_CODEGEN_FAMILY } from './contracts.js';
 export {
   GRAPHQL_CODEGEN_FAMILY,
   OPENAPI_GENERATOR_FAMILY,

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
@@ -20,7 +20,6 @@ import {
   normalizeToAbsolutePath,
   type NormalizedAbsolutePath,
 } from '../../../../../../shared/src/helpers/files.js';
-import { relativeToAncestorPath } from '../files.js';
 import type { DerivedGeneratedSources, GeneratedSourceFileMatcher } from './contracts.js';
 
 const OBVIOUS_BUILD_OR_CACHE_SEGMENTS = new Set([
@@ -97,7 +96,13 @@ export function resolveLiteralPath(
 }
 
 export function isLiteralPathToken(value: string) {
-  return value.length > 0 && !value.includes('$') && !value.includes('`') && !value.includes('+');
+  return (
+    value.length > 0 &&
+    !value.includes('$') &&
+    !value.includes('`') &&
+    !value.includes('+') &&
+    !value.includes('$(')
+  );
 }
 
 export function isSourceFile(
@@ -333,7 +338,7 @@ function resolveEqualsFlagValue(token: string, flags: string[]) {
 }
 
 function isWithinBaseDir(path: NormalizedAbsolutePath, baseDir: NormalizedAbsolutePath) {
-  const relativePath = relativeToAncestorPath(path, baseDir);
+  const relativePath = getRelativeToAncestorPath(path, baseDir);
   return relativePath !== undefined;
 }
 
@@ -341,8 +346,20 @@ function isSafeChildEntryPath(
   path: NormalizedAbsolutePath,
   parentDirectory: NormalizedAbsolutePath,
 ) {
-  const relativePath = relativeToAncestorPath(path, parentDirectory);
+  const relativePath = getRelativeToAncestorPath(path, parentDirectory);
   return relativePath !== undefined && !hasObviousBuildOrCacheDirectory(relativePath);
+}
+
+function getRelativeToAncestorPath(
+  filePath: NormalizedAbsolutePath,
+  topDir: NormalizedAbsolutePath,
+) {
+  const topDirPrefix = topDir.endsWith('/') ? topDir : `${topDir}/`;
+  if (filePath === topDir) {
+    return '';
+  }
+
+  return filePath.startsWith(topDirPrefix) ? filePath.slice(topDirPrefix.length) : undefined;
 }
 
 function hasObviousBuildOrCacheDirectory(path: string) {
@@ -370,7 +387,7 @@ function getLastPathSegment(path: string) {
 }
 
 function isShellGeneratedToken(token: string) {
-  return token.includes('$') || token.includes('`');
+  return token.includes('$') || token.includes('`') || token.includes('$(');
 }
 
 function isEnvironmentAssignment(token: string) {

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
@@ -96,13 +96,7 @@ export function resolveLiteralPath(
 }
 
 export function isLiteralPathToken(value: string) {
-  return (
-    value.length > 0 &&
-    !value.includes('$') &&
-    !value.includes('`') &&
-    !value.includes('+') &&
-    !value.includes('$(')
-  );
+  return value.length > 0 && !value.includes('$') && !value.includes('`') && !value.includes('+');
 }
 
 export function isSourceFile(
@@ -387,7 +381,7 @@ function getLastPathSegment(path: string) {
 }
 
 function isShellGeneratedToken(token: string) {
-  return token.includes('$') || token.includes('`') || token.includes('$(');
+  return token.includes('$') || token.includes('`');
 }
 
 function isEnvironmentAssignment(token: string) {

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/shared.ts
@@ -377,7 +377,7 @@ function sortPaths<T extends NormalizedAbsolutePath>(paths: Iterable<T>) {
   return [...paths].sort(comparePathsAlphabetically);
 }
 
-function sortPathEntries<T>(entries: Iterable<[NormalizedAbsolutePath, T]>) {
+export function sortPathEntries<T>(entries: Iterable<[NormalizedAbsolutePath, T]>) {
   return [...entries].sort(([left], [right]) => comparePathsAlphabetically(left, right));
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
+++ b/packages/analysis/src/jsts/rules/helpers/generated-sources/task-invocations.ts
@@ -61,13 +61,9 @@ const packageJsonTaskInvocationProvider = {
   },
 } satisfies TaskInvocationProvider;
 
-// The package.json script parser intentionally recognizes only simple command chains.
-// Shell preambles such as `NODE_ENV=production tool ...`, command separators other than
-// `&&`, and runner options such as `npx --yes tool ...` are left out until a detector
-// needs that broader shell surface and can justify the parsing rules.
-export const GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS: readonly TaskInvocationProvider[] = [
+export const GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS = [
   packageJsonTaskInvocationProvider,
-];
+] as const satisfies readonly TaskInvocationProvider[];
 
 export async function collectGeneratedSourceTaskInvocations(context: {
   baseDir: NormalizedAbsolutePath;
@@ -77,7 +73,7 @@ export async function collectGeneratedSourceTaskInvocations(context: {
   const taskInvocations: TaskInvocation[] = [];
 
   for (const provider of GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS) {
-    taskInvocations.push(...(await provider.collect(context)));
+    taskInvocations.push(...(await Promise.resolve(provider.collect(context))));
   }
 
   return taskInvocations;

--- a/packages/analysis/src/telemetry.ts
+++ b/packages/analysis/src/telemetry.ts
@@ -85,6 +85,23 @@ type ProgramCreationTelemetry = {
   failed: number;
 };
 
+export type GeneratedSourceFamilyTelemetry = {
+  family: string;
+  resolvedFileCount: number;
+  taggedFileCount: number;
+  outOfScopeFileCount: number;
+  excludedFileCount: number;
+};
+
+export type GeneratedSourcesTelemetry = {
+  familyCount: number;
+  resolvedFileCount: number;
+  taggedFileCount: number;
+  outOfScopeFileCount: number;
+  excludedFileCount: number;
+  families: GeneratedSourceFamilyTelemetry[];
+};
+
 export type ProjectAnalysisTelemetry = {
   typescriptVersions: string[];
   typescriptNativePreview: boolean;
@@ -94,7 +111,28 @@ export type ProjectAnalysisTelemetry = {
   esmFileCount: number;
   cjsFileCount: number;
   denoImportCounts: Record<string, number>;
+  generatedSources: GeneratedSourcesTelemetry;
 };
+
+export function createEmptyGeneratedSourcesTelemetry(): GeneratedSourcesTelemetry {
+  return {
+    familyCount: 0,
+    resolvedFileCount: 0,
+    taggedFileCount: 0,
+    outOfScopeFileCount: 0,
+    excludedFileCount: 0,
+    families: [],
+  };
+}
+
+export function cloneGeneratedSourcesTelemetry(
+  telemetry: GeneratedSourcesTelemetry,
+): GeneratedSourcesTelemetry {
+  return {
+    ...telemetry,
+    families: telemetry.families.map(family => ({ ...family })),
+  };
+}
 
 export function resetProjectAnalysisTelemetry() {
   projectAnalysisTelemetryCollector = new ProjectAnalysisTelemetryCollector();
@@ -128,6 +166,7 @@ export class ProjectAnalysisTelemetryCollector {
   private esmFileCount = 0;
   private cjsFileCount = 0;
   private readonly denoImportCountsByProtocol = new Map<string, number>();
+  private generatedSources = createEmptyGeneratedSourcesTelemetry();
 
   constructor() {
     const { typeScriptVersionSignals, hasTypeScriptNativePreview } =
@@ -178,6 +217,10 @@ export class ProjectAnalysisTelemetryCollector {
     }
   }
 
+  recordGeneratedSources(generatedSources: GeneratedSourcesTelemetry) {
+    this.generatedSources = cloneGeneratedSourcesTelemetry(generatedSources);
+  }
+
   getTelemetry(): ProjectAnalysisTelemetry {
     const compilerOptions: Record<string, string[]> = {};
     for (const [optionName, values] of this.compilerOptionValues.entries()) {
@@ -199,6 +242,7 @@ export class ProjectAnalysisTelemetryCollector {
       esmFileCount: this.esmFileCount,
       cjsFileCount: this.cjsFileCount,
       denoImportCounts: Object.fromEntries(this.denoImportCountsByProtocol),
+      generatedSources: cloneGeneratedSourcesTelemetry(this.generatedSources),
     };
   }
 

--- a/packages/analysis/tests/analyzeProject-sonarqube.test.ts
+++ b/packages/analysis/tests/analyzeProject-sonarqube.test.ts
@@ -296,6 +296,14 @@ describe('SonarQube project analysis', () => {
           esmFileCount: 0,
           cjsFileCount: 0,
           denoImportCounts: {},
+          generatedSources: {
+            familyCount: 0,
+            resolvedFileCount: 0,
+            taggedFileCount: 0,
+            outOfScopeFileCount: 0,
+            excludedFileCount: 0,
+            families: [],
+          },
           programCreation: {
             attempted: 0,
             succeeded: 0,

--- a/packages/analysis/tests/common/configuration.test.ts
+++ b/packages/analysis/tests/common/configuration.test.ts
@@ -42,6 +42,15 @@ describe('createConfiguration', () => {
       new Error('baseDir is required and must be a string'),
     );
   });
+
+  it('should default generated-code detection to true and allow overriding it', () => {
+    const baseDir = '/path/to/project';
+
+    expect(createConfiguration({ baseDir }).detectGeneratedCode).toBe(true);
+    expect(createConfiguration({ baseDir, detectGeneratedCode: false }).detectGeneratedCode).toBe(
+      false,
+    );
+  });
 });
 
 describe('isYamlFile', () => {

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -1088,7 +1088,7 @@ export default config;
             },
             scripts: {
               graphql: 'graphql-codegen --config ./codegen.yml',
-              openapi: 'openapi-generator-cli generate --output=./outside/api',
+              openapi: 'openapi-generator-cli generate -g typescript-axios --output=./outside/api',
             },
           },
           null,

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -31,12 +31,14 @@ import {
   deriveGeneratedSources,
   extractFlagValues,
 } from '../../../src/jsts/rules/helpers/generated-sources/derive.js';
-import { graphqlCodegenDetector } from '../../../src/jsts/rules/helpers/generated-sources/detectors/graphql-codegen.js';
 import {
+  GRAPHQL_CODEGEN_FAMILY,
+  OPENAPI_GENERATOR_FAMILY,
+  PROTO_LOADER_GEN_TYPES_FAMILY,
   GENERATED_SOURCE_DETECTORS,
   GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS,
+  GENERATED_SOURCE_WATCHED_FILENAMES,
   collectGeneratedSourceTaskInvocations,
-  getGeneratedSourceWatchedFilenames,
 } from '../../../src/jsts/rules/helpers/generated-sources/index.js';
 import {
   joinPaths,
@@ -50,9 +52,6 @@ const fixtures = joinPaths(
   'fixtures',
   'generated-sources',
 );
-const GRAPHQL_CODEGEN_FAMILY = '@graphql-codegen/cli';
-const OPENAPI_GENERATOR_FAMILY = '@openapitools/openapi-generator-cli';
-const PROTO_LOADER_GEN_TYPES_FAMILY = 'proto-loader-gen-types';
 
 function createPackageJsonMap(
   packageDir: NormalizedAbsolutePath,
@@ -73,13 +72,6 @@ async function writeFixtureFile(filePath: string, content = '') {
   await writeFile(filePath, content);
 }
 
-async function writeOpenApiFilesManifest(outputDir: string, filePaths: string[]) {
-  await writeFixtureFile(
-    join(outputDir, '.openapi-generator', 'FILES'),
-    `${filePaths.join('\n')}\n`,
-  );
-}
-
 describe('generated sources project metadata', () => {
   beforeEach(() => {
     dependencyManifestStore.clearCache();
@@ -96,32 +88,16 @@ describe('generated sources project metadata', () => {
     expect(GENERATED_SOURCE_TASK_INVOCATION_PROVIDERS.map(provider => provider.kind)).toEqual([
       'package-json-scripts',
     ]);
-    expect(getGeneratedSourceWatchedFilenames()).toEqual(
+    expect(GENERATED_SOURCE_WATCHED_FILENAMES).toEqual(
       expect.arrayContaining([
-        '.graphqlrc',
-        '.graphqlrc.cjs',
-        '.graphqlrc.cts',
-        '.graphqlrc.js',
-        '.graphqlrc.json',
-        '.graphqlrc.mjs',
-        '.graphqlrc.mts',
-        '.graphqlrc.ts',
-        '.graphqlrc.yaml',
-        '.graphqlrc.yml',
-        '.graphqlconfig',
-        '.graphqlconfig.json',
-        '.graphqlconfig.yaml',
-        '.graphqlconfig.yml',
         'codegen.config.cjs',
         'codegen.config.cts',
         'codegen.config.js',
         'codegen.config.mjs',
         'codegen.config.mts',
         'codegen.config.ts',
-        'codegen.cts',
         'codegen.js',
         'codegen.json',
-        'codegen.mts',
         'codegen.ts',
         'codegen.yaml',
         'codegen.yml',
@@ -130,20 +106,7 @@ describe('generated sources project metadata', () => {
         '.codegenrc.ts',
         '.codegenrc.yaml',
         '.codegenrc.yml',
-        'graphql.config.cjs',
-        'graphql.config.cts',
-        'graphql.config.js',
-        'graphql.config.json',
-        'graphql.config.mjs',
-        'graphql.config.mts',
-        'graphql.config.ts',
-        'graphql.config.yaml',
-        'graphql.config.yml',
-        'package.json',
       ]),
-    );
-    expect(getGeneratedSourceWatchedFilenames()).not.toEqual(
-      expect.arrayContaining(['.graphqlrc.toml', 'graphql.config.toml']),
     );
   });
 
@@ -206,107 +169,7 @@ describe('generated sources project metadata', () => {
     }
   });
 
-  it('derives GraphQL outputs from explicit codegen.cts and codegen.mts flags', async () => {
-    const cases = [
-      {
-        configContents: `const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export = config;
-`,
-        configFilename: 'codegen.cts',
-      },
-      {
-        configContents: `const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export default config;
-`,
-        configFilename: 'codegen.mts',
-      },
-    ] satisfies ReadonlyArray<{
-      configContents: string;
-      configFilename: string;
-    }>;
-
-    for (const testCase of cases) {
-      const baseDir = await createTempBaseDir();
-      const configPath = joinPaths(baseDir, testCase.configFilename);
-      const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-      try {
-        await writeFixtureFile(configPath, testCase.configContents);
-        await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-        const derived = await deriveGeneratedSources(
-          baseDir,
-          createPackageJsonMap(baseDir, {
-            devDependencies: {
-              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-            },
-            scripts: {
-              codegen: `graphql-codegen --config ./${testCase.configFilename}`,
-            },
-          }),
-        );
-
-        expect(derived.configPaths).toEqual(new Set([configPath]));
-        expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      } finally {
-        await rm(baseDir, { recursive: true, force: true });
-      }
-    }
-  });
-
-  it('derives GraphQL outputs from an implicit codegen.config.js fallback file', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'codegen.config.js');
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `module.exports = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-          scripts: {
-            codegen: 'graphql-codegen',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('extracts output flag values from separate and equals syntax', () => {
+  it('extracts flag values from separate and equals syntax', () => {
     expect(
       extractFlagValues('graphql-codegen --config ./codegen.yml --config=./other.yml', [
         '--config',
@@ -616,329 +479,6 @@ export = config;
     }
   });
 
-  it('ignores circular identifier references while resolving GraphQL config objects', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'codegen.ts');
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `const circularA = circularB;
-const circularB = circularA;
-const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      presetConfig: circularA,
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export default config;
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-          scripts: {
-            codegen: 'graphql-codegen --config ./codegen.ts',
-          },
-        }),
-      );
-
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('ignores GraphQL fallback configs without task or dependency evidence', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'codegen.yml');
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `generates:
-  ./src/generated/sdk.ts:
-    plugins:
-      - typescript
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          scripts: {
-            lint: 'eslint .',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set());
-      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('skips GraphQL fallback config probing without task or dependency evidence', async ({
-    mock,
-  }) => {
-    const baseDir = await createTempBaseDir();
-    const packageJson = {
-      name: 'graphql-no-evidence-fixture',
-      scripts: {
-        lint: 'eslint .',
-      },
-    };
-
-    try {
-      await writeFixtureFile(join(baseDir, 'package.json'), JSON.stringify(packageJson, null, 2));
-      mock.method(JSON, 'parse');
-      const jsonParseMock = (JSON.parse as Mock<typeof JSON.parse>).mock;
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, packageJson),
-      );
-
-      expect(derived.configPaths).toEqual(new Set());
-      expect(derived.familyByFile).toEqual(new Map());
-      expect(jsonParseMock.calls).toHaveLength(1);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('supports additional GraphQL source config syntaxes and watched directories', async () => {
-    const baseDir = await createTempBaseDir();
-    const mtsConfigPath = joinPaths(baseDir, 'codegen.config.mts');
-    const jsConfigPath = joinPaths(baseDir, 'codegen.js');
-    const generatedNearOperationPath = joinPaths(baseDir, 'src', 'App.generated.ts');
-    const handWrittenPath = joinPaths(baseDir, 'src', 'App.ts');
-    const asExpressionPath = joinPaths(baseDir, 'src', 'generated', 'as-expression.ts');
-    const callExpressionPath = joinPaths(baseDir, 'src', 'generated', 'call-expression.ts');
-    const satisfiesExpressionPath = joinPaths(
-      baseDir,
-      'src',
-      'generated',
-      'satisfies-expression.ts',
-    );
-    const typeAssertionPath = joinPaths(baseDir, 'src', 'generated', 'type-asserted.ts');
-    const watchedOutputDirectory = joinPaths(baseDir, 'src', 'runtime');
-
-    try {
-      await writeFixtureFile(
-        mtsConfigPath,
-        `const dynamicKey = './src/generated/ignored-computed.ts';
-const config = ({
-  1: true,
-  generates: {
-    [dynamicKey]: { plugins: ['typescript'] },
-    '$INVALID_OUTPUT': { plugins: ['typescript'] },
-    './src/': {
-      preset: 'near-operation-file',
-    },
-    './src/generated/as-expression.ts': ({ plugins: ['typescript'] } as const),
-    './src/generated/call-expression.ts': buildTarget(),
-    './src/generated/satisfies-expression.ts': ({
-      plugins: ['typescript'],
-    } satisfies Record<string, unknown>),
-    './src/generated/type-asserted.ts': <Record<string, unknown>>{
-      plugins: ['typescript'],
-    },
-  },
-});
-
-function buildTarget() {
-  return { plugins: ['typescript'] };
-}
-
-export default config;
-`,
-      );
-      await writeFixtureFile(
-        jsConfigPath,
-        `module.exports = {
-  generates: {
-    './src/runtime/': {
-      plugins: ['typescript'],
-    },
-  },
-};
-`,
-      );
-      await writeFixtureFile(generatedNearOperationPath, 'export const generated = true;\n');
-      await writeFixtureFile(handWrittenPath, 'export const handwritten = true;\n');
-      await writeFixtureFile(asExpressionPath, 'export const asExpression = true;\n');
-      await writeFixtureFile(callExpressionPath, 'export const callExpression = true;\n');
-      await writeFixtureFile(satisfiesExpressionPath, 'export const satisfiesExpression = true;\n');
-      await writeFixtureFile(typeAssertionPath, 'export const typeAssertion = true;\n');
-      await writeFixtureFile(join(watchedOutputDirectory, 'placeholder.txt'), 'placeholder\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-          scripts: {
-            codegenJs: 'graphql-codegen --config ./codegen.js',
-            codegenMts: 'graphql-codegen --config ./codegen.config.mts',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([jsConfigPath, mtsConfigPath]));
-      expect(derived.familyByFile.get(generatedNearOperationPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      expect(derived.familyByFile.get(handWrittenPath)).toBeUndefined();
-      expect(derived.familyByFile.get(asExpressionPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      expect(derived.familyByFile.get(callExpressionPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      expect(derived.familyByFile.get(satisfiesExpressionPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      expect(derived.familyByFile.get(typeAssertionPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      expect(
-        derived.familyByFile.get(joinPaths(baseDir, 'src', 'generated', 'ignored-computed.ts')),
-      ).toBeUndefined();
-      expect(derived.watchedOutputPaths.has(watchedOutputDirectory)).toBe(true);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('handles unsupported GraphQL config structures defensively', async () => {
-    const cases = [
-      {
-        configFilename: 'codegen.json',
-        configContents: JSON.stringify(
-          {
-            generates: {
-              $INVALID_OUTPUT: {
-                plugins: ['typescript'],
-              },
-              './src/generated/sdk.ts': {
-                plugins: ['typescript'],
-              },
-            },
-          },
-          null,
-          2,
-        ),
-        expectedOutputDetected: true,
-        script: 'graphql-codegen --config ./codegen.json',
-      },
-      {
-        configFilename: 'codegen.yml',
-        configContents: 'generates: true\n',
-        expectedOutputDetected: false,
-        script: 'graphql-codegen --config ./codegen.yml',
-      },
-      {
-        configFilename: 'codegen.json',
-        configContents: JSON.stringify(
-          {
-            generates: ['./src/generated/sdk.ts'],
-          },
-          null,
-          2,
-        ),
-        expectedOutputDetected: false,
-        expectNoWatchedOutputs: true,
-        script: 'graphql-codegen --config ./codegen.json',
-      },
-      {
-        configFilename: 'codegen.ts',
-        configContents: `function createConfig() {
-  return {
-    generates: {
-      './src/generated/sdk.ts': {
-        plugins: ['typescript'],
-      },
-    },
-  };
-}
-
-export default createConfig();
-`,
-        expectedOutputDetected: false,
-        script: 'graphql-codegen --config ./codegen.ts',
-      },
-      {
-        configFilename: 'codegen.config.ts',
-        configContents: `export default {
-  generates: 0,
-};
-`,
-        expectedOutputDetected: false,
-        script: 'graphql-codegen --config ./codegen.config.ts',
-      },
-      {
-        configFilename: 'codegen.config.cjs',
-        configContents: `module.exports = {
-  generates: {
-    '../../../outside/': {
-      plugins: ['typescript'],
-    },
-  },
-};
-`,
-        expectedOutputDetected: false,
-        expectNoWatchedOutputs: true,
-        script: 'graphql-codegen --config ./codegen.config.cjs',
-      },
-    ] satisfies ReadonlyArray<{
-      configFilename: string;
-      configContents: string;
-      expectedOutputDetected: boolean;
-      expectNoWatchedOutputs?: boolean;
-      script: string;
-    }>;
-
-    for (const {
-      configFilename,
-      configContents,
-      expectedOutputDetected,
-      expectNoWatchedOutputs = false,
-      script,
-    } of cases) {
-      const baseDir = await createTempBaseDir();
-      const configPath = joinPaths(baseDir, configFilename);
-      const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-      try {
-        await writeFixtureFile(configPath, configContents);
-        await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-        const derived = await deriveGeneratedSources(
-          baseDir,
-          createPackageJsonMap(baseDir, {
-            devDependencies: {
-              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-            },
-            scripts: {
-              codegen: script,
-            },
-          }),
-        );
-
-        expect(derived.familyByFile.get(outputPath) !== undefined).toBe(expectedOutputDetected);
-        if (expectNoWatchedOutputs) {
-          expect(derived.watchedOutputPaths).toEqual(new Set());
-        }
-      } finally {
-        await rm(baseDir, { recursive: true, force: true });
-      }
-    }
-  });
-
   it('refreshes generated-source metadata when an explicit GraphQL config file is created later', async () => {
     const baseDir = await createTempBaseDir();
     const configPath = joinPaths(baseDir, 'config', 'custom-codegen.ts');
@@ -1065,7 +605,192 @@ export default config;
     }
   });
 
-  it('derives OpenAPI outputs from .openapi-generator/FILES manifests', async () => {
+  it('does not derive GraphQL outputs when graphql-codegen is only echoed', async () => {
+    const baseDir = await createTempBaseDir();
+    const configPath = joinPaths(baseDir, 'config', 'custom-codegen.ts');
+    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
+
+    try {
+      await writeFixtureFile(
+        configPath,
+        `const config = {
+  generates: {
+    './src/generated/sdk.ts': {
+      plugins: ['typescript'],
+    },
+  },
+};
+
+export default config;
+`,
+      );
+      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+          },
+          scripts: {
+            codegen: 'echo graphql-codegen --config ./config/custom-codegen.ts',
+          },
+        }),
+      );
+
+      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives GraphQL outputs from an explicit package-local codegen.config.ts flag', async () => {
+    const baseDir = await createTempBaseDir();
+    const configPath = joinPaths(baseDir, 'codegen.config.ts');
+    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
+
+    try {
+      await writeFixtureFile(
+        configPath,
+        `const config = {
+  generates: {
+    './src/generated/sdk.ts': {
+      plugins: ['typescript'],
+    },
+  },
+};
+
+export default config;
+`,
+      );
+      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+          },
+          scripts: {
+            codegen: 'graphql-codegen --config ./codegen.config.ts',
+          },
+        }),
+      );
+
+      expect(derived.configPaths).toEqual(new Set([configPath]));
+      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not auto-discover a package-local codegen.config.ts without an explicit task invocation', async () => {
+    const baseDir = await createTempBaseDir();
+    const configPath = joinPaths(baseDir, 'codegen.config.ts');
+    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
+
+    try {
+      await writeFixtureFile(
+        configPath,
+        `const config = {
+  generates: {
+    './src/generated/sdk.ts': {
+      plugins: ['typescript'],
+    },
+  },
+};
+
+export default config;
+`,
+      );
+      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+          },
+        }),
+      );
+
+      expect(derived.configPaths).toEqual(new Set());
+      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives GraphQL outputs from a package-local .codegenrc.yml fallback file', async () => {
+    const baseDir = await createTempBaseDir();
+    const configPath = joinPaths(baseDir, '.codegenrc.yml');
+    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
+
+    try {
+      await writeFixtureFile(
+        configPath,
+        `generates:
+  ./src/generated/sdk.ts:
+    plugins:
+      - typescript
+`,
+      );
+      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+          },
+        }),
+      );
+
+      expect(derived.configPaths).toEqual(new Set([configPath]));
+      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives GraphQL outputs from a package-local .codegenrc.ts fallback file', async () => {
+    const baseDir = await createTempBaseDir();
+    const configPath = joinPaths(baseDir, '.codegenrc.ts');
+    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
+
+    try {
+      await writeFixtureFile(
+        configPath,
+        `const config = {
+  generates: {
+    './src/generated/sdk.ts': {
+      plugins: ['typescript'],
+    },
+  },
+};
+
+export default config;
+`,
+      );
+      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
+
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        createPackageJsonMap(baseDir, {
+          devDependencies: {
+            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+          },
+        }),
+      );
+
+      expect(derived.configPaths).toEqual(new Set([configPath]));
+      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives OpenAPI outputs only from immediate output directory children', async () => {
     const baseDir = joinPaths(fixtures, 'openapi');
     await initFileStores(createConfiguration({ baseDir }));
 
@@ -1074,13 +799,10 @@ export default config;
     );
     expect(
       generatedSourceStore.getFamily(joinPaths(baseDir, 'src', 'api', 'models', 'pet.ts')),
-    ).toEqual(OPENAPI_GENERATOR_FAMILY);
+    ).toBeUndefined();
     expect(
       generatedSourceStore.getFamily(joinPaths(baseDir, 'build', 'api', 'ignored.ts')),
     ).toEqual(OPENAPI_GENERATOR_FAMILY);
-    expect(
-      generatedSourceStore.getFamily(joinPaths(baseDir, 'src', 'api', 'manual.ts')),
-    ).toBeUndefined();
   });
 
   it('derives OpenAPI outputs from an output flag using equals syntax', async () => {
@@ -1089,7 +811,6 @@ export default config;
 
     try {
       await writeFixtureFile(outputPath, 'export const api = true;\n');
-      await writeOpenApiFilesManifest(join(baseDir, 'src', 'api'), ['index.ts']);
 
       const derived = await deriveGeneratedSources(
         baseDir,
@@ -1116,7 +837,6 @@ export default config;
 
     try {
       await writeFixtureFile(outputPath, 'export const api = true;\n');
-      await writeOpenApiFilesManifest(join(baseDir, 'src', 'api'), ['index.ts']);
 
       const derived = await deriveGeneratedSources(
         baseDir,
@@ -1136,60 +856,6 @@ export default config;
     }
   });
 
-  it('does not derive OpenAPI outputs without an .openapi-generator/FILES manifest', async () => {
-    const baseDir = await createTempBaseDir();
-    const outputPath = joinPaths(baseDir, 'src', 'api', 'index.ts');
-
-    try {
-      await writeFixtureFile(outputPath, 'export const api = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
-          },
-          scripts: {
-            generate: 'openapi-generator-cli generate -g typescript-axios --output ./src/api',
-          },
-        }),
-      );
-
-      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('does not tag handwritten files outside the OpenAPI FILES manifest for mixed output roots', async () => {
-    const baseDir = await createTempBaseDir();
-    const generatedPath = joinPaths(baseDir, 'src', 'generated.ts');
-    const handwrittenPath = joinPaths(baseDir, 'src', 'handwritten.ts');
-
-    try {
-      await writeFixtureFile(generatedPath, 'export const generated = true;\n');
-      await writeFixtureFile(handwrittenPath, 'export const handwritten = true;\n');
-      await writeOpenApiFilesManifest(baseDir, ['src/generated.ts']);
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
-          },
-          scripts: {
-            generate: 'openapi-generator-cli generate -g typescript-axios -o .',
-          },
-        }),
-      );
-
-      expect(derived.familyByFile.get(generatedPath)).toEqual(OPENAPI_GENERATOR_FAMILY);
-      expect(derived.familyByFile.get(handwrittenPath)).toBeUndefined();
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
   it('refreshes generated-source metadata when a declared OpenAPI output file is created later', async () => {
     const baseDir = await createTempBaseDir();
     const outputPath = joinPaths(baseDir, 'src', 'api', 'index.ts');
@@ -1203,7 +869,8 @@ export default config;
               [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
             },
             scripts: {
-              generate: 'openapi-generator-cli generate -g typescript-axios --output ./src/api',
+              generate:
+                'openapi-generator-cli generate -g typescript-axios --output ./src/api',
             },
           },
           null,
@@ -1215,7 +882,6 @@ export default config;
       expect(generatedSourceStore.getFamily(outputPath)).toBeUndefined();
 
       await writeFixtureFile(outputPath, 'export const api = true;\n');
-      await writeOpenApiFilesManifest(join(baseDir, 'src', 'api'), ['index.ts']);
 
       const configuration = createConfiguration({
         baseDir,
@@ -1315,885 +981,6 @@ export default config;
       await rm(baseDir, { recursive: true, force: true });
     }
   });
-  it('does not derive GraphQL outputs when graphql-codegen is only echoed', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'config', 'custom-codegen.ts');
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export default config;
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-          scripts: {
-            codegen: 'echo graphql-codegen --config ./config/custom-codegen.ts',
-          },
-        }),
-      );
-
-      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('derives GraphQL outputs from an explicit package-local codegen.config.ts flag', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'codegen.config.ts');
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export default config;
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-          scripts: {
-            codegen: 'graphql-codegen --config ./codegen.config.ts',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('derives GraphQL outputs from explicit GraphQL Config paths', async () => {
-    const cases = [
-      {
-        configContents: JSON.stringify(
-          {
-            name: 'graphql-explicit-package-json-fixture',
-            scripts: {
-              codegen: 'graphql-codegen --config ./package.json',
-            },
-            devDependencies: {
-              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-            },
-            graphql: {
-              extensions: {
-                codegen: {
-                  generates: {
-                    './src/gql/': {
-                      preset: 'client',
-                    },
-                  },
-                },
-              },
-            },
-          },
-          null,
-          2,
-        ),
-        configFilename: 'package.json',
-        outputPath: 'src/gql/graphql.ts',
-      },
-      {
-        configContents: `projects:
-  server:
-    extensions:
-      codegen:
-        generates:
-          src/contra-api/__generated__/types.ts:
-            plugins:
-              - typescript
-`,
-        configFilename: '.graphqlrc',
-        outputPath: 'src/contra-api/__generated__/types.ts',
-      },
-      {
-        configContents: `const config = {
-  extensions: {
-    codegen: {
-      generates: {
-        './src/generated/graphql.ts': {
-          plugins: ['typescript'],
-        },
-      },
-    },
-  },
-};
-
-export default config;
-`,
-        configFilename: 'graphql.config.ts',
-        outputPath: 'src/generated/graphql.ts',
-      },
-    ] satisfies ReadonlyArray<{
-      configContents: string;
-      configFilename: string;
-      outputPath: string;
-    }>;
-
-    for (const testCase of cases) {
-      const baseDir = await createTempBaseDir();
-      const configPath = joinPaths(baseDir, testCase.configFilename);
-      const outputPath = joinPaths(baseDir, testCase.outputPath);
-
-      try {
-        await writeFixtureFile(configPath, testCase.configContents);
-        await writeFixtureFile(outputPath, 'export const generated = true;\n');
-
-        const packageJson =
-          testCase.configFilename === 'package.json'
-            ? JSON.parse(testCase.configContents)
-            : {
-                scripts: {
-                  codegen: `graphql-codegen --config ./${testCase.configFilename}`,
-                },
-                devDependencies: {
-                  [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-                },
-              };
-
-        const derived = await deriveGeneratedSources(
-          baseDir,
-          createPackageJsonMap(baseDir, packageJson),
-        );
-
-        expect(derived.configPaths).toEqual(new Set([configPath]));
-        expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      } finally {
-        await rm(baseDir, { recursive: true, force: true });
-      }
-    }
-  });
-
-  it('does not auto-discover a package-local codegen.config.ts without an explicit task invocation', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'codegen.config.ts');
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export default config;
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set());
-      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('does not auto-discover package-local codegen.cts or codegen.mts without an explicit task invocation', async () => {
-    const cases = [
-      {
-        configContents: `const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export = config;
-`,
-        configFilename: 'codegen.cts',
-      },
-      {
-        configContents: `const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export default config;
-`,
-        configFilename: 'codegen.mts',
-      },
-    ] satisfies ReadonlyArray<{
-      configContents: string;
-      configFilename: string;
-    }>;
-
-    for (const testCase of cases) {
-      const baseDir = await createTempBaseDir();
-      const configPath = joinPaths(baseDir, testCase.configFilename);
-      const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-      try {
-        await writeFixtureFile(configPath, testCase.configContents);
-        await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-        const derived = await deriveGeneratedSources(
-          baseDir,
-          createPackageJsonMap(baseDir, {
-            devDependencies: {
-              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-            },
-            scripts: {
-              codegen: 'graphql-codegen',
-            },
-          }),
-        );
-
-        expect(derived.configPaths).toEqual(new Set());
-        expect(derived.familyByFile.get(outputPath)).toBeUndefined();
-      } finally {
-        await rm(baseDir, { recursive: true, force: true });
-      }
-    }
-  });
-
-  it('derives GraphQL outputs from a package-local .codegenrc.yml fallback file', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, '.codegenrc.yml');
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `generates:
-  ./src/generated/sdk.ts:
-    plugins:
-      - typescript
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('derives YAML near-operation outputs from merged GraphQL config entries', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'codegen.yml');
-    const outputPath = joinPaths(baseDir, 'src', 'query.gql.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `shared: &shared
-  preset: near-operation-file
-  presetConfig:
-    extension: .gql.ts
-
-generates:
-  ./src/:
-    <<: *shared
-    plugins:
-      - typescript
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const query = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-          scripts: {
-            codegen: 'graphql-codegen',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('derives GraphQL outputs from a package-local .codegenrc.ts fallback file', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, '.codegenrc.ts');
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `const config = {
-  generates: {
-    './src/generated/sdk.ts': {
-      plugins: ['typescript'],
-    },
-  },
-};
-
-export default config;
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('derives GraphQL outputs from package.json#codegen fallback config', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'package.json');
-    const outputPath = joinPaths(baseDir, 'src', 'gql', 'graphql.ts');
-    const packageJson = {
-      name: 'graphql-package-config-fixture',
-      scripts: {
-        codegen: 'graphql-codegen',
-      },
-      devDependencies: {
-        [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-      },
-      codegen: {
-        generates: {
-          './src/gql/': {
-            preset: 'client',
-          },
-        },
-      },
-    };
-
-    try {
-      await writeFixtureFile(configPath, JSON.stringify(packageJson, null, 2));
-      await writeFixtureFile(outputPath, 'export const graphql = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, packageJson),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('derives GraphQL outputs from package.json#graphql.extensions.codegen fallback config', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'package.json');
-    const outputPath = joinPaths(baseDir, 'src', 'gql', 'graphql.ts');
-    const packageJson = {
-      name: 'graphql-package-graphql-config-fixture',
-      scripts: {
-        codegen: 'graphql-codegen',
-      },
-      devDependencies: {
-        [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-      },
-      graphql: {
-        extensions: {
-          codegen: {
-            generates: {
-              './src/gql/': {
-                preset: 'client',
-              },
-            },
-          },
-        },
-      },
-    };
-
-    try {
-      await writeFixtureFile(configPath, JSON.stringify(packageJson, null, 2));
-      await writeFixtureFile(outputPath, 'export const graphql = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, packageJson),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('does not treat a plain package.json as GraphQL config evidence', async () => {
-    const baseDir = await createTempBaseDir();
-    let dependencyLookups = 0;
-
-    try {
-      await writeFixtureFile(
-        joinPaths(baseDir, 'package.json'),
-        JSON.stringify({ name: 'plain-package-json-fixture' }, null, 2),
-      );
-
-      const derived = await graphqlCodegenDetector.detect({
-        baseDir,
-        packageDir: baseDir,
-        getDependencies: () => {
-          dependencyLookups++;
-          return new Map([[GRAPHQL_CODEGEN_FAMILY, '1.0.0']]);
-        },
-        taskInvocations: [],
-        sourceFileMatcher: undefined,
-      });
-
-      expect(derived.configPaths).toEqual(new Set());
-      expect(derived.familyByFile.size).toEqual(0);
-      expect(dependencyLookups).toEqual(1);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('derives GraphQL outputs from a package-local .graphqlrc fallback file', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, '.graphqlrc');
-    const outputPath = joinPaths(baseDir, 'src', 'contra-api', '__generated__', 'types.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `projects:
-  app:
-    extensions:
-      codegen:
-        generates:
-          ../../packages/graphql-types/src/types.ts:
-            plugins:
-              - typescript
-  server:
-    extensions:
-      codegen:
-        generates:
-          src/contra-api/__generated__/types.ts:
-            plugins:
-              - typescript
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const types = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          scripts: {
-            codegen: 'graphql-codegen',
-          },
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('derives GraphQL outputs from dotted .graphqlrc fallback variants', async () => {
-    const cases = [
-      {
-        configContents: `projects:
-  server:
-    extensions:
-      codegen:
-        generates:
-          src/contra-api/__generated__/types.ts:
-            plugins:
-              - typescript
-`,
-        configFilename: '.graphqlrc.yml',
-      },
-      {
-        configContents: `projects:
-  server:
-    extensions:
-      codegen:
-        generates:
-          src/contra-api/__generated__/types.ts:
-            plugins:
-              - typescript
-`,
-        configFilename: '.graphqlrc.yaml',
-      },
-      {
-        configContents: JSON.stringify(
-          {
-            projects: {
-              server: {
-                extensions: {
-                  codegen: {
-                    generates: {
-                      'src/contra-api/__generated__/types.ts': {
-                        plugins: ['typescript'],
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          null,
-          2,
-        ),
-        configFilename: '.graphqlrc.json',
-      },
-      {
-        configContents: `const config = {
-  projects: {
-    server: {
-      extensions: {
-        codegen: {
-          generates: {
-            'src/contra-api/__generated__/types.ts': {
-              plugins: ['typescript'],
-            },
-          },
-        },
-      },
-    },
-  },
-};
-
-export default config;
-`,
-        configFilename: '.graphqlrc.ts',
-      },
-      {
-        configContents: `module.exports = {
-  projects: {
-    server: {
-      extensions: {
-        codegen: {
-          generates: {
-            'src/contra-api/__generated__/types.ts': {
-              plugins: ['typescript'],
-            },
-          },
-        },
-      },
-    },
-  },
-};
-`,
-        configFilename: '.graphqlrc.cjs',
-      },
-      {
-        configContents: `const config = {
-  projects: {
-    server: {
-      extensions: {
-        codegen: {
-          generates: {
-            'src/contra-api/__generated__/types.ts': {
-              plugins: ['typescript'],
-            },
-          },
-        },
-      },
-    },
-  },
-};
-
-export = config;
-`,
-        configFilename: '.graphqlrc.cts',
-      },
-      {
-        configContents: `export default {
-  projects: {
-    server: {
-      extensions: {
-        codegen: {
-          generates: {
-            'src/contra-api/__generated__/types.ts': {
-              plugins: ['typescript'],
-            },
-          },
-        },
-      },
-    },
-  },
-};
-`,
-        configFilename: '.graphqlrc.mjs',
-      },
-      {
-        configContents: `export default {
-  projects: {
-    server: {
-      extensions: {
-        codegen: {
-          generates: {
-            'src/contra-api/__generated__/types.ts': {
-              plugins: ['typescript'],
-            },
-          },
-        },
-      },
-    },
-  },
-};
-`,
-        configFilename: '.graphqlrc.mts',
-      },
-    ] satisfies ReadonlyArray<{
-      configContents: string;
-      configFilename: string;
-    }>;
-
-    for (const testCase of cases) {
-      const baseDir = await createTempBaseDir();
-      const configPath = joinPaths(baseDir, testCase.configFilename);
-      const outputPath = joinPaths(baseDir, 'src', 'contra-api', '__generated__', 'types.ts');
-
-      try {
-        await writeFixtureFile(configPath, testCase.configContents);
-        await writeFixtureFile(outputPath, 'export const types = true;\n');
-
-        const derived = await deriveGeneratedSources(
-          baseDir,
-          createPackageJsonMap(baseDir, {
-            scripts: {
-              codegen: 'graphql-codegen',
-            },
-            devDependencies: {
-              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-            },
-          }),
-        );
-
-        expect(derived.configPaths).toEqual(new Set([configPath]));
-        expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      } finally {
-        await rm(baseDir, { recursive: true, force: true });
-      }
-    }
-  });
-
-  it('derives GraphQL outputs from legacy .graphqlconfig fallback variants', async () => {
-    const cases = [
-      {
-        configContents: `projects:
-  server:
-    extensions:
-      codegen:
-        generates:
-          src/contra-api/__generated__/types.ts:
-            plugins:
-              - typescript
-`,
-        configFilename: '.graphqlconfig',
-      },
-      {
-        configContents: `projects:
-  server:
-    extensions:
-      codegen:
-        generates:
-          src/contra-api/__generated__/types.ts:
-            plugins:
-              - typescript
-`,
-        configFilename: '.graphqlconfig.yml',
-      },
-    ] satisfies ReadonlyArray<{
-      configContents: string;
-      configFilename: string;
-    }>;
-
-    for (const testCase of cases) {
-      const baseDir = await createTempBaseDir();
-      const configPath = joinPaths(baseDir, testCase.configFilename);
-      const outputPath = joinPaths(baseDir, 'src', 'contra-api', '__generated__', 'types.ts');
-
-      try {
-        await writeFixtureFile(configPath, testCase.configContents);
-        await writeFixtureFile(outputPath, 'export const types = true;\n');
-
-        const derived = await deriveGeneratedSources(
-          baseDir,
-          createPackageJsonMap(baseDir, {
-            scripts: {
-              codegen: 'graphql-codegen',
-            },
-            devDependencies: {
-              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-            },
-          }),
-        );
-
-        expect(derived.configPaths).toEqual(new Set([configPath]));
-        expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      } finally {
-        await rm(baseDir, { recursive: true, force: true });
-      }
-    }
-  });
-
-  it('derives GraphQL outputs from a package-local graphql.config.ts fallback file', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'graphql.config.ts');
-    const generatedFilePath = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
-    const nearOperationGeneratedPath = joinPaths(baseDir, 'lib', 'user.generated.ts');
-    const handWrittenPath = joinPaths(baseDir, 'lib', 'user.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `const config = {
-  schema: 'schema.graphql',
-  extensions: {
-    codegen: {
-      generates: {
-        './src/generated/graphql.ts': {
-          plugins: ['typescript'],
-        },
-        './lib/': {
-          preset: 'near-operation-file-preset',
-          presetConfig: {
-            extension: '.generated.ts',
-          },
-        },
-      },
-    },
-  },
-};
-
-export default config;
-`,
-      );
-      await writeFixtureFile(generatedFilePath, 'export const generated = true;\n');
-      await writeFixtureFile(nearOperationGeneratedPath, 'export const near = true;\n');
-      await writeFixtureFile(handWrittenPath, 'export const handWritten = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          scripts: {
-            codegen: 'graphql-codegen',
-          },
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set([configPath]));
-      expect(derived.familyByFile.get(generatedFilePath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      expect(derived.familyByFile.get(nearOperationGeneratedPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
-      expect(derived.familyByFile.get(handWrittenPath)).toBeUndefined();
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('does not derive GraphQL outputs from a package-local graphql.config.toml file', async () => {
-    const baseDir = await createTempBaseDir();
-    const configPath = joinPaths(baseDir, 'graphql.config.toml');
-    const outputPath = joinPaths(baseDir, 'src', 'contra-api', '__generated__', 'types.ts');
-
-    try {
-      await writeFixtureFile(
-        configPath,
-        `[projects.app.extensions.codegen.generates."../../packages/graphql-types/src/types.ts"]
-plugins = [
-  "typescript",
-]
-
-[projects.server.extensions.codegen.generates."src/contra-api/__generated__/types.ts"]
-plugins = [
-  "typescript",
-]
-`,
-      );
-      await writeFixtureFile(outputPath, 'export const types = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          scripts: {
-            codegen: 'graphql-codegen',
-          },
-          devDependencies: {
-            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
-          },
-        }),
-      );
-
-      expect(derived.configPaths).toEqual(new Set());
-      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
 
   it('derives proto-loader outputs from the standard fixture', async () => {
     const baseDir = joinPaths(fixtures, 'proto-loader');
@@ -2235,98 +1022,6 @@ plugins = [
     }
   });
 
-  it('derives proto-loader outputs from generated-like directory names with separator variants', async () => {
-    const cases = [
-      {
-        outputDirFlag: './src/generated-types',
-        outputPathSegments: ['src', 'generated-types', 'service.ts'],
-      },
-      {
-        outputDirFlag: './src/generated_types',
-        outputPathSegments: ['src', 'generated_types', 'service.ts'],
-      },
-      {
-        outputDirFlag: './src/types-generated',
-        outputPathSegments: ['src', 'types-generated', 'service.ts'],
-      },
-      {
-        outputDirFlag: './src/types_generated',
-        outputPathSegments: ['src', 'types_generated', 'service.ts'],
-      },
-    ] satisfies ReadonlyArray<{
-      outputDirFlag: string;
-      outputPathSegments: readonly string[];
-    }>;
-
-    for (const testCase of cases) {
-      const baseDir = await createTempBaseDir();
-      const outputPath = joinPaths(baseDir, ...testCase.outputPathSegments);
-
-      try {
-        await writeFixtureFile(outputPath, 'export const service = true;\n');
-
-        const derived = await deriveGeneratedSources(
-          baseDir,
-          createPackageJsonMap(baseDir, {
-            scripts: {
-              codegen: `proto-loader-gen-types -O=${testCase.outputDirFlag} ./proto/service.proto`,
-            },
-          }),
-        );
-
-        expect(derived.familyByFile.get(outputPath)).toEqual(PROTO_LOADER_GEN_TYPES_FAMILY);
-      } finally {
-        await rm(baseDir, { recursive: true, force: true });
-      }
-    }
-  });
-
-  it('derives proto-loader outputs from the --outDir long flag', async () => {
-    const baseDir = await createTempBaseDir();
-    const outputPath = joinPaths(baseDir, 'src', 'generated', 'service.ts');
-
-    try {
-      await writeFixtureFile(outputPath, 'export const service = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          scripts: {
-            codegen: 'proto-loader-gen-types --outDir=./src/generated ./proto/service.proto',
-          },
-        }),
-      );
-
-      expect(derived.familyByFile.get(outputPath)).toEqual(PROTO_LOADER_GEN_TYPES_FAMILY);
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
-  it('does not derive proto-loader outputs from arbitrary directory names', async () => {
-    const baseDir = await createTempBaseDir();
-    const outputDirectory = joinPaths(baseDir, 'src', 'types');
-    const outputPath = joinPaths(outputDirectory, 'service.ts');
-
-    try {
-      await writeFixtureFile(outputPath, 'export const service = true;\n');
-
-      const derived = await deriveGeneratedSources(
-        baseDir,
-        createPackageJsonMap(baseDir, {
-          scripts: {
-            codegen: 'proto-loader-gen-types -O=./src/types ./proto/service.proto',
-          },
-        }),
-      );
-
-      expect(derived.familyByFile.get(outputPath)).toBeUndefined();
-      expect(derived.watchedOutputPaths).toEqual(new Set([outputDirectory]));
-    } finally {
-      await rm(baseDir, { recursive: true, force: true });
-    }
-  });
-
   it('refreshes generated-source matches when the explicit request file set changes', async () => {
     const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
     const firstGeneratedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
@@ -2361,6 +1056,181 @@ plugins = [
 
     expect(generatedSourceStore.getFamily(firstGeneratedFile)).toBeUndefined();
     expect(generatedSourceStore.getFamily(secondGeneratedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+  });
+
+  it('records the current configuration when post-processing exits early', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const configuration = createConfiguration({ baseDir, canAccessFileSystem: false });
+
+    await generatedSourceStore.postProcess(configuration);
+
+    expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+  });
+
+  it('records generated-source observability for tagged, excluded, and out-of-scope files', async ({
+    mock,
+  }) => {
+    const baseDir = await createTempBaseDir();
+    const taggedFile = joinPaths(baseDir, 'src', 'generated', 'keep.ts');
+    const excludedFile = joinPaths(baseDir, 'src', 'excluded', 'blocked.ts');
+    const outOfScopeFile = joinPaths(baseDir, 'outside', 'api', 'index.ts');
+    const originalConsoleLog = console.log;
+    console.log = mock.fn(console.log);
+
+    try {
+      await writeFixtureFile(
+        joinPaths(baseDir, 'package.json'),
+        JSON.stringify(
+          {
+            devDependencies: {
+              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+              [OPENAPI_GENERATOR_FAMILY]: '1.0.0',
+            },
+            scripts: {
+              graphql: 'graphql-codegen --config ./codegen.yml',
+              openapi: 'openapi-generator-cli generate --output=./outside/api',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFixtureFile(
+        joinPaths(baseDir, 'codegen.yml'),
+        `generates:
+  ./src/generated/keep.ts:
+    plugins:
+      - typescript
+  ./src/excluded/blocked.ts:
+    plugins:
+      - typescript
+`,
+      );
+      await writeFixtureFile(taggedFile, 'export const tagged = true;\n');
+      await writeFixtureFile(excludedFile, 'export const excluded = true;\n');
+      await writeFixtureFile(outOfScopeFile, 'export const outOfScope = true;\n');
+
+      await initFileStores(
+        createConfiguration({
+          baseDir,
+          sources: ['src'],
+          exclusions: ['src/excluded/**'],
+        }),
+      );
+
+      expect(generatedSourceStore.getFamily(taggedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+      expect(generatedSourceStore.getFamily(excludedFile)).toBeUndefined();
+      expect(generatedSourceStore.getFamily(outOfScopeFile)).toBeUndefined();
+      expect(generatedSourceStore.getObservabilityTelemetry()).toEqual({
+        familyCount: 2,
+        resolvedFileCount: 3,
+        taggedFileCount: 1,
+        outOfScopeFileCount: 1,
+        excludedFileCount: 1,
+        families: [
+          {
+            family: GRAPHQL_CODEGEN_FAMILY,
+            resolvedFileCount: 2,
+            taggedFileCount: 1,
+            outOfScopeFileCount: 0,
+            excludedFileCount: 1,
+          },
+          {
+            family: OPENAPI_GENERATOR_FAMILY,
+            resolvedFileCount: 1,
+            taggedFileCount: 0,
+            outOfScopeFileCount: 1,
+            excludedFileCount: 0,
+          },
+        ],
+      });
+
+      const logs = (console.log as Mock<typeof console.log>).mock.calls.map(
+        call => call.arguments[0],
+      );
+      expect(logs).toContain(
+        'Generated source observability: families=2, resolvedFiles=3, taggedFiles=1, outOfScopeFiles=1, excludedFiles=1',
+      );
+      expect(logs).toContain(
+        'Generated source family=@graphql-codegen/cli resolvedFiles=2 taggedFiles=1 outOfScopeFiles=0 excludedFiles=1',
+      );
+      expect(logs).toContain(
+        'DEBUG Generated source family=@graphql-codegen/cli excluded sample=src/excluded/blocked.ts',
+      );
+      expect(logs).toContain(
+        'DEBUG Generated source family=@openapitools/openapi-generator-cli outOfScope sample=outside/api/index.ts',
+      );
+    } finally {
+      console.log = originalConsoleLog;
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores declaration-only default-excluded generated families in observability', async ({
+    mock,
+  }) => {
+    const baseDir = await createTempBaseDir();
+    const declarationFile = joinPaths(baseDir, 'src', 'generated', 'operations.d.ts');
+    const originalConsoleLog = console.log;
+    console.log = mock.fn(console.log);
+
+    try {
+      await writeFixtureFile(
+        joinPaths(baseDir, 'package.json'),
+        JSON.stringify(
+          {
+            devDependencies: {
+              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+            },
+            scripts: {
+              graphql: 'graphql-codegen --config ./codegen.yml',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFixtureFile(
+        joinPaths(baseDir, 'codegen.yml'),
+        `generates:
+  ./src/generated/operations.d.ts:
+    plugins:
+      - typescript
+`,
+      );
+      await writeFixtureFile(declarationFile, 'export type Operation = string;\n');
+
+      await initFileStores(
+        createConfiguration({
+          baseDir,
+          sources: ['src'],
+        }),
+      );
+
+      expect(sourceFileStore.getFiles()[declarationFile]).toBeUndefined();
+      expect(generatedSourceStore.getFamily(declarationFile)).toBeUndefined();
+      expect(generatedSourceStore.getObservabilityTelemetry()).toEqual({
+        familyCount: 0,
+        resolvedFileCount: 0,
+        taggedFileCount: 0,
+        outOfScopeFileCount: 0,
+        excludedFileCount: 0,
+        families: [],
+      });
+
+      const logs = (console.log as Mock<typeof console.log>).mock.calls.map(
+        call => call.arguments[0],
+      );
+      expect(logs).toContain(
+        'Generated source observability: families=0, resolvedFiles=0, taggedFiles=0, outOfScopeFiles=0, excludedFiles=0',
+      );
+      expect(logs).toContain(
+        'DEBUG Generated source family=@graphql-codegen/cli ignored for observability because all resolved outputs are declaration files excluded by default **/*.d.ts: src/generated/operations.d.ts',
+      );
+    } finally {
+      console.log = originalConsoleLog;
+      await rm(baseDir, { recursive: true, force: true });
+    }
   });
 
   it('recomputes generated-source metadata when filesystem access becomes available again', async () => {

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -1058,6 +1058,37 @@ export default config;
     expect(generatedSourceStore.getFamily(secondGeneratedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
+  it('memoizes explicit request-file keys per analyzable-file set', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+    const configuration = createConfiguration({ baseDir });
+    const { files: inputFiles } = await sanitizeRawInputFiles(
+      {
+        [generatedFile]: {
+          filePath: generatedFile,
+          fileType: 'MAIN',
+        },
+      },
+      configuration,
+    );
+
+    await initFileStores(configuration, inputFiles);
+
+    const explicitRequestFilesKeys = (
+      generatedSourceStore as unknown as {
+        explicitRequestFilesKeys?: WeakMap<object, string>;
+      }
+    ).explicitRequestFilesKeys;
+    expect(explicitRequestFilesKeys).toBeInstanceOf(WeakMap);
+
+    const cachedKey = explicitRequestFilesKeys?.get(inputFiles);
+    expect(cachedKey).toBeDefined();
+
+    await generatedSourceStore.isInitialized(configuration, inputFiles);
+
+    expect(explicitRequestFilesKeys?.get(inputFiles)).toEqual(cachedKey);
+  });
+
   it('records the current configuration when post-processing exits early', async () => {
     const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
     const configuration = createConfiguration({ baseDir, canAccessFileSystem: false });
@@ -1221,7 +1252,7 @@ export default config;
       const logs = (console.log as Mock<typeof console.log>).mock.calls.map(
         call => call.arguments[0],
       );
-      expect(logs).toContain(
+      expect(logs).not.toContain(
         'Generated source observability: families=0, resolvedFiles=0, taggedFiles=0, outOfScopeFiles=0, excludedFiles=0',
       );
       expect(logs).toContain(

--- a/packages/analysis/tests/telemetry.test.ts
+++ b/packages/analysis/tests/telemetry.test.ts
@@ -141,4 +141,55 @@ describe('project analysis telemetry', () => {
       useUnknownInCatchVariables: ['true'],
     });
   });
+
+  it('should expose generated-source telemetry summaries', () => {
+    const collector = new ProjectAnalysisTelemetryCollector();
+    collector.recordGeneratedSources({
+      familyCount: 2,
+      resolvedFileCount: 9,
+      taggedFileCount: 5,
+      outOfScopeFileCount: 2,
+      excludedFileCount: 2,
+      families: [
+        {
+          family: '@graphql-codegen/cli',
+          resolvedFileCount: 4,
+          taggedFileCount: 2,
+          outOfScopeFileCount: 1,
+          excludedFileCount: 1,
+        },
+        {
+          family: 'proto-loader-gen-types',
+          resolvedFileCount: 5,
+          taggedFileCount: 3,
+          outOfScopeFileCount: 1,
+          excludedFileCount: 1,
+        },
+      ],
+    });
+
+    expect(collector.getTelemetry().generatedSources).toEqual({
+      familyCount: 2,
+      resolvedFileCount: 9,
+      taggedFileCount: 5,
+      outOfScopeFileCount: 2,
+      excludedFileCount: 2,
+      families: [
+        {
+          family: '@graphql-codegen/cli',
+          resolvedFileCount: 4,
+          taggedFileCount: 2,
+          outOfScopeFileCount: 1,
+          excludedFileCount: 1,
+        },
+        {
+          family: 'proto-loader-gen-types',
+          resolvedFileCount: 5,
+          taggedFileCount: 3,
+          outOfScopeFileCount: 1,
+          excludedFileCount: 1,
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## What changed

- wires generated-source plumbing through `GeneratedSourceStore`, including generated-code observability telemetry and the `detectGeneratedCode` configuration flag
- keeps the shared generated-source contracts, watched-filename exports, and detector helpers aligned on top of `fix/generated-code-detection-05-proto-loader-detector`
- fixes the rebase integration for the proto-loader detector and the observability test fixture

## Why it changed

This branch is the plumbing step on top of the proto-loader detector branch. It needs to carry the generated-source store changes, cache invalidation hooks, and observability reporting while staying compatible with the helper APIs and detector behavior that already exist on the rebased base branch.

## Impact

- generated-source tagging now records resolved, tagged, excluded, and out-of-scope counts for observability
- proto-loader detection keeps the newer output-path handling after the rebase
- the generated-source tests remain aligned with the OpenAPI JS/TS generator gating rules

## Root cause

Rebasing onto `fix/generated-code-detection-05-proto-loader-detector` surfaced a few API mismatches between this branch's plumbing work and the detector/helper code already present on the base branch.

## Checks

- `npm run grpc:generate-proto && tsx --tsconfig packages/tsconfig.test.json --test --test-concurrency=4 --test-reporter=spec --test-reporter-destination stdout packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts packages/analysis/tests/common/configuration.test.ts`
