### PR TITLE
JS-1597 narrow generated-source cache invalidation

### DIFF
--- a/docs/file-stores.md
+++ b/docs/file-stores.md
@@ -195,34 +195,43 @@ It maintains two caches:
 - a **detector cache** with generated-file to family mappings, config paths used by generated-source detectors, and watched output paths
 - a **match cache** with the subset of detector matches visible to the current analysis request
 
-It depends on a mix of the other stores:
+The most useful way to reason about this store is by the corresponding Sonar property families.
 
-- **project helper files** because the detector cache derives metadata from files such as `package.json`
-- **source-file selection** because the match cache should only surface analyzable source files to the linter
+- **Source-scope properties**: `sonar.sources`, `sonar.tests`, `sonar.inclusions`, `sonar.exclusions`, `sonar.test.inclusions`, and `sonar.test.exclusions`
+- **Filesystem-walk exclusions**: `sonar.javascript.exclusions` and `sonar.typescript.exclusions`
+
+Internally, the source-scope properties map to `sources`, `tests`, `inclusions`, `exclusions`, `testInclusions`, and `testExclusions`.
+They decide which discovered source files remain visible to analysis, so they affect the **match cache**.
+
+Internally, `sonar.javascript.exclusions` and `sonar.typescript.exclusions` are merged into `jsTsExclusions`.
+They are different from `sonar.exclusions`: they are applied during `findFiles()`, before helper files such as `package.json` are discovered.
+Because the detector cache derives metadata from those helper files, the current implementation conservatively invalidates the **detector cache** whenever `jsTsExclusions` changes.
+
+For example:
+
+- changing `sonar.exclusions` to ignore `src/generated/**` only changes the visible generated-file matches
+- changing `sonar.javascript.exclusions` or `sonar.typescript.exclusions` to ignore `**/package.json` changes detector inputs and invalidates the detector cache
+
+The store also depends on:
+
 - **explicit request files** in request-driven analysis, where the visible match-cache subset may change from one request to the next
-
-Those dependencies are not represented by two disjoint configuration keys.
-
-- `jsTsExclusions` participates in **analyzable-file selection**
-- the same `jsTsExclusions` also participates in **project-file discovery**, because the filesystem walk skips excluded paths before helper files such as `package.json` are discovered
-
-That means a change classified as an analyzable-file-selection change is not automatically safe for a match-cache-only refresh. If it changes helper-file discovery, it also invalidates the detector cache.
+- **project helper files** because the detector cache derives metadata from files such as `package.json`
+- **JS/TS suffix settings** because detector output matching depends on the supported source extensions
 
 ### Refresh Model
 
-`generatedSourceStore` is refreshed when:
+`generatedSourceStore` recomputes the detector cache when:
 
 - the base directory changes
 - filesystem access mode changes
-- project-file-discovery configuration changes
+- JS/TS suffix settings change
+- `sonar.javascript.exclusions` or `sonar.typescript.exclusions` changes
 - `fsEvents` mention a relevant helper file, generated-source config file, or watched output path
 
-The detector cache is recomputed in those cases because the project-level detection inputs may have changed.
+`generatedSourceStore` refreshes only the match cache when:
 
-It also has a lighter-weight match-cache refresh:
-
-- when analyzable-file-selection configuration changes in a way that does **not** change helper-file discovery inputs
-- when the explicit request file set changes but the detector cache is still valid
+- `sonar.sources`, `sonar.tests`, `sonar.inclusions`, `sonar.exclusions`, `sonar.test.inclusions`, or `sonar.test.exclusions` changes
+- the explicit request file set changes but the detector cache is still valid
 
 This is why `generated-sources` is the hybrid store: its detector cache depends on helper-file discovery, while its match cache also depends on the currently visible source-file set.
 

--- a/docs/file-stores.md
+++ b/docs/file-stores.md
@@ -190,18 +190,23 @@ Like `tsconfigs`, this store is intentionally independent from the current set o
 
 See [Generated Source Detection](./generated-sources.md) for the detector pipeline, linter integration, and cache behavior behind this store.
 
-It stores:
+It maintains two caches:
 
-- generated-file to family mappings
-- config paths used by generated-source detectors
-- watched output paths
-- a filtered view of those matches for the current request
+- a **detector cache** with generated-file to family mappings, config paths used by generated-source detectors, and watched output paths
+- a **match cache** with the subset of detector matches visible to the current analysis request
 
 It depends on a mix of the other stores:
 
-- **project helper files** because detectors derive metadata from files such as `package.json`
-- **source-file selection** because only analyzable source files should be surfaced to the linter
-- **explicit request files** in request-driven analysis, where the visible generated-file subset may change from one request to the next
+- **project helper files** because the detector cache derives metadata from files such as `package.json`
+- **source-file selection** because the match cache should only surface analyzable source files to the linter
+- **explicit request files** in request-driven analysis, where the visible match-cache subset may change from one request to the next
+
+Those dependencies are not represented by two disjoint configuration keys.
+
+- `jsTsExclusions` participates in **analyzable-file selection**
+- the same `jsTsExclusions` also participates in **project-file discovery**, because the filesystem walk skips excluded paths before helper files such as `package.json` are discovered
+
+That means a change classified as an analyzable-file-selection change is not automatically safe for a match-cache-only refresh. If it changes helper-file discovery, it also invalidates the detector cache.
 
 ### Refresh Model
 
@@ -209,15 +214,17 @@ It depends on a mix of the other stores:
 
 - the base directory changes
 - filesystem access mode changes
-- analyzable-file-selection configuration changes
 - project-file-discovery configuration changes
 - `fsEvents` mention a relevant helper file, generated-source config file, or watched output path
 
-It also has a lighter-weight request refresh:
+The detector cache is recomputed in those cases because the project-level detection inputs may have changed.
 
-- when the explicit request file set changes but the derived metadata is still valid, the store can refresh its filtered view without recomputing everything
+It also has a lighter-weight match-cache refresh:
 
-This is why `generated-sources` is the hybrid store: it depends on both helper-file discovery and the currently visible source-file set.
+- when analyzable-file-selection configuration changes in a way that does **not** change helper-file discovery inputs
+- when the explicit request file set changes but the detector cache is still valid
+
+This is why `generated-sources` is the hybrid store: its detector cache depends on helper-file discovery, while its match cache also depends on the currently visible source-file set.
 
 ## `fsEvents`
 

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -20,10 +20,7 @@ import type { FileStore } from './store-type.js';
 import type { Configuration } from '../common/configuration.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
-import {
-  getAnalyzableFilesConfigKey,
-  getProjectFileDiscoveryConfigKey,
-} from '../common/configuration.js';
+import { getAnalyzableFilesConfigKey } from '../common/configuration.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
 import { getGeneratedSourceWatchedFilenames } from '../jsts/rules/helpers/generated-sources/index.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
@@ -39,7 +36,6 @@ class GeneratedSourceStore implements FileStore {
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
-  private projectFileDiscoveryConfigKey: string | undefined = undefined;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
   private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
@@ -84,11 +80,6 @@ class GeneratedSourceStore implements FileStore {
       return;
     }
 
-    if (getProjectFileDiscoveryConfigKey(configuration) !== this.projectFileDiscoveryConfigKey) {
-      this.clearCache();
-      return;
-    }
-
     const generatedSourceWatchedFilenames = getGeneratedSourceWatchedFilenames();
     for (const filename of fsEvents) {
       if (this.isRelevantEvent(filename, generatedSourceWatchedFilenames)) {
@@ -102,7 +93,6 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
     this.analyzableFilesConfigKey = undefined;
-    this.projectFileDiscoveryConfigKey = undefined;
     this.activeRequestFilesKey = undefined;
     this.clearDerivedState();
   }
@@ -111,7 +101,6 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
     this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
-    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     this.clearDerivedState();
   }
 
@@ -131,7 +120,6 @@ class GeneratedSourceStore implements FileStore {
       this.baseDir = configuration.baseDir;
       this.canAccessFileSystem = configuration.canAccessFileSystem;
       this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
-      this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     }
 
     const { baseDir, canAccessFileSystem } = this;

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -35,7 +35,10 @@ class GeneratedSourceStore implements FileStore {
   private readonly explicitRequestFilesKeys = new WeakMap<AnalyzableFiles, string>();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
+  private derivedConfigKey: string | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
+  private needsFilteredRefresh = false;
+  private derivedMetadataInitialized = false;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
   private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
@@ -50,6 +53,17 @@ class GeneratedSourceStore implements FileStore {
     this.activeRequestFilesKey = requestFilesKey;
     if (this.baseDir === undefined) {
       return false;
+    }
+
+    if (this.needsFilteredRefresh) {
+      if (requestFilesKey === undefined || inputFiles === undefined) {
+        return false;
+      }
+
+      this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+      this.refreshFilteredState(inputFiles, requestFilesKey);
+      this.needsFilteredRefresh = false;
+      return true;
     }
 
     if (requestFilesKey === this.requestFilesKey) {
@@ -75,7 +89,7 @@ class GeneratedSourceStore implements FileStore {
       return;
     }
 
-    if (getAnalyzableFilesConfigKey(configuration) !== this.analyzableFilesConfigKey) {
+    if (getGeneratedSourceConfigKey(configuration) !== this.derivedConfigKey) {
       this.clearCache();
       return;
     }
@@ -87,12 +101,19 @@ class GeneratedSourceStore implements FileStore {
         return;
       }
     }
+
+    if (getAnalyzableFilesConfigKey(configuration) !== this.analyzableFilesConfigKey) {
+      this.needsFilteredRefresh = true;
+    }
   }
 
   clearCache() {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
+    this.derivedConfigKey = undefined;
     this.analyzableFilesConfigKey = undefined;
+    this.needsFilteredRefresh = false;
+    this.derivedMetadataInitialized = false;
     this.activeRequestFilesKey = undefined;
     this.clearDerivedState();
   }
@@ -100,8 +121,7 @@ class GeneratedSourceStore implements FileStore {
   setup(configuration: Configuration) {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
-    this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
-    this.clearDerivedState();
+    this.derivedConfigKey = getGeneratedSourceConfigKey(configuration);
   }
 
   async processFile(
@@ -115,33 +135,41 @@ class GeneratedSourceStore implements FileStore {
     if (
       this.baseDir === undefined ||
       this.canAccessFileSystem === undefined ||
-      this.analyzableFilesConfigKey === undefined
+      this.derivedConfigKey === undefined
     ) {
       this.baseDir = configuration.baseDir;
       this.canAccessFileSystem = configuration.canAccessFileSystem;
-      this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+      this.derivedConfigKey = getGeneratedSourceConfigKey(configuration);
     }
 
     const { baseDir, canAccessFileSystem } = this;
     if (!baseDir || !canAccessFileSystem) {
+      this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
+      this.needsFilteredRefresh = false;
       return;
     }
 
-    const derived = await deriveGeneratedSources(
-      baseDir,
-      dependencyManifestStore.getPackageJsons(),
-      {
-        sourceFileMatcher: createConfiguredGeneratedSourceFileMatcher(configuration),
-      },
-    );
-    this.derivedFamilyByFile = new Map(derived.familyByFile);
-    this.resolvedFiles = new Set(this.derivedFamilyByFile.keys());
-    this.configPaths = derived.configPaths;
-    this.watchedOutputPaths = derived.watchedOutputPaths;
+    if (!this.derivedMetadataInitialized) {
+      const derived = await deriveGeneratedSources(
+        baseDir,
+        dependencyManifestStore.getPackageJsons(),
+        {
+          sourceFileMatcher: createConfiguredGeneratedSourceFileMatcher(configuration),
+        },
+      );
+      this.derivedFamilyByFile = new Map(derived.familyByFile);
+      this.resolvedFiles = new Set(this.derivedFamilyByFile.keys());
+      this.configPaths = derived.configPaths;
+      this.watchedOutputPaths = derived.watchedOutputPaths;
+      this.derivedMetadataInitialized = true;
+    }
+
+    this.analyzableFilesConfigKey = getAnalyzableFilesConfigKey(configuration);
     this.refreshFilteredState(
       analyzableFiles,
       this.activeRequestFilesKey ?? this.getRequestFilesKey(canAccessFileSystem, analyzableFiles),
     );
+    this.needsFilteredRefresh = false;
   }
 
   private isRelevantEvent(
@@ -207,6 +235,13 @@ class GeneratedSourceStore implements FileStore {
     this.requestFilesKey = requestFilesKey;
     this.familyByFile = filterAnalyzableGeneratedFiles(this.derivedFamilyByFile, analyzableFiles);
   }
+}
+
+function getGeneratedSourceConfigKey(configuration: Configuration) {
+  return JSON.stringify({
+    jsSuffixes: configuration.jsSuffixes,
+    tsSuffixes: configuration.tsSuffixes,
+  });
 }
 
 function filterAnalyzableGeneratedFiles(

--- a/packages/analysis/src/file-stores/generated-sources.ts
+++ b/packages/analysis/src/file-stores/generated-sources.ts
@@ -20,7 +20,10 @@ import type { FileStore } from './store-type.js';
 import type { Configuration } from '../common/configuration.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
-import { getAnalyzableFilesConfigKey } from '../common/configuration.js';
+import {
+  getAnalyzableFilesConfigKey,
+  getProjectFileDiscoveryConfigKey,
+} from '../common/configuration.js';
 import { dependencyManifestStore } from './dependency-manifests.js';
 import { getGeneratedSourceWatchedFilenames } from '../jsts/rules/helpers/generated-sources/index.js';
 import { isPreloadableDependencyManifestPath } from '../jsts/rules/helpers/dependency-manifests/index.js';
@@ -31,17 +34,25 @@ const EXPLICIT_FILE_SET_REQUEST_KEY_PREFIX = 'explicit';
 
 type RequestFilesKey = string | undefined;
 
+/**
+ * Maintains two generated-source caches:
+ * - the detector cache, which stores the project-level outputs of generated-source detection
+ * - the match cache, which stores the current analyzable subset exposed by the store
+ */
 class GeneratedSourceStore implements FileStore {
   private readonly explicitRequestFilesKeys = new WeakMap<AnalyzableFiles, string>();
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
   private derivedConfigKey: string | undefined = undefined;
+  private projectFileDiscoveryConfigKey: string | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
   private needsFilteredRefresh = false;
   private derivedMetadataInitialized = false;
   private activeRequestFilesKey: RequestFilesKey = undefined;
   private requestFilesKey: RequestFilesKey = undefined;
+  // Detector cache: generated-source families derived from project metadata.
   private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
+  // Match cache: detector results filtered to the current analyzable/requested files.
   private familyByFile = new Map<NormalizedAbsolutePath, string>();
   private resolvedFiles = new Set<NormalizedAbsolutePath>();
   private configPaths = new Set<NormalizedAbsolutePath>();
@@ -94,6 +105,13 @@ class GeneratedSourceStore implements FileStore {
       return;
     }
 
+    if (
+      getProjectFileDiscoveryConfigKey(configuration) !== this.projectFileDiscoveryConfigKey
+    ) {
+      this.clearCache();
+      return;
+    }
+
     const generatedSourceWatchedFilenames = getGeneratedSourceWatchedFilenames();
     for (const filename of fsEvents) {
       if (this.isRelevantEvent(filename, generatedSourceWatchedFilenames)) {
@@ -111,6 +129,7 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = undefined;
     this.canAccessFileSystem = undefined;
     this.derivedConfigKey = undefined;
+    this.projectFileDiscoveryConfigKey = undefined;
     this.analyzableFilesConfigKey = undefined;
     this.needsFilteredRefresh = false;
     this.derivedMetadataInitialized = false;
@@ -122,24 +141,27 @@ class GeneratedSourceStore implements FileStore {
     this.baseDir = configuration.baseDir;
     this.canAccessFileSystem = configuration.canAccessFileSystem;
     this.derivedConfigKey = getGeneratedSourceConfigKey(configuration);
+    this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
   }
 
   async processFile(
     _filename: NormalizedAbsolutePath,
     _configuration: Configuration,
   ): Promise<void> {
-    // Generated-source detection is derived from project metadata during postProcess.
+    // The detector cache is derived from project metadata during postProcess().
   }
 
   async postProcess(configuration: Configuration, analyzableFiles?: AnalyzableFiles) {
     if (
       this.baseDir === undefined ||
       this.canAccessFileSystem === undefined ||
-      this.derivedConfigKey === undefined
+      this.derivedConfigKey === undefined ||
+      this.projectFileDiscoveryConfigKey === undefined
     ) {
       this.baseDir = configuration.baseDir;
       this.canAccessFileSystem = configuration.canAccessFileSystem;
       this.derivedConfigKey = getGeneratedSourceConfigKey(configuration);
+      this.projectFileDiscoveryConfigKey = getProjectFileDiscoveryConfigKey(configuration);
     }
 
     const { baseDir, canAccessFileSystem } = this;
@@ -233,6 +255,7 @@ class GeneratedSourceStore implements FileStore {
     requestFilesKey: RequestFilesKey,
   ) {
     this.requestFilesKey = requestFilesKey;
+    // Refresh only the match cache from the stable detector cache.
     this.familyByFile = filterAnalyzableGeneratedFiles(this.derivedFamilyByFile, analyzableFiles);
   }
 }

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -2363,6 +2363,46 @@ plugins = [
     expect(generatedSourceStore.getFamily(secondGeneratedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
+  it('memoizes explicit request-file keys per analyzable-file set', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+    const configuration = createConfiguration({ baseDir });
+    const { files: inputFiles } = await sanitizeRawInputFiles(
+      {
+        [generatedFile]: {
+          filePath: generatedFile,
+          fileType: 'MAIN',
+        },
+      },
+      configuration,
+    );
+
+    await initFileStores(configuration, inputFiles);
+
+    const explicitRequestFilesKeys = (
+      generatedSourceStore as unknown as {
+        explicitRequestFilesKeys?: WeakMap<object, string>;
+      }
+    ).explicitRequestFilesKeys;
+    expect(explicitRequestFilesKeys).toBeInstanceOf(WeakMap);
+
+    const cachedKey = explicitRequestFilesKeys?.get(inputFiles);
+    expect(cachedKey).toBeDefined();
+
+    await generatedSourceStore.isInitialized(configuration, inputFiles);
+
+    expect(explicitRequestFilesKeys?.get(inputFiles)).toEqual(cachedKey);
+  });
+
+  it('records the current configuration when post-processing exits early', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const configuration = createConfiguration({ baseDir, canAccessFileSystem: false });
+
+    await generatedSourceStore.postProcess(configuration);
+
+    expect(await generatedSourceStore.isInitialized(configuration)).toBe(true);
+  });
+
   it('recomputes generated-source metadata when filesystem access becomes available again', async () => {
     const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
 

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -2363,6 +2363,33 @@ plugins = [
     expect(generatedSourceStore.getFamily(secondGeneratedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
+  it('reuses derived generated-source metadata when only exclusions change', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+
+    await initFileStores(createConfiguration({ baseDir }));
+
+    const generatedSourceStoreState = generatedSourceStore as unknown as {
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+      familyByFile: Map<NormalizedAbsolutePath, string>;
+    };
+    const initialDerivedFamilyByFile = generatedSourceStoreState.derivedFamilyByFile;
+    const initialFamilyByFile = generatedSourceStoreState.familyByFile;
+
+    expect(generatedSourceStore.getFamily(generatedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+
+    await initFileStores(
+      createConfiguration({
+        baseDir,
+        jsTsExclusions: ['**/src/generated/**'],
+      }),
+    );
+
+    expect(generatedSourceStoreState.derivedFamilyByFile).toBe(initialDerivedFamilyByFile);
+    expect(generatedSourceStoreState.familyByFile).not.toBe(initialFamilyByFile);
+    expect(generatedSourceStore.getFamily(generatedFile)).toBeUndefined();
+  });
+
   it('memoizes explicit request-file keys per analyzable-file set', async () => {
     const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
     const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -2363,7 +2363,7 @@ plugins = [
     expect(generatedSourceStore.getFamily(secondGeneratedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
-  it('reuses derived generated-source metadata when only exclusions change', async () => {
+  it('reuses derived generated-source metadata when only source-file scope changes', async () => {
     const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
     const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
 
@@ -2381,13 +2381,38 @@ plugins = [
     await initFileStores(
       createConfiguration({
         baseDir,
-        jsTsExclusions: ['**/src/generated/**'],
+        exclusions: ['**/src/generated/**'],
       }),
     );
 
     expect(generatedSourceStoreState.derivedFamilyByFile).toBe(initialDerivedFamilyByFile);
     expect(generatedSourceStoreState.familyByFile).not.toBe(initialFamilyByFile);
     expect(generatedSourceStore.getFamily(generatedFile)).toBeUndefined();
+  });
+
+  it('recomputes generated-source metadata when exclusions change package.json discovery', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+
+    await initFileStores(
+      createConfiguration({
+        baseDir,
+        jsTsExclusions: ['**/package.json'],
+      }),
+    );
+
+    const generatedSourceStoreState = generatedSourceStore as unknown as {
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+      familyByFile: Map<NormalizedAbsolutePath, string>;
+    };
+    const initialDerivedFamilyByFile = generatedSourceStoreState.derivedFamilyByFile;
+
+    expect(generatedSourceStore.getFamily(generatedFile)).toBeUndefined();
+
+    await initFileStores(createConfiguration({ baseDir }));
+
+    expect(generatedSourceStoreState.derivedFamilyByFile).not.toBe(initialDerivedFamilyByFile);
+    expect(generatedSourceStore.getFamily(generatedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
   it('memoizes explicit request-file keys per analyzable-file set', async () => {


### PR DESCRIPTION
## What changed

This PR narrows generated-source cache reuse in `generatedSourceStore`.

It keeps the lightweight match-cache refresh for true source-scope changes and explicit request-file-set changes, but it now hard-invalidates the detector cache when project-file discovery inputs change.

It also updates the file-store documentation to explain the detector cache vs match cache split in terms of the corresponding Sonar properties.

## Why it changed

The previous reuse logic treated every analyzable-file configuration change as match-cache-only.
That was too broad for `sonar.javascript.exclusions` and `sonar.typescript.exclusions`, which are merged into `jsTsExclusions` and are applied during the filesystem walk.

That means they can change which helper files, especially `package.json`, are discovered. When that happened, `generatedSourceStore` could incorrectly reuse a stale detector cache built from incomplete project metadata.

## Impact

- Keeps the intended optimization for source-scope-only changes such as `sonar.exclusions`
- Fixes stale generated-source metadata when JS/TS exclusions change helper-file discovery
- Documents the real refresh boundaries for the generated-source file store

## Validation

- `tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec --test-reporter-destination stdout packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts`
- `tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec --test-reporter-destination stdout packages/analysis/tests/file-stores.test.ts`
