### PR TITLE
JS-1909 Refactor shared file loading in file stores

### DIFF
--- a/docs/file-stores.md
+++ b/docs/file-stores.md
@@ -231,9 +231,12 @@ The store also depends on:
 - **project helper files** because the detector cache derives metadata from files such as `package.json`
 - **JS/TS suffix settings** because detector output matching depends on the supported source extensions
 
-There is one additional implementation detail worth keeping explicit: store order matters.
-`generatedSourceStore` intentionally runs after `sourceFileStore` and `dependencyManifestStore`
-so it can reuse their cached file contents instead of rereading the same detector inputs itself.
+There is one additional implementation detail worth keeping explicit: file reads are centralized in
+`file-stores/index.ts`.
+
+Each store declares whether it wants a given file path only or needs the shared `File` object too.
+If any pending store needs contents, `initFileStores()` reads the file once and passes the same
+object to every interested store.
 
 ### Refresh Model
 

--- a/docs/generated-sources.md
+++ b/docs/generated-sources.md
@@ -68,13 +68,13 @@ Before `generatedSourceStore.postProcess()` runs, the store has already captured
 
 At the same time:
 
-- `sourceFileStore` has already cached overlapping JS/TS file contents, which
-  `generatedSourceStore` reuses for detector config files
+- `file-stores/index.ts` has already fanned out any requested file contents as shared `File`
+  objects, so overlapping detector inputs are read at most once
 - `dependencyManifestStore` has already collected raw `package.json` contents, which
   `generatedSourceStore` reuses as task-invocation and fallback-config input
 
-So generated-source derivation still comes from the single shared walk. It just reuses the other
-stores as owners for inputs they already cache.
+So generated-source derivation still comes from the single shared walk. It just reuses the
+shared-walk snapshot plus the manifest-store inputs it already owns.
 
 This is also why the store now only runs when filesystem access is available. Request-only analyses do not execute generated-source derivation.
 
@@ -99,7 +99,7 @@ in-memory view containing:
 
 - walked directories
 - walked JS/TS source-file paths
-- preloaded detector-specific files captured by `generatedSourceStore`
+- preloaded detector-specific files captured during the shared walk
 - raw `package.json` files owned by `dependencyManifestStore`
 
 `deriveGeneratedSources()` then:

--- a/docs/node-analysis-caches.md
+++ b/docs/node-analysis-caches.md
@@ -144,9 +144,10 @@ tagged subset and generated-source telemetry are computed later in `analyzeProje
 
 During traversal it also collects a temporary project snapshot made of walked directories,
 walked JS/TS file paths matching the current suffix set, and a small detector-specific set of
-preloaded files. It reuses `sourceFileStore` for overlapping JS/TS config contents and
-`dependencyManifestStore` for raw `package.json` contents, then `postProcess()` derives the cached
-metadata from that combined in-memory snapshot.
+preloaded files. File reads are centralized in `file-stores/index.ts`, which reads each requested
+path at most once and passes the same shared `File` object to every interested store. The
+generated-source store also reuses `dependencyManifestStore` for raw `package.json` contents, then
+`postProcess()` derives the cached metadata from that combined in-memory snapshot.
 
 ## Initialization Flow
 
@@ -199,10 +200,9 @@ The walk is intentionally broader than the final analyzable source-file set beca
 - dependency manifests
 - parent-directory relationships
 
-The store order in `file-stores/index.ts` is intentional:
-
-- `sourceFileStore` runs before `generatedSourceStore` so detector config files can reuse cached JS/TS contents
-- `dependencyManifestStore` runs before `generatedSourceStore` so `package.json` ownership stays in one place
+For file entries, `initFileStores()` first asks each pending store whether it wants the path only or
+needs contents too. If any pending store needs contents, the file is read once and the same shared
+`File` object is passed to every interested store.
 
 ### Population Mode 2: Simulated Traversal From Explicit Request Files
 

--- a/packages/analysis/src/file-stores/dependency-manifests.ts
+++ b/packages/analysis/src/file-stores/dependency-manifests.ts
@@ -14,8 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { readFile } from 'node:fs/promises';
-import { warn, debug } from '../../../shared/src/helpers/logging.js';
+import { debug } from '../../../shared/src/helpers/logging.js';
 import type { FileStore } from './store-type.js';
 import {
   type File,
@@ -108,23 +107,16 @@ export class DependencyManifestStore implements FileStore {
     this.dirnameToParent.set(configuration.baseDir, undefined);
   }
 
-  async processFile(filename: NormalizedAbsolutePath) {
+  wantsFile(filename: NormalizedAbsolutePath, _configuration: Configuration) {
+    return isPreloadableDependencyManifestPath(filename) ? 'content' : false;
+  }
+
+  async processFile(filename: NormalizedAbsolutePath, _configuration: Configuration, file?: File) {
     if (!this.baseDir) {
       throw new Error(UNINITIALIZED_ERROR);
     }
-    if (!isPreloadableDependencyManifestPath(filename)) {
-      return;
-    }
-    try {
-      const content = await readFile(filename, 'utf-8');
-      const file = { content, path: filename };
-      const manifestName = getPreloadableDependencyManifestName(filename);
-      if (manifestName) {
-        this.manifestsByName[manifestName].set(dirnamePath(filename), file);
-      }
-    } catch (e) {
-      warn(`Error reading dependency manifest ${filename}: ${e}`);
-    }
+    const manifestName = getPreloadableDependencyManifestName(filename)!;
+    this.manifestsByName[manifestName].set(dirnamePath(filename), file!);
   }
 
   processDirectory(dir: NormalizedAbsolutePath) {

--- a/packages/analysis/src/file-stores/generated-sources/detectors/graphql-codegen-config.ts
+++ b/packages/analysis/src/file-stores/generated-sources/detectors/graphql-codegen-config.ts
@@ -30,11 +30,8 @@ const GRAPHQL_YAML_CONFIG_BASENAMES = new Set(['.graphqlrc', '.graphqlconfig']);
 const PACKAGE_JSON_BASENAME = 'package.json';
 
 export function parseGraphqlGeneratesFile(configFile: File) {
-  const configPath = configFile.path;
-  const configContents =
-    typeof configFile.content === 'string'
-      ? configFile.content
-      : configFile.content.toString('utf8');
+  const configPath = configFile.filePath;
+  const configContents = configFile.fileContent;
   const configBasename = basename(configPath).toLowerCase();
   const configExtension = extname(configPath).toLowerCase();
 

--- a/packages/analysis/src/file-stores/generated-sources/detectors/openapi-generator.ts
+++ b/packages/analysis/src/file-stores/generated-sources/detectors/openapi-generator.ts
@@ -162,11 +162,7 @@ function readOpenApiFilesManifest(
   const preloadedFile = projectSnapshot?.preloadedFiles.get(manifestPath);
 
   if (preloadedFile) {
-    return parseOpenApiFilesManifestContents(
-      typeof preloadedFile.content === 'string'
-        ? preloadedFile.content
-        : preloadedFile.content.toString('utf8'),
-    );
+    return parseOpenApiFilesManifestContents(preloadedFile.fileContent);
   }
 
   return undefined;

--- a/packages/analysis/src/file-stores/generated-sources/store.ts
+++ b/packages/analysis/src/file-stores/generated-sources/store.ts
@@ -17,7 +17,6 @@
 import { basename } from 'node:path/posix';
 import type { FileStore } from '../store-type.js';
 import type { DependencyManifestStore } from '../dependency-manifests.js';
-import type { SourceFileStore } from '../source-files.js';
 import {
   getProjectFileDiscoveryConfigKey,
   isJsTsFile,
@@ -45,14 +44,10 @@ import {
 } from './observability.js';
 import { shouldCaptureGeneratedSourceSnapshotPath } from './snapshot-files.js';
 
-type SourceFileContentLookup = Pick<SourceFileStore, 'getFileContent'>;
 type DependencyManifestLookup = Pick<DependencyManifestStore, 'getPackageJsons'>;
 
 export class GeneratedSourceStore implements FileStore {
-  constructor(
-    private readonly sourceFileStore: SourceFileContentLookup,
-    private readonly dependencyManifestStore: DependencyManifestLookup,
-  ) {}
+  constructor(private readonly dependencyManifestStore: DependencyManifestLookup) {}
 
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
@@ -170,23 +165,26 @@ export class GeneratedSourceStore implements FileStore {
     this.walkedDirectories.add(configuration.baseDir);
   }
 
-  async processFile(filename: NormalizedAbsolutePath, configuration: Configuration): Promise<void> {
+  wantsFile(filename: NormalizedAbsolutePath, configuration: Configuration) {
+    if (shouldCaptureGeneratedSourceSnapshotPath(filename)) {
+      return 'content';
+    }
+
+    return isJsTsFile(filename, configuration) ? 'path' : false;
+  }
+
+  async processFile(
+    filename: NormalizedAbsolutePath,
+    configuration: Configuration,
+    file?: File,
+  ): Promise<void> {
     if (isJsTsFile(filename, configuration)) {
       this.sourceFiles.add(filename);
     }
 
-    if (this.canAccessFileSystem === false) {
-      return;
+    if (file) {
+      this.preloadedFiles.set(filename, file);
     }
-
-    if (!shouldCaptureGeneratedSourceSnapshotPath(filename)) {
-      return;
-    }
-
-    this.preloadedFiles.set(filename, {
-      content: await this.sourceFileStore.getFileContent(filename),
-      path: filename,
-    });
   }
 
   processDirectory(dir: NormalizedAbsolutePath) {
@@ -270,7 +268,7 @@ export class GeneratedSourceStore implements FileStore {
 
   private addPackageJsonsToSnapshot(packageJsons: ReadonlyMap<NormalizedAbsolutePath, File>) {
     for (const file of packageJsons.values()) {
-      this.preloadedFiles.set(file.path, file);
+      this.preloadedFiles.set(file.filePath, file);
     }
   }
 

--- a/packages/analysis/src/file-stores/index.ts
+++ b/packages/analysis/src/file-stores/index.ts
@@ -136,12 +136,10 @@ async function processPendingFileStores(
   for (const store of pendingStores) {
     const storeWantsFile = store.wantsFile(filePath, configuration);
     if (storeWantsFile === 'content') {
-      if (sharedFile === undefined) {
-        sharedFile = {
-          filePath,
-          fileContent: fileContent ?? (await readFile(filePath)),
-        };
-      }
+      sharedFile ??= {
+        filePath,
+        fileContent: fileContent ?? (await readFile(filePath)),
+      };
       await store.processFile(filePath, configuration, sharedFile);
     } else if (storeWantsFile === 'path') {
       await store.processFile(filePath, configuration);

--- a/packages/analysis/src/file-stores/index.ts
+++ b/packages/analysis/src/file-stores/index.ts
@@ -29,7 +29,6 @@ import {
   dirnamePath,
 } from '../../../shared/src/helpers/files.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
-import { warn } from '../../../shared/src/helpers/logging.js';
 
 export const sourceFileStore = new SourceFileStore();
 export const dependencyManifestStore = new DependencyManifestStore();
@@ -160,10 +159,5 @@ async function createSharedFile(
     return { filePath, fileContent };
   }
 
-  try {
-    return { filePath, fileContent: await readFile(filePath) };
-  } catch (error) {
-    warn(`Error reading file ${filePath}: ${error}`);
-    return undefined;
-  }
+  return { filePath, fileContent: await readFile(filePath) };
 }

--- a/packages/analysis/src/file-stores/index.ts
+++ b/packages/analysis/src/file-stores/index.ts
@@ -23,25 +23,22 @@ import type { FileStore } from './store-type.js';
 import type { Configuration } from '../common/configuration.js';
 import {
   isRoot,
+  readFile,
+  type File,
   type NormalizedAbsolutePath,
   dirnamePath,
 } from '../../../shared/src/helpers/files.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
+import { warn } from '../../../shared/src/helpers/logging.js';
 
 export const sourceFileStore = new SourceFileStore();
 export const dependencyManifestStore = new DependencyManifestStore();
-export const generatedSourceStore = new GeneratedSourceStore(
-  sourceFileStore,
-  dependencyManifestStore,
-);
+export const generatedSourceStore = new GeneratedSourceStore(dependencyManifestStore);
 export const tsConfigStore = new TsConfigStore();
 
 const fileStores: FileStore[] = [
   sourceFileStore,
   dependencyManifestStore,
-  // Order matters: generatedSourceStore reuses sourceFileStore content for overlapping
-  // JS/TS config files and dependencyManifestStore package.json contents, so both stores
-  // must run before generatedSourceStore.
   generatedSourceStore,
   tsConfigStore,
 ];
@@ -72,14 +69,15 @@ export async function initFileStores(configuration: Configuration, inputFiles?: 
   }
 
   if (canAccessFileSystem) {
-    await findFiles(baseDir, jsTsExclusions, async (file, filePath) => {
+    await findFiles(baseDir, jsTsExclusions, async (entry, filePath) => {
       for (const store of pendingStores) {
-        if (file.isFile()) {
-          await store.processFile(filePath, configuration);
-        }
-        if (file.isDirectory()) {
+        if (entry.isDirectory()) {
           store.processDirectory?.(filePath, configuration);
         }
+      }
+
+      if (entry.isFile()) {
+        await processPendingFileStores(pendingStores, filePath, configuration);
       }
     });
   } else if (inputFiles) {
@@ -116,9 +114,56 @@ export async function simulateFromInputFiles(
         store.processDirectory(dir, configuration);
       }
     }
-    //files need to be processed after as ignored files logic depends on ignored paths being ingested
-    for (const filePath of filePaths) {
+  }
+
+  // files need to be processed after as ignored files logic depends on ignored paths being ingested
+  for (const filePath of filePaths) {
+    await processPendingFileStores(
+      pendingStores,
+      filePath,
+      configuration,
+      inputFiles[filePath].fileContent,
+    );
+  }
+}
+
+async function processPendingFileStores(
+  pendingStores: FileStore[],
+  filePath: NormalizedAbsolutePath,
+  configuration: Configuration,
+  fileContent?: string,
+) {
+  let file: File | undefined = undefined;
+  let fileResolved = false;
+  for (const store of pendingStores) {
+    const storeWantsFile = store.wantsFile(filePath, configuration);
+    if (storeWantsFile === 'content') {
+      if (!fileResolved) {
+        file = await createSharedFile(filePath, fileContent);
+        fileResolved = true;
+      }
+
+      if (file !== undefined) {
+        await store.processFile(filePath, configuration, file);
+      }
+    } else if (storeWantsFile === 'path') {
       await store.processFile(filePath, configuration);
     }
+  }
+}
+
+async function createSharedFile(
+  filePath: NormalizedAbsolutePath,
+  fileContent?: string,
+): Promise<File | undefined> {
+  if (fileContent !== undefined) {
+    return { filePath, fileContent };
+  }
+
+  try {
+    return { filePath, fileContent: await readFile(filePath) };
+  } catch (error) {
+    warn(`Error reading file ${filePath}: ${error}`);
+    return undefined;
   }
 }

--- a/packages/analysis/src/file-stores/index.ts
+++ b/packages/analysis/src/file-stores/index.ts
@@ -132,32 +132,19 @@ async function processPendingFileStores(
   configuration: Configuration,
   fileContent?: string,
 ) {
-  let file: File | undefined = undefined;
-  let fileResolved = false;
+  let sharedFile: File | undefined;
   for (const store of pendingStores) {
     const storeWantsFile = store.wantsFile(filePath, configuration);
     if (storeWantsFile === 'content') {
-      if (!fileResolved) {
-        file = await createSharedFile(filePath, fileContent);
-        fileResolved = true;
+      if (sharedFile === undefined) {
+        sharedFile = {
+          filePath,
+          fileContent: fileContent ?? (await readFile(filePath)),
+        };
       }
-
-      if (file !== undefined) {
-        await store.processFile(filePath, configuration, file);
-      }
+      await store.processFile(filePath, configuration, sharedFile);
     } else if (storeWantsFile === 'path') {
       await store.processFile(filePath, configuration);
     }
   }
-}
-
-async function createSharedFile(
-  filePath: NormalizedAbsolutePath,
-  fileContent?: string,
-): Promise<File | undefined> {
-  if (fileContent !== undefined) {
-    return { filePath, fileContent };
-  }
-
-  return { filePath, fileContent: await readFile(filePath) };
 }

--- a/packages/analysis/src/file-stores/source-files.ts
+++ b/packages/analysis/src/file-stores/source-files.ts
@@ -36,6 +36,7 @@ import {
 } from '../../../shared/src/helpers/files.js';
 import { filterPathAndGetFileType } from '../common/filter/filter-path.js';
 import { dirname } from 'node:path/posix';
+import type { FileType } from '../contracts/file.js';
 
 export const UNINITIALIZED_ERROR = 'Files cache has not been initialized. Call loadFiles() first.';
 
@@ -44,6 +45,7 @@ export class SourceFileStore implements FileStore {
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
   private readonly ignoredPaths = new Set<string>();
+  private readonly pendingFileTypes = new Map<NormalizedAbsolutePath, FileType>();
   private files: AnalyzableFiles | undefined = undefined;
   private readonly directoryIndex = new DirectoryIndex();
 
@@ -96,6 +98,7 @@ export class SourceFileStore implements FileStore {
     this.analyzableFilesConfigKey = undefined;
     this.files = undefined;
     this.ignoredPaths.clear();
+    this.pendingFileTypes.clear();
     this.directoryIndex.clear();
   }
 
@@ -108,15 +111,24 @@ export class SourceFileStore implements FileStore {
 
   wantsFile(filename: NormalizedAbsolutePath, configuration: Configuration) {
     const shouldIgnoreParams = getShouldIgnoreParams(configuration);
-    return isAnalyzableFile(filename, shouldIgnoreParams) &&
-      !this.anyParentIsIgnored(filename) &&
-      filterPathAndGetFileType(filename, getFilterPathParams(configuration))
-      ? 'content'
-      : false;
+    if (!isAnalyzableFile(filename, shouldIgnoreParams) || this.anyParentIsIgnored(filename)) {
+      return false;
+    }
+
+    const fileType = filterPathAndGetFileType(filename, getFilterPathParams(configuration));
+    if (!fileType) {
+      return false;
+    }
+
+    this.pendingFileTypes.set(filename, fileType);
+    return 'content';
   }
 
   async processFile(filename: NormalizedAbsolutePath, configuration: Configuration, file?: File) {
-    const fileType = filterPathAndGetFileType(filename, getFilterPathParams(configuration));
+    const fileType =
+      this.pendingFileTypes.get(filename) ??
+      filterPathAndGetFileType(filename, getFilterPathParams(configuration));
+    this.pendingFileTypes.delete(filename);
     // we don't call shouldIgnoreFile because the isJsTsExcluded method has already been
     // called while walking the project tree
     if (
@@ -142,7 +154,7 @@ export class SourceFileStore implements FileStore {
   }
 
   async postProcess(_configuration: Configuration) {
-    // No-op: files are added directly in processFile()
+    this.pendingFileTypes.clear();
   }
 
   private anyParentIsIgnored(filePath: NormalizedAbsolutePath) {

--- a/packages/analysis/src/file-stores/source-files.ts
+++ b/packages/analysis/src/file-stores/source-files.ts
@@ -14,7 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { type AnalyzableFiles, createAnalyzableFiles } from '../projectAnalysis.js';
+import {
+  type AnalyzableFiles,
+  createAnalyzableFiles,
+  promoteToAnalyzableFile,
+} from '../projectAnalysis.js';
 import { JSTS_ANALYSIS_DEFAULTS } from '../jsts/analysis/analysis.js';
 import {
   isAnalyzableFile,
@@ -26,9 +30,9 @@ import {
 import type { FileStore } from './store-type.js';
 import { accept } from '../common/filter/filter.js';
 import {
-  readFile,
   DirectoryIndex,
   type NormalizedAbsolutePath,
+  type File,
 } from '../../../shared/src/helpers/files.js';
 import { filterPathAndGetFileType } from '../common/filter/filter-path.js';
 import { dirname } from 'node:path/posix';
@@ -102,23 +106,31 @@ export class SourceFileStore implements FileStore {
     this.files = createAnalyzableFiles();
   }
 
-  async processFile(filename: NormalizedAbsolutePath, configuration: Configuration) {
+  wantsFile(filename: NormalizedAbsolutePath, configuration: Configuration) {
     const shouldIgnoreParams = getShouldIgnoreParams(configuration);
-    if (isAnalyzableFile(filename, shouldIgnoreParams) && !this.anyParentIsIgnored(filename)) {
-      const fileContent = await this.getFileContent(filename);
-      const fileType = filterPathAndGetFileType(filename, getFilterPathParams(configuration));
-      // we don't call shouldIgnoreFile because the isJsTsExcluded method has already been
-      // called while walking the project tree
-      if (fileType && accept(filename, fileContent, shouldIgnoreParams)) {
-        // Files discovered from filesystem (not from request) default to 'SAME' status
-        this.files![filename] = {
-          fileType,
-          filePath: filename,
-          fileContent,
-          fileStatus: JSTS_ANALYSIS_DEFAULTS.fileStatus,
-        };
-        this.directoryIndex.addFile(filename);
-      }
+    return isAnalyzableFile(filename, shouldIgnoreParams) &&
+      !this.anyParentIsIgnored(filename) &&
+      filterPathAndGetFileType(filename, getFilterPathParams(configuration))
+      ? 'content'
+      : false;
+  }
+
+  async processFile(filename: NormalizedAbsolutePath, configuration: Configuration, file?: File) {
+    const fileType = filterPathAndGetFileType(filename, getFilterPathParams(configuration));
+    // we don't call shouldIgnoreFile because the isJsTsExcluded method has already been
+    // called while walking the project tree
+    if (
+      file &&
+      fileType &&
+      accept(filename, file.fileContent, getShouldIgnoreParams(configuration))
+    ) {
+      // Promote the shared walk entry in place so helper stores can reuse the same object.
+      this.files![filename] = promoteToAnalyzableFile(
+        file,
+        fileType,
+        JSTS_ANALYSIS_DEFAULTS.fileStatus,
+      );
+      this.directoryIndex.addFile(filename);
     }
   }
 
@@ -127,11 +139,6 @@ export class SourceFileStore implements FileStore {
     if (this.anyParentIsIgnored(dir) || isExcludedPath) {
       this.ignoredPaths.add(dir);
     }
-  }
-
-  // we check if we already have the contents in the files cache before reading FS
-  async getFileContent(filePath: NormalizedAbsolutePath) {
-    return this.files?.[filePath]?.fileContent ?? (await readFile(filePath));
   }
 
   async postProcess(_configuration: Configuration) {

--- a/packages/analysis/src/file-stores/source-files.ts
+++ b/packages/analysis/src/file-stores/source-files.ts
@@ -45,7 +45,8 @@ export class SourceFileStore implements FileStore {
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
   private readonly ignoredPaths = new Set<string>();
-  private readonly pendingFileTypes = new Map<NormalizedAbsolutePath, FileType>();
+  private pendingFileType: { filePath: NormalizedAbsolutePath; fileType: FileType } | undefined =
+    undefined;
   private files: AnalyzableFiles | undefined = undefined;
   private readonly directoryIndex = new DirectoryIndex();
 
@@ -98,7 +99,7 @@ export class SourceFileStore implements FileStore {
     this.analyzableFilesConfigKey = undefined;
     this.files = undefined;
     this.ignoredPaths.clear();
-    this.pendingFileTypes.clear();
+    this.pendingFileType = undefined;
     this.directoryIndex.clear();
   }
 
@@ -120,15 +121,17 @@ export class SourceFileStore implements FileStore {
       return false;
     }
 
-    this.pendingFileTypes.set(filename, fileType);
+    this.pendingFileType = { filePath: filename, fileType };
     return 'content';
   }
 
   async processFile(filename: NormalizedAbsolutePath, configuration: Configuration, file?: File) {
+    const pendingFileType = this.pendingFileType;
+    this.pendingFileType = undefined;
     const fileType =
-      this.pendingFileTypes.get(filename) ??
-      filterPathAndGetFileType(filename, getFilterPathParams(configuration));
-    this.pendingFileTypes.delete(filename);
+      pendingFileType?.filePath === filename
+        ? pendingFileType.fileType
+        : filterPathAndGetFileType(filename, getFilterPathParams(configuration));
     // we don't call shouldIgnoreFile because the isJsTsExcluded method has already been
     // called while walking the project tree
     if (
@@ -154,7 +157,7 @@ export class SourceFileStore implements FileStore {
   }
 
   async postProcess(_configuration: Configuration) {
-    this.pendingFileTypes.clear();
+    this.pendingFileType = undefined;
   }
 
   private anyParentIsIgnored(filePath: NormalizedAbsolutePath) {

--- a/packages/analysis/src/file-stores/store-type.ts
+++ b/packages/analysis/src/file-stores/store-type.ts
@@ -14,9 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
+import type { File, NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
 import type { Configuration } from '../common/configuration.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
+
+export type FileProcessingMode = 'path' | 'content';
 
 export abstract class FileStore {
   /**
@@ -37,9 +39,15 @@ export abstract class FileStore {
    */
   abstract setup(configuration: Configuration): void;
 
+  abstract wantsFile(
+    filename: NormalizedAbsolutePath,
+    configuration: Configuration,
+  ): FileProcessingMode | false;
+
   abstract processFile(
     filename: NormalizedAbsolutePath,
     configuration: Configuration,
+    file?: File,
   ): Promise<void>;
 
   /**

--- a/packages/analysis/src/file-stores/tsconfigs.ts
+++ b/packages/analysis/src/file-stores/tsconfigs.ts
@@ -18,7 +18,7 @@ import { debug, error, info } from '../../../shared/src/helpers/logging.js';
 import { basename } from 'node:path/posix';
 import { Minimatch } from 'minimatch';
 import type { FileStore } from './store-type.js';
-import type { NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
+import type { File, NormalizedAbsolutePath } from '../../../shared/src/helpers/files.js';
 import { type Configuration, getProjectFileDiscoveryConfigKey } from '../common/configuration.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 import { clearTsConfigContentCache } from '../jsts/program/cache/tsconfigCache.js';
@@ -151,7 +151,13 @@ export class TsConfigStore implements FileStore {
     return tsConfigPaths.join(',');
   }
 
-  async processFile(filename: NormalizedAbsolutePath, _configuration: Configuration) {
+  wantsFile(filename: NormalizedAbsolutePath, _configuration: Configuration) {
+    return this.filenameMatchesProvidedTsConfig(filename) || this.filenameMatchesTsConfig(filename)
+      ? 'path'
+      : false;
+  }
+
+  async processFile(filename: NormalizedAbsolutePath, _configuration: Configuration, _file?: File) {
     if (this.filenameMatchesProvidedTsConfig(filename)) {
       this.foundPropertyTsConfigs.push(filename);
     }

--- a/packages/analysis/src/jsts/rules/S6647/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6647/unit.test.ts
@@ -21,9 +21,9 @@ import { rules } from '../external/typescript-eslint/index.js';
 import parser from '@babel/eslint-parser';
 import { decorate } from './decorator.js';
 import { Linter } from 'eslint';
-import { readFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { expect } from 'expect';
+import { normalizeToAbsolutePath, readFile } from '../../../../../shared/src/helpers/files.js';
 
 const ruleTester = new RuleTester({
   parser,
@@ -37,8 +37,10 @@ describe('S6647', async () => {
   // When this test fails to pass, we can remove our implementation and go back to decorated
   // 'no-useless-constructor' from 'typescript-eslint'
   // https://github.com/SonarSource/SonarJS/pull/4473
-  const problemFile = join(import.meta.dirname, 'fixtures', 'problemCode.js');
-  const problemCode = await readFile(problemFile, 'utf8');
+  const problemFile = normalizeToAbsolutePath(
+    join(import.meta.dirname, 'fixtures', 'problemCode.js'),
+  );
+  const problemCode = await readFile(problemFile);
 
   it('S6647', () => {
     ruleTester.run(`Unnecessary constructors should be removed`, rule, {

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/closest.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/closest.ts
@@ -30,7 +30,7 @@ export function getClosestDependencyManifestDir(
     const manifestPath = closestPatternCache
       .get(manifestName)
       .get(topDir ?? getPathRoot(dir))
-      .get(dir)?.path;
+      .get(dir)?.filePath;
 
     // All candidates are on the same ancestor chain of `dir`, so the longest path is the closest.
     if (

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts
@@ -281,13 +281,13 @@ function getTypeScriptVersionSignalsFromPackageJson(packageJson: PackageJson): s
 }
 
 export function getTypeScriptSignalsFromPackageJsonFiles(
-  packageJsonFiles: Iterable<{ content: string | Buffer }>,
+  packageJsonFiles: Iterable<{ fileContent: string }>,
 ): { typeScriptVersionSignals: string[]; hasTypeScriptNativePreview: boolean } {
   const typeScriptVersionSignals: string[] = [];
   let hasTypeScriptNativePreview = false;
 
   for (const packageJsonFile of packageJsonFiles) {
-    const packageJson = parsePackageJsonContent(packageJsonFile.content);
+    const packageJson = parsePackageJsonContent(packageJsonFile.fileContent);
     if (packageJson === undefined) {
       continue;
     }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parsed-dependency-files.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/parsed-dependency-files.ts
@@ -35,7 +35,7 @@ function getOrSetParsedDependencyFile<T>(
   file: File,
   parse: (file: File) => T | undefined,
 ): T | undefined {
-  const cacheKey = normalizeToAbsolutePath(file.path);
+  const cacheKey = normalizeToAbsolutePath(file.filePath);
   if (cache.has(cacheKey)) {
     return cache.get(cacheKey);
   }
@@ -46,17 +46,16 @@ function getOrSetParsedDependencyFile<T>(
 
 export function parsePackageJson(file: File): PackageJson | undefined {
   return getOrSetParsedDependencyFile(parsedPackageJsonCache, file, file =>
-    parsePackageJsonContent(file.content, file.path),
+    parsePackageJsonContent(file.fileContent, file.filePath),
   );
 }
 
 export function parsePackageJsonContent(
-  content: string | Buffer,
+  content: string,
   filePath?: string,
 ): PackageJson | undefined {
-  const packageJsonContent = typeof content === 'string' ? content : content.toString();
   try {
-    return JSON.parse(stripBOM(packageJsonContent)) as PackageJson;
+    return JSON.parse(stripBOM(content)) as PackageJson;
   } catch (error) {
     if (filePath) {
       console.debug(`Error parsing package.json ${filePath}: ${error}`);
@@ -71,7 +70,7 @@ export function parsePnpmWorkspace(file: File): Workspace | undefined {
 
 function parsePnpmWorkspaceContent(file: File): Workspace | undefined {
   try {
-    const parsedPnpm = yaml.parse(file.content.toString());
+    const parsedPnpm = yaml.parse(file.fileContent);
     if (
       parsedPnpm &&
       ('catalog' in parsedPnpm || 'catalogs' in parsedPnpm || 'packages' in parsedPnpm)
@@ -80,7 +79,7 @@ function parsePnpmWorkspaceContent(file: File): Workspace | undefined {
     }
     return undefined;
   } catch (error) {
-    console.debug(`Error parsing pnpm workspace ${file.path}: ${error}`);
+    console.debug(`Error parsing pnpm workspace ${file.filePath}: ${error}`);
     return undefined;
   }
 }
@@ -92,15 +91,15 @@ export function parseDenoManifest(file: File): DenoJson | undefined {
 function parseDenoManifestContent(file: File): DenoJson | undefined {
   try {
     // ts.parseConfigFileTextToJson handles JSON with comments and trailing commas
-    const parsed = ts.parseConfigFileTextToJson(file.path, stripBOM(file.content.toString()));
+    const parsed = ts.parseConfigFileTextToJson(file.filePath, stripBOM(file.fileContent));
     if (parsed.error) {
       const message = ts.flattenDiagnosticMessageText(parsed.error.messageText, '\n');
-      console.debug(`Error parsing deno manifest ${file.path}: ${message}`);
+      console.debug(`Error parsing deno manifest ${file.filePath}: ${message}`);
       return;
     }
     return parsed.config as DenoJson;
   } catch (error) {
-    console.debug(`Error parsing deno manifest ${file.path}: ${error}`);
+    console.debug(`Error parsing deno manifest ${file.filePath}: ${error}`);
     return;
   }
 }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/helpers.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/helpers.ts
@@ -28,7 +28,7 @@ export function getManifestFileInDir(
   fileSystem?: Filesystem,
 ): File | undefined {
   const file = closestPatternCache.get(manifestName, fileSystem).get(topDir).get(dir);
-  if (file && dirnamePath(file.path) === dir) {
+  if (file && dirnamePath(file.filePath) === dir) {
     return file;
   }
   return undefined;

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/package-json.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/package-json.ts
@@ -202,7 +202,7 @@ function findClosestParentPackageJsonWithCatalogs(
       return parsed;
     }
 
-    const fileDir = dirnamePath(file.path);
+    const fileDir = dirnamePath(file.filePath);
     if (fileDir === topDir) {
       return undefined;
     }

--- a/packages/analysis/src/jsts/rules/helpers/files.ts
+++ b/packages/analysis/src/jsts/rules/helpers/files.ts
@@ -33,8 +33,8 @@ export type NormalizedAbsolutePath = string & {
   readonly __normalizedAbsolutePathBrand: 'NormalizedAbsolutePath';
 };
 export type File = {
-  readonly path: NormalizedAbsolutePath;
-  readonly content: Buffer | string;
+  readonly filePath: NormalizedAbsolutePath;
+  readonly fileContent: string;
 };
 
 /**

--- a/packages/analysis/src/jsts/rules/helpers/find-up/find-minimatch.ts
+++ b/packages/analysis/src/jsts/rules/helpers/find-up/find-minimatch.ts
@@ -55,8 +55,8 @@ export const MinimatchCache = new ComputedCache<
 
           if (stats.isFile()) {
             files.push({
-              path: fullEntryPath,
-              content: filesystem.readFileSync(fullEntryPath),
+              filePath: fullEntryPath,
+              fileContent: filesystem.readFileSync(fullEntryPath, 'utf8'),
             });
           }
         }

--- a/packages/analysis/src/projectAnalysis.ts
+++ b/packages/analysis/src/projectAnalysis.ts
@@ -19,7 +19,7 @@ import type { RuleConfig } from './jsts/linter/config/rule-config.js';
 import type { RuleConfig as CssRuleConfig } from './css/linter/config.js';
 import type { EmbeddedAnalysisOutput } from './jsts/embedded/analysis/analysis.js';
 import type { CssAnalysisOutput } from './css/analysis/analysis.js';
-import type { NormalizedAbsolutePath } from '../../shared/src/helpers/files.js';
+import type { File, NormalizedAbsolutePath } from '../../shared/src/helpers/files.js';
 import type { ProjectAnalysisTelemetry } from './telemetry.js';
 import type { ParsingError } from './contracts/project-analysis.js';
 import type { FileType } from './contracts/file.js';
@@ -59,9 +59,7 @@ type FileErrorResult = { error: string };
  * Contains the per-file fields needed for storage and analysis.
  * The remaining fields are filled from configuration when actually analyzing the file.
  */
-export type AnalyzableFile = {
-  filePath: NormalizedAbsolutePath;
-  fileContent: string;
+export type AnalyzableFile = File & {
   fileType: FileType;
   fileStatus: FileStatus;
 };
@@ -82,6 +80,17 @@ export type AnalyzableFiles = { [key: NormalizedAbsolutePath]: AnalyzableFile } 
  */
 export function createAnalyzableFiles(): AnalyzableFiles {
   return {} as AnalyzableFiles;
+}
+
+/**
+ * Promotes a shared file-walk entry into an analyzable source file without creating a wrapper.
+ */
+export function promoteToAnalyzableFile(
+  file: File,
+  fileType: FileType,
+  fileStatus: FileStatus,
+): AnalyzableFile {
+  return Object.assign(file, { fileType, fileStatus });
 }
 
 /**

--- a/packages/analysis/src/telemetry.ts
+++ b/packages/analysis/src/telemetry.ts
@@ -330,7 +330,7 @@ function resolveTypeScriptVersion(typeScriptSignal: string): string | undefined 
   }
 }
 
-function getPackageJsonFiles(): Iterable<{ content: string | Buffer }> {
+function getPackageJsonFiles(): Iterable<{ fileContent: string }> {
   try {
     return dependencyManifestStore.getPackageJsons().values();
   } catch {

--- a/packages/analysis/tests/dependency-manifests.test.ts
+++ b/packages/analysis/tests/dependency-manifests.test.ts
@@ -20,8 +20,7 @@ import { join, dirname } from 'node:path/posix';
 import fs from 'node:fs';
 import yaml from 'yaml';
 import { initFileStores, dependencyManifestStore } from '../src/file-stores/index.js';
-import { readFile } from 'node:fs/promises';
-import { normalizeToAbsolutePath } from '../../shared/src/helpers/files.js';
+import { normalizeToAbsolutePath, readFile } from '../../shared/src/helpers/files.js';
 import { createConfiguration } from '../src/common/configuration.js';
 import { UNINITIALIZED_ERROR } from '../src/file-stores/dependency-manifests.js';
 import {
@@ -68,15 +67,15 @@ describe('files', () => {
     const baseDir = normalizeToAbsolutePath(join(fixtures, 'dependencies'));
     const configuration = createConfiguration({ baseDir });
     await initFileStores(configuration);
-    const path = join(fixtures, 'dependencies', 'package.json');
-    const content = await readFile(path, 'utf-8');
+    const path = normalizeToAbsolutePath(join(fixtures, 'dependencies', 'package.json'));
+    const content = await readFile(path);
     expect(dependencyManifestStore.getPackageJsons()).toEqual(
       new Map([
         [
           dirname(path),
           {
-            path,
-            content,
+            filePath: path,
+            fileContent: content,
           },
         ],
       ]),
@@ -109,7 +108,7 @@ describe('files', () => {
     await initFileStores(configuration);
 
     expect(closestPnpmWorkspaceCache.has(baseDir)).toEqual(true);
-    expect(closestPnpmWorkspaceCache.get(baseDir).get(baseDir)?.path).toEqual(
+    expect(closestPnpmWorkspaceCache.get(baseDir).get(baseDir)?.filePath).toEqual(
       join(baseDir, PNPM_WORKSPACE_YAML),
     );
   });
@@ -139,8 +138,8 @@ describe('files', () => {
   it('should fill package.json parent caches correctly even when dirs are registered child-first', async () => {
     const baseDir = normalizeToAbsolutePath(join(fixtures, 'child-parent-merge'));
     const subDir = normalizeToAbsolutePath(join(baseDir, 'subdir'));
-    const parentContent = await readFile(join(baseDir, 'package.json'), 'utf-8');
-    const childContent = await readFile(join(subDir, 'package.json'), 'utf-8');
+    const parentContent = await readFile(normalizeToAbsolutePath(join(baseDir, 'package.json')));
+    const childContent = await readFile(normalizeToAbsolutePath(join(subDir, 'package.json')));
 
     fillManifestCaches(
       PACKAGE_JSON,
@@ -148,15 +147,15 @@ describe('files', () => {
         [
           subDir,
           {
-            path: normalizeToAbsolutePath(join(subDir, 'package.json')),
-            content: childContent,
+            filePath: normalizeToAbsolutePath(join(subDir, 'package.json')),
+            fileContent: childContent,
           },
         ],
         [
           baseDir,
           {
-            path: normalizeToAbsolutePath(join(baseDir, 'package.json')),
-            content: parentContent,
+            filePath: normalizeToAbsolutePath(join(baseDir, 'package.json')),
+            fileContent: parentContent,
           },
         ],
       ]),

--- a/packages/analysis/tests/dependency-manifests.test.ts
+++ b/packages/analysis/tests/dependency-manifests.test.ts
@@ -116,18 +116,22 @@ describe('files', () => {
   it('should warm package.json caches without sync filesystem fallbacks', async ({ mock }) => {
     const baseDir = normalizeToAbsolutePath(join(fixtures, 'child-parent-merge'));
     const configuration = createConfiguration({ baseDir });
+    const packageJsonPath = normalizeToAbsolutePath(join(baseDir, 'package.json'));
+    const childPackageJsonPath = normalizeToAbsolutePath(join(baseDir, 'subdir/package.json'));
     const readdirSyncSpy = mock.method(fs, 'readdirSync');
     const readFileSyncSpy = mock.method(fs, 'readFileSync');
     const statSyncSpy = mock.method(fs, 'statSync');
 
     dependencyManifestStore.setup(configuration);
     dependencyManifestStore.processDirectory(normalizeToAbsolutePath(join(baseDir, 'subdir')));
-    await dependencyManifestStore.processFile(
-      normalizeToAbsolutePath(join(baseDir, 'package.json')),
-    );
-    await dependencyManifestStore.processFile(
-      normalizeToAbsolutePath(join(baseDir, 'subdir/package.json')),
-    );
+    await dependencyManifestStore.processFile(packageJsonPath, configuration, {
+      filePath: packageJsonPath,
+      fileContent: await readFile(packageJsonPath),
+    });
+    await dependencyManifestStore.processFile(childPackageJsonPath, configuration, {
+      filePath: childPackageJsonPath,
+      fileContent: await readFile(childPackageJsonPath),
+    });
     await dependencyManifestStore.postProcess(configuration);
 
     expect(readdirSyncSpy.mock.calls).toHaveLength(0);

--- a/packages/analysis/tests/file-stores.test.ts
+++ b/packages/analysis/tests/file-stores.test.ts
@@ -17,6 +17,7 @@
 // Mock FileStore implementation
 import { beforeEach, describe, it } from 'node:test';
 import { expect } from 'expect';
+import fs from 'node:fs';
 import { join } from 'node:path/posix';
 import { FileStore, type FileProcessingMode } from '../src/file-stores/store-type.js';
 import {
@@ -285,5 +286,35 @@ describe('initFileStores', () => {
 
     expect(setupMock.mock.calls).toHaveLength(0);
     expect(postProcessMock.mock.calls).toHaveLength(0);
+  });
+
+  it('should fail when an analyzable source file cannot be read', async ({ mock }) => {
+    const baseDir = normalizeToAbsolutePath(join(import.meta.dirname, 'fixtures-package-jsons'));
+    const fixtureDir = normalizeToAbsolutePath(join(baseDir, 'dependencies'));
+    const configuration = createConfiguration({ baseDir: fixtureDir });
+    const originalReadFile = fs.promises.readFile;
+    mock.method(fs.promises, 'readFile', async (path, options) => {
+      if (path === normalizeToAbsolutePath(join(fixtureDir, 'index.js'))) {
+        throw new Error('boom');
+      }
+      return Reflect.apply(originalReadFile, fs.promises, [path, options]);
+    });
+
+    await expect(initFileStores(configuration)).rejects.toThrow('boom');
+  });
+
+  it('should fail when a helper file cannot be read', async ({ mock }) => {
+    const baseDir = normalizeToAbsolutePath(join(import.meta.dirname, 'fixtures-package-jsons'));
+    const fixtureDir = normalizeToAbsolutePath(join(baseDir, 'dependencies'));
+    const configuration = createConfiguration({ baseDir: fixtureDir });
+    const originalReadFile = fs.promises.readFile;
+    mock.method(fs.promises, 'readFile', async (path, options) => {
+      if (path === normalizeToAbsolutePath(join(fixtureDir, 'package.json'))) {
+        throw new Error('boom');
+      }
+      return Reflect.apply(originalReadFile, fs.promises, [path, options]);
+    });
+
+    await expect(initFileStores(configuration)).rejects.toThrow('boom');
   });
 });

--- a/packages/analysis/tests/file-stores.test.ts
+++ b/packages/analysis/tests/file-stores.test.ts
@@ -18,8 +18,12 @@
 import { beforeEach, describe, it } from 'node:test';
 import { expect } from 'expect';
 import { join } from 'node:path/posix';
-import { FileStore } from '../src/file-stores/store-type.js';
-import { normalizePath, normalizeToAbsolutePath } from '../../shared/src/helpers/files.js';
+import { FileStore, type FileProcessingMode } from '../src/file-stores/store-type.js';
+import {
+  normalizePath,
+  normalizeToAbsolutePath,
+  type File,
+} from '../../shared/src/helpers/files.js';
 import { createConfiguration, type Configuration } from '../src/common/configuration.js';
 import type { AnalyzableFiles } from '../src/projectAnalysis.js';
 import { sanitizeRawInputFiles } from '../src/common/input-sanitize.js';
@@ -36,8 +40,11 @@ const sourceFileFixtures = normalizeToAbsolutePath(
 );
 
 class MockFileStore implements FileStore {
+  constructor(private readonly fileRequest: FileProcessingMode | false = 'path') {}
+
   public processedDirectories: string[] = [];
   public processedFiles: string[] = [];
+  public receivedFiles: Array<File | undefined> = [];
   public setupCalled = false;
   public postProcessCalled = false;
 
@@ -52,12 +59,17 @@ class MockFileStore implements FileStore {
     this.setupCalled = true;
   }
 
+  wantsFile(_filename: string, _configuration: Configuration): FileProcessingMode | false {
+    return this.fileRequest;
+  }
+
   processDirectory(dir: string): void {
     this.processedDirectories.push(dir);
   }
 
-  async processFile(filename: string, _configuration: Configuration): Promise<void> {
+  async processFile(filename: string, _configuration: Configuration, file?: File): Promise<void> {
     this.processedFiles.push(filename);
+    this.receivedFiles.push(file);
   }
 
   async postProcess(_configuration: Configuration): Promise<void> {
@@ -125,7 +137,14 @@ describe('simulateFromInputFiles', () => {
         return false;
       }
       setup(_configuration: Configuration): void {}
-      async processFile(filename: string, _configuration: Configuration): Promise<void> {
+      wantsFile(_filename: string, _configuration: Configuration): FileProcessingMode | false {
+        return 'path';
+      }
+      async processFile(
+        filename: string,
+        _configuration: Configuration,
+        _file?: File,
+      ): Promise<void> {
         this.processedFiles.push(filename);
       }
       async postProcess(_configuration: Configuration): Promise<void> {}
@@ -188,6 +207,57 @@ describe('simulateFromInputFiles', () => {
 
     expect(mockStore1.processedFiles).toContain(normalizePath('/project/src/app.js'));
     expect(mockStore2.processedFiles).toContain(normalizePath('/project/src/app.js'));
+  });
+
+  it('should share the same file object across content stores', async () => {
+    const mockStore1 = new MockFileStore('content');
+    const mockStore2 = new MockFileStore('content');
+    const configuration = createConfiguration({
+      baseDir: normalizeToAbsolutePath('/project'),
+    });
+    const { files: inputFiles } = await sanitizeRawInputFiles(
+      {
+        file1: {
+          filePath: '/project/src/app.js',
+          fileType: 'MAIN',
+          fileContent: 'console.log("shared");',
+        },
+      },
+      configuration,
+    );
+
+    await simulateFromInputFiles(inputFiles, configuration, [mockStore1, mockStore2]);
+
+    expect(mockStore1.receivedFiles[0]).toBeDefined();
+    expect(mockStore1.receivedFiles[0]).toBe(mockStore2.receivedFiles[0]);
+    expect(mockStore1.receivedFiles[0]?.fileContent).toEqual('console.log("shared");');
+  });
+
+  it('should skip files for stores that do not want them', async () => {
+    class FilteringMockStore extends MockFileStore {
+      override wantsFile(
+        filename: string,
+        _configuration: Configuration,
+      ): FileProcessingMode | false {
+        return filename.endsWith('.ts') ? 'path' : false;
+      }
+    }
+
+    const mockStore = new FilteringMockStore();
+    const configuration = createConfiguration({
+      baseDir: normalizeToAbsolutePath('/project'),
+    });
+    const { files: inputFiles } = await sanitizeRawInputFiles(
+      {
+        file1: { filePath: '/project/src/app.js', fileType: 'MAIN', fileContent: '' },
+        file2: { filePath: '/project/src/app.ts', fileType: 'MAIN', fileContent: '' },
+      },
+      configuration,
+    );
+
+    await simulateFromInputFiles(inputFiles, configuration, [mockStore]);
+
+    expect(mockStore.processedFiles).toEqual([normalizePath('/project/src/app.ts')]);
   });
 });
 

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -67,7 +67,7 @@ function createPackageJsonMap(
 ) {
   const packageJsonPath = joinPaths(packageDir, 'package.json');
   return new Map<NormalizedAbsolutePath, File>([
-    [packageDir, { path: packageJsonPath, content: JSON.stringify(packageJson, null, 2) }],
+    [packageDir, { filePath: packageJsonPath, fileContent: JSON.stringify(packageJson, null, 2) }],
   ]);
 }
 
@@ -115,7 +115,7 @@ async function createGeneratedSourceProjectSnapshot(
   const configuration = createConfiguration({ baseDir });
   const directories = new Set<NormalizedAbsolutePath>([baseDir]);
   const preloadedFiles = new Map<NormalizedAbsolutePath, File>(
-    [...packageJsons.values()].map(file => [file.path, file]),
+    [...packageJsons.values()].map(file => [file.filePath, file]),
   );
   const sourceFiles = new Set<NormalizedAbsolutePath>();
   const isSourceFile = sourceFileMatcher ?? (filePath => isJsTsFile(filePath, configuration));
@@ -139,8 +139,8 @@ async function createGeneratedSourceProjectSnapshot(
     }
 
     preloadedFiles.set(filePath, {
-      content: await readFile(filePath),
-      path: filePath,
+      fileContent: await readFile(filePath),
+      filePath,
     });
   });
 
@@ -324,12 +324,12 @@ describe('generated sources project metadata', () => {
               [
                 configPath,
                 {
-                  content: `generates:
+                  fileContent: `generates:
   ./src/generated/graphql.ts:
     plugins:
       - typescript
 `,
-                  path: configPath,
+                  filePath: configPath,
                 },
               ],
             ]),
@@ -371,8 +371,8 @@ describe('generated sources project metadata', () => {
               [
                 manifestPath,
                 {
-                  content: 'client.ts\n',
-                  path: manifestPath,
+                  fileContent: 'client.ts\n',
+                  filePath: manifestPath,
                 },
               ],
             ]),

--- a/packages/analysis/tests/jsts/rules/helpers/find-up.test.ts
+++ b/packages/analysis/tests/jsts/rules/helpers/find-up.test.ts
@@ -64,10 +64,10 @@ describe('findUp', () => {
 
     for (const entries of [abcEntries, abcEntries2, abcEntries3, abcEntries4]) {
       equal(entries.length, 2);
-      equal(entries[0].path, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
-      equal(entries[0].content.toString(), '/a/b/c/foo.bar content');
-      equal(entries[1].path, joinPaths(ROOT, 'a', 'foo.bar'));
-      equal(entries[1].content.toString(), '/a/foo.bar content');
+      equal(entries[0].filePath, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
+      equal(entries[0].fileContent, '/a/b/c/foo.bar content');
+      equal(entries[1].filePath, joinPaths(ROOT, 'a', 'foo.bar'));
+      equal(entries[1].fileContent, '/a/foo.bar content');
     }
 
     equal(filesystemReadFileSpy.mock.calls.length, 2);
@@ -100,14 +100,14 @@ describe('findUp', () => {
       .get(joinPaths(ROOT, 'a', 'b', 'c'));
 
     equal(entriesUpToRoot.length, 3);
-    equal(entriesUpToRoot[0].path, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
-    equal(entriesUpToRoot[1].path, joinPaths(ROOT, 'a', 'foo.bar'));
-    equal(entriesUpToRoot[2].path, joinPaths(ROOT, 'foo.bar'));
+    equal(entriesUpToRoot[0].filePath, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
+    equal(entriesUpToRoot[1].filePath, joinPaths(ROOT, 'a', 'foo.bar'));
+    equal(entriesUpToRoot[2].filePath, joinPaths(ROOT, 'foo.bar'));
     equal(entriesUpToA.length, 2);
-    equal(entriesUpToA[0].path, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
-    equal(entriesUpToA[1].path, joinPaths(ROOT, 'a', 'foo.bar'));
+    equal(entriesUpToA[0].filePath, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
+    equal(entriesUpToA[1].filePath, joinPaths(ROOT, 'a', 'foo.bar'));
     equal(entriesUpToAB.length, 1);
-    equal(entriesUpToAB[0].path, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
+    equal(entriesUpToAB[0].filePath, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
   });
 
   it('honors the glob pattern', () => {
@@ -131,14 +131,14 @@ describe('findUp', () => {
       .get(joinPaths(ROOT, 'a', 'b', 'c'));
 
     equal(entriesUpToRoot.length, 3);
-    equal(entriesUpToRoot[0].path, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
-    equal(entriesUpToRoot[1].path, joinPaths(ROOT, 'a', 'foo.x.bar'));
-    equal(entriesUpToRoot[2].path, joinPaths(ROOT, 'foo.y.bar'));
+    equal(entriesUpToRoot[0].filePath, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
+    equal(entriesUpToRoot[1].filePath, joinPaths(ROOT, 'a', 'foo.x.bar'));
+    equal(entriesUpToRoot[2].filePath, joinPaths(ROOT, 'foo.y.bar'));
     equal(entriesUpToA.length, 2);
-    equal(entriesUpToA[0].path, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
-    equal(entriesUpToA[1].path, joinPaths(ROOT, 'a', 'foo.x.bar'));
+    equal(entriesUpToA[0].filePath, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
+    equal(entriesUpToA[1].filePath, joinPaths(ROOT, 'a', 'foo.x.bar'));
     equal(entriesUpToAB.length, 1);
-    equal(entriesUpToAB[0].path, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
+    equal(entriesUpToAB[0].filePath, joinPaths(ROOT, 'a', 'b', 'c', 'foo.bar'));
   });
 
   it('patternInParentsCache throws when from is outside topDir', () => {

--- a/packages/analysis/tests/source-files.test.ts
+++ b/packages/analysis/tests/source-files.test.ts
@@ -20,7 +20,11 @@ import { join } from 'node:path/posix';
 import { initFileStores, sourceFileStore } from '../src/file-stores/index.js';
 import { createConfiguration } from '../src/common/configuration.js';
 import { sanitizeRawInputFiles } from '../src/common/input-sanitize.js';
-import { normalizePath, normalizeToAbsolutePath } from '../../shared/src/helpers/files.js';
+import {
+  normalizePath,
+  normalizeToAbsolutePath,
+  type File,
+} from '../../shared/src/helpers/files.js';
 import { UNINITIALIZED_ERROR } from '../src/file-stores/source-files.js';
 
 const fixtures = join(import.meta.dirname, 'fixtures-source-files');
@@ -91,5 +95,26 @@ describe('files', () => {
     expect([
       ...sourceFileStore.getFilesInDirectory(normalizeToAbsolutePath('/project/src'))!,
     ]).toEqual(['second.ts']);
+  });
+
+  it('should promote shared walk files without allocating a wrapper', async () => {
+    const baseDir = normalizeToAbsolutePath('/project');
+    const configuration = createConfiguration({ baseDir });
+    const file: File = {
+      filePath: normalizeToAbsolutePath('/project/src/app.js'),
+      fileContent: 'console.log("shared");\n',
+    };
+
+    sourceFileStore.setup(configuration);
+    await sourceFileStore.processFile(file.filePath, configuration, file);
+
+    const storedFile = sourceFileStore.getFiles()[file.filePath];
+    expect(storedFile).toBe(file);
+    expect(storedFile).toMatchObject({
+      filePath: file.filePath,
+      fileContent: file.fileContent,
+      fileType: 'MAIN',
+      fileStatus: 'SAME',
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR refactors file-store initialization so file content loading is centralized in `packages/analysis/src/file-stores/index.ts`.

Each file store now declares whether it needs only the path or also the file contents. The shared project walk reads a file at most once when contents are required, passes the same `File` object to every interested store, and keeps best-effort behavior for unreadable auxiliary files.

## What changed

- introduced `wantsFile()` on the `FileStore` contract with three outcomes:
  - `false`: the store is not interested in the file
  - `'path'`: the store only needs the normalized file path
  - `'content'`: the store needs the normalized path plus UTF-8 file contents
- centralized file reads in `packages/analysis/src/file-stores/index.ts`
  - the filesystem walk and the request-file simulation both go through the same helper
  - when multiple stores request contents for the same path, we create one shared `File` object and pass it to all of them
  - if reading an optional helper file fails, we warn once and skip content-based processing for that path instead of creating an invalid `File`
- narrowed the shared `File` shape to the data we actually use in this flow
  - renamed fields from `path` / `content` to `filePath` / `fileContent`
  - narrowed `fileContent` to `string`
- updated `SourceFileStore` to request `'content'` and promote the shared walk entry into `AnalyzableFile` in place instead of allocating a wrapper object
- updated `DependencyManifestStore` to consume shared `File` objects instead of reading manifests itself
- updated `GeneratedSourceStore` to consume:
  - shared walk files for config/helper inputs
  - `DependencyManifestStore` package.json ownership for manifest inputs
  - this removes the direct dependency on a source-file content accessor
- updated `TsConfigStore` to participate through `wantsFile()` as a path-only store
- updated generated-source detectors, dependency-manifest helpers, telemetry, and find-up helpers to use the new shared `File` shape
- refreshed docs to describe the centralized read path and the shared-file model
- added/updated tests around:
  - sharing the same file object across content stores
  - skipping uninterested stores cleanly
  - promoting shared source-file entries in place
  - generated-source snapshot expectations
  - dependency-manifest warmup and cache reuse

## Expected improvement

This is intended as a cleanup/refactor after the generated-source work rather than a functional feature change.

The expected runtime improvements are:

- fewer duplicate file reads during the initial project walk when multiple stores care about the same file
  - this matters especially for files that overlap between normal source-file handling and generated-source detection inputs
- lower transient allocation pressure by reusing one shared `File` object across content-interested stores
  - `SourceFileStore` now promotes that object in place to `AnalyzableFile` instead of wrapping/copying it
- clearer ownership boundaries between stores
  - `SourceFileStore` owns analyzable files
  - `DependencyManifestStore` owns manifests
  - `GeneratedSourceStore` derives metadata from the shared walk snapshot plus manifest-store inputs instead of reaching back into other stores to reread content
- unchanged cache/invalidation behavior for the existing stores
  - source-file, manifest, generated-source, and tsconfig invalidation still live in the same stores
  - request-only analyses still simulate the walk through the same shared pipeline
- preserved best-effort behavior for unreadable auxiliary files
  - content stores skip the unreadable path after a warning
  - path-only stores continue to run

## Validation

- `npx prettier --check docs/file-stores.md docs/generated-sources.md docs/node-analysis-caches.md packages/analysis/src/file-stores/dependency-manifests.ts packages/analysis/src/file-stores/generated-sources/detectors/graphql-codegen-config.ts packages/analysis/src/file-stores/generated-sources/detectors/openapi-generator.ts packages/analysis/src/file-stores/generated-sources/store.ts packages/analysis/src/file-stores/index.ts packages/analysis/src/file-stores/source-files.ts packages/analysis/src/file-stores/store-type.ts packages/analysis/src/file-stores/tsconfigs.ts packages/analysis/src/jsts/rules/S6647/unit.test.ts packages/analysis/src/jsts/rules/helpers/dependency-manifests/closest.ts packages/analysis/src/jsts/rules/helpers/dependency-manifests/dependencies.ts packages/analysis/src/jsts/rules/helpers/dependency-manifests/parsed-dependency-files.ts packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/helpers.ts packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/package-json.ts packages/analysis/src/jsts/rules/helpers/files.ts packages/analysis/src/jsts/rules/helpers/find-up/find-minimatch.ts packages/analysis/src/projectAnalysis.ts packages/analysis/src/telemetry.ts packages/analysis/tests/dependency-manifests.test.ts packages/analysis/tests/file-stores.test.ts packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts packages/analysis/tests/jsts/rules/helpers/find-up.test.ts packages/analysis/tests/source-files.test.ts`
- `npx tsx --test packages/analysis/tests/file-stores.test.ts packages/analysis/tests/source-files.test.ts packages/analysis/tests/dependency-manifests.test.ts packages/analysis/tests/tsconfigs.test.ts packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts packages/analysis/tests/jsts/rules/helpers/find-up.test.ts packages/analysis/src/jsts/rules/S6647/unit.test.ts`
- manual repro with an unreadable `package.json`
  - result: warn once and continue without aborting initialization
