### PR TITLE
JS-1833/JS-1836/JS-1844 Raise S1874 on deprecated CSS selectors, at-rules, and keyword values

### DIFF
--- a/its/ruling/src/test/expected/ant-design/css-S1874.json
+++ b/its/ruling/src/test/expected/ant-design/css-S1874.json
@@ -1,0 +1,17 @@
+{
+"ant-design:components/descriptions/style/index.less": [
+90
+],
+"ant-design:components/timeline/style/index.less": [
+85
+],
+"ant-design:components/tooltip/style/index.less": [
+22
+],
+"ant-design:site/theme/static/demo.less": [
+157
+],
+"ant-design:site/theme/template/Home/MorePage.less": [
+28
+]
+}

--- a/its/ruling/src/test/expected/backbone/css-S1874.json
+++ b/its/ruling/src/test/expected/backbone/css-S1874.json
@@ -1,0 +1,14 @@
+{
+"backbone:docs/docco.css": [
+89,
+241,
+259
+],
+"backbone:examples/todos/todos.css": [
+127
+],
+"backbone:index.html": [
+188,
+194
+]
+}

--- a/its/ruling/src/test/expected/bulma/css-S1874.json
+++ b/its/ruling/src/test/expected/bulma/css-S1874.json
@@ -1,0 +1,11 @@
+{
+"bulma:css/bulma-rtl.css": [
+3122
+],
+"bulma:css/bulma.css": [
+3122
+],
+"bulma:docs/css/bulma-docs.css": [
+3123
+]
+}

--- a/its/ruling/src/test/expected/console/css-S1874.json
+++ b/its/ruling/src/test/expected/console/css-S1874.json
@@ -1,0 +1,6 @@
+{
+"console:src/styles/graphiql.css": [
+805,
+808
+]
+}

--- a/its/ruling/src/test/expected/courselit/css-S1874.json
+++ b/its/ruling/src/test/expected/courselit/css-S1874.json
@@ -1,0 +1,5 @@
+{
+"courselit:packages/rich-text/src/styles.css": [
+2
+]
+}

--- a/its/ruling/src/test/expected/desktop/css-S1874.json
+++ b/its/ruling/src/test/expected/desktop/css-S1874.json
@@ -1,0 +1,19 @@
+{
+"desktop:app/static/common/markdown.css": [
+144,
+146,
+148,
+150,
+152,
+154,
+397,
+406,
+455
+],
+"desktop:app/styles/ui/dialogs/_usage-reporting.scss": [
+3
+],
+"desktop:app/styles/ui/history/_history.scss": [
+145
+]
+}

--- a/its/ruling/src/test/expected/fresh/css-S1874.json
+++ b/its/ruling/src/test/expected/fresh/css-S1874.json
@@ -1,0 +1,16 @@
+{
+"fresh:www/static/docsearch.css": [
+280
+],
+"fresh:www/static/markdown.css": [
+164,
+166,
+168,
+170,
+172,
+174,
+397,
+406,
+448
+]
+}

--- a/its/ruling/src/test/expected/it-tools/css-S1874.json
+++ b/its/ruling/src/test/expected/it-tools/css-S1874.json
@@ -1,0 +1,5 @@
+{
+"it-tools:src/ui/c-input-text/c-input-text.vue": [
+270
+]
+}

--- a/its/ruling/src/test/expected/underscore/css-S1874.json
+++ b/its/ruling/src/test/expected/underscore/css-S1874.json
@@ -1,0 +1,11 @@
+{
+"underscore:docs/docco.css": [
+89,
+241,
+259
+],
+"underscore:index.html": [
+126,
+132
+]
+}

--- a/its/ruling/src/test/expected/vuetify/css-S1874.json
+++ b/its/ruling/src/test/expected/vuetify/css-S1874.json
@@ -1,0 +1,5 @@
+{
+"vuetify:packages/vuetify/src/components/VMessages/VMessages.sass": [
+15
+]
+}

--- a/packages/analysis/src/css/rules/metadata.ts
+++ b/packages/analysis/src/css/rules/metadata.ts
@@ -61,6 +61,46 @@ export const cssRulesMeta: CssRuleMeta[] = [
     stylelintKey: 'no-duplicate-at-import-rules',
   },
   {
+    sqKey: 'S1874',
+    stylelintKey: 'selector-no-deprecated',
+    listParam: [
+      {
+        sqKey: 'ignoreSelectors',
+        javaField: 'ignoreSelectors',
+        description: 'Comma-separated list of selector names and/or regular expressions to ignore.',
+        default: '',
+        stylelintOptionKey: 'ignoreSelectors',
+      },
+    ],
+  },
+  {
+    sqKey: 'S1874',
+    stylelintKey: 'declaration-property-value-keyword-no-deprecated',
+    listParam: [
+      {
+        sqKey: 'ignoreKeywords',
+        javaField: 'ignoreKeywords',
+        description:
+          'Comma-separated list of strings and/or regular expressions for deprecated keywords to ignore.',
+        default: '',
+        stylelintOptionKey: 'ignoreKeywords',
+      },
+    ],
+  },
+  {
+    sqKey: 'S1874',
+    stylelintKey: 'at-rule-no-deprecated',
+    listParam: [
+      {
+        sqKey: 'ignoreAtRules',
+        javaField: 'ignoreAtRules',
+        description: 'Comma-separated list of deprecated "at-rules" to ignore.',
+        default: '',
+        stylelintOptionKey: 'ignoreAtRules',
+      },
+    ],
+  },
+  {
     sqKey: 'S4647',
     stylelintKey: 'color-no-invalid-hex',
   },
@@ -196,7 +236,7 @@ export const cssRulesMeta: CssRuleMeta[] = [
     listParam: [
       {
         sqKey: 'ignoreAtRules',
-        javaField: 'ignoredAtRules',
+        javaField: 'ignoreAtRules',
         description: 'Comma-separated list of "at-rules" to consider as valid.',
         default:
           'value,at-root,content,debug,each,else,error,for,function,if,include,mixin,return,warn,while,extend,use,forward,tailwind,apply,layer,container,theme,utility,custom-variant,source,plugin,config,reference,variant,/^@.*/',

--- a/packages/analysis/tests/css/linter/at-rule-no-deprecated.test.ts
+++ b/packages/analysis/tests/css/linter/at-rule-no-deprecated.test.ts
@@ -1,0 +1,59 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { StylelintRuleTester } from '../tools/tester/tester.js';
+
+const ruleTester = new StylelintRuleTester('at-rule-no-deprecated');
+const ruleTesterWithIgnore = new StylelintRuleTester('at-rule-no-deprecated', [
+  true,
+  { ignoreAtRules: ['viewport'] },
+]);
+
+describe('at-rule-no-deprecated', () => {
+  it('accepts current at-rules', async () => {
+    await ruleTester.valid({
+      code: '@starting-style {} a { @layer {} }',
+    });
+  });
+
+  it('reports deprecated @viewport', async () => {
+    await ruleTester.invalid({
+      code: '@viewport { width: device-width; }',
+      errors: [{ text: 'Deprecated at-rule "@viewport" (at-rule-no-deprecated)', line: 1 }],
+    });
+  });
+
+  it('reports deprecated @document', async () => {
+    await ruleTester.invalid({
+      code: '@document url("https://example.com") { .hero { color: red; } }',
+      errors: [{ text: 'Deprecated at-rule "@document" (at-rule-no-deprecated)', line: 1 }],
+    });
+  });
+
+  it('reports deprecated @nest', async () => {
+    await ruleTester.invalid({
+      code: '.foo { @nest .bar & { color: red; } }',
+      errors: [{ text: 'Deprecated at-rule "@nest" (at-rule-no-deprecated)', line: 1 }],
+    });
+  });
+
+  it('ignores at-rules listed in ignoreAtRules', async () => {
+    await ruleTesterWithIgnore.valid({
+      code: '@viewport { width: device-width; }',
+    });
+  });
+});

--- a/packages/analysis/tests/css/linter/declaration-property-value-keyword-no-deprecated.test.ts
+++ b/packages/analysis/tests/css/linter/declaration-property-value-keyword-no-deprecated.test.ts
@@ -1,0 +1,50 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { StylelintRuleTester } from '../tools/tester/tester.js';
+
+const ruleTester = new StylelintRuleTester('declaration-property-value-keyword-no-deprecated');
+const configuredRuleTester = new StylelintRuleTester(
+  'declaration-property-value-keyword-no-deprecated',
+  [true, { ignoreKeywords: ['overlay', 'blink'] }],
+);
+
+describe('declaration-property-value-keyword-no-deprecated', () => {
+  it('accepts non-deprecated keyword values', async () => {
+    await ruleTester.valid({
+      code: 'b { overflow: auto; }',
+    });
+  });
+
+  it('reports deprecated keyword values', async () => {
+    await ruleTester.invalid({
+      code: 'a { overflow: overlay; }',
+      errors: [
+        {
+          text: 'Expected "overlay" to be "auto" (declaration-property-value-keyword-no-deprecated)',
+          line: 1,
+        },
+      ],
+    });
+  });
+
+  it('ignores configured deprecated keywords', async () => {
+    await configuredRuleTester.valid({
+      code: 'a { overflow: overlay; } c { text-decoration: blink; }',
+    });
+  });
+});

--- a/packages/analysis/tests/css/linter/selector-no-deprecated.test.ts
+++ b/packages/analysis/tests/css/linter/selector-no-deprecated.test.ts
@@ -1,0 +1,67 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { StylelintRuleTester } from '../tools/tester/tester.js';
+
+const ruleTester = new StylelintRuleTester('selector-no-deprecated');
+const configuredRuleTester = new StylelintRuleTester('selector-no-deprecated', [
+  true,
+  { ignoreSelectors: ['acronym', '/^focus-/'] },
+]);
+
+describe('selector-no-deprecated', () => {
+  it('accepts supported selectors', async () => {
+    await ruleTester.valid({
+      code: `
+abbr {}
+a:focus-visible {}
+`,
+    });
+  });
+
+  it('reports deprecated type selectors', async () => {
+    await ruleTester.invalid({
+      code: `
+acronym {}
+`,
+      errors: [{ text: 'Deprecated selector "acronym" (selector-no-deprecated)', line: 2 }],
+    });
+  });
+
+  it('reports deprecated pseudo-class selectors with replacements', async () => {
+    await ruleTester.invalid({
+      code: `
+a:focus-ring {}
+`,
+      errors: [
+        {
+          text: 'Expected ":focus-ring" to be ":focus-visible" (selector-no-deprecated)',
+          line: 2,
+        },
+      ],
+    });
+  });
+
+  it('ignores configured selector names and regexes', async () => {
+    await configuredRuleTester.valid({
+      code: `
+acronym {}
+a:focus-ring {}
+`,
+    });
+  });
+});

--- a/packages/grpc/src/RULE_CONFIG_PATTERNS.md
+++ b/packages/grpc/src/RULE_CONFIG_PATTERNS.md
@@ -193,7 +193,7 @@ ignoreParams: [{
 
 Some rules have multiple ignore params (e.g., S4654 has `ignoreProperties` and `ignoreSelectors`), which are merged into a single secondary options object.
 
-**Rules using this pattern:** S4649, S4653, S4654, S4659, S4660, S4662, S4670, S8759, S8777 (9 rules)
+**Rules using this pattern:** S1874, S4649, S4653, S4654, S4659, S4660, S4662, S4670, S8759, S8777 (10 rules)
 
 ---
 
@@ -255,12 +255,26 @@ Rules without `ignoreParams` or `booleanParam` have no configurable parameters. 
 
 ---
 
+### Multi-Binding (one sqKey → N stylelint rules)
+
+One SonarQube rule maps to multiple stylelint rules. `buildRuleConfigurations` returns one `CssRuleConfig` per stylelint binding; each consumes only its own `listParam` entries. The reverse map (`reverseCssRuleKeyMap`) maps every stylelint key back to the shared sqKey.
+
+**Metadata:** N `CssRuleMeta` entries with the same `sqKey`, each with its own `stylelintKey` and `listParam`.
+
+**Transformer output:** Array of `CssRuleConfig[]` (one per binding).
+
+**Rules using this pattern:**
+
+- S1874: `selector-no-deprecated` (`ignoreSelectors`), `declaration-property-value-keyword-no-deprecated` (`ignoreKeywords`), `at-rule-no-deprecated` (`ignoreAtRules`)
+
+---
+
 ## CSS Summary Table
 
 | Pattern       | Count | Description                  | Stylelint Output                 |
 | ------------- | ----- | ---------------------------- | -------------------------------- |
 | No params     | 24    | Rule enabled with defaults   | `true`                           |
-| Ignore params | 9     | Comma-separated string lists | `[true, { key: ['v1', 'v2'] }]`  |
+| Ignore params | 10    | Comma-separated string lists | `[true, { key: ['v1', 'v2'] }]`  |
 | Boolean param | 1     | Conditional fixed options    | `[true, { key: ['v'] }]` or `[]` |
 
 **Total: 30 CSS rules (9 with configurable parameters)**

--- a/packages/grpc/src/transformers/request.ts
+++ b/packages/grpc/src/transformers/request.ts
@@ -92,10 +92,7 @@ function transformActiveRules(activeRules: analyzer.IActiveRule[]): {
 
     switch (repo) {
       case 'css': {
-        const cssRuleConfig = buildCssRuleConfigurations(ruleKey, activeRule.params || []);
-        if (cssRuleConfig) {
-          cssRules.push(cssRuleConfig);
-        }
+        cssRules.push(...buildCssRuleConfigurations(ruleKey, activeRule.params || []));
         break;
       }
       case 'javascript':

--- a/packages/grpc/src/transformers/rule-configurations/css.ts
+++ b/packages/grpc/src/transformers/rule-configurations/css.ts
@@ -20,36 +20,44 @@ import { isString } from '../../../../shared/src/helpers/sanitize.js';
 import { cssRulesMeta, type CssRuleMeta } from '../../../../analysis/src/css/rules/metadata.js';
 import type { RuleConfig as CssRuleConfig } from '../../../../analysis/src/css/linter/config.js';
 
-/** Map from SonarQube key to CSS rule metadata (includes param definitions) */
-const cssRuleMetaMap = new Map<string, CssRuleMeta>(cssRulesMeta.map(r => [r.sqKey, r]));
+/** Map from SonarQube key to CSS rule metadata entries (one sqKey may cover multiple stylelint rules) */
+const cssRuleMetaMap = new Map<string, CssRuleMeta[]>();
+for (const r of cssRulesMeta) {
+  const group = cssRuleMetaMap.get(r.sqKey) ?? [];
+  group.push(r);
+  cssRuleMetaMap.set(r.sqKey, group);
+}
 
 /**
- * Build a CssRuleConfig from a SonarQube rule key and gRPC params.
+ * Build CssRuleConfigs from a SonarQube rule key and gRPC params.
  *
- * Looks up the rule in cssRuleMetaMap, then builds stylelint configurations
- * mirroring the Java-generated `stylelintOptions()` logic:
+ * Returns one CssRuleConfig per stylelint rule bound to the sqKey, each
+ * consuming only its own listParam entries. Most rules have a single binding;
+ * multi-binding rules (e.g. S1874) return multiple configs.
+ *
+ * Configurations mirror the Java-generated `stylelintOptions()` logic:
  * - For `listParam`: builds `[true, { stylelintOptionKey: splitValues, ... }]`
  * - For `booleanParam`: when true, builds `[true, { optKey: values }]`; when false, `[]`
  * - No params: returns `[]` (stylelint will use `true` as the rule value)
  *
  * @param ruleKey - The SonarQube rule key (e.g. 'S4662')
  * @param params - Rule parameters from the gRPC request
- * @returns CssRuleConfig with stylelint key and configurations, or null if the rule is unknown
+ * @returns Array of CssRuleConfigs (empty array if the rule is unknown)
  */
 export function buildRuleConfigurations(
   ruleKey: string,
   params: analyzer.IRuleParam[],
-): CssRuleConfig | null {
-  const meta = cssRuleMetaMap.get(ruleKey);
-  if (!meta) {
+): CssRuleConfig[] {
+  const metas = cssRuleMetaMap.get(ruleKey);
+  if (!metas) {
     warn(`Ignoring unknown CSS rule ${ruleKey}. Not found in cssRuleMetaMap.`);
-    return null;
+    return [];
   }
 
-  return {
+  return metas.map(meta => ({
     key: meta.stylelintKey,
     configurations: buildConfigurations(params, meta),
-  };
+  }));
 }
 
 function sanitizeBooleanString(value: string | undefined, defaultValue: boolean) {

--- a/packages/grpc/tests/transformers.test.ts
+++ b/packages/grpc/tests/transformers.test.ts
@@ -20,6 +20,7 @@ import { transformRequestToProjectInput } from '../src/transformers/request.js';
 import { transformProjectOutputToResponse } from '../src/transformers/response.js';
 import { buildRuleConfigurations as buildCssRuleConfigurations } from '../src/transformers/rule-configurations/css.js';
 import { buildRuleConfigurations as buildJstsRuleConfigurations } from '../src/transformers/rule-configurations/jsts.js';
+import { reverseCssRuleKeyMap } from '../../analysis/src/css/rules/metadata.js';
 import { analyzer } from '../src/proto/language_analyzer.js';
 
 describe('transformRequestToProjectInput', () => {
@@ -249,93 +250,101 @@ describe('transformRequestToProjectInput', () => {
 });
 
 describe('CSS rule configurations', () => {
-  it('should return null for unknown CSS rule', () => {
-    expect(buildCssRuleConfigurations('UNKNOWN_RULE', [])).toBeNull();
+  it('should return empty array for unknown CSS rule', () => {
+    expect(buildCssRuleConfigurations('UNKNOWN_RULE', [])).toEqual([]);
   });
 
   it('should return empty configurations for a rule with no params', () => {
     // S4658 (block-no-empty) has no listParam or booleanParam
     const result = buildCssRuleConfigurations('S4658', []);
-    expect(result).toEqual({ key: 'block-no-empty', configurations: [] });
+    expect(result).toEqual([{ key: 'block-no-empty', configurations: [] }]);
   });
 
   it('should map S8759 to at-rule-no-vendor-prefix', () => {
-    expect(buildCssRuleConfigurations('S8759', [])).toEqual({
-      key: 'at-rule-no-vendor-prefix',
-      configurations: [],
-    });
+    expect(buildCssRuleConfigurations('S8759', [])).toEqual([
+      {
+        key: 'at-rule-no-vendor-prefix',
+        configurations: [],
+      },
+    ]);
   });
 
   it('should map S8765 to the stylelint custom property rule', () => {
     const result = buildCssRuleConfigurations('S8765', []);
-    expect(result).toEqual({
-      key: 'custom-property-no-missing-var-function',
-      configurations: [],
-    });
+    expect(result).toEqual([
+      {
+        key: 'custom-property-no-missing-var-function',
+        configurations: [],
+      },
+    ]);
   });
 
   it('should map S8770 to at-rule-descriptor-no-unknown', () => {
-    expect(buildCssRuleConfigurations('S8770', [])).toEqual({
-      key: 'at-rule-descriptor-no-unknown',
-      configurations: [],
-    });
+    expect(buildCssRuleConfigurations('S8770', [])).toEqual([
+      {
+        key: 'at-rule-descriptor-no-unknown',
+        configurations: [],
+      },
+    ]);
   });
 
   it('should map S8775 to at-rule-descriptor-value-no-unknown', () => {
     const result = buildCssRuleConfigurations('S8775', []);
-    expect(result).toEqual({ key: 'at-rule-descriptor-value-no-unknown', configurations: [] });
+    expect(result).toEqual([{ key: 'at-rule-descriptor-value-no-unknown', configurations: [] }]);
   });
 
   it('should map S8777 to at-rule-prelude-no-invalid', () => {
-    expect(buildCssRuleConfigurations('S8777', [])).toEqual({
-      key: 'at-rule-prelude-no-invalid',
-      configurations: [],
-    });
+    expect(buildCssRuleConfigurations('S8777', [])).toEqual([
+      {
+        key: 'at-rule-prelude-no-invalid',
+        configurations: [],
+      },
+    ]);
   });
 
   describe('listParam', () => {
     it('should use default values when no params are sent', () => {
       // S4659: ignorePseudoClasses default is 'local,global,export,import,deep'
-      const result = buildCssRuleConfigurations('S4659', []);
-      expect(result!.configurations).toEqual([
+      const [result] = buildCssRuleConfigurations('S4659', []);
+      expect(result.configurations).toEqual([
         true,
         { ignorePseudoClasses: ['local', 'global', 'export', 'import', 'deep'] },
       ]);
     });
 
     it('should use explicit param value overriding the default', () => {
-      const result = buildCssRuleConfigurations('S4659', [
+      const [result] = buildCssRuleConfigurations('S4659', [
         { key: 'ignorePseudoClasses', value: 'local,custom' },
       ]);
-      expect(result!.configurations).toEqual([true, { ignorePseudoClasses: ['local', 'custom'] }]);
+      expect(result.configurations).toEqual([true, { ignorePseudoClasses: ['local', 'custom'] }]);
     });
 
     it('should trim whitespace from comma-separated values', () => {
-      const result = buildCssRuleConfigurations('S4659', [
+      const [result] = buildCssRuleConfigurations('S4659', [
         { key: 'ignorePseudoClasses', value: ' local , custom ' },
       ]);
-      expect(result!.configurations).toEqual([true, { ignorePseudoClasses: ['local', 'custom'] }]);
+      expect(result.configurations).toEqual([true, { ignorePseudoClasses: ['local', 'custom'] }]);
     });
 
     it('should return empty configurations when param value is empty string', () => {
       // Explicit '' overrides the default and produces no secondary options
-      const result = buildCssRuleConfigurations('S4659', [
+      const [result] = buildCssRuleConfigurations('S4659', [
         { key: 'ignorePseudoClasses', value: '' },
       ]);
-      expect(result!.configurations).toEqual([]);
+      expect(result.configurations).toEqual([]);
     });
 
     it('should treat null param value as empty string, not the default', () => {
       // null → stored as '' via isString guard → not in secondary options → []
-      const result = buildCssRuleConfigurations('S4659', [
+      const [result] = buildCssRuleConfigurations('S4659', [
         { key: 'ignorePseudoClasses', value: null },
       ]);
-      expect(result!.configurations).toEqual([]);
+      expect(result.configurations).toEqual([]);
     });
 
     it('should skip params with a falsy key, falling back to defaults', () => {
-      const result = buildCssRuleConfigurations('S4659', [{ key: null, value: 'local' }]);
-      expect(result!.configurations).toEqual([
+      const [result] = buildCssRuleConfigurations('S4659', [{ key: null, value: 'local' }]);
+      expect(result.configurations).toEqual([
         true,
         { ignorePseudoClasses: ['local', 'global', 'export', 'import', 'deep'] },
       ]);
@@ -343,8 +352,8 @@ describe('CSS rule configurations', () => {
 
     it('should merge multiple listParams using defaults when no params sent', () => {
       // S4654 (property-no-unknown) has two listParams: ignoreTypes and ignoreSelectors
-      const result = buildCssRuleConfigurations('S4654', []);
-      expect(result!.configurations).toEqual([
+      const [result] = buildCssRuleConfigurations('S4654', []);
+      expect(result.configurations).toEqual([
         true,
         {
           ignoreProperties: ['composes', '/^mso-/'],
@@ -354,8 +363,10 @@ describe('CSS rule configurations', () => {
     });
 
     it('should partially override multiple listParams, keeping defaults for unset ones', () => {
-      const result = buildCssRuleConfigurations('S4654', [{ key: 'ignoreTypes', value: 'myProp' }]);
-      expect(result!.configurations).toEqual([
+      const [result] = buildCssRuleConfigurations('S4654', [
+        { key: 'ignoreTypes', value: 'myProp' },
+      ]);
+      expect(result.configurations).toEqual([
         true,
         {
           ignoreProperties: ['myProp'],
@@ -365,11 +376,11 @@ describe('CSS rule configurations', () => {
     });
 
     it('should return empty configurations when all listParam values are empty', () => {
-      const result = buildCssRuleConfigurations('S4654', [
+      const [result] = buildCssRuleConfigurations('S4654', [
         { key: 'ignoreTypes', value: '' },
         { key: 'ignoreSelectors', value: '' },
       ]);
-      expect(result!.configurations).toEqual([]);
+      expect(result.configurations).toEqual([]);
     });
   });
 
@@ -378,35 +389,114 @@ describe('CSS rule configurations', () => {
     const onTrue = [true, { ignore: ['consecutive-duplicates-with-different-values'] }];
 
     it('should use the default (true) when no params are sent', () => {
-      const result = buildCssRuleConfigurations('S4656', []);
-      expect(result!.configurations).toEqual(onTrue);
+      const [result] = buildCssRuleConfigurations('S4656', []);
+      expect(result.configurations).toEqual(onTrue);
     });
 
     it('should enable with explicit true value', () => {
-      const result = buildCssRuleConfigurations('S4656', [
+      const [result] = buildCssRuleConfigurations('S4656', [
         { key: 'ignoreFallbacks', value: 'true' },
       ]);
-      expect(result!.configurations).toEqual(onTrue);
+      expect(result.configurations).toEqual(onTrue);
     });
 
     it('should disable with explicit false value', () => {
-      const result = buildCssRuleConfigurations('S4656', [
+      const [result] = buildCssRuleConfigurations('S4656', [
         { key: 'ignoreFallbacks', value: 'false' },
       ]);
-      expect(result!.configurations).toEqual([]);
+      expect(result.configurations).toEqual([]);
     });
 
     it('should fall back to the default for unrecognized values', () => {
-      const result = buildCssRuleConfigurations('S4656', [
+      const [result] = buildCssRuleConfigurations('S4656', [
         { key: 'ignoreFallbacks', value: 'yes' },
       ]);
-      expect(result!.configurations).toEqual(onTrue);
+      expect(result.configurations).toEqual(onTrue);
     });
 
     it('should fall back to the default for null value', () => {
       // null → '' via isString guard → neither 'true' nor 'false' → uses default
-      const result = buildCssRuleConfigurations('S4656', [{ key: 'ignoreFallbacks', value: null }]);
-      expect(result!.configurations).toEqual(onTrue);
+      const [result] = buildCssRuleConfigurations('S4656', [
+        { key: 'ignoreFallbacks', value: null },
+      ]);
+      expect(result.configurations).toEqual(onTrue);
+    });
+  });
+
+  describe('S1874 multi-binding (deprecated CSS)', () => {
+    it('returns 3 configs when no params are sent', () => {
+      const results = buildCssRuleConfigurations('S1874', []);
+      expect(results).toHaveLength(3);
+      expect(results.map(r => r.key)).toEqual([
+        'selector-no-deprecated',
+        'declaration-property-value-keyword-no-deprecated',
+        'at-rule-no-deprecated',
+      ]);
+    });
+
+    it('all three bindings have empty configurations by default (all params default to empty)', () => {
+      const results = buildCssRuleConfigurations('S1874', []);
+      for (const r of results) {
+        expect(r.configurations).toEqual([]);
+      }
+    });
+
+    it('routes ignoreSelectors only to selector-no-deprecated', () => {
+      const results = buildCssRuleConfigurations('S1874', [
+        { key: 'ignoreSelectors', value: 'acronym' },
+      ]);
+      expect(results[0]).toEqual({
+        key: 'selector-no-deprecated',
+        configurations: [true, { ignoreSelectors: ['acronym'] }],
+      });
+      expect(results[1].configurations).toEqual([]);
+      expect(results[2].configurations).toEqual([]);
+    });
+
+    it('routes ignoreKeywords only to declaration-property-value-keyword-no-deprecated', () => {
+      const results = buildCssRuleConfigurations('S1874', [
+        { key: 'ignoreKeywords', value: 'overlay' },
+      ]);
+      expect(results[0].configurations).toEqual([]);
+      expect(results[1]).toEqual({
+        key: 'declaration-property-value-keyword-no-deprecated',
+        configurations: [true, { ignoreKeywords: ['overlay'] }],
+      });
+      expect(results[2].configurations).toEqual([]);
+    });
+
+    it('routes ignoreAtRules only to at-rule-no-deprecated', () => {
+      const results = buildCssRuleConfigurations('S1874', [
+        { key: 'ignoreAtRules', value: 'viewport' },
+      ]);
+      expect(results[0].configurations).toEqual([]);
+      expect(results[1].configurations).toEqual([]);
+      expect(results[2]).toEqual({
+        key: 'at-rule-no-deprecated',
+        configurations: [true, { ignoreAtRules: ['viewport'] }],
+      });
+    });
+
+    it('routes all three params independently when all are set', () => {
+      const results = buildCssRuleConfigurations('S1874', [
+        { key: 'ignoreSelectors', value: 'acronym' },
+        { key: 'ignoreKeywords', value: 'overlay' },
+        { key: 'ignoreAtRules', value: 'viewport' },
+      ]);
+      expect(results[0].configurations).toEqual([true, { ignoreSelectors: ['acronym'] }]);
+      expect(results[1].configurations).toEqual([true, { ignoreKeywords: ['overlay'] }]);
+      expect(results[2].configurations).toEqual([true, { ignoreAtRules: ['viewport'] }]);
+    });
+
+    it('maps all three stylelint violation ruleIds to S1874', () => {
+      const stylelintKeys = [
+        'selector-no-deprecated',
+        'declaration-property-value-keyword-no-deprecated',
+        'at-rule-no-deprecated',
+      ];
+      for (const key of stylelintKeys) {
+        expect(reverseCssRuleKeyMap.get(key)).toBe('S1874');
+      }
     });
   });
 });

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/StylelintRule.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/StylelintRule.java
@@ -27,4 +27,12 @@ public class StylelintRule {
     this.key = key;
     this.configurations = configurations;
   }
+
+  public String getKey() {
+    return key;
+  }
+
+  public List<Object> getConfigurations() {
+    return configurations;
+  }
 }

--- a/sonar-plugin/css/src/main/java/org/sonar/css/rules/CssRule.java
+++ b/sonar-plugin/css/src/main/java/org/sonar/css/rules/CssRule.java
@@ -18,11 +18,16 @@ package org.sonar.css.rules;
 
 import java.util.Collections;
 import java.util.List;
+import org.sonar.plugins.javascript.bridge.StylelintRule;
 
 public interface CssRule {
   String stylelintKey();
 
   default List<Object> stylelintOptions() {
     return Collections.emptyList();
+  }
+
+  default List<StylelintRule> stylelintRules() {
+    return Collections.singletonList(new StylelintRule(stylelintKey(), stylelintOptions()));
   }
 }

--- a/sonar-plugin/css/src/main/java/org/sonar/css/rules/RuleUtils.java
+++ b/sonar-plugin/css/src/main/java/org/sonar/css/rules/RuleUtils.java
@@ -31,4 +31,8 @@ public class RuleUtils {
     String[] split = parameterValue.split(",");
     return Arrays.stream(split).map(String::trim).toList();
   }
+
+  public static List<Object> toOptions(Object ignoreOption) {
+    return Arrays.asList(true, ignoreOption);
+  }
 }

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -429,6 +429,112 @@ async function generateCssJavaCheckClass(rule: CssRuleMeta): Promise<void> {
   );
 }
 
+/**
+ * Generate a Java check class for a sqKey that maps to multiple stylelint rules.
+ * The class overrides stylelintRules() to return one StylelintRule per binding.
+ */
+async function generateCssMultiBindingJavaCheckClass(
+  sqKey: string,
+  metas: CssRuleMeta[],
+): Promise<void> {
+  const multiStylelintKey = `multi_${metas.map(meta => meta.stylelintKey).join('_')}`;
+  const imports = new Set<string>([
+    'import static org.sonar.css.rules.RuleUtils.splitAndTrim;',
+    'import static org.sonar.css.rules.RuleUtils.toOptions;',
+    'import java.util.Arrays;',
+    'import java.util.Collections;',
+    'import java.util.List;',
+    'import org.sonar.check.RuleProperty;',
+    'import org.sonar.plugins.javascript.bridge.StylelintRule;',
+  ]);
+
+  const lines: string[] = [];
+
+  // @RuleProperty fields — one per listParam entry across all bindings
+  for (const meta of metas) {
+    for (const param of meta.listParam ?? []) {
+      lines.push(`@RuleProperty(`);
+      lines.push(`  key = "${param.sqKey}",`);
+      lines.push(`  description = "${escapeJavaString(param.description)}",`);
+      lines.push(`  defaultValue = ""`);
+      lines.push(`)`);
+      lines.push(`String ${param.javaField} = "";`);
+      lines.push('');
+    }
+  }
+
+  // stylelintRules() override — one entry per binding.
+  // Split each field once into a local variable to avoid the duplicate splitAndTrim call
+  // that would arise from passing it to both toOptions() and the option class constructor.
+  lines.push('@Override');
+  lines.push('public List<StylelintRule> stylelintRules() {');
+  for (const meta of metas) {
+    for (const param of meta.listParam ?? []) {
+      lines.push(`  List<String> ${param.javaField}Split = splitAndTrim(${param.javaField});`);
+    }
+  }
+  lines.push('  return Arrays.asList(');
+  for (let i = 0; i < metas.length; i++) {
+    const meta = metas[i];
+    const isLast = i === metas.length - 1;
+    const params = meta.listParam ?? [];
+    if (params.length > 0) {
+      const optClass = `${capitalize(params[0].stylelintOptionKey)}IgnoreOption`;
+      const ctorArgs = params.map(p => `${p.javaField}Split`).join(', ');
+      const anyNonEmpty = params.map(p => `!${p.javaField}Split.isEmpty()`).join(' || ');
+      lines.push(
+        `    new StylelintRule("${meta.stylelintKey}", ${anyNonEmpty} ? toOptions(new ${optClass}(${ctorArgs})) : Collections.emptyList())${isLast ? '' : ','}`,
+      );
+    } else {
+      lines.push(
+        `    new StylelintRule("${meta.stylelintKey}", Collections.emptyList())${isLast ? '' : ','}`,
+      );
+    }
+  }
+  lines.push('  );');
+  lines.push('}');
+  lines.push('');
+
+  // Inner option classes — one per binding with listParams, covering all listParam fields
+  for (const meta of metas) {
+    const params = meta.listParam ?? [];
+    if (!params.length) continue;
+    const optClass = `${capitalize(params[0].stylelintOptionKey)}IgnoreOption`;
+    lines.push(`private static class ${optClass} {`);
+    lines.push('');
+    for (const param of params) {
+      lines.push(`  // Used by GSON serialization`);
+      lines.push(`  private final List<String> ${param.stylelintOptionKey};`);
+    }
+    lines.push('');
+    const ctorArgs = params.map(p => `List<String> ${p.stylelintOptionKey}`).join(', ');
+    lines.push(`  ${optClass}(${ctorArgs}) {`);
+    for (const param of params) {
+      lines.push(`    this.${param.stylelintOptionKey} = ${param.stylelintOptionKey};`);
+    }
+    lines.push('  }');
+    lines.push('}');
+    lines.push('');
+  }
+
+  await inflateTemplateToFile(
+    join(JAVA_TEMPLATES_FOLDER, 'css-check.template'),
+    join(CSS_JAVA_CHECKS_FOLDER, `${sqKey}.java`),
+    {
+      ___HEADER___: header,
+      ___IMPORTS___: [...imports].sort().join('\n'),
+      ___RULE_KEY___: sqKey,
+      ___CLASS_NAME___: sqKey,
+      ___STYLELINT_KEY___: multiStylelintKey,
+      ___BODY___: lines.join('\n'),
+    },
+  );
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 async function generateCssParsingErrorClass(): Promise<void> {
   await inflateTemplateToFile(
     join(JAVA_TEMPLATES_FOLDER, 'css-check.template'),
@@ -444,17 +550,25 @@ async function generateCssParsingErrorClass(): Promise<void> {
   );
 }
 
-function generateCssRuleTestBody(rules: typeof cssRulesMeta): {
+function generateCssRuleTestBody(
+  rules: typeof cssRulesMeta,
+  multiBindingGroups: Map<string, CssRuleMeta[]>,
+): {
   perRuleTests: string;
   rulesWithOptionsClasses: string;
   propertiesCount: number;
 } {
-  const rulesWithOptions = rules.filter(r => r.listParam?.length || r.booleanParam);
-  const sortedRulesWithOptions = rulesWithOptions.toSorted((a, b) =>
+  // Exclude multi-binding rules: their stylelintOptions() returns [] (interface default),
+  // so they must not appear in rulesWithStylelintOptions (which asserts non-empty).
+  const multiBindingKeys = new Set([...multiBindingGroups.keys()]);
+  const singleBindingWithOptions = rules.filter(
+    r => !multiBindingKeys.has(r.sqKey) && (r.listParam?.length || r.booleanParam),
+  );
+  const sortedSingleWithOptions = singleBindingWithOptions.toSorted((a, b) =>
     sonarKeySorter(a.sqKey, b.sqKey),
   );
 
-  const rulesWithOptionsClasses = sortedRulesWithOptions
+  const rulesWithOptionsClasses = sortedSingleWithOptions
     .map(r => `${r.sqKey}.class`)
     .join(',\n      ');
 
@@ -466,7 +580,8 @@ function generateCssRuleTestBody(rules: typeof cssRulesMeta): {
 
   const testMethods: string[] = [];
 
-  for (const rule of sortedRulesWithOptions) {
+  // Tests for single-binding rules with params (asserting stylelintOptions())
+  for (const rule of sortedSingleWithOptions) {
     const methodPrefix = rule.sqKey.toLowerCase(); // e.g. 's4662'
 
     if (rule.listParam?.length) {
@@ -538,11 +653,81 @@ function generateCssRuleTestBody(rules: typeof cssRulesMeta): {
     }
   }
 
+  // Tests for multi-binding rules (asserting stylelintRules())
+  for (const [sqKey, metas] of [...multiBindingGroups].toSorted(([a], [b]) =>
+    sonarKeySorter(a, b),
+  )) {
+    const methodPrefix = sqKey.toLowerCase();
+    const multiStylelintKey = `multi_${metas.map(meta => meta.stylelintKey).join('_')}`;
+
+    testMethods.push(`  @Test`);
+    testMethods.push(`  void ${methodPrefix}_bindings_count() {`);
+    testMethods.push(`    assertThat(new ${sqKey}().stylelintRules()).hasSize(${metas.length});`);
+    testMethods.push(`  }`);
+    testMethods.push('');
+
+    testMethods.push(`  @Test`);
+    testMethods.push(`  void ${methodPrefix}_stylelint_key() {`);
+    testMethods.push(
+      `    assertThat(new ${sqKey}().stylelintKey()).isEqualTo("${multiStylelintKey}");`,
+    );
+    testMethods.push(`  }`);
+    testMethods.push('');
+
+    for (let i = 0; i < metas.length; i++) {
+      const meta = metas[i];
+      const param = meta.listParam?.[0];
+      if (!param) continue;
+      const bindingPrefix = `${methodPrefix}_${param.javaField.toLowerCase()}`;
+
+      // Empty default → empty configurations
+      testMethods.push(`  @Test`);
+      testMethods.push(`  void ${bindingPrefix}_empty() {`);
+      testMethods.push(`    StylelintRule sr = new ${sqKey}().stylelintRules().get(${i});`);
+      testMethods.push(`    assertThat(sr.getKey()).isEqualTo("${meta.stylelintKey}");`);
+      testMethods.push(`    assertThat(sr.getConfigurations()).isEmpty();`);
+      testMethods.push(`  }`);
+      testMethods.push('');
+
+      // Custom value → [true, { optionKey: [...] }]
+      const customOptionObj: Record<string, string[]> = {
+        [param.stylelintOptionKey]: ['testValue1', 'testValue2'],
+      };
+      const customJson = JSON.stringify([true, customOptionObj]).replace(/"/g, '\\"');
+
+      testMethods.push(`  @Test`);
+      testMethods.push(`  void ${bindingPrefix}_custom() {`);
+      testMethods.push(`    ${sqKey} instance = new ${sqKey}();`);
+      testMethods.push(`    instance.${param.javaField} = "testValue1, testValue2";`);
+      testMethods.push(`    StylelintRule sr = instance.stylelintRules().get(${i});`);
+      testMethods.push(
+        `    assertThat(GSON.toJson(sr.getConfigurations())).isEqualTo("${customJson}");`,
+      );
+      testMethods.push(`  }`);
+      testMethods.push('');
+    }
+  }
+
   return { perRuleTests: testMethods.join('\n'), rulesWithOptionsClasses, propertiesCount };
 }
 
-for (const cssRule of cssRulesMeta) {
-  await generateCssJavaCheckClass(cssRule);
+// Group cssRulesMeta by sqKey; multi-member groups become single multi-binding classes
+const cssRuleGroups = new Map<string, CssRuleMeta[]>();
+for (const rule of cssRulesMeta) {
+  const group = cssRuleGroups.get(rule.sqKey) ?? [];
+  group.push(rule);
+  cssRuleGroups.set(rule.sqKey, group);
+}
+const cssMultiBindingGroups = new Map(
+  [...cssRuleGroups.entries()].filter(([, metas]) => metas.length > 1),
+);
+
+for (const [sqKey, metas] of cssRuleGroups) {
+  if (metas.length === 1) {
+    await generateCssJavaCheckClass(metas[0]);
+  } else {
+    await generateCssMultiBindingJavaCheckClass(sqKey, metas);
+  }
 }
 await generateCssParsingErrorClass();
 
@@ -568,8 +753,10 @@ await inflateTemplateToFile(
 );
 
 // Generate CssRuleTest.java
-const { perRuleTests, rulesWithOptionsClasses, propertiesCount } =
-  generateCssRuleTestBody(cssRulesMeta);
+const { perRuleTests, rulesWithOptionsClasses, propertiesCount } = generateCssRuleTestBody(
+  cssRulesMeta,
+  cssMultiBindingGroups,
+);
 
 await inflateTemplateToFile(
   join(JAVA_TEMPLATES_FOLDER, 'css-rule-test.template'),

--- a/tools/templates/java/css-rule-test.template
+++ b/tools/templates/java/css-rule-test.template
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.internal.util.collections.Sets;
 import org.sonar.check.RuleProperty;
 import org.sonar.css.CssRules;
+import org.sonar.plugins.javascript.bridge.StylelintRule;
 
 class CssRuleTest {
 

--- a/tools/templates/java/css-rules.template
+++ b/tools/templates/java/css-rules.template
@@ -35,7 +35,10 @@ public class CssRules {
     this.rules = checks.all();
     stylelintKeyToRuleKey = new HashMap<>();
     for (CssRule rule : rules) {
-      stylelintKeyToRuleKey.put(rule.stylelintKey(), checks.ruleKey(rule));
+      RuleKey ruleKey = checks.ruleKey(rule);
+      for (StylelintRule sr : rule.stylelintRules()) {
+        stylelintKeyToRuleKey.put(sr.getKey(), ruleKey);
+      }
     }
   }
 
@@ -54,8 +57,8 @@ ___RULE_CLASSES___
 
   public List<StylelintRule> getStylelintRules() {
     return this.rules.stream()
-      .filter(rule -> !CSS_PARSING_ERROR_STYLELINT_KEY.equals(rule.stylelintKey()))
-      .map(rule -> new StylelintRule(rule.stylelintKey(), rule.stylelintOptions()))
+      .flatMap(rule -> rule.stylelintRules().stream())
+      .filter(sr -> !CSS_PARSING_ERROR_STYLELINT_KEY.equals(sr.getKey()))
       .toList();
   }
 }


### PR DESCRIPTION
## Summary

- Consolidates three open PRs (#7199 JS-1833, #7206 JS-1836, #7212 JS-1844) into one: instead of three new sqKeys (S8771/S8766/S8779), all deprecated-CSS findings now surface under existing rule **S1874** ("Deprecated APIs should not be used"), matching how the same concept is handled in Java, Kotlin, JavaScript, and every other Sonar language.
- Adds a multi-binding infrastructure to `cssRulesMeta` so one sqKey can map to multiple stylelint rules, each with its own parameter set.
- Stub resource files (`resources/rule-data/css/S1874.json/.html`) are committed for build continuity; they will be overwritten by `sync-rspec` + `deploy-rule-data` once the rspec PR lands.

## Mapped rules

| Stylelint rule | SonarQube param | Example noncompliant |
|---|---|---|
| `selector-no-deprecated` | `ignoreSelectors` | `acronym {}` |
| `declaration-property-value-keyword-no-deprecated` | `ignoreKeywords` | `overflow: overlay` |
| `at-rule-no-deprecated` | `ignoreAtRules` | `@viewport { width: device-width }` |

## Design

`CssRuleMeta` unchanged. Multiple entries sharing the same `sqKey` form a group. The gRPC transformer (`rule-configurations/css.ts`) now returns `CssRuleConfig[]` (one per binding); the reverse map (`stylelintKey -> sqKey`) works unchanged since stylelint keys remain unique. On the Java side, `CssRule` gains a default `stylelintRules()` method; generated `S1874.java` overrides it to return all three bindings; `CssRules.java` uses `stylelintRules()` for routing. Codegen grouping is done in `tools/generate-java-rule-classes.ts`.

See `packages/grpc/src/RULE_CONFIG_PATTERNS.md` for the new "Multi-Binding" pattern section.

## rspec PR

SonarSource/rspec branch `feat/js-1833-1836-1844-rspec-s1874-css` — adds `rules/S1874/css/` language variant.
Supersedes rspec PRs #7029, #7024, #7038.

## Supersedes

Closes #7199 (JS-1833), #7206 (JS-1836), #7212 (JS-1844).

## Functional Validation

Artifact: [js-1833-1836-1844-fv.zip](https://github.com/user-attachments/files/28871620/js-1833-1836-1844-fv.zip)

Unzip and follow `README.md`. Expected output is in `expected-output.txt`. Baseline (master) shows 0 deprecated-CSS findings; review branch shows 3 findings, all sqKey=S1874.
