### PR TITLE
JS-1886 Reuse shared build number across config-maven jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,9 @@ jobs:
     needs: [setup, get_build_number, populate_npm_cache, sync_rspec]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: &shared_build_number
+      # Reuse the build number minted once in get_build_number across every config-maven caller.
+      BUILD_NUMBER: ${{ needs.get_build_number.outputs.build-number }}
     steps:
       - *checkout
       - *mise
@@ -262,9 +265,10 @@ jobs:
   build_win:
     runs-on: github-windows-latest-m
     name: Build SonarJS on Windows
-    needs: [setup, populate_npm_cache_win, sync_rspec]
+    needs: [setup, get_build_number, populate_npm_cache_win, sync_rspec]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - *checkout
       - *mise
@@ -531,9 +535,10 @@ jobs:
   analyze_primary:
     runs-on: sonar-m
     name: Analyze in SonarQube NEXT
-    needs: [setup, test_js, build]
+    needs: [setup, get_build_number, test_js, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - &checkout_with_tags
         name: Checkout source code with tags
@@ -595,9 +600,10 @@ jobs:
   analyze_shadows:
     runs-on: sonar-m
     name: Analyze in ${{ matrix.platform }}
-    needs: [setup, test_js, build]
+    needs: [setup, get_build_number, test_js, build]
     permissions: *read_permissions
     if: github.event_name == 'schedule'
+    env: *shared_build_number
     strategy:
       matrix:
         include:
@@ -647,9 +653,10 @@ jobs:
   plugin_qa_with_node:
     runs-on: sonar-m
     name: QA with Node ${{ matrix.node-version }} on Ubuntu
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.node-matrix) }}
     steps:
@@ -692,9 +699,10 @@ jobs:
   plugin_qa_fast_with_node:
     runs-on: sonar-m
     name: Fast QA with Node ${{ matrix.node-version }} on Ubuntu
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.node-matrix) }}
     steps:
@@ -718,9 +726,10 @@ jobs:
   plugin_qa_without_node:
     runs-on: sonar-m
     name: QA without Node on Ubuntu SQ:LATEST_RELEASE
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - *checkout
       - &mise_java_only
@@ -765,9 +774,10 @@ jobs:
   plugin_qa_without_node_dev:
     runs-on: sonar-m
     name: QA without Node on Ubuntu SQ:DEV
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name == 'schedule'
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - *checkout
       - *mise_java_only
@@ -846,9 +856,10 @@ jobs:
   plugin_qa_fast_without_node:
     runs-on: sonar-m
     name: Fast QA without Node on Ubuntu SQ:LATEST_RELEASE
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - *checkout
       - *mise_java_only
@@ -873,9 +884,10 @@ jobs:
   plugin_qa_fast_without_node_dev:
     runs-on: sonar-m
     name: Fast QA without Node on Ubuntu SQ:DEV
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name == 'schedule'
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - *checkout
       - *mise_java_only
@@ -928,9 +940,10 @@ jobs:
   plugin_qa_win:
     runs-on: github-windows-latest-m
     name: QA on Windows (${{ matrix.group }})
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     strategy:
       matrix:
         include:
@@ -968,9 +981,10 @@ jobs:
   plugin_qa_sonarlint_win:
     runs-on: github-windows-latest-m
     name: QA SonarLint on Windows
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - *checkout
       - *mise
@@ -987,9 +1001,10 @@ jobs:
   plugin_qa_win_fast_with_node:
     runs-on: github-windows-latest-m
     name: Fast QA on Windows with Node (${{ matrix.group }})
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     strategy:
       matrix:
         include:
@@ -1248,9 +1263,10 @@ jobs:
   ruling:
     runs-on: sonar-xl
     name: Ruling Test
-    needs: [setup, build]
+    needs: [setup, get_build_number, build]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - *checkout_with_submodules
       - *mise


### PR DESCRIPTION
get_build_number should be the single source of truth for BUILD_NUMBER in this workflow.

This change injects that value into build and every downstream job that calls config-maven, so they reuse the same project version instead of minting a new one on cache misses.

That prevents Windows QA, ruling, and analysis jobs from resolving a different Maven artifact version than the one built and deployed earlier in the run.