### PR TITLE
JS-1867 S4790: suppress when hash output is truncated/sliced

### DIFF
--- a/its/ruling/src/test/expected/Ghost/javascript-S4790.json
+++ b/its/ruling/src/test/expected/Ghost/javascript-S4790.json
@@ -1,7 +1,4 @@
 {
-"Ghost:core/server/config/index.js": [
-157
-],
 "Ghost:core/server/data/xml/rss/index.js": [
 111
 ],

--- a/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
@@ -47,6 +47,13 @@ crypto.createHash('sha1').update(p).digest('hex').toUpperCase().slice(0, 5);
 const h1 = crypto.createHash('sha1').update(x).digest('hex');
 h1.slice(0, 8);
 
+const PREFIX = 8;
+crypto.createHash('sha1').update(x).digest('hex').slice(0, PREFIX);
+crypto.createHash('md5').update(x).digest('hex').substring(0, PREFIX);
+
+const hConst = crypto.createHash('sha1').update(x).digest('hex');
+hConst.slice(0, PREFIX);
+
 const h2 = crypto.createHash('md5').update(x).digest('hex'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 useFully(h2);
 
@@ -65,6 +72,8 @@ crypto.createHash('md5').update(x).digest('hex').substring(0); // Noncompliant {
 crypto.createHash('sha1').update(x).digest('hex').slice(-0); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('sha1').update(x).digest('hex').slice(0, undefined); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('sha1').update(x).digest('hex').slice(0, Infinity); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('sha1').update(x).digest('hex').slice(undefined); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('sha1').update(x).digest('hex').slice('foo'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('md5').update(x).digest('hex').substring(0, undefined); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('md5').update(x).digest('hex').substring(-1); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('md5').update(x).digest('hex').substring('foo'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
@@ -75,6 +84,8 @@ async function subtleTruncated() {
   const b1 = await crypto.subtle.digest('SHA-1', data);
   b1.slice(0, 4);
 
+  const LEN = 4;
+  (await crypto.subtle.digest('SHA-1', data)).slice(0, LEN);
   (await crypto.subtle.digest('SHA-1', data)).slice(0, 4);
 
   crypto.subtle.digest('SHA-1', data).then(buf => buf.slice(0, 4));

--- a/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
@@ -62,6 +62,10 @@ h3.slice(0, 8);
 crypto.createHash('sha1').update(x).digest('hex').slice(); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('sha1').update(x).digest('hex').slice(0); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('md5').update(x).digest('hex').substring(0); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('sha1').update(x).digest('hex').slice(-0); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('sha1').update(x).digest('hex').slice(0, undefined); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('sha1').update(x).digest('hex').slice(0, Infinity); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('md5').update(x).digest('hex').substring(0, undefined); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 
 // crypto.subtle.digest truncation — same idiom, async via await or .then
 async function subtleTruncated() {

--- a/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
@@ -36,3 +36,19 @@ crypto.subtle.digest('SHA-512', data);
 notCrypto.subtle.digest('SHA-1', data);
 crypto.notSubtle.digest('SHA-1', data);
 crypto.subtle.notDigest('SHA-1', data);
+
+// Truncated digest output — short identifier, cache key, ETag
+crypto.createHash('sha1').update(x).digest('hex').slice(0, 8);
+crypto.createHash('md5').update(url).digest('hex').substring(0, 4);
+crypto.createHash('sha1').update(x).digest('hex').slice(-6);
+crypto.createHash('md5').update(payload).digest().slice(0, 4);
+crypto.createHash('sha1').update(p).digest('hex').toUpperCase().slice(0, 5);
+
+const h1 = crypto.createHash('sha1').update(x).digest('hex');
+h1.slice(0, 8);
+
+const h2 = crypto.createHash('md5').update(x).digest('hex'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+useFully(h2);
+
+crypto.createHash('sha1').update(x).digest('hex'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('md5').update(x).digest('hex').toString(); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}

--- a/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
@@ -53,6 +53,16 @@ useFully(h2);
 crypto.createHash('sha1').update(x).digest('hex'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('md5').update(x).digest('hex').toString(); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 
+// Mixed-use binding: one ref full, one sliced — full ref still sensitive
+const h3 = crypto.createHash('md5').update(password).digest('hex'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+storeCredential(h3);
+h3.slice(0, 8);
+
+// No-op slices don't actually truncate
+crypto.createHash('sha1').update(x).digest('hex').slice(); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('sha1').update(x).digest('hex').slice(0); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('md5').update(x).digest('hex').substring(0); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+
 // crypto.subtle.digest truncation — same idiom, async via await or .then
 async function subtleTruncated() {
   const b1 = await crypto.subtle.digest('SHA-1', data);

--- a/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
@@ -52,3 +52,19 @@ useFully(h2);
 
 crypto.createHash('sha1').update(x).digest('hex'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('md5').update(x).digest('hex').toString(); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+
+// crypto.subtle.digest truncation — same idiom, async via await or .then
+async function subtleTruncated() {
+  const b1 = await crypto.subtle.digest('SHA-1', data);
+  b1.slice(0, 4);
+
+  (await crypto.subtle.digest('SHA-1', data)).slice(0, 4);
+
+  crypto.subtle.digest('SHA-1', data).then(buf => buf.slice(0, 4));
+  crypto.subtle.digest('SHA-1', data).then(function (buf) { return buf.slice(0, 4); });
+
+  const b2 = await crypto.subtle.digest('SHA-1', data); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+  sendFully(b2);
+
+  crypto.subtle.digest('SHA-1', data).then(buf => sendFully(buf)); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+}

--- a/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S4790/cb.fixture.js
@@ -66,6 +66,9 @@ crypto.createHash('sha1').update(x).digest('hex').slice(-0); // Noncompliant {{M
 crypto.createHash('sha1').update(x).digest('hex').slice(0, undefined); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('sha1').update(x).digest('hex').slice(0, Infinity); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 crypto.createHash('md5').update(x).digest('hex').substring(0, undefined); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('md5').update(x).digest('hex').substring(-1); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('md5').update(x).digest('hex').substring('foo'); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+crypto.createHash('md5').update(x).digest('hex').substring(undefined); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
 
 // crypto.subtle.digest truncation — same idiom, async via await or .then
 async function subtleTruncated() {

--- a/packages/analysis/src/jsts/rules/S4790/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4790/rule.ts
@@ -202,9 +202,11 @@ function isIdentifierTruncated(identifier: estree.Node): boolean {
   );
 }
 
-// Reject no-op slices that don't actually shorten the digest: `.slice()`, `.slice(0)`, `.substring(0)`.
-// Length-bound checks (e.g. `.slice(0, 64)` on a 40-char sha1 hex) are out of scope — that needs
-// digest-length and encoding awareness.
+// Conservative truncation check: only treat the call as truncation when at least one argument is a
+// non-zero numeric literal (positive or negative). Rejects all the obvious no-ops — `.slice()`,
+// `.slice(0)`, `.slice(-0)`, `.slice(0, undefined)`, `.slice(0, Infinity)`, etc.
+// Length-bound checks against the digest's own size (e.g. `.slice(0, 64)` on a 40-char sha1 hex)
+// remain out of scope — that needs digest-length and encoding awareness.
 function isTruncationCall(call: estree.CallExpression): boolean {
   if (call.callee.type !== 'MemberExpression' || call.callee.property.type !== 'Identifier') {
     return false;
@@ -212,12 +214,15 @@ function isTruncationCall(call: estree.CallExpression): boolean {
   if (!TRUNCATION_METHODS.has(call.callee.property.name)) {
     return false;
   }
-  if (call.arguments.length === 0) {
-    return false;
+  return call.arguments.some(isNonZeroNumericLiteral);
+}
+
+function isNonZeroNumericLiteral(node: estree.Node | estree.SpreadElement): boolean {
+  if (node.type === 'Literal') {
+    return typeof node.value === 'number' && node.value !== 0;
   }
-  const [first] = call.arguments;
-  if (call.arguments.length === 1 && first.type === 'Literal' && first.value === 0) {
-    return false;
+  if (node.type === 'UnaryExpression' && (node.operator === '-' || node.operator === '+')) {
+    return isNonZeroNumericLiteral(node.argument);
   }
-  return true;
+  return false;
 }

--- a/packages/analysis/src/jsts/rules/S4790/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4790/rule.ts
@@ -202,27 +202,35 @@ function isIdentifierTruncated(identifier: estree.Node): boolean {
   );
 }
 
-// Conservative truncation check: only treat the call as truncation when at least one argument is a
-// non-zero numeric literal (positive or negative). Rejects all the obvious no-ops — `.slice()`,
-// `.slice(0)`, `.slice(-0)`, `.slice(0, undefined)`, `.slice(0, Infinity)`, etc.
-// Length-bound checks against the digest's own size (e.g. `.slice(0, 64)` on a 40-char sha1 hex)
-// remain out of scope — that needs digest-length and encoding awareness.
+// `slice` allows negative offsets; `substring` clamps negatives to 0.
 function isTruncationCall(call: estree.CallExpression): boolean {
   if (call.callee.type !== 'MemberExpression' || call.callee.property.type !== 'Identifier') {
     return false;
   }
-  if (!TRUNCATION_METHODS.has(call.callee.property.name)) {
+  const method = call.callee.property.name;
+  if (!TRUNCATION_METHODS.has(method)) {
     return false;
   }
-  return call.arguments.some(isNonZeroNumericLiteral);
+  const allowNegatives = method === 'slice';
+  return call.arguments.some(arg => isTruncatingArg(arg, allowNegatives));
 }
 
-function isNonZeroNumericLiteral(node: estree.Node | estree.SpreadElement): boolean {
+function isTruncatingArg(
+  node: estree.Node | estree.SpreadElement,
+  allowNegatives: boolean,
+): boolean {
   if (node.type === 'Literal') {
-    return typeof node.value === 'number' && node.value !== 0;
+    return typeof node.value === 'number' && node.value > 0;
   }
-  if (node.type === 'UnaryExpression' && (node.operator === '-' || node.operator === '+')) {
-    return isNonZeroNumericLiteral(node.argument);
+  if (node.type === 'UnaryExpression' && node.operator === '+') {
+    return isTruncatingArg(node.argument, allowNegatives);
+  }
+  if (node.type === 'UnaryExpression' && node.operator === '-' && allowNegatives) {
+    return (
+      node.argument.type === 'Literal' &&
+      typeof node.argument.value === 'number' &&
+      node.argument.value !== 0
+    );
   }
   return false;
 }

--- a/packages/analysis/src/jsts/rules/S4790/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4790/rule.ts
@@ -210,7 +210,9 @@ type SubstringKind = 'zero' | 'length' | 'other';
 
 // Treat `slice` / `substring` as truncation unless the argument pattern obviously preserves the
 // whole output. This keeps named constants and unresolved bounds in scope while excluding simple
-// no-op forms like `.slice()`, `.slice(0, undefined)`, or `.substring('foo')`.
+// no-op forms like `.slice()`, `.slice(0, undefined)`, or `.substring('foo')`. Other shortening
+// helpers (`substr`, `at`, `charAt`, `subarray`, transform-based extraction, etc.) are
+// intentionally left out here to keep this PR scoped to the existing `slice` / `substring` idiom.
 function isTruncationCall(context: Rule.RuleContext, call: estree.CallExpression): boolean {
   if (call.callee.type !== 'MemberExpression' || call.callee.property.type !== 'Identifier') {
     return false;

--- a/packages/analysis/src/jsts/rules/S4790/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4790/rule.ts
@@ -315,28 +315,36 @@ function getStaticValue(node: estree.Node): StaticValue {
     return coerceLiteralValue(node.value);
   }
   if (node.type === 'Identifier') {
-    if (node.name === 'undefined') {
-      return undefined;
-    }
-    if (node.name === 'Infinity') {
-      return Infinity;
-    }
-    if (node.name === 'NaN') {
-      return NaN;
-    }
-    return UNKNOWN_VALUE;
+    return getIdentifierStaticValue(node);
   }
   if (node.type === 'UnaryExpression' && (node.operator === '+' || node.operator === '-')) {
-    const value = getStaticValue(node.argument);
-    if (value === UNKNOWN_VALUE) {
-      return UNKNOWN_VALUE;
-    }
-    if (value === undefined) {
-      return NaN;
-    }
-    return node.operator === '+' ? value : -value;
+    return getUnaryStaticValue(node);
   }
   return UNKNOWN_VALUE;
+}
+
+function getIdentifierStaticValue(node: estree.Identifier): StaticValue {
+  switch (node.name) {
+    case 'undefined':
+      return undefined;
+    case 'Infinity':
+      return Infinity;
+    case 'NaN':
+      return Number.NaN;
+    default:
+      return UNKNOWN_VALUE;
+  }
+}
+
+function getUnaryStaticValue(node: estree.UnaryExpression): StaticValue {
+  const value = getStaticValue(node.argument);
+  if (value === UNKNOWN_VALUE) {
+    return UNKNOWN_VALUE;
+  }
+  if (value === undefined) {
+    return Number.NaN;
+  }
+  return node.operator === '+' ? value : -value;
 }
 
 function coerceLiteralValue(value: estree.Literal['value']): StaticValue {

--- a/packages/analysis/src/jsts/rules/S4790/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4790/rule.ts
@@ -56,7 +56,7 @@ export const rule: Rule.RuleModule = {
     function checkSubtleCrypto(fqn: string | null, node: estree.CallExpression) {
       // crypto.subtle#digest
       const { callee, arguments: args } = node;
-      if (fqn === 'crypto.subtle.digest') {
+      if (fqn === 'crypto.subtle.digest' && !isSubtleDigestTruncated(context, node)) {
         checkUnsecureAlgorithm(callee, args[0], SUBTLE_UNSECURE_HASH_ALGORITHMS);
       }
     }
@@ -120,19 +120,64 @@ function isDigestTruncated(
   return digestCall !== null && isBoundToTruncatedReference(context, digestCall);
 }
 
-function isBoundToTruncatedReference(
-  context: Rule.RuleContext,
-  digestCall: estree.CallExpression,
-): boolean {
-  const declarator = getNodeParent(digestCall);
+function isBoundToTruncatedReference(context: Rule.RuleContext, initNode: estree.Node): boolean {
+  const declarator = getNodeParent(initNode);
   if (
     declarator?.type !== 'VariableDeclarator' ||
-    declarator.init !== digestCall ||
+    declarator.init !== initNode ||
     declarator.id.type !== 'Identifier'
   ) {
     return false;
   }
   const variable = getVariableFromName(context, declarator.id.name, declarator.id);
+  return !!variable && variable.references.some(ref => isIdentifierTruncated(ref.identifier));
+}
+
+// crypto.subtle.digest(...) returns Promise<ArrayBuffer>. Truncation can happen via .then callback,
+// after await on a binding, or immediately on the awaited value.
+function isSubtleDigestTruncated(
+  context: Rule.RuleContext,
+  digestCall: estree.CallExpression,
+): boolean {
+  if (isPromiseThenTruncated(context, digestCall)) {
+    return true;
+  }
+  const parent = getNodeParent(digestCall);
+  const valueNode = parent?.type === 'AwaitExpression' ? parent : digestCall;
+  return isIdentifierTruncated(valueNode) || isBoundToTruncatedReference(context, valueNode);
+}
+
+function isPromiseThenTruncated(
+  context: Rule.RuleContext,
+  digestCall: estree.CallExpression,
+): boolean {
+  const member = getNodeParent(digestCall);
+  if (
+    member?.type !== 'MemberExpression' ||
+    member.object !== digestCall ||
+    member.property.type !== 'Identifier' ||
+    member.property.name !== 'then'
+  ) {
+    return false;
+  }
+  const thenCall = getNodeParent(member);
+  if (
+    thenCall?.type !== 'CallExpression' ||
+    thenCall.callee !== member ||
+    thenCall.arguments.length === 0
+  ) {
+    return false;
+  }
+  const callback = thenCall.arguments[0];
+  if (
+    (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression') ||
+    callback.params.length === 0 ||
+    callback.params[0].type !== 'Identifier'
+  ) {
+    return false;
+  }
+  const param = callback.params[0];
+  const variable = getVariableFromName(context, param.name, param);
   return !!variable && variable.references.some(ref => isIdentifierTruncated(ref.identifier));
 }
 

--- a/packages/analysis/src/jsts/rules/S4790/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4790/rule.ts
@@ -20,7 +20,8 @@ import type { Rule } from 'eslint';
 import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
-import { getUniqueWriteUsageOrNode, isStringLiteral } from '../helpers/ast.js';
+import { getNodeParent } from '../helpers/ancestor.js';
+import { getUniqueWriteUsageOrNode, getVariableFromName, isStringLiteral } from '../helpers/ast.js';
 import * as meta from './generated-meta.js';
 
 const message = 'Make sure this weak hash algorithm is not used in a sensitive context here.';
@@ -39,6 +40,7 @@ const CRYPTO_UNSECURE_HASH_ALGORITHMS = new Set([
   'sha1',
 ]);
 const SUBTLE_UNSECURE_HASH_ALGORITHMS = new Set(['sha-1']);
+const TRUNCATION_METHODS = new Set(['slice', 'substring']);
 
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta),
@@ -46,7 +48,7 @@ export const rule: Rule.RuleModule = {
     function checkNodejsCrypto(fqn: string | null, node: estree.CallExpression) {
       // crypto#createHash
       const { callee, arguments: args } = node;
-      if (fqn === 'crypto.createHash') {
+      if (fqn === 'crypto.createHash' && !isDigestTruncated(context, node)) {
         checkUnsecureAlgorithm(callee, args[0], CRYPTO_UNSECURE_HASH_ALGORITHMS);
       }
     }
@@ -86,3 +88,64 @@ export const rule: Rule.RuleModule = {
     };
   },
 };
+
+// A truncated digest cannot serve password storage, signing, or integrity checks — those all need the
+// full output — so the use is non-cryptographic (short identifier, cache key, ETag).
+function isDigestTruncated(
+  context: Rule.RuleContext,
+  createHashCall: estree.CallExpression,
+): boolean {
+  let node: estree.Node = createHashCall;
+  let digestCall: estree.CallExpression | null = null;
+
+  while (true) {
+    const parent = getNodeParent(node);
+    if (parent?.type !== 'MemberExpression' || parent.object !== node) {
+      break;
+    }
+    const grandParent = getNodeParent(parent);
+    if (grandParent?.type !== 'CallExpression' || grandParent.callee !== parent) {
+      break;
+    }
+    const methodName = parent.property.type === 'Identifier' ? parent.property.name : null;
+    if (digestCall && methodName && TRUNCATION_METHODS.has(methodName)) {
+      return true;
+    }
+    if (methodName === 'digest') {
+      digestCall = grandParent;
+    }
+    node = grandParent;
+  }
+
+  return digestCall !== null && isBoundToTruncatedReference(context, digestCall);
+}
+
+function isBoundToTruncatedReference(
+  context: Rule.RuleContext,
+  digestCall: estree.CallExpression,
+): boolean {
+  const declarator = getNodeParent(digestCall);
+  if (
+    declarator?.type !== 'VariableDeclarator' ||
+    declarator.init !== digestCall ||
+    declarator.id.type !== 'Identifier'
+  ) {
+    return false;
+  }
+  const variable = getVariableFromName(context, declarator.id.name, declarator.id);
+  return !!variable && variable.references.some(ref => isIdentifierTruncated(ref.identifier));
+}
+
+function isIdentifierTruncated(identifier: estree.Node): boolean {
+  const parent = getNodeParent(identifier);
+  if (
+    parent?.type !== 'MemberExpression' ||
+    parent.object !== identifier ||
+    parent.property.type !== 'Identifier' ||
+    !TRUNCATION_METHODS.has(parent.property.name)
+  ) {
+    return false;
+  }
+  const grandParent = getNodeParent(parent);
+  return grandParent?.type === 'CallExpression' && grandParent.callee === parent;
+}

--- a/packages/analysis/src/jsts/rules/S4790/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4790/rule.ts
@@ -16,7 +16,7 @@
  */
 // https://sonarsource.github.io/rspec/#/rspec/S4790/javascript
 
-import type { Rule } from 'eslint';
+import type { Rule, Scope } from 'eslint';
 import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
@@ -108,7 +108,7 @@ function isDigestTruncated(
       break;
     }
     const methodName = parent.property.type === 'Identifier' ? parent.property.name : null;
-    if (digestCall && methodName && TRUNCATION_METHODS.has(methodName)) {
+    if (digestCall && isTruncationCall(grandParent)) {
       return true;
     }
     if (methodName === 'digest') {
@@ -120,6 +120,9 @@ function isDigestTruncated(
   return digestCall !== null && isBoundToTruncatedReference(context, digestCall);
 }
 
+// Only suppress when every read of the bound digest is truncated — otherwise a mixed-use binding
+// (one full + one sliced) would silently silence the sensitive use. Write refs are skipped: the
+// declarator init is itself a write and reassignments don't consume the value.
 function isBoundToTruncatedReference(context: Rule.RuleContext, initNode: estree.Node): boolean {
   const declarator = getNodeParent(initNode);
   if (
@@ -130,7 +133,12 @@ function isBoundToTruncatedReference(context: Rule.RuleContext, initNode: estree
     return false;
   }
   const variable = getVariableFromName(context, declarator.id.name, declarator.id);
-  return !!variable && variable.references.some(ref => isIdentifierTruncated(ref.identifier));
+  return !!variable && hasOnlyTruncatedReads(variable);
+}
+
+function hasOnlyTruncatedReads(variable: Scope.Variable): boolean {
+  const reads = variable.references.filter(ref => ref.isRead());
+  return reads.length > 0 && reads.every(ref => isIdentifierTruncated(ref.identifier));
 }
 
 // crypto.subtle.digest(...) returns Promise<ArrayBuffer>. Truncation can happen via .then callback,
@@ -178,19 +186,38 @@ function isPromiseThenTruncated(
   }
   const param = callback.params[0];
   const variable = getVariableFromName(context, param.name, param);
-  return !!variable && variable.references.some(ref => isIdentifierTruncated(ref.identifier));
+  return !!variable && hasOnlyTruncatedReads(variable);
 }
 
 function isIdentifierTruncated(identifier: estree.Node): boolean {
   const parent = getNodeParent(identifier);
-  if (
-    parent?.type !== 'MemberExpression' ||
-    parent.object !== identifier ||
-    parent.property.type !== 'Identifier' ||
-    !TRUNCATION_METHODS.has(parent.property.name)
-  ) {
+  if (parent?.type !== 'MemberExpression' || parent.object !== identifier) {
     return false;
   }
   const grandParent = getNodeParent(parent);
-  return grandParent?.type === 'CallExpression' && grandParent.callee === parent;
+  return (
+    grandParent?.type === 'CallExpression' &&
+    grandParent.callee === parent &&
+    isTruncationCall(grandParent)
+  );
+}
+
+// Reject no-op slices that don't actually shorten the digest: `.slice()`, `.slice(0)`, `.substring(0)`.
+// Length-bound checks (e.g. `.slice(0, 64)` on a 40-char sha1 hex) are out of scope — that needs
+// digest-length and encoding awareness.
+function isTruncationCall(call: estree.CallExpression): boolean {
+  if (call.callee.type !== 'MemberExpression' || call.callee.property.type !== 'Identifier') {
+    return false;
+  }
+  if (!TRUNCATION_METHODS.has(call.callee.property.name)) {
+    return false;
+  }
+  if (call.arguments.length === 0) {
+    return false;
+  }
+  const [first] = call.arguments;
+  if (call.arguments.length === 1 && first.type === 'Literal' && first.value === 0) {
+    return false;
+  }
+  return true;
 }

--- a/packages/analysis/src/jsts/rules/S4790/rule.ts
+++ b/packages/analysis/src/jsts/rules/S4790/rule.ts
@@ -108,7 +108,7 @@ function isDigestTruncated(
       break;
     }
     const methodName = parent.property.type === 'Identifier' ? parent.property.name : null;
-    if (digestCall && isTruncationCall(grandParent)) {
+    if (digestCall && isTruncationCall(context, grandParent)) {
       return true;
     }
     if (methodName === 'digest') {
@@ -133,12 +133,12 @@ function isBoundToTruncatedReference(context: Rule.RuleContext, initNode: estree
     return false;
   }
   const variable = getVariableFromName(context, declarator.id.name, declarator.id);
-  return !!variable && hasOnlyTruncatedReads(variable);
+  return !!variable && hasOnlyTruncatedReads(context, variable);
 }
 
-function hasOnlyTruncatedReads(variable: Scope.Variable): boolean {
+function hasOnlyTruncatedReads(context: Rule.RuleContext, variable: Scope.Variable): boolean {
   const reads = variable.references.filter(ref => ref.isRead());
-  return reads.length > 0 && reads.every(ref => isIdentifierTruncated(ref.identifier));
+  return reads.length > 0 && reads.every(ref => isIdentifierTruncated(context, ref.identifier));
 }
 
 // crypto.subtle.digest(...) returns Promise<ArrayBuffer>. Truncation can happen via .then callback,
@@ -152,7 +152,9 @@ function isSubtleDigestTruncated(
   }
   const parent = getNodeParent(digestCall);
   const valueNode = parent?.type === 'AwaitExpression' ? parent : digestCall;
-  return isIdentifierTruncated(valueNode) || isBoundToTruncatedReference(context, valueNode);
+  return (
+    isIdentifierTruncated(context, valueNode) || isBoundToTruncatedReference(context, valueNode)
+  );
 }
 
 function isPromiseThenTruncated(
@@ -186,10 +188,10 @@ function isPromiseThenTruncated(
   }
   const param = callback.params[0];
   const variable = getVariableFromName(context, param.name, param);
-  return !!variable && hasOnlyTruncatedReads(variable);
+  return !!variable && hasOnlyTruncatedReads(context, variable);
 }
 
-function isIdentifierTruncated(identifier: estree.Node): boolean {
+function isIdentifierTruncated(context: Rule.RuleContext, identifier: estree.Node): boolean {
   const parent = getNodeParent(identifier);
   if (parent?.type !== 'MemberExpression' || parent.object !== identifier) {
     return false;
@@ -198,12 +200,18 @@ function isIdentifierTruncated(identifier: estree.Node): boolean {
   return (
     grandParent?.type === 'CallExpression' &&
     grandParent.callee === parent &&
-    isTruncationCall(grandParent)
+    isTruncationCall(context, grandParent)
   );
 }
 
-// `slice` allows negative offsets; `substring` clamps negatives to 0.
-function isTruncationCall(call: estree.CallExpression): boolean {
+const UNKNOWN_VALUE = Symbol('unknown');
+type StaticValue = number | undefined | typeof UNKNOWN_VALUE;
+type SubstringKind = 'zero' | 'length' | 'other';
+
+// Treat `slice` / `substring` as truncation unless the argument pattern obviously preserves the
+// whole output. This keeps named constants and unresolved bounds in scope while excluding simple
+// no-op forms like `.slice()`, `.slice(0, undefined)`, or `.substring('foo')`.
+function isTruncationCall(context: Rule.RuleContext, call: estree.CallExpression): boolean {
   if (call.callee.type !== 'MemberExpression' || call.callee.property.type !== 'Identifier') {
     return false;
   }
@@ -211,26 +219,135 @@ function isTruncationCall(call: estree.CallExpression): boolean {
   if (!TRUNCATION_METHODS.has(method)) {
     return false;
   }
-  const allowNegatives = method === 'slice';
-  return call.arguments.some(arg => isTruncatingArg(arg, allowNegatives));
+  return !isObviouslyFullOutput(context, method, call.arguments);
 }
 
-function isTruncatingArg(
-  node: estree.Node | estree.SpreadElement,
-  allowNegatives: boolean,
+function isObviouslyFullOutput(
+  context: Rule.RuleContext,
+  method: string,
+  args: Array<estree.Node | estree.SpreadElement>,
 ): boolean {
+  if (args.length === 0) {
+    return true;
+  }
+  if (method === 'slice') {
+    return isSliceFullOutput(context, args);
+  }
+  return isSubstringFullOutput(context, args);
+}
+
+function isSliceFullOutput(
+  context: Rule.RuleContext,
+  args: Array<estree.Node | estree.SpreadElement>,
+): boolean {
+  if (!isSliceNoOpStart(resolveStaticValue(context, args[0]))) {
+    return false;
+  }
+  return args.length === 1 || isSliceFullOutputEnd(resolveStaticValue(context, args[1]));
+}
+
+function isSubstringFullOutput(
+  context: Rule.RuleContext,
+  args: Array<estree.Node | estree.SpreadElement>,
+): boolean {
+  const startKind = getSubstringStartKind(resolveStaticValue(context, args[0]));
+  if (args.length === 1) {
+    return startKind === 'zero';
+  }
+  const endKind = getSubstringEndKind(resolveStaticValue(context, args[1]));
+  return (
+    (startKind === 'zero' && endKind === 'length') || (startKind === 'length' && endKind === 'zero')
+  );
+}
+
+function isSliceNoOpStart(value: StaticValue): boolean {
+  return value === undefined || (typeof value === 'number' && (value === 0 || Number.isNaN(value)));
+}
+
+function isSliceFullOutputEnd(value: StaticValue): boolean {
+  return value === undefined || value === Infinity;
+}
+
+function getSubstringStartKind(value: StaticValue): SubstringKind {
+  if (value === undefined) {
+    return 'zero';
+  }
+  if (typeof value === 'number') {
+    if (value === Infinity) {
+      return 'length';
+    }
+    if (value <= 0 || Number.isNaN(value)) {
+      return 'zero';
+    }
+  }
+  return 'other';
+}
+
+function getSubstringEndKind(value: StaticValue): SubstringKind {
+  if (value === undefined) {
+    return 'length';
+  }
+  if (typeof value === 'number') {
+    if (value === Infinity) {
+      return 'length';
+    }
+    if (value <= 0 || Number.isNaN(value)) {
+      return 'zero';
+    }
+  }
+  return 'other';
+}
+
+function resolveStaticValue(
+  context: Rule.RuleContext,
+  node: estree.Node | estree.SpreadElement,
+): StaticValue {
+  if (node.type === 'SpreadElement') {
+    return UNKNOWN_VALUE;
+  }
+  return getStaticValue(getUniqueWriteUsageOrNode(context, node, true));
+}
+
+function getStaticValue(node: estree.Node): StaticValue {
   if (node.type === 'Literal') {
-    return typeof node.value === 'number' && node.value > 0;
+    return coerceLiteralValue(node.value);
   }
-  if (node.type === 'UnaryExpression' && node.operator === '+') {
-    return isTruncatingArg(node.argument, allowNegatives);
+  if (node.type === 'Identifier') {
+    if (node.name === 'undefined') {
+      return undefined;
+    }
+    if (node.name === 'Infinity') {
+      return Infinity;
+    }
+    if (node.name === 'NaN') {
+      return NaN;
+    }
+    return UNKNOWN_VALUE;
   }
-  if (node.type === 'UnaryExpression' && node.operator === '-' && allowNegatives) {
-    return (
-      node.argument.type === 'Literal' &&
-      typeof node.argument.value === 'number' &&
-      node.argument.value !== 0
-    );
+  if (node.type === 'UnaryExpression' && (node.operator === '+' || node.operator === '-')) {
+    const value = getStaticValue(node.argument);
+    if (value === UNKNOWN_VALUE) {
+      return UNKNOWN_VALUE;
+    }
+    if (value === undefined) {
+      return NaN;
+    }
+    return node.operator === '+' ? value : -value;
   }
-  return false;
+  return UNKNOWN_VALUE;
+}
+
+function coerceLiteralValue(value: estree.Literal['value']): StaticValue {
+  switch (typeof value) {
+    case 'number':
+      return value;
+    case 'string':
+    case 'boolean':
+    case 'bigint':
+      return Number(value);
+    case 'object':
+      return value === null ? 0 : UNKNOWN_VALUE;
+    default:
+      return UNKNOWN_VALUE;
+  }
 }


### PR DESCRIPTION
## Summary
- Suppress S4790 when the result of `crypto.createHash(...).update(...).digest(...)` flows into `.slice` / `.substring`, either directly on the chain or via a `const`-bound variable.
- Truncated weak digests cannot serve password storage, signing, or integrity — those need the full output — so the use is non-cryptographic (short identifier, cache key, ETag, k-anonymity prefix).