### PR TITLE
JS-1764 Fix Windows .cmd spawning in RSPEC scripts

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -94,6 +94,7 @@ It skips:
 Important details:
 
 - `npm run generate-meta` reuses prepared RSPEC outputs when they already exist, and refreshes them when they do not.
+- To force an RSPEC refresh, or to apply a new root `rspec.sha` pin, run `npm run generate-rule-data:maven` or run `mvn clean` before `npm run generate-meta`.
 - The `bridge` module still adds `target/generated-sources` to the Java source roots, so an existing generated stub directory can be reused without re-running protobuf generation.
 - This flag is intended for Java-only loops after a previous non-skipped build.
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -40,9 +40,9 @@ Examples:
    source ~/.zshenv
    ```
 
-`npm run generate-meta` refreshes RSPEC rule data only when the generated local outputs are missing. On a fresh checkout, or after `mvn clean`, it runs Maven first and uses either your GitHub CLI auth or `GITHUB_TOKEN` to fetch from `SonarSource/rspec`.
+`npm run generate-meta` reuses prepared RSPEC outputs when the generated local rule data directories and per-language `rspec.sha` files are already present. On a fresh checkout, or after `mvn clean`, it runs Maven first and uses either your GitHub CLI auth or `GITHUB_TOKEN` to fetch from `SonarSource/rspec`.
 
-To pin all rule data generation to an exact RSPEC revision, write the commit SHA to `rspec.sha` at the repository root before running `npm run generate-meta` or `npm run generate-rule-data:maven`. When this ignored file is present, the Maven wrapper passes it to `rspec-maven-plugin` for both JavaScript and CSS.
+To pin all rule data generation to an exact RSPEC revision, write the commit SHA to `rspec.sha` at the repository root and run `npm run generate-rule-data:maven`. If you want to use `npm run generate-meta`, run it after `mvn clean` (or otherwise remove the prepared rule data) so the Maven wrapper is invoked. When the ignored root pin is present, the Maven wrapper passes it to `rspec-maven-plugin` for both JavaScript and CSS.
 
 Prepared rule data keeps separate generated pins in `sonar-plugin/javascript-checks/src/main/resources/rspec.sha` and `sonar-plugin/css/src/main/resources/rspec.sha`. If there is no root pin, the Maven wrapper falls back to these per-language generated pins when they are present. For direct Maven commands that generate rule data, pass `-Drspec.sha=<commit-sha>` to pin both languages, or `-Drspec.javascript.sha=<commit-sha>` and `-Drspec.css.sha=<commit-sha>` to pin them independently.
 

--- a/tools/generate-meta.mjs
+++ b/tools/generate-meta.mjs
@@ -58,12 +58,14 @@ const command =
     : process.execPath;
 const commandArgumentsPrefix =
   process.env.npm_execpath === undefined ? [] : [process.env.npm_execpath];
+const shouldUseShell = process.platform === 'win32' && command.toLowerCase().endsWith('.cmd');
 const scripts = hasPreparedRuleData
   ? ['generate-meta:raw']
   : ['generate-rule-data:maven', 'generate-meta:raw'];
 
 for (const script of scripts) {
   const result = spawnSync(command, [...commandArgumentsPrefix, 'run', script], {
+    shell: shouldUseShell,
     stdio: 'inherit',
   });
 

--- a/tools/generate-rule-data.mjs
+++ b/tools/generate-rule-data.mjs
@@ -56,6 +56,7 @@ for (const pin of languagePins) {
 generateArgs.push('generate-resources');
 
 const command = process.platform === 'win32' ? 'mvn.cmd' : 'mvn';
+const shouldUseShell = process.platform === 'win32' && command.toLowerCase().endsWith('.cmd');
 runMaven(bootstrapArgs);
 runMaven(generateArgs);
 
@@ -72,7 +73,10 @@ function readRspecSha(paths) {
 }
 
 function runMaven(args) {
-  const result = spawnSync(command, args, { stdio: 'inherit' });
+  const result = spawnSync(command, args, {
+    shell: shouldUseShell,
+    stdio: 'inherit',
+  });
 
   if (result.error !== undefined) {
     console.error(result.error);


### PR DESCRIPTION
Part of JS-1764

## Summary
- reproduce the Windows failure from #7059 on fresh master
- run Windows .cmd wrappers through a shell in the RSPEC wrapper scripts only when needed
- keep direct 
ode execution unchanged

## Testing
- npm.cmd run generate-rule-data:maven
- npm.cmd run generate-meta