### PR TITLE
JS-1913 Use GitHub-hosted runner for eslint-plugin trusted publish

### DIFF
--- a/.github/workflows/.npmrc
+++ b/.github/workflows/.npmrc
@@ -1,3 +1,0 @@
-always-auth=true
-email=helpdesk+npmjs@sonarsource.com
-registry=https://registry.npmjs.org/

--- a/.github/workflows/release_eslint_plugin.yml
+++ b/.github/workflows/release_eslint_plugin.yml
@@ -16,7 +16,7 @@ jobs:
   publish:
     permissions:
       id-token: write # required for GitHub OIDC and SonarSource/vault-action-wrapper
-    runs-on: sonar-xs
+    runs-on: github-ubuntu-latest-s # npm Trusted Publishers require a GitHub-hosted runner
     environment: release
     env:
       RELEASE_TAG: ${{ github.event.inputs.release_version }}
@@ -51,7 +51,6 @@ jobs:
         with:
           artifactory-reader-role: private-reader
           disable-caching: 'true'
-      - run: cp .github/workflows/.npmrc .npmrc
       - name: Publish npm package
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).RSPEC_GITHUB_TOKEN }}
@@ -59,7 +58,6 @@ jobs:
           jfrog rt npm-config --repo-resolve npm --repo-deploy sonarsource-npm-public-qa
           jfrog rt npm-ci
           npm run eslint-plugin:compile
-          cp .npmrc lib/.npmrc
           cd lib
           npm version $RELEASE_TAG --no-git-tag-version
           npm publish --provenance


### PR DESCRIPTION
## Summary
- run the eslint plugin release job on `github-ubuntu-latest-s`
- remove the workflow-local `.npmrc` and its copy steps
- keep the existing custom eslint plugin packaging and promotion flow unchanged

## Why
The failed 4.1.0 release reached `npm publish --provenance` but failed with `ENEEDAUTH`. `eslint-plugin-sonarjs` is already configured as an npm Trusted Publisher for `release_eslint_plugin.yml` / `release`, so the remaining mismatch is the job runner: npm Trusted Publishers require a GitHub-hosted runner.

## Validation
- `git diff --check`
- workflow not executed from this branch because the `release` environment currently only allows `master` and tags