### PR TITLE
JS-1597 wire detectGeneratedCode configuration

### DIFF
--- a/packages/analysis/src/analyzeProject.ts
+++ b/packages/analysis/src/analyzeProject.ts
@@ -88,6 +88,7 @@ export async function analyzeProject(
     globals,
     bundles,
     baseDir,
+    detectGeneratedCode: configuration.detectGeneratedCode,
     isGeneratedSourceFile: filePath => generatedSourceStore.getFamily(filePath) !== undefined,
     rulesWorkdir,
     testFileExtensions,

--- a/packages/analysis/src/common/configuration.ts
+++ b/packages/analysis/src/common/configuration.ts
@@ -82,6 +82,7 @@ export type Configuration = {
   testInclusions: Minimatch[] /* sonar.test.inclusions - WILDCARD to narrow down sonar.tests */;
   testExclusions: Minimatch[] /* sonar.test.exclusions - WILDCARD to narrow down sonar.tests */;
   detectBundles: boolean /* sonar.javascript.detectBundles - whether files looking like bundled code should be ignored */;
+  detectGeneratedCode: boolean /* sonar.javascript.detectGeneratedCode - whether generated-source detection should affect analysis behavior */;
   createTSProgramForOrphanFiles: boolean /* sonar.javascript.createTSProgramForOrphanFiles - whether to create a TS program for orphan files */;
   disableTypeChecking: boolean /* sonar.javascript.disableTypeChecking - whether to completely disable TypeScript type checking */;
   skipNodeModuleLookupOutsideBaseDir: boolean /* sonar.internal.analysis.skipNodeModuleLookupOutsideBaseDir - whether to skip node_modules lookups outside baseDir in TS compiler host */;
@@ -118,6 +119,7 @@ export type ConfigurationInput = {
   testInclusions?: string[];
   testExclusions?: string[];
   detectBundles?: boolean;
+  detectGeneratedCode?: boolean;
   createTSProgramForOrphanFiles?: boolean;
   disableTypeChecking?: boolean;
   skipNodeModuleLookupOutsideBaseDir?: boolean;
@@ -256,6 +258,7 @@ export function createConfiguration(raw: unknown): Configuration {
     testInclusions: isStringArray(raw.testInclusions) ? raw.testInclusions : undefined,
     testExclusions: isStringArray(raw.testExclusions) ? raw.testExclusions : undefined,
     detectBundles: isBoolean(raw.detectBundles) ? raw.detectBundles : undefined,
+    detectGeneratedCode: isBoolean(raw.detectGeneratedCode) ? raw.detectGeneratedCode : undefined,
     createTSProgramForOrphanFiles: isBoolean(raw.createTSProgramForOrphanFiles)
       ? raw.createTSProgramForOrphanFiles
       : undefined,
@@ -308,6 +311,7 @@ export function createConfigurationFromInput(input: ConfigurationInput): Configu
     testInclusions: normalizeGlobs(input.testInclusions, baseDir),
     testExclusions: normalizeGlobs(input.testExclusions, baseDir),
     detectBundles: input.detectBundles ?? true,
+    detectGeneratedCode: input.detectGeneratedCode ?? true,
     createTSProgramForOrphanFiles: input.createTSProgramForOrphanFiles ?? true,
     disableTypeChecking: input.disableTypeChecking ?? false,
     skipNodeModuleLookupOutsideBaseDir: input.skipNodeModuleLookupOutsideBaseDir ?? false,

--- a/packages/analysis/tests/common/configuration.test.ts
+++ b/packages/analysis/tests/common/configuration.test.ts
@@ -42,6 +42,15 @@ describe('createConfiguration', () => {
       new Error('baseDir is required and must be a string'),
     );
   });
+
+  it('should default generated-code detection to true and allow overriding it', () => {
+    const baseDir = '/path/to/project';
+
+    expect(createConfiguration({ baseDir }).detectGeneratedCode).toBe(true);
+    expect(createConfiguration({ baseDir, detectGeneratedCode: false }).detectGeneratedCode).toBe(
+      false,
+    );
+  });
 });
 
 describe('isYamlFile', () => {


### PR DESCRIPTION
## What changed

- adds `detectGeneratedCode` to the analyze-project gRPC configuration and maps it into Node-side normalization
- serializes `shouldDetectGeneratedCode()` from the Java bridge request builder
- reads `sonar.javascript.detectGeneratedCode` from `JsTsContext` and covers the bridge and WebSensor paths with regression tests

## Why

- the previous change only wired the flag in the direct analysis configuration helper
- real analyses go through the Java -> gRPC -> Node bridge, where the field was missing and the value fell back to `true`
- as a result, `sonar.javascript.detectGeneratedCode=false` was still ignored in production analysis runs

## Validation

- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/grpc/tests/analyze-project-normalize.test.ts`
- `mvn -pl sonar-plugin/bridge -Dtest=AnalyzeProjectMessagesTest test`
- `mvn -pl sonar-plugin/sonar-javascript-plugin -am -Dtest=WebSensorTest#should_send_detectGeneratedCode_false_when_disabled -Dsurefire.failIfNoSpecifiedTests=false test`
