### PR TITLE
JS-1801 Narrow S7766 typed union suppression

### DIFF
--- a/packages/analysis/src/jsts/rules/S7766/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7766/decorator.ts
@@ -113,8 +113,8 @@ function getTypedMinMaxEvidence(
  * Converts a TypeScript type into a reporting decision.
  *
  * Decision rules:
- * 1. Union: return `unknown` if any branch is unknown, `suppress` if any branch
- *    is suppressible, otherwise `report`.
+ * 1. Union: return `unknown` if any branch is unknown, `report` if any branch
+ *    is numeric, otherwise `suppress`.
  * 2. `any` / `unknown`: return `unknown` so the syntax fallback can decide.
  * 3. Type parameters and intersections: return `suppress`.
  * 4. Plain numeric types: return `report`.
@@ -128,6 +128,9 @@ function classifyMinMaxType(type: ts.Type): TypedMinMaxEvidence {
       const evidence = classifyMinMaxType(constituent);
       if (evidence === 'unknown') {
         return 'unknown';
+      }
+      if (evidence === 'report') {
+        return 'report';
       }
       sawSuppressibleType ||= evidence === 'suppress';
     }

--- a/packages/analysis/src/jsts/rules/S7766/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7766/unit.test.ts
@@ -415,15 +415,15 @@ earliestValue(new Date(1), new Date(2));
     });
   });
 
-  it('classifies typed unions and intersections in the decorated rule', () => {
+  it('reports typed unions with numeric constituents in the decorated rule', () => {
     const ruleTester = new RuleTester();
     ruleTester.run('Decorated rule', decorate(conditionalExpressionRule), {
       valid: [
         {
           code: `
-type NumericOrDate = number | Date;
+type StringOrDate = string | Date;
 
-function lowerNumericOrDate(left: NumericOrDate, right: NumericOrDate): NumericOrDate {
+function lowerStringOrDate(left: StringOrDate, right: StringOrDate): StringOrDate {
   return left < right ? left : right;
 }
           `,
@@ -444,6 +444,16 @@ function earliestBrandedTimestamp(
         },
       ],
       invalid: [
+        {
+          code: `
+type NumericOrDate = number | Date;
+
+function earliestNumericOrDate(left: NumericOrDate, right: NumericOrDate): NumericOrDate {
+  return left < right ? left : right;
+}
+          `,
+          errors: 1,
+        },
         {
           code: `
 type NumericValue = 1 | 2 | 3;
@@ -631,6 +641,39 @@ const first = getTimestamp(1);
 const second = getTimestamp(2);
 
 const earliest = Math.min(first, second);
+          `,
+          errors: 1,
+        },
+        {
+          code: `
+interface FormlyJSONSchema7 {
+  maxLength?: number;
+  maximum?: number;
+  title?: string;
+}
+
+function merge(base: FormlyJSONSchema7, schema: FormlyJSONSchema7) {
+  (['maxLength', 'maximum'] as (keyof FormlyJSONSchema7)[]).forEach(prop => {
+    if (base[prop] != null && schema[prop] != null) {
+      (base as any)[prop] = base[prop] < schema[prop] ? base[prop] : schema[prop];
+    }
+  });
+}
+          `,
+          output: `
+interface FormlyJSONSchema7 {
+  maxLength?: number;
+  maximum?: number;
+  title?: string;
+}
+
+function merge(base: FormlyJSONSchema7, schema: FormlyJSONSchema7) {
+  (['maxLength', 'maximum'] as (keyof FormlyJSONSchema7)[]).forEach(prop => {
+    if (base[prop] != null && schema[prop] != null) {
+      (base as any)[prop] = Math.min(base[prop], schema[prop]);
+    }
+  });
+}
           `,
           errors: 1,
         },


### PR DESCRIPTION
## Summary

This PR is a follow-up to the Peach impact analysis of [JS-1801](https://sonarsource.atlassian.net/browse/JS-1801), which revealed suppressed true positives after the initial false-positive escape.

The false-positive escape was introduced with the assumption that a union type meant the value should not be treated as numeric. Peach showed that this assumption was too broad: in practice, a union can still mean the value is numeric, but the type annotations are not narrow enough to tie it to only `number`.

The consequence is that unions containing `number` must not go through the false-positive escape. This change narrows the suppression logic so any union with a numeric constituent is reported instead of suppressed.

## Validation

- `npx tsx --tsconfig packages/tsconfig.test.json --test --test-concurrency=1 --test-reporter=spec --test-reporter-destination=stdout packages/analysis/src/jsts/rules/S7766/unit.test.ts`
- GitHub CI on PR #7283


[JS-1801]: https://sonarsource.atlassian.net/browse/JS-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ