### PR TITLE
JS-1898 Add check for multer sub-function

### DIFF
--- a/packages/analysis/src/jsts/rules/S5693/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S5693/cb.fixture.js
@@ -23,7 +23,7 @@ const config = {
     },
   }),
   limits: {
-    fileSize: 10 * 1024 * 1024,
+    fileSize: 5 * 1024 * 1024,
     fieldSize: 1024 * 1024,
     fieldNameSize: 5,
     files: 1,

--- a/packages/analysis/src/jsts/rules/S5693/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S5693/cb.fixture.js
@@ -1,7 +1,6 @@
-const multer = require('multer');
-const { diskStorage } = require('multer');
-const { randomBytes } = require('crypto');
-const { extname } = require('path');
+import multer, { diskStorage } from 'multer';
+import { randomBytes } from 'node:crypto';
+import { extname } from 'node:path';
 
 const tmpFolder = '/tmp';
 
@@ -32,6 +31,6 @@ const config = {
 };
 
 // multer without limits is not compliant
-const upload = multer({ storage }); // Noncompliant {{Make sure the content length limit is safe here.}}
+const upload = multer({ dest: '/uploads' }); // Noncompliant {{Make sure the content length limit is safe here.}}
 
 const upload_safe = multer(config); // Compliant

--- a/packages/analysis/src/jsts/rules/S5693/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S5693/cb.fixture.js
@@ -1,0 +1,37 @@
+const multer = require('multer');
+const { diskStorage } = require('multer');
+const { randomBytes } = require('crypto');
+const { extname } = require('path');
+
+const tmpFolder = '/tmp';
+
+function slugify(str) {
+  return str;
+}
+
+// Compliant: diskStorage is a multer sub-function.
+const config = {
+  storage: diskStorage({
+    destination: tmpFolder,
+    filename(_request, file, callback) {
+      const fileHash = randomBytes(10).toString('hex');
+      const extension = extname(file.originalname);
+      const name = slugify(
+        file.originalname.replace(new RegExp(`${extension}$`), ''),
+      );
+      const fileName = fileHash.concat('-', name, extension);
+      return callback(null, fileName);
+    },
+  }),
+  limits: {
+    fileSize: 10 * 1024 * 1024,
+    fieldSize: 1024 * 1024,
+    fieldNameSize: 5,
+    files: 1,
+  },
+};
+
+// multer without limits is not compliant
+const upload = multer({ storage }); // Noncompliant {{Make sure the content length limit is safe here.}}
+
+const upload_safe = multer(config); // Compliant

--- a/packages/analysis/src/jsts/rules/S5693/cb.test.ts
+++ b/packages/analysis/src/jsts/rules/S5693/cb.test.ts
@@ -1,10 +1,10 @@
 /*
  * SonarQube JavaScript Plugin
- * Copyright (C) 2011-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/packages/analysis/src/jsts/rules/S5693/cb.test.ts
+++ b/packages/analysis/src/jsts/rules/S5693/cb.test.ts
@@ -1,0 +1,24 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) 2011-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { test } from '../../../../tests/jsts/tools/testers/comment-based/checker.js';
+import { rule } from './rule.js';
+import { describe } from 'node:test';
+import * as meta from './generated-meta.js';
+
+describe('Rule S5693', () => {
+  test(meta, rule, import.meta.dirname);
+});

--- a/packages/analysis/src/jsts/rules/S5693/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5693/rule.ts
@@ -129,6 +129,14 @@ function checkMulter(context: Rule.RuleContext, callExpression: estree.CallExpre
     return;
   }
 
+  // Skip destructured imports of multer sub-functions (e.g., `import { diskStorage } from 'multer'`)
+  if (callExpression.callee.type === 'Identifier') {
+    const fqn = getFullyQualifiedName(context, callExpression.callee);
+    if (fqn && fqn !== MULTER_MODULE) {
+      return;
+    }
+  }
+
   if (callExpression.arguments.length === 0) {
     report(context, callExpression.callee);
     return;

--- a/packages/analysis/src/jsts/rules/S5693/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5693/rule.ts
@@ -223,6 +223,22 @@ function getSizeValue(context: Rule.RuleContext, node: estree.Node): number | nu
       return parse(literal.value);
     }
   }
+  if (node.type === 'BinaryExpression') {
+    const left = getSizeValue(context, node.left);
+    const right = getSizeValue(context, node.right);
+    if (left != null && right != null) {
+      switch (node.operator) {
+        case '*':
+          return left * right;
+        case '+':
+          return left + right;
+        case '-':
+          return left - right;
+        case '/':
+          return left / right;
+      }
+    }
+  }
   return null;
 }
 

--- a/packages/analysis/src/jsts/rules/S5693/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5693/rule.ts
@@ -227,15 +227,23 @@ function getSizeValue(context: Rule.RuleContext, node: estree.Node): number | nu
     const left = getSizeValue(context, node.left);
     const right = getSizeValue(context, node.right);
     if (left != null && right != null) {
+      let result: number | null = null;
       switch (node.operator) {
         case '*':
-          return left * right;
+          result = left * right;
+          break;
         case '+':
-          return left + right;
+          result = left + right;
+          break;
         case '-':
-          return left - right;
+          result = left - right;
+          break;
         case '/':
-          return left / right;
+          result = left / right;
+          break;
+      }
+      if (result != null && Number.isFinite(result)) {
+        return result;
       }
     }
   }

--- a/packages/analysis/src/jsts/rules/S5693/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5693/rule.ts
@@ -222,9 +222,10 @@ function visitAssignment(context: Rule.RuleContext, assignment: estree.Assignmen
 function evaluateBinaryExpression(
   context: Rule.RuleContext,
   node: estree.BinaryExpression,
+  visited: Set<estree.Node>,
 ): number | null {
-  const left = getSizeValue(context, node.left);
-  const right = getSizeValue(context, node.right);
+  const left = getSizeValue(context, node.left, visited);
+  const right = getSizeValue(context, node.right, visited);
   if (left == null || right == null) {
     return null;
   }
@@ -249,10 +250,18 @@ function evaluateBinaryExpression(
   return result != null && Number.isFinite(result) ? result : null;
 }
 
-function getSizeValue(context: Rule.RuleContext, node: estree.Node): number | null {
+function getSizeValue(
+  context: Rule.RuleContext,
+  node: estree.Node,
+  visited: Set<estree.Node> = new Set(),
+): number | null {
+  if (visited.has(node)) {
+    return null;
+  }
+  visited.add(node);
   const resolved = getUniqueWriteUsageOrNode(context, node, true);
   if (resolved !== node) {
-    return getSizeValue(context, resolved);
+    return getSizeValue(context, resolved, visited);
   }
   const literal = getValueOfExpression(context, node, 'Literal');
   if (literal) {
@@ -263,7 +272,7 @@ function getSizeValue(context: Rule.RuleContext, node: estree.Node): number | nu
     }
   }
   if (node.type === 'BinaryExpression') {
-    return evaluateBinaryExpression(context, node);
+    return evaluateBinaryExpression(context, node, visited);
   }
   return null;
 }

--- a/packages/analysis/src/jsts/rules/S5693/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5693/rule.ts
@@ -22,7 +22,12 @@ import { getVariablePropertyFromAssignment } from '../S2598/rule.js';
 import { parse } from 'bytes';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
-import { getLhsVariable, getProperty, getValueOfExpression } from '../helpers/ast.js';
+import {
+  getLhsVariable,
+  getProperty,
+  getUniqueWriteUsageOrNode,
+  getValueOfExpression,
+} from '../helpers/ast.js';
 import type { FromSchema } from 'json-schema-to-ts';
 import * as meta from './generated-meta.js';
 
@@ -214,7 +219,41 @@ function visitAssignment(context: Rule.RuleContext, assignment: estree.Assignmen
   }
 }
 
+function evaluateBinaryExpression(
+  context: Rule.RuleContext,
+  node: estree.BinaryExpression,
+): number | null {
+  const left = getSizeValue(context, node.left);
+  const right = getSizeValue(context, node.right);
+  if (left == null || right == null) {
+    return null;
+  }
+  let result: number | null = null;
+  switch (node.operator) {
+    case '*':
+      result = left * right;
+      break;
+    case '+':
+      result = left + right;
+      break;
+    case '-':
+      result = left - right;
+      break;
+    case '/':
+      result = left / right;
+      break;
+    case '**':
+      result = left ** right;
+      break;
+  }
+  return result != null && Number.isFinite(result) ? result : null;
+}
+
 function getSizeValue(context: Rule.RuleContext, node: estree.Node): number | null {
+  const resolved = getUniqueWriteUsageOrNode(context, node, true);
+  if (resolved !== node) {
+    return getSizeValue(context, resolved);
+  }
   const literal = getValueOfExpression(context, node, 'Literal');
   if (literal) {
     if (typeof literal.value === 'number') {
@@ -224,28 +263,7 @@ function getSizeValue(context: Rule.RuleContext, node: estree.Node): number | nu
     }
   }
   if (node.type === 'BinaryExpression') {
-    const left = getSizeValue(context, node.left);
-    const right = getSizeValue(context, node.right);
-    if (left != null && right != null) {
-      let result: number | null = null;
-      switch (node.operator) {
-        case '*':
-          result = left * right;
-          break;
-        case '+':
-          result = left + right;
-          break;
-        case '-':
-          result = left - right;
-          break;
-        case '/':
-          result = left / right;
-          break;
-      }
-      if (result != null && Number.isFinite(result)) {
-        return result;
-      }
-    }
+    return evaluateBinaryExpression(context, node);
   }
   return null;
 }

--- a/packages/analysis/src/jsts/rules/S5693/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5693/unit.test.ts
@@ -49,6 +49,51 @@ describe('S5693', () => {
         },
         {
           code: `
+      import { diskStorage } from 'multer';
+      const storage = diskStorage({
+        destination: '/tmp/uploads',
+        filename: function (req, file, cb) { cb(null, file.fieldname) }
+      });
+        `,
+          options,
+        },
+        {
+          code: `
+      import * as multer from 'multer';
+      multer({ limits: { fileSize: 5 * 1024 * 1024 } });
+        `,
+          options,
+        },
+        {
+          code: `
+      import * as multer from 'multer';
+      multer({ limits: { fileSize: 4000000 + 2000000 } });
+        `,
+          options,
+        },
+        {
+          code: `
+      import * as multer from 'multer';
+      multer({ limits: { fileSize: 16000000 - 10000000 } });
+        `,
+          options,
+        },
+        {
+          code: `
+      import * as multer from 'multer';
+      multer({ limits: { fileSize: 16000000 / 2 } });
+        `,
+          options,
+        },
+        {
+          code: `
+      import * as multer from 'multer';
+      multer({ limits: { fileSize: 1024 / 0 } });
+        `,
+          options,
+        },
+        {
+          code: `
       import { formidable } from 'formidable';
       const form = formidable({}); // Ok, default is used which is less than parameter
       `,
@@ -169,6 +214,7 @@ describe('S5693', () => {
       multer();            // Noncompliant
       multer({ storage }); // Noncompliant
       multer({ limits: {} }); // Noncompliant
+      multer({ limits: { fileSize: 10 * 1024 * 1024 } }); // Noncompliant, 10MB > 8MB
       `,
           errors: [
             { messageId: 'safeLimit', line: 3 },
@@ -176,6 +222,7 @@ describe('S5693', () => {
             { messageId: 'safeLimit', line: 9 },
             { messageId: 'safeLimit', line: 10 },
             { messageId: 'safeLimit', line: 11 },
+            { messageId: 'safeLimit', line: 12 },
           ],
           options,
         },

--- a/packages/analysis/src/jsts/rules/S5693/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5693/unit.test.ts
@@ -94,6 +94,21 @@ describe('S5693', () => {
         },
         {
           code: `
+      import * as multer from 'multer';
+      multer({ limits: { fileSize: 2 ** 20 } });
+        `,
+          options,
+        },
+        {
+          code: `
+      import * as multer from 'multer';
+      const MB = 1024 ** 2;
+      multer({ limits: { fileSize: 5 * MB } });
+        `,
+          options,
+        },
+        {
+          code: `
       import { formidable } from 'formidable';
       const form = formidable({}); // Ok, default is used which is less than parameter
       `,

--- a/packages/analysis/src/jsts/rules/S5693/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5693/unit.test.ts
@@ -109,6 +109,14 @@ describe('S5693', () => {
         },
         {
           code: `
+      import * as multer from 'multer';
+      let a = a * 2;
+      multer({ limits: { fileSize: a } });
+        `,
+          options,
+        },
+        {
+          code: `
       import { formidable } from 'formidable';
       const form = formidable({}); // Ok, default is used which is less than parameter
       `,


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Rule Analysis Improvements:**
  - Added logic in `checkMulter` to ignore destructured imports of `multer` sub-functions like `diskStorage`.
  - Added support for binary expressions in `getSizeValue` to correctly evaluate arithmetic operations when calculating file size limits.
- **Test Infrastructure:**
  - Added a new fixture file `cb.fixture.js` to validate compliant and noncompliant multer configurations.
  - Added `cb.test.ts` test suite using the comment-based checker for rule `S5693` validation.


<sub>This will update automatically on new commits.</sub>