### PR TITLE
JS-1597 add generated-source observability

### DIFF
--- a/packages/analysis/src/analyzeProject.ts
+++ b/packages/analysis/src/analyzeProject.ts
@@ -36,7 +36,11 @@ import type { WsIncrementalResult } from './incremental-result.js';
 import { setSourceFilesContext } from './jsts/program/cache/sourceFileCache.js';
 import { generatedSourceStore, sourceFileStore } from './file-stores/index.js';
 import type { NormalizedAbsolutePath } from '../../shared/src/helpers/files.js';
-import { getProjectAnalysisTelemetry, resetProjectAnalysisTelemetry } from './telemetry.js';
+import {
+  getProjectAnalysisTelemetry,
+  getProjectAnalysisTelemetryCollector,
+  resetProjectAnalysisTelemetry,
+} from './telemetry.js';
 
 const analysisStatus = {
   cancelled: false,
@@ -79,6 +83,9 @@ export async function analyzeProject(
   };
   const { baseDir, environments, globals, sonarlint, canAccessFileSystem } = configuration;
   resetProjectAnalysisTelemetry();
+  getProjectAnalysisTelemetryCollector().recordGeneratedSources(
+    generatedSourceStore.getObservabilityTelemetry(),
+  );
   const jsTsConfigFields = getJsTsConfigFields(configuration);
   setSourceFilesContext(filesToAnalyze);
   const { testFileExtensions } = getFilterPathParams(configuration);

--- a/packages/analysis/src/common/filter/filter-path.ts
+++ b/packages/analysis/src/common/filter/filter-path.ts
@@ -21,6 +21,14 @@ import type { FileType } from '../../contracts/file.js';
 import { type FilterPathParams } from '../configuration.js';
 import { isTestRelatedFile } from '../../jsts/rules/helpers/test-file-pattern.js';
 
+type CandidateClassification = 'MATCH' | 'EXCLUDED' | 'OUT_OF_SCOPE' | 'NO_MATCH';
+
+type FilePathClassification =
+  | { status: 'MAIN'; fileType: 'MAIN' }
+  | { status: 'TEST'; fileType: 'TEST' }
+  | { status: 'EXCLUDED' }
+  | { status: 'OUT_OF_SCOPE' };
+
 /**
  * Checks whether a given file path is excluded based on JavaScript/TypeScript exclusion
  * properties sonar.typescript.exclusions and sonar.javascript.exclusions wildcards.
@@ -62,21 +70,55 @@ export function filterPathAndGetFileType(
   filePath: NormalizedAbsolutePath,
   params: FilterPathParams,
 ): FileType | undefined {
-  if (fileIsTest(filePath, params)) {
-    return 'TEST';
-  }
-
-  if (fileIsMain(filePath, params)) {
-    return 'MAIN';
+  const classification = classifyFilePathInternal(filePath, params, true);
+  if (classification.status === 'TEST' || classification.status === 'MAIN') {
+    return classification.fileType;
   }
   debug(`File ignored due to analysis scope filters: ${filePath}`);
+}
+
+export function classifyFilePath(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+): FilePathClassification {
+  return classifyFilePathInternal(filePath, params, false);
 }
 
 function fileIsUnder(filePath: NormalizedAbsolutePath, paths: NormalizedAbsolutePath[]): boolean {
   return paths.some(path => filePath === path || filePath.startsWith(`${path}/`));
 }
 
-function fileIsTest(filePath: NormalizedAbsolutePath, params: FilterPathParams): boolean {
+function classifyFilePathInternal(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+  logHeuristicTestDetection: boolean,
+): FilePathClassification {
+  const testClassification = classifyTestPath(filePath, params, logHeuristicTestDetection);
+  if (testClassification === 'MATCH') {
+    return { status: 'TEST', fileType: 'TEST' };
+  }
+
+  const mainClassification = classifyMainPath(filePath, params);
+  if (mainClassification === 'MATCH') {
+    return { status: 'MAIN', fileType: 'MAIN' };
+  }
+
+  if (mainClassification === 'EXCLUDED' || testClassification === 'EXCLUDED') {
+    return { status: 'EXCLUDED' };
+  }
+
+  if (mainClassification === 'OUT_OF_SCOPE' || testClassification === 'OUT_OF_SCOPE') {
+    return { status: 'OUT_OF_SCOPE' };
+  }
+
+  return { status: 'OUT_OF_SCOPE' };
+}
+
+function classifyTestPath(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+  logHeuristicTestDetection: boolean,
+): CandidateClassification {
   const {
     testPaths,
     testExclusions,
@@ -95,41 +137,44 @@ function fileIsTest(filePath: NormalizedAbsolutePath, params: FilterPathParams):
       fileIsUnder(filePath, sourcesPaths) &&
       inclusions.some(inclusion => inclusion.match(filePath))
     ) {
-      return false;
+      return 'NO_MATCH';
     }
     const doesLookLikeTestFile = isTestRelatedFile(filePath, testFileExtensions);
-    if (doesLookLikeTestFile) {
+    if (doesLookLikeTestFile && logHeuristicTestDetection) {
       debug(
         `Test file detected: ${filePath}. If this file should not be treated as a test, please configure sonar.tests or adjust your sonar.sources/sonar.inclusions to explicitly include it as MAIN.`,
       );
     }
-    return doesLookLikeTestFile;
+    return doesLookLikeTestFile ? 'MATCH' : 'NO_MATCH';
   }
 
   if (!fileIsUnder(filePath, testPaths)) {
-    return false;
+    return 'NO_MATCH';
   }
   if (testExclusions?.some(exclusion => exclusion.match(filePath))) {
-    return false;
+    return 'EXCLUDED';
   }
   if (testInclusions?.length) {
-    return testInclusions.some(inclusion => inclusion.match(filePath));
+    return testInclusions.some(inclusion => inclusion.match(filePath)) ? 'MATCH' : 'OUT_OF_SCOPE';
   }
-  return true;
+  return 'MATCH';
 }
 
-function fileIsMain(filePath: NormalizedAbsolutePath, params: FilterPathParams): boolean {
+function classifyMainPath(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+): CandidateClassification {
   const { sourcesPaths, exclusions, inclusions } = params;
   if (!fileIsUnder(filePath, sourcesPaths)) {
-    return false;
+    return 'NO_MATCH';
   }
 
   if (exclusions?.some(exclusion => exclusion.match(filePath))) {
-    return false;
+    return 'EXCLUDED';
   }
 
   if (inclusions?.length) {
-    return inclusions.some(inclusion => inclusion.match(filePath));
+    return inclusions.some(inclusion => inclusion.match(filePath)) ? 'MATCH' : 'OUT_OF_SCOPE';
   }
-  return true;
+  return 'MATCH';
 }

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -17,22 +17,51 @@
 import { createHash } from 'node:crypto';
 import { basename, extname } from 'node:path/posix';
 import type { FileStore } from './store-type.js';
-import type { Configuration } from '../common/configuration.js';
-import type { AnalyzableFiles } from '../projectAnalysis.js';
-import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
 import {
   getAnalyzableFilesConfigKey,
+  getFilterPathParams,
   getProjectFileDiscoveryConfigKey,
+  type Configuration,
 } from '../common/configuration.js';
+import { classifyFilePath } from '../common/filter/filter-path.js';
+import type { AnalyzableFiles } from '../projectAnalysis.js';
+import {
+  normalizeToAbsolutePath,
+  type NormalizedAbsolutePath,
+} from '../../../shared/src/helpers/files.js';
+import { debug, info } from '../../../shared/src/helpers/logging.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
 import { getGeneratedSourceWatchedFilenames } from '../jsts/rules/helpers/generated-sources/index.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
 import { deriveGeneratedSources } from '../jsts/rules/helpers/generated-sources/derive.js';
+import { relativeToAncestorPath } from '../jsts/rules/helpers/files.js';
+import {
+  cloneGeneratedSourcesTelemetry,
+  createEmptyGeneratedSourcesTelemetry,
+  type GeneratedSourceFamilyTelemetry,
+  type GeneratedSourcesTelemetry,
+} from '../telemetry.js';
 
+const DEFAULT_DTS_EXCLUSION_PATTERN = '**/*.d.ts';
+const OBSERVABILITY_SAMPLE_LIMIT = 3;
 const ALL_FILES_REQUEST_KEY = 'all-files';
 const EXPLICIT_FILE_SET_REQUEST_KEY_PREFIX = 'explicit';
 
 type RequestFilesKey = string | undefined;
+
+type GeneratedSourceFamilyObservability = GeneratedSourceFamilyTelemetry & {
+  excludedPaths: NormalizedAbsolutePath[];
+  outOfScopePaths: NormalizedAbsolutePath[];
+};
+
+type GeneratedSourceObservability = {
+  telemetry: GeneratedSourcesTelemetry;
+  families: GeneratedSourceFamilyObservability[];
+  ignoredDefaultDtsFamilies: Array<{
+    family: string;
+    filePaths: NormalizedAbsolutePath[];
+  }>;
+};
 
 class GeneratedSourceStore implements FileStore {
   private readonly explicitRequestFilesKeys = new WeakMap<AnalyzableFiles, string>();
@@ -47,6 +76,7 @@ class GeneratedSourceStore implements FileStore {
   private resolvedFiles = new Set<NormalizedAbsolutePath>();
   private configPaths = new Set<NormalizedAbsolutePath>();
   private watchedOutputPaths = new Set<NormalizedAbsolutePath>();
+  private observabilityTelemetry = createEmptyGeneratedSourcesTelemetry();
 
   async isInitialized(configuration: Configuration, inputFiles?: AnalyzableFiles) {
     this.dirtyCachesIfNeeded(configuration);
@@ -64,12 +94,16 @@ class GeneratedSourceStore implements FileStore {
       return false;
     }
 
-    this.refreshFilteredState(inputFiles, requestFilesKey);
+    this.refreshFilteredState(configuration, inputFiles, requestFilesKey);
     return true;
   }
 
   getFamily(filePath: NormalizedAbsolutePath): string | undefined {
     return this.familyByFile.get(filePath);
+  }
+
+  getObservabilityTelemetry(): GeneratedSourcesTelemetry {
+    return cloneGeneratedSourcesTelemetry(this.observabilityTelemetry);
   }
 
   dirtyCachesIfNeeded(configuration: Configuration) {
@@ -151,6 +185,7 @@ class GeneratedSourceStore implements FileStore {
     this.configPaths = derived.configPaths;
     this.watchedOutputPaths = derived.watchedOutputPaths;
     this.refreshFilteredState(
+      configuration,
       analyzableFiles,
       this.activeRequestFilesKey ?? this.getRequestFilesKey(canAccessFileSystem, analyzableFiles),
     );
@@ -192,6 +227,7 @@ class GeneratedSourceStore implements FileStore {
     this.resolvedFiles = new Set();
     this.configPaths = new Set();
     this.watchedOutputPaths = new Set();
+    this.observabilityTelemetry = createEmptyGeneratedSourcesTelemetry();
   }
 
   private getRequestFilesKey(
@@ -213,11 +249,23 @@ class GeneratedSourceStore implements FileStore {
   }
 
   private refreshFilteredState(
+    configuration: Configuration,
     analyzableFiles: AnalyzableFiles | undefined,
     requestFilesKey: RequestFilesKey,
   ) {
+    if (!this.baseDir) {
+      return;
+    }
+
     this.requestFilesKey = requestFilesKey;
     this.familyByFile = filterAnalyzableGeneratedFiles(this.derivedFamilyByFile, analyzableFiles);
+    const observability = buildGeneratedSourceObservability(
+      this.derivedFamilyByFile,
+      this.familyByFile,
+      configuration,
+    );
+    this.observabilityTelemetry = observability.telemetry;
+    logGeneratedSourceObservability(this.baseDir, observability);
   }
 }
 
@@ -260,3 +308,175 @@ function createConfiguredGeneratedSourceFileMatcher(configuration: Configuration
 }
 
 export const generatedSourceStore = new GeneratedSourceStore();
+
+function buildGeneratedSourceObservability(
+  resolvedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
+  taggedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
+  configuration: Configuration,
+): GeneratedSourceObservability {
+  const filterPathParams = getFilterPathParams(configuration);
+  const pathsByFamily = new Map<string, NormalizedAbsolutePath[]>();
+
+  for (const [filePath, family] of sortPathEntries(resolvedFamilyByFile.entries())) {
+    let familyPaths = pathsByFamily.get(family);
+    if (!familyPaths) {
+      familyPaths = [];
+      pathsByFamily.set(family, familyPaths);
+    }
+    familyPaths.push(filePath);
+  }
+
+  const families: GeneratedSourceFamilyObservability[] = [];
+  const ignoredDefaultDtsFamilies: GeneratedSourceObservability['ignoredDefaultDtsFamilies'] = [];
+
+  for (const family of [...pathsByFamily.keys()].sort((left, right) => left.localeCompare(right))) {
+    const filePaths = pathsByFamily.get(family) ?? [];
+    if (
+      shouldIgnoreDefaultDtsFamily(filePaths, taggedFamilyByFile, configuration, filterPathParams)
+    ) {
+      ignoredDefaultDtsFamilies.push({
+        family,
+        filePaths,
+      });
+      continue;
+    }
+
+    const familySummary: GeneratedSourceFamilyObservability = {
+      family,
+      resolvedFileCount: filePaths.length,
+      taggedFileCount: 0,
+      outOfScopeFileCount: 0,
+      excludedFileCount: 0,
+      excludedPaths: [],
+      outOfScopePaths: [],
+    };
+
+    for (const filePath of filePaths) {
+      if (taggedFamilyByFile.get(filePath) === family) {
+        familySummary.taggedFileCount += 1;
+        continue;
+      }
+
+      const pathClassification = classifyFilePath(filePath, filterPathParams);
+      if (pathClassification.status === 'OUT_OF_SCOPE') {
+        familySummary.outOfScopeFileCount += 1;
+        familySummary.outOfScopePaths.push(filePath);
+      } else {
+        familySummary.excludedFileCount += 1;
+        familySummary.excludedPaths.push(filePath);
+      }
+    }
+
+    families.push(familySummary);
+  }
+
+  const telemetryFamilies: GeneratedSourceFamilyTelemetry[] = families.map(family => ({
+    family: family.family,
+    resolvedFileCount: family.resolvedFileCount,
+    taggedFileCount: family.taggedFileCount,
+    outOfScopeFileCount: family.outOfScopeFileCount,
+    excludedFileCount: family.excludedFileCount,
+  }));
+
+  return {
+    telemetry: {
+      familyCount: telemetryFamilies.length,
+      resolvedFileCount: telemetryFamilies.reduce(
+        (count, family) => count + family.resolvedFileCount,
+        0,
+      ),
+      taggedFileCount: telemetryFamilies.reduce(
+        (count, family) => count + family.taggedFileCount,
+        0,
+      ),
+      outOfScopeFileCount: telemetryFamilies.reduce(
+        (count, family) => count + family.outOfScopeFileCount,
+        0,
+      ),
+      excludedFileCount: telemetryFamilies.reduce(
+        (count, family) => count + family.excludedFileCount,
+        0,
+      ),
+      families: telemetryFamilies,
+    },
+    families,
+    ignoredDefaultDtsFamilies,
+  };
+}
+
+function shouldIgnoreDefaultDtsFamily(
+  filePaths: readonly NormalizedAbsolutePath[],
+  taggedFamilyByFile: ReadonlyMap<NormalizedAbsolutePath, string>,
+  configuration: Configuration,
+  filterPathParams: ReturnType<typeof getFilterPathParams>,
+) {
+  if (
+    filePaths.length === 0 ||
+    !configuration.jsTsExclusions.some(
+      exclusion =>
+        exclusion.pattern ===
+        normalizeToAbsolutePath(DEFAULT_DTS_EXCLUSION_PATTERN, configuration.baseDir),
+    )
+  ) {
+    return false;
+  }
+
+  return filePaths.every(filePath => {
+    if (!filePath.endsWith('.d.ts') || taggedFamilyByFile.has(filePath)) {
+      return false;
+    }
+
+    const pathClassification = classifyFilePath(filePath, filterPathParams);
+    return pathClassification.status === 'MAIN' || pathClassification.status === 'TEST';
+  });
+}
+
+function logGeneratedSourceObservability(
+  baseDir: NormalizedAbsolutePath,
+  observability: GeneratedSourceObservability,
+) {
+  if (observability.telemetry.familyCount > 0) {
+    info(
+      `Generated source observability: families=${observability.telemetry.familyCount}, resolvedFiles=${observability.telemetry.resolvedFileCount}, taggedFiles=${observability.telemetry.taggedFileCount}, outOfScopeFiles=${observability.telemetry.outOfScopeFileCount}, excludedFiles=${observability.telemetry.excludedFileCount}`,
+    );
+  }
+
+  for (const family of observability.families) {
+    info(
+      `Generated source family=${family.family} resolvedFiles=${family.resolvedFileCount} taggedFiles=${family.taggedFileCount} outOfScopeFiles=${family.outOfScopeFileCount} excludedFiles=${family.excludedFileCount}`,
+    );
+
+    if (family.outOfScopePaths.length > 0) {
+      debug(
+        `Generated source family=${family.family} outOfScope sample=${formatSamplePaths(baseDir, family.outOfScopePaths)}`,
+      );
+    }
+
+    if (family.excludedPaths.length > 0) {
+      debug(
+        `Generated source family=${family.family} excluded sample=${formatSamplePaths(baseDir, family.excludedPaths)}`,
+      );
+    }
+  }
+
+  for (const ignoredFamily of observability.ignoredDefaultDtsFamilies) {
+    debug(
+      `Generated source family=${ignoredFamily.family} ignored for observability because all resolved outputs are declaration files excluded by default ${DEFAULT_DTS_EXCLUSION_PATTERN}: ${formatSamplePaths(baseDir, ignoredFamily.filePaths)}`,
+    );
+  }
+}
+
+function formatSamplePaths(
+  baseDir: NormalizedAbsolutePath,
+  filePaths: readonly NormalizedAbsolutePath[],
+) {
+  const samplePaths = filePaths
+    .slice(0, OBSERVABILITY_SAMPLE_LIMIT)
+    .map(filePath => relativeToAncestorPath(filePath, baseDir) ?? filePath);
+  const moreCount = filePaths.length - samplePaths.length;
+  return moreCount > 0 ? `${samplePaths.join(', ')} (+${moreCount} more)` : samplePaths.join(', ');
+}
+
+function sortPathEntries<T>(entries: Iterable<[NormalizedAbsolutePath, T]>) {
+  return [...entries].sort(([left], [right]) => left.localeCompare(right));
+}

--- a/packages/analysis/src/telemetry.ts
+++ b/packages/analysis/src/telemetry.ts
@@ -85,6 +85,23 @@ type ProgramCreationTelemetry = {
   failed: number;
 };
 
+export type GeneratedSourceFamilyTelemetry = {
+  family: string;
+  resolvedFileCount: number;
+  taggedFileCount: number;
+  outOfScopeFileCount: number;
+  excludedFileCount: number;
+};
+
+export type GeneratedSourcesTelemetry = {
+  familyCount: number;
+  resolvedFileCount: number;
+  taggedFileCount: number;
+  outOfScopeFileCount: number;
+  excludedFileCount: number;
+  families: GeneratedSourceFamilyTelemetry[];
+};
+
 export type ProjectAnalysisTelemetry = {
   typescriptVersions: string[];
   typescriptNativePreview: boolean;
@@ -94,7 +111,28 @@ export type ProjectAnalysisTelemetry = {
   esmFileCount: number;
   cjsFileCount: number;
   denoImportCounts: Record<string, number>;
+  generatedSources: GeneratedSourcesTelemetry;
 };
+
+export function createEmptyGeneratedSourcesTelemetry(): GeneratedSourcesTelemetry {
+  return {
+    familyCount: 0,
+    resolvedFileCount: 0,
+    taggedFileCount: 0,
+    outOfScopeFileCount: 0,
+    excludedFileCount: 0,
+    families: [],
+  };
+}
+
+export function cloneGeneratedSourcesTelemetry(
+  telemetry: GeneratedSourcesTelemetry,
+): GeneratedSourcesTelemetry {
+  return {
+    ...telemetry,
+    families: telemetry.families.map(family => ({ ...family })),
+  };
+}
 
 export function resetProjectAnalysisTelemetry() {
   projectAnalysisTelemetryCollector = new ProjectAnalysisTelemetryCollector();
@@ -128,6 +166,7 @@ export class ProjectAnalysisTelemetryCollector {
   private esmFileCount = 0;
   private cjsFileCount = 0;
   private readonly denoImportCountsByProtocol = new Map<string, number>();
+  private generatedSources = createEmptyGeneratedSourcesTelemetry();
 
   constructor() {
     const { typeScriptVersionSignals, hasTypeScriptNativePreview } =
@@ -178,6 +217,10 @@ export class ProjectAnalysisTelemetryCollector {
     }
   }
 
+  recordGeneratedSources(generatedSources: GeneratedSourcesTelemetry) {
+    this.generatedSources = cloneGeneratedSourcesTelemetry(generatedSources);
+  }
+
   getTelemetry(): ProjectAnalysisTelemetry {
     const compilerOptions: Record<string, string[]> = {};
     for (const [optionName, values] of this.compilerOptionValues.entries()) {
@@ -199,6 +242,7 @@ export class ProjectAnalysisTelemetryCollector {
       esmFileCount: this.esmFileCount,
       cjsFileCount: this.cjsFileCount,
       denoImportCounts: Object.fromEntries(this.denoImportCountsByProtocol),
+      generatedSources: cloneGeneratedSourcesTelemetry(this.generatedSources),
     };
   }
 

--- a/packages/analysis/tests/analyzeProject-sonarqube.test.ts
+++ b/packages/analysis/tests/analyzeProject-sonarqube.test.ts
@@ -296,6 +296,14 @@ describe('SonarQube project analysis', () => {
           esmFileCount: 0,
           cjsFileCount: 0,
           denoImportCounts: {},
+          generatedSources: {
+            familyCount: 0,
+            resolvedFileCount: 0,
+            taggedFileCount: 0,
+            outOfScopeFileCount: 0,
+            excludedFileCount: 0,
+            families: [],
+          },
           programCreation: {
             attempted: 0,
             succeeded: 0,

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -2363,6 +2363,166 @@ plugins = [
     expect(generatedSourceStore.getFamily(secondGeneratedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
+  it('records generated-source observability for tagged, excluded, and out-of-scope files', async ({
+    mock,
+  }) => {
+    const baseDir = await createTempBaseDir();
+    const taggedFile = joinPaths(baseDir, 'src', 'generated', 'keep.ts');
+    const excludedFile = joinPaths(baseDir, 'src', 'excluded', 'blocked.ts');
+    const outOfScopeFile = joinPaths(baseDir, 'outside', 'api', 'index.ts');
+    const originalConsoleLog = console.log;
+    console.log = mock.fn(console.log);
+
+    try {
+      await writeFixtureFile(
+        joinPaths(baseDir, 'package.json'),
+        JSON.stringify(
+          {
+            devDependencies: {
+              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+            },
+            scripts: {
+              graphql: 'graphql-codegen --config ./codegen.yml',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFixtureFile(
+        joinPaths(baseDir, 'codegen.yml'),
+        `generates:
+  ./src/generated/keep.ts:
+    plugins:
+      - typescript
+  ./src/excluded/blocked.ts:
+    plugins:
+      - typescript
+  ./outside/api/index.ts:
+    plugins:
+      - typescript
+`,
+      );
+      await writeFixtureFile(taggedFile, 'export const tagged = true;\n');
+      await writeFixtureFile(excludedFile, 'export const excluded = true;\n');
+      await writeFixtureFile(outOfScopeFile, 'export const outOfScope = true;\n');
+
+      await initFileStores(
+        createConfiguration({
+          baseDir,
+          sources: ['src'],
+          exclusions: ['src/excluded/**'],
+        }),
+      );
+
+      expect(generatedSourceStore.getFamily(taggedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+      expect(generatedSourceStore.getFamily(excludedFile)).toBeUndefined();
+      expect(generatedSourceStore.getFamily(outOfScopeFile)).toBeUndefined();
+      expect(generatedSourceStore.getObservabilityTelemetry()).toEqual({
+        familyCount: 1,
+        resolvedFileCount: 3,
+        taggedFileCount: 1,
+        outOfScopeFileCount: 1,
+        excludedFileCount: 1,
+        families: [
+          {
+            family: GRAPHQL_CODEGEN_FAMILY,
+            resolvedFileCount: 3,
+            taggedFileCount: 1,
+            outOfScopeFileCount: 1,
+            excludedFileCount: 1,
+          },
+        ],
+      });
+
+      const logs = (console.log as Mock<typeof console.log>).mock.calls.map(
+        call => call.arguments[0],
+      );
+      expect(logs).toContain(
+        'Generated source observability: families=1, resolvedFiles=3, taggedFiles=1, outOfScopeFiles=1, excludedFiles=1',
+      );
+      expect(logs).toContain(
+        'Generated source family=@graphql-codegen/cli resolvedFiles=3 taggedFiles=1 outOfScopeFiles=1 excludedFiles=1',
+      );
+      expect(logs).toContain(
+        'DEBUG Generated source family=@graphql-codegen/cli excluded sample=src/excluded/blocked.ts',
+      );
+      expect(logs).toContain(
+        'DEBUG Generated source family=@graphql-codegen/cli outOfScope sample=outside/api/index.ts',
+      );
+    } finally {
+      console.log = originalConsoleLog;
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores declaration-only default-excluded generated families in observability', async ({
+    mock,
+  }) => {
+    const baseDir = await createTempBaseDir();
+    const declarationFile = joinPaths(baseDir, 'src', 'generated', 'operations.d.ts');
+    const originalConsoleLog = console.log;
+    console.log = mock.fn(console.log);
+
+    try {
+      await writeFixtureFile(
+        joinPaths(baseDir, 'package.json'),
+        JSON.stringify(
+          {
+            devDependencies: {
+              [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+            },
+            scripts: {
+              graphql: 'graphql-codegen --config ./codegen.yml',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFixtureFile(
+        joinPaths(baseDir, 'codegen.yml'),
+        `generates:
+  ./src/generated/operations.d.ts:
+    plugins:
+      - typescript
+`,
+      );
+      await writeFixtureFile(declarationFile, 'export type Operation = string;\n');
+
+      await initFileStores(
+        createConfiguration({
+          baseDir,
+          sources: ['src'],
+        }),
+      );
+
+      expect(sourceFileStore.getFiles()[declarationFile]).toBeUndefined();
+      expect(generatedSourceStore.getFamily(declarationFile)).toBeUndefined();
+      expect(generatedSourceStore.getObservabilityTelemetry()).toEqual({
+        familyCount: 0,
+        resolvedFileCount: 0,
+        taggedFileCount: 0,
+        outOfScopeFileCount: 0,
+        excludedFileCount: 0,
+        families: [],
+      });
+
+      const logs = (console.log as Mock<typeof console.log>).mock.calls.map(
+        call => call.arguments[0],
+      );
+      expect(logs).not.toContain(
+        'Generated source observability: families=0, resolvedFiles=0, taggedFiles=0, outOfScopeFiles=0, excludedFiles=0',
+      );
+      expect(logs).toContain(
+        'DEBUG Generated source family=@graphql-codegen/cli ignored for observability because all resolved outputs are declaration files excluded by default **/*.d.ts: src/generated/operations.d.ts',
+      );
+    } finally {
+      console.log = originalConsoleLog;
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   it('recomputes generated-source metadata when filesystem access becomes available again', async () => {
     const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
 

--- a/packages/analysis/tests/telemetry.test.ts
+++ b/packages/analysis/tests/telemetry.test.ts
@@ -141,4 +141,55 @@ describe('project analysis telemetry', () => {
       useUnknownInCatchVariables: ['true'],
     });
   });
+
+  it('should expose generated-source telemetry summaries', () => {
+    const collector = new ProjectAnalysisTelemetryCollector();
+    collector.recordGeneratedSources({
+      familyCount: 2,
+      resolvedFileCount: 9,
+      taggedFileCount: 5,
+      outOfScopeFileCount: 2,
+      excludedFileCount: 2,
+      families: [
+        {
+          family: '@graphql-codegen/cli',
+          resolvedFileCount: 4,
+          taggedFileCount: 2,
+          outOfScopeFileCount: 1,
+          excludedFileCount: 1,
+        },
+        {
+          family: 'proto-loader-gen-types',
+          resolvedFileCount: 5,
+          taggedFileCount: 3,
+          outOfScopeFileCount: 1,
+          excludedFileCount: 1,
+        },
+      ],
+    });
+
+    expect(collector.getTelemetry().generatedSources).toEqual({
+      familyCount: 2,
+      resolvedFileCount: 9,
+      taggedFileCount: 5,
+      outOfScopeFileCount: 2,
+      excludedFileCount: 2,
+      families: [
+        {
+          family: '@graphql-codegen/cli',
+          resolvedFileCount: 4,
+          taggedFileCount: 2,
+          outOfScopeFileCount: 1,
+          excludedFileCount: 1,
+        },
+        {
+          family: 'proto-loader-gen-types',
+          resolvedFileCount: 5,
+          taggedFileCount: 3,
+          outOfScopeFileCount: 1,
+          excludedFileCount: 1,
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## What changed

- Adds generated-source observability summaries and telemetry types.
- Classifies resolved generated files as tagged, excluded, or out of scope.
- Publishes the generated-source telemetry through project analysis metadata and logs.
- Adds targeted tests for telemetry and observability behavior.

## Why

- This follow-up adds visibility into generated-source detection results without mixing in detector-specific work.

## Validation

- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/tests/telemetry.test.ts packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts`
- `npx tsc -p packages/tsconfig.json --noEmit --pretty false`
