### PR TITLE
JS-1897 Reuse shared build number in NPM cache and promote jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,9 +90,12 @@ jobs:
   populate_npm_cache:
     runs-on: sonar-xs
     name: Populate NPM cache for Linux
-    needs: setup
+    needs: [setup, get_build_number]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: &shared_build_number
+      # Reuse the build number minted once in get_build_number everywhere workflow metadata is configured or promoted.
+      BUILD_NUMBER: ${{ needs.get_build_number.outputs.build-number }}
     steps: &populate_npm_cache_steps
       - name: Cache NPM dependencies
         id: cache
@@ -193,9 +196,7 @@ jobs:
     needs: [setup, get_build_number, populate_npm_cache, sync_rspec]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
-    env: &shared_build_number
-      # Reuse the build number minted once in get_build_number across every config-maven caller.
-      BUILD_NUMBER: ${{ needs.get_build_number.outputs.build-number }}
+    env: *shared_build_number
     steps:
       - *checkout
       - *mise
@@ -1320,6 +1321,7 @@ jobs:
   promote:
     runs-on: sonar-xs
     needs:
+      - get_build_number
       - build
       - build_win
       - test_js
@@ -1341,6 +1343,7 @@ jobs:
       !failure() && !cancelled() &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     permissions: *read_permissions
+    env: *shared_build_number
     steps:
       - *checkout
       - *mise


### PR DESCRIPTION
## Summary
- reuse the `get_build_number` output in the Linux NPM cache job so `config-npm@v1` does not mint a second build number
- pass the same shared build number into the `promote` job so `promote@v1` promotes the build info published by the Maven build
- keep the existing build-number reuse behavior for the `config-maven` callers introduced in #7248

## Validation
- `git diff --check`
- `ruby -e 'require "psych"; Psych.parse_stream(File.read(".github/workflows/build.yml"))'`
- `actionlint` is not installed in this environment

## Root cause
`get-build-number@master` minted `42212`, but `config-npm@v1` in `populate_npm_cache` minted `42213` later in the same workflow. The Maven build published Artifactory build info as `SonarJS/42212`, while `promote@v1` restored `42213` and failed with `No build was found for build name: SonarJS, build number: 42213`.