### PR TITLE
JS-1597 narrow generated-source cache invalidation

### DIFF
--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -20,10 +20,7 @@ import type { FileStore } from './store-type.js';
 import type { Configuration } from '../common/configuration.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
-import {
-  getAnalyzableFilesConfigKey,
-  getProjectFileDiscoveryConfigKey,
-} from '../common/configuration.js';
+import { getAnalyzableFilesConfigKey } from '../common/configuration.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
 import { getGeneratedSourceWatchedFilenames } from '../jsts/rules/helpers/generated-sources/index.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
@@ -39,7 +36,6 @@ class GeneratedSourceStore implements FileStore {
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
-  private projectFileDiscoveryConfigKey: string | undefined = undefined;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
   private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
@@ -84,11 +80,6 @@ class GeneratedSourceStore implements FileStore {
       return;
     }
 
-    if (getProjectFileDiscoveryConfigKey(configuration) !== this.projectFileDiscoveryConfigKey) {
-      this.clearCache();
-      return;
-    }
-
     const generatedSourceWatchedFilenames = getGeneratedSourceWatchedFilenames();
     for (const filename of fsEvents) {
       if (this.isRelevantEvent(filename, generatedSourceWatchedFilenames)) {
@@ -102,7 +93,6 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
     this.analyzableFilesConfigKey = undefined;
-    this.projectFileDiscoveryConfigKey = undefined;
     this.activeRequestFilesKey = undefined;
     this.clearDerivedState();
   }
@@ -111,7 +101,6 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
     this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
-    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     this.clearDerivedState();
   }
 
@@ -131,7 +120,6 @@ class GeneratedSourceStore implements FileStore {
       this.baseDir = configuration.baseDir;
       this.canAccessFileSystem = configuration.canAccessFileSystem;
       this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
-      this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     }
 
     const { baseDir, canAccessFileSystem } = this;

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -35,7 +35,10 @@ class GeneratedSourceStore implements FileStore {
   private readonly explicitRequestFilesKeys = new WeakMap<AnalyzableFiles, string>();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
+  private derivedConfigKey: string | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
+  private needsFilteredRefresh = false;
+  private derivedMetadataInitialized = false;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
   private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
@@ -50,6 +53,17 @@ class GeneratedSourceStore implements FileStore {
     this.activeRequestFilesKey = requestFilesKey;
     if (this.baseDir === undefined) {
       return false;
+    }
+
+    if (this.needsFilteredRefresh) {
+      if (requestFilesKey === undefined || inputFiles === undefined) {
+        return false;
+      }
+
+      this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+      this.refreshFilteredState(inputFiles, requestFilesKey);
+      this.needsFilteredRefresh = false;
+      return true;
     }
 
     if (requestFilesKey === this.requestFilesKey) {
@@ -75,7 +89,7 @@ class GeneratedSourceStore implements FileStore {
       return;
     }
 
-    if (getAnalyzableFilesConfigKey(configuration) !== this.analyzableFilesConfigKey) {
+    if (getGeneratedSourceConfigKey(configuration) !== this.derivedConfigKey) {
       this.clearCache();
       return;
     }
@@ -87,12 +101,19 @@ class GeneratedSourceStore implements FileStore {
         return;
       }
     }
+
+    if (getAnalyzableFilesConfigKey(configuration) !== this.analyzableFilesConfigKey) {
+      this.needsFilteredRefresh = true;
+    }
   }
 
   clearCache() {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
+    this.derivedConfigKey = undefined;
     this.analyzableFilesConfigKey = undefined;
+    this.needsFilteredRefresh = false;
+    this.derivedMetadataInitialized = false;
     this.activeRequestFilesKey = undefined;
     this.clearDerivedState();
   }
@@ -100,8 +121,7 @@ class GeneratedSourceStore implements FileStore {
   setup(configuration: Configuration) {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
-    this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
-    this.clearDerivedState();
+    this.derivedConfigKey = getGeneratedSourceConfigKey(configuration);
   }
 
   async processFile(
@@ -115,33 +135,41 @@ class GeneratedSourceStore implements FileStore {
     if (
       this.baseDir === undefined ||
       this.canAccessFileSystem === undefined ||
-      this.analyzableFilesConfigKey === undefined
+      this.derivedConfigKey === undefined
     ) {
       this.baseDir = configuration.baseDir;
       this.canAccessFileSystem = configuration.canAccessFileSystem;
-      this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+      this.derivedConfigKey = getGeneratedSourceConfigKey(configuration);
     }
 
     const { baseDir, canAccessFileSystem } = this;
     if (!baseDir || !canAccessFileSystem) {
+      this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+      this.needsFilteredRefresh = false;
       return;
     }
 
-    const derived = await deriveGeneratedSources(
-      baseDir,
-      dependencyManifestStore.getPackageJsons(),
-      {
-        sourceFileMatcher: createConfiguredGeneratedSourceFileMatcher(configuration),
-      },
-    );
-    this.derivedFamilyByFile = new Map(derived.familyByFile);
-    this.resolvedFiles = new Set(this.derivedFamilyByFile.keys());
-    this.configPaths = derived.configPaths;
-    this.watchedOutputPaths = derived.watchedOutputPaths;
+    if (!this.derivedMetadataInitialized) {
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        dependencyManifestStore.getPackageJsons(),
+        {
+          sourceFileMatcher: createConfiguredGeneratedSourceFileMatcher(configuration),
+        },
+      );
+      this.derivedFamilyByFile = new Map(derived.familyByFile);
+      this.resolvedFiles = new Set(this.derivedFamilyByFile.keys());
+      this.configPaths = derived.configPaths;
+      this.watchedOutputPaths = derived.watchedOutputPaths;
+      this.derivedMetadataInitialized = true;
+    }
+
+    this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
     this.refreshFilteredState(
       analyzableFiles,
       this.activeRequestFilesKey ?? this.getRequestFilesKey(canAccessFileSystem, analyzableFiles),
     );
+    this.needsFilteredRefresh = false;
   }
 
   private isRelevantEvent(
@@ -207,6 +235,13 @@ class GeneratedSourceStore implements FileStore {
     this.requestFilesKey = requestFilesKey;
     this.familyByFile = filterAnalyzableGeneratedFiles(this.derivedFamilyByFile, analyzableFiles);
   }
+}
+
+function getGeneratedSourceConfigKey(configuration: Configuration) {
+  return JSON.stringify({
+    jsSuffixes: configuration.jsSuffixes,
+    tsSuffixes: configuration.tsSuffixes,
+  });
 }
 
 function filterAnalyzableGeneratedFiles(

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -2363,6 +2363,46 @@ plugins = [
     expect(generatedSourceStore.getFamily(secondGeneratedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
+  it('memoizes explicit request-file keys per analyzable-file set', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+    const configuration = createConfiguration({ baseDir });
+    const { files: inputFiles } = await sanitizeRawInputFiles(
+      {
+        [generatedFile]: {
+          filePath: generatedFile,
+          fileType: 'MAIN',
+        },
+      },
+      configuration,
+    );
+
+    await initFileStores(configuration, inputFiles);
+
+    const explicitRequestFilesKeys = (
+      generatedSourceStore as unknown as {
+        explicitRequestFilesKeys?: WeakMap<object, string>;
+      }
+    ).explicitRequestFilesKeys;
+    expect(explicitRequestFilesKeys).toBeInstanceOf(WeakMap);
+
+    const cachedKey = explicitRequestFilesKeys?.get(inputFiles);
+    expect(cachedKey).toBeDefined();
+
+    await generatedSourceStore.isInitialized(configuration, inputFiles);
+
+    expect(explicitRequestFilesKeys?.get(inputFiles)).toEqual(cachedKey);
+  });
+
+  it('records the current configuration when post-processing exits early', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const configuration = createConfiguration({ baseDir, canAccessFileSystem: false });
+
+    await generatedSourceStore.postProcess(configuration);
+
+    expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+  });
+
   it('recomputes generated-source metadata when filesystem access becomes available again', async () => {
     const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
 

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -2363,6 +2363,33 @@ plugins = [
     expect(generatedSourceStore.getFamily(secondGeneratedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
+  it('reuses derived generated-source metadata when only exclusions change', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+
+    await initFileStores(createConfiguration({ baseDir }));
+
+    const generatedSourceStoreState = generatedSourceStore as unknown as {
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+      familyByFile: Map<NormalizedAbsolutePath, string>;
+    };
+    const initialDerivedFamilyByFile = generatedSourceStoreState.derivedFamilyByFile;
+    const initialFamilyByFile = generatedSourceStoreState.familyByFile;
+
+    expect(generatedSourceStore.getFamily(generatedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+
+    await initFileStores(
+      createConfiguration({
+        baseDir,
+        jsTsExclusions: ['**/src/generated/**'],
+      }),
+    );
+
+    expect(generatedSourceStoreState.derivedFamilyByFile).toBe(initialDerivedFamilyByFile);
+    expect(generatedSourceStoreState.familyByFile).not.toBe(initialFamilyByFile);
+    expect(generatedSourceStore.getFamily(generatedFile)).toBeUndefined();
+  });
+
   it('memoizes explicit request-file keys per analyzable-file set', async () => {
     const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
     const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');


### PR DESCRIPTION
## What changed

- Split the generated-source store refresh into two levels:
  - recompute project-level generated-source metadata only when generator discovery inputs change
  - refresh the filtered per-analysis view when only analyzable-file filters change
- Add a regression test covering exclusion-only configuration changes

## Why

Generated-source classification and analyzable-file filtering are different concerns.
The classification step derives a code-generation family from project metadata such as package manifests, generator configs, and supported JS/TS suffixes.
Analysis inclusions and exclusions do not change that family assignment; they only change whether an already-classified file belongs to the current analyzable set.

Keeping both concerns behind the same cache invalidation path caused exclusion-only analyses to clear and recompute derived generated-source metadata unnecessarily.
This change keeps the derived metadata cache when it is still valid and refreshes only the filtered view that depends on the current analyzable files.

## Validation

- `tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec --test-reporter-destination=stdout packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts`
