### PR TITLE
JS-1876 Update LITS to 0.12.0.5861

### DIFF
--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.javascript.TypeScriptLanguage;
 
 public final class SonarScannerIntegrationHelper {
 
-  static final String LITS_VERSION = "0.12.0.5851";
+  static final String LITS_VERSION = "0.12.0.5861";
 
   /**
    * Get the engine version based on the sonar.runtimeVersion system property.

--- a/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
@@ -56,7 +56,7 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 class RulingTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RulingTest.class);
-  static final String LITS_VERSION = "0.12.0.5851";
+  static final String LITS_VERSION = "0.12.0.5861";
   static final String SCANNER_VERSION = "5.0.1.3006";
 
   static final String DEFAULT_EXCLUSIONS = "**/.*,**/*.d.ts";


### PR DESCRIPTION
## Summary
- update the SonarJS ruling and fast IT LITS version from `0.12.0.5851` to `0.12.0.5861`

## Verification
- not run locally
