### PR TITLE
JS-1597 wire detectGeneratedCode configuration

### DIFF
--- a/packages/analysis/src/analyzeProject.ts
+++ b/packages/analysis/src/analyzeProject.ts
@@ -88,6 +88,7 @@ export async function analyzeProject(
     globals,
     bundles,
     baseDir,
+    detectGeneratedCode: configuration.detectGeneratedCode,
     isGeneratedSourceFile: filePath => generatedSourceStore.getFamily(filePath) !== undefined,
     rulesWorkdir,
     testFileExtensions,

--- a/packages/analysis/src/common/configuration.ts
+++ b/packages/analysis/src/common/configuration.ts
@@ -82,6 +82,7 @@ export type Configuration = {
   testInclusions: Minimatch[] /* sonar.test.inclusions - WILDCARD to narrow down sonar.tests */;
   testExclusions: Minimatch[] /* sonar.test.exclusions - WILDCARD to narrow down sonar.tests */;
   detectBundles: boolean /* sonar.javascript.detectBundles - whether files looking like bundled code should be ignored */;
+  detectGeneratedCode: boolean /* sonar.javascript.detectGeneratedCode - whether generated-source detection should affect analysis behavior */;
   createTSProgramForOrphanFiles: boolean /* sonar.javascript.createTSProgramForOrphanFiles - whether to create a TS program for orphan files */;
   disableTypeChecking: boolean /* sonar.javascript.disableTypeChecking - whether to completely disable TypeScript type checking */;
   skipNodeModuleLookupOutsideBaseDir: boolean /* sonar.internal.analysis.skipNodeModuleLookupOutsideBaseDir - whether to skip node_modules lookups outside baseDir in TS compiler host */;
@@ -118,6 +119,7 @@ export type ConfigurationInput = {
   testInclusions?: string[];
   testExclusions?: string[];
   detectBundles?: boolean;
+  detectGeneratedCode?: boolean;
   createTSProgramForOrphanFiles?: boolean;
   disableTypeChecking?: boolean;
   skipNodeModuleLookupOutsideBaseDir?: boolean;
@@ -265,11 +267,8 @@ export function createConfiguration(raw: unknown): Configuration {
     testInclusions: getOptionalValue(raw, 'testInclusions', isStringArray),
     testExclusions: getOptionalValue(raw, 'testExclusions', isStringArray),
     detectBundles: getOptionalValue(raw, 'detectBundles', isBoolean),
-    createTSProgramForOrphanFiles: getOptionalValue(
-      raw,
-      'createTSProgramForOrphanFiles',
-      isBoolean,
-    ),
+    detectGeneratedCode: getOptionalValue(raw, 'detectGeneratedCode', isBoolean),
+    createTSProgramForOrphanFiles: getOptionalValue(raw, 'createTSProgramForOrphanFiles', isBoolean),
     disableTypeChecking: getOptionalValue(raw, 'disableTypeChecking', isBoolean),
     skipNodeModuleLookupOutsideBaseDir: getOptionalValue(
       raw,
@@ -319,6 +318,7 @@ export function createConfigurationFromInput(input: ConfigurationInput): Configu
     testInclusions: normalizeGlobs(input.testInclusions, baseDir),
     testExclusions: normalizeGlobs(input.testExclusions, baseDir),
     detectBundles: input.detectBundles ?? true,
+    detectGeneratedCode: input.detectGeneratedCode ?? true,
     createTSProgramForOrphanFiles: input.createTSProgramForOrphanFiles ?? true,
     disableTypeChecking: input.disableTypeChecking ?? false,
     skipNodeModuleLookupOutsideBaseDir: input.skipNodeModuleLookupOutsideBaseDir ?? false,

--- a/packages/analysis/src/file-stores/index.ts
+++ b/packages/analysis/src/file-stores/index.ts
@@ -36,13 +36,15 @@ export { generatedSourceStore } from './generated-sources.js';
 export async function initFileStores(configuration: Configuration, inputFiles?: AnalyzableFiles) {
   const { baseDir, canAccessFileSystem, jsTsExclusions } = configuration;
   const pendingStores: FileStore[] = [];
+  const fileStores = configuration.detectGeneratedCode
+    ? [sourceFileStore, dependencyManifestStore, generatedSourceStore, tsConfigStore]
+    : [sourceFileStore, dependencyManifestStore, tsConfigStore];
 
-  for (const store of [
-    sourceFileStore,
-    dependencyManifestStore,
-    generatedSourceStore,
-    tsConfigStore,
-  ]) {
+  if (!configuration.detectGeneratedCode) {
+    generatedSourceStore.clearCache();
+  }
+
+  for (const store of fileStores) {
     if (!(await store.isInitialized(configuration, inputFiles))) {
       pendingStores.push(store);
     }

--- a/packages/analysis/tests/common/configuration.test.ts
+++ b/packages/analysis/tests/common/configuration.test.ts
@@ -42,6 +42,15 @@ describe('createConfiguration', () => {
       new Error('baseDir is required and must be a string'),
     );
   });
+
+  it('should default generated-code detection to true and allow overriding it', () => {
+    const baseDir = '/path/to/project';
+
+    expect(createConfiguration({ baseDir }).detectGeneratedCode).toBe(true);
+    expect(createConfiguration({ baseDir, detectGeneratedCode: false }).detectGeneratedCode).toBe(
+      false,
+    );
+  });
 });
 
 describe('isYamlFile', () => {

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -2466,6 +2466,25 @@ plugins = [
     ).toEqual(GRAPHQL_CODEGEN_FAMILY);
   });
 
+  it('skips generated-source metadata derivation when detectGeneratedCode is disabled', async () => {
+    const baseDir = joinPaths(fixtures, 'graphql-codegen-standard');
+    const generatedFile = joinPaths(baseDir, 'src', 'generated', 'graphql.ts');
+    const generatedSourceStoreState = generatedSourceStore as unknown as {
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+      familyByFile: Map<NormalizedAbsolutePath, string>;
+    };
+
+    await initFileStores(createConfiguration({ baseDir, detectGeneratedCode: false }));
+
+    expect(generatedSourceStoreState.derivedFamilyByFile).toEqual(new Map());
+    expect(generatedSourceStoreState.familyByFile).toEqual(new Map());
+    expect(generatedSourceStore.getFamily(generatedFile)).toBeUndefined();
+
+    await initFileStores(createConfiguration({ baseDir }));
+
+    expect(generatedSourceStore.getFamily(generatedFile)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+  });
+
   it('ignores malformed GraphQL config parse errors', async () => {
     const baseDir = await createTempBaseDir();
 

--- a/packages/grpc/src/analyze-project-normalize.ts
+++ b/packages/grpc/src/analyze-project-normalize.ts
@@ -116,6 +116,7 @@ function createConfigurationFromProto(configuration: ProjectConfiguration | null
     testInclusions: repeatedStringValues(configuration.testInclusions),
     testExclusions: repeatedStringValues(configuration.testExclusions),
     detectBundles: optionalBoolean(configuration.detectBundles),
+    detectGeneratedCode: optionalBoolean(configuration.detectGeneratedCode),
     canAccessFileSystem: optionalBoolean(configuration.canAccessFileSystem),
     createTSProgramForOrphanFiles: optionalBoolean(configuration.createTsProgramForOrphanFiles),
     disableTypeChecking: optionalBoolean(configuration.disableTypeChecking),

--- a/packages/grpc/src/proto/analyze-project.proto
+++ b/packages/grpc/src/proto/analyze-project.proto
@@ -84,6 +84,7 @@ message ProjectConfiguration {
   optional bool clear_dependencies_cache = 31;
   optional bool clear_ts_config_cache = 32;
   optional bool report_ncloc_for_test_files = 33;
+  optional bool detect_generated_code = 34;
 }
 
 message StringList {

--- a/packages/grpc/tests/analyze-project-normalize.test.ts
+++ b/packages/grpc/tests/analyze-project-normalize.test.ts
@@ -272,6 +272,24 @@ describe('normalizeAnalyzeProjectRequest', () => {
     expect(normalized.configuration.canAccessFileSystem).toBe(false);
   });
 
+  it('should preserve detectGeneratedCode from protobuf configuration', async () => {
+    const baseDir = await createBaseDir();
+
+    const normalized = await normalizeAnalyzeProjectRequest({
+      configuration: {
+        baseDir,
+        canAccessFileSystem: false,
+        detectGeneratedCode: false,
+      },
+      files: {},
+      rules: [],
+      cssRules: [],
+      bundles: [],
+    } as unknown as sonarjs.analyzeproject.v1.IAnalyzeProjectRequest);
+
+    expect(normalized.configuration.detectGeneratedCode).toBe(false);
+  });
+
   it('should reject malformed requests', async () => {
     const baseDir = await createBaseDir();
 

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalysisConfiguration.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalysisConfiguration.java
@@ -93,6 +93,10 @@ public interface AnalysisConfiguration {
     return true;
   }
 
+  default boolean shouldDetectGeneratedCode() {
+    return true;
+  }
+
   default boolean canAccessFileSystem() {
     return true;
   }

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalyzeProjectMessages.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/AnalyzeProjectMessages.java
@@ -70,6 +70,7 @@ public final class AnalyzeProjectMessages {
       .addAllTestInclusions(analysisConfiguration.getTestInclusions())
       .addAllTestExclusions(analysisConfiguration.getTestExclusions())
       .setDetectBundles(analysisConfiguration.shouldDetectBundles())
+      .setDetectGeneratedCode(analysisConfiguration.shouldDetectGeneratedCode())
       .setCanAccessFileSystem(analysisConfiguration.canAccessFileSystem())
       .setCreateTsProgramForOrphanFiles(analysisConfiguration.shouldCreateTSProgramForOrphanFiles())
       .setDisableTypeChecking(analysisConfiguration.shouldDisableTypeChecking())

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/AnalyzeProjectMessagesTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/AnalyzeProjectMessagesTest.java
@@ -225,6 +225,11 @@ class AnalyzeProjectMessagesTest {
       }
 
       @Override
+      public boolean shouldDetectGeneratedCode() {
+        return false;
+      }
+
+      @Override
       public boolean canAccessFileSystem() {
         return false;
       }
@@ -310,6 +315,7 @@ class AnalyzeProjectMessagesTest {
     assertThat(proto.getTestInclusionsList()).containsExactly("**/*.spec.ts");
     assertThat(proto.getTestExclusionsList()).containsExactly("**/*.snap.ts");
     assertThat(proto.getDetectBundles()).isFalse();
+    assertThat(proto.getDetectGeneratedCode()).isFalse();
     assertThat(proto.getCanAccessFileSystem()).isFalse();
     assertThat(proto.getCreateTsProgramForOrphanFiles()).isFalse();
     assertThat(proto.getDisableTypeChecking()).isTrue();
@@ -323,12 +329,18 @@ class AnalyzeProjectMessagesTest {
       "/base",
       new AnalysisConfiguration() {}
     ).build();
+    var detectGeneratedCodeField = proto
+      .getDescriptorForType()
+      .findFieldByName("detect_generated_code");
 
     assertThat(proto.getBaseDir()).isEqualTo("/base");
     assertThat(proto.getAnalysisMode()).isEqualTo(
       org.sonar.plugins.javascript.analyzeproject.grpc.AnalysisMode.ANALYSIS_MODE_DEFAULT
     );
     assertThat(proto.getDetectBundles()).isTrue();
+    assertThat(detectGeneratedCodeField).isNotNull();
+    assertThat(proto.hasField(detectGeneratedCodeField)).isTrue();
+    assertThat(proto.getField(detectGeneratedCodeField)).isEqualTo(true);
     assertThat(proto.getCanAccessFileSystem()).isTrue();
     assertThat(proto.getCreateTsProgramForOrphanFiles()).isTrue();
     assertThat(proto.getDisableTypeChecking()).isFalse();

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/JavaScriptPlugin.java
@@ -144,6 +144,8 @@ public class JavaScriptPlugin implements Plugin {
 
   public static final String SKIP_NODE_PROVISIONING_PROPERTY = "sonar.scanner.skipNodeProvisioning";
   public static final String DETECT_BUNDLES_PROPERTY = "sonar.javascript.detectBundles";
+  public static final String DETECT_GENERATED_CODE_PROPERTY =
+    "sonar.javascript.detectGeneratedCode";
   public static final String NO_FS = "sonar.javascript.canAccessFileSystem";
   public static final String CREATE_TS_PROGRAM_FOR_ORPHAN_FILES =
     "sonar.javascript.createTSProgramForOrphanFiles";

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsContext.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/JsTsContext.java
@@ -314,6 +314,15 @@ public class JsTsContext<T extends SensorContext> implements AnalysisConfigurati
   }
 
   @Override
+  public boolean shouldDetectGeneratedCode() {
+    return shouldDetectGeneratedCode(context.config());
+  }
+
+  public static boolean shouldDetectGeneratedCode(Configuration config) {
+    return config.getBoolean(JavaScriptPlugin.DETECT_GENERATED_CODE_PROPERTY).orElse(true);
+  }
+
+  @Override
   public boolean canAccessFileSystem() {
     return canAccessFileSystem(context.config());
   }

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
@@ -543,6 +543,22 @@ class WebSensorTest {
   }
 
   @Test
+  void should_send_detectGeneratedCode_false_when_disabled() {
+    context.setSettings(
+      new MapSettings().setProperty(JavaScriptPlugin.DETECT_GENERATED_CODE_PROPERTY, "false")
+    );
+
+    var configuration = executeSensorAndCaptureHandler(createSensor(), context)
+      .getRequest()
+      .getConfiguration();
+    var field = configuration.getDescriptorForType().findFieldByName("detect_generated_code");
+
+    assertThat(field).isNotNull();
+    assertThat(configuration.hasField(field)).isTrue();
+    assertThat(configuration.getField(field)).isEqualTo(false);
+  }
+
+  @Test
   void should_send_skipNodeModuleLookupOutsideBaseDir_false_by_default() {
     assertThat(
       executeSensorAndCaptureHandler(createSensor(), context)


### PR DESCRIPTION
## Summary
- wire the `detectGeneratedCode` scanner setting through the Java plugin, bridge protobuf payload, and Node analysis configuration
- default generated-code detection to enabled while allowing it to be explicitly disabled
- add coverage for the configuration, protobuf normalization, and WebSensor/bridge wiring paths

## Validation
- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/tests/common/configuration.test.ts packages/grpc/tests/analyze-project-normalize.test.ts`
- `mvn -pl sonar-plugin/bridge,sonar-plugin/sonar-javascript-plugin -Dtest=AnalyzeProjectMessagesTest,WebSensorTest test`
