### PR TITLE
JS-1914 Add ensure-rule-data lifecycle for RSPEC outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rspec-rule-data-${{ github.sha }}
-          path: sonar-plugin
+          path: .
       - &maven_cache
         uses: ./.github/actions/maven-cache
         with:
@@ -276,6 +276,7 @@ jobs:
             sonar-plugin/javascript-checks/src/main/resources/rspec.sha
             sonar-plugin/css/src/main/resources/org/sonar/l10n/css/rules/css
             sonar-plugin/css/src/main/resources/rspec.sha
+            resources/rule-data-state.json
           retention-days: 1
 
   build_eslint_plugin:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,8 +263,8 @@ jobs:
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-rspec token | RSPEC_GITHUB_TOKEN;
-      - name: Generate and deploy RSPEC rule data
-        run: npm run generate-rule-data:maven
+      - name: Generate and stamp RSPEC rule data
+        run: npm run ensure-rule-data
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.rspec-secrets.outputs.vault).RSPEC_GITHUB_TOKEN }}
       - name: Upload prepared RSPEC rule data
@@ -449,7 +449,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rspec-rule-data-${{ github.sha }}
-          path: sonar-plugin
+          path: .
       - if: steps.cache.outputs.cache-hit != 'true'
         name: Run JS tests with coverage
         run: |
@@ -494,7 +494,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rspec-rule-data-${{ github.sha }}
-          path: sonar-plugin
+          path: .
       - if: steps.cache.outputs.cache-hit != 'true'
         name: Run JS tests on Windows
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ Desktop.ini
 # ---- Sonar
 .sonar
 .scannerwork
-.sonarjs-build-state/
 
 # eslint-plugin-sonarjs
 eslint-plugin-sonarjs-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ Desktop.ini
 # ---- Sonar
 .sonar
 .scannerwork
+.sonarjs-build-state/
 
 # eslint-plugin-sonarjs
 eslint-plugin-sonarjs-*.tgz

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -4,16 +4,17 @@
 
 Run `npm ci` first on a fresh checkout, and again after any `package.json` or lockfile change.
 
-Use `mvn install` for normal development after Node dependencies are installed.
-When generated RSPEC outputs are already present, this reuses them instead of refetching RSPEC.
+Use `mvn install` for normal development after Node dependencies are installed. When generated RSPEC
+outputs are already present, this reuses them instead of refetching RSPEC.
 
 Rule-data preparation is materialized by `npm run ensure-rule-data`. This command refreshes
-`generate-rule-data:maven` outputs when they are missing or when the checkout no longer matches
-the ignored state stored in `resources/rule-data-state.json`.
+`generate-rule-data:maven` outputs when they are missing or when the checkout no longer matches the
+ignored state stored in `resources/rule-data-state.json`. For the full RSPEC sync and stamp model,
+see [RSPEC Rule-Data Lifecycle](./rule-data-lifecycle.md).
 
 Avoid `mvn clean` while iterating. The fast Java-only loop reuses previously generated artifacts,
-and `clean` deletes them. Only use `mvn clean install` when you explicitly want to rebuild
-generated assets from scratch.
+and `clean` deletes them. Only use `mvn clean install` when you explicitly want to rebuild generated
+assets from scratch.
 
 ## Common commands
 
@@ -61,6 +62,9 @@ Ensure rule data is prepared for the current checkout:
 npm run ensure-rule-data
 ```
 
+The detailed behavior of this command is documented in
+[RSPEC Rule-Data Lifecycle](./rule-data-lifecycle.md).
+
 Validate quickfix declarations:
 
 ```bash
@@ -78,12 +82,13 @@ The `sonar-plugin` reactor builds modules in this order:
 5. `sonar-javascript-plugin`
 6. `standalone`
 
-`javascript-checks` stays before `bridge` because bridge generation consumes rule metadata prepared earlier in the build.
+`javascript-checks` stays before `bridge` because bridge generation consumes rule metadata prepared
+earlier in the build.
 
 ## Fast Java iteration flags
 
-The fast path is implemented with property-activated profiles in `sonar-plugin/pom.xml`.
-These are repo-specific toggles, not built-in Maven flags.
+The fast path is implemented with property-activated profiles in `sonar-plugin/pom.xml`. These are
+repo-specific toggles, not built-in Maven flags.
 
 ### `-Dskip-nodejs`
 
@@ -105,11 +110,12 @@ It skips:
 
 Important details:
 
-- `npm run generate-meta` reuses prepared RSPEC outputs when they already exist, and refreshes them when they do not.
-- To force an RSPEC refresh, or to apply a new root `rspec.sha` pin, run
-  `npm run ensure-rule-data`; `npm run generate-meta` also invokes this check before generating
-  metadata.
-- The `bridge` module still adds `target/generated-sources` to the Java source roots, so an existing generated stub directory can be reused without re-running protobuf generation.
+- `npm run generate-meta` reuses prepared RSPEC outputs when they already exist, and refreshes them
+  when they do not.
+- To force an RSPEC refresh, or to apply a new root `rspec.sha` pin, run `npm run ensure-rule-data`;
+  `npm run generate-meta` also invokes this check before generating metadata.
+- The `bridge` module still adds `target/generated-sources` to the Java source roots, so an existing
+  generated stub directory can be reused without re-running protobuf generation.
 - This flag is intended for Java-only loops after a previous non-skipped build.
 
 Do not use `-Dskip-nodejs`:
@@ -141,7 +147,8 @@ The clean phase removes the outputs that make the fast loop work:
 - `sonar-plugin/sonar-javascript-plugin/src/main/resources/node-info.properties`
 - `lib/` and `bin/`
 - downloaded rule data under `resources/rule-data`
-- generated rule data copied under `sonar-plugin/javascript-checks/src/main/resources` and `sonar-plugin/css/src/main/resources`
+- generated rule data copied under `sonar-plugin/javascript-checks/src/main/resources` and
+  `sonar-plugin/css/src/main/resources`
 - generated rule metadata under `packages/analysis/src/jsts/rules`
 
 Because of that, a common workflow is:
@@ -185,5 +192,7 @@ Because of that, a common workflow is:
 
 ## Notes
 
-- `-Dsurefire.failIfNoSpecifiedTests=false` is useful with `-pl ... -am -Dtest=...` because upstream modules in the reactor may not contain the selected test class.
-- If the fast path starts failing because generated artifacts are missing or stale, drop the skip flags and run a regular `mvn install`.
+- `-Dsurefire.failIfNoSpecifiedTests=false` is useful with `-pl ... -am -Dtest=...` because upstream
+  modules in the reactor may not contain the selected test class.
+- If the fast path starts failing because generated artifacts are missing or stale, drop the skip
+  flags and run a regular `mvn install`.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -9,7 +9,7 @@ When generated RSPEC outputs are already present, this reuses them instead of re
 
 Rule-data preparation is materialized by `npm run ensure-rule-data`. This command refreshes
 `generate-rule-data:maven` outputs when they are missing or when the checkout no longer matches
-the ignored state stored under `.sonarjs-build-state/`.
+the ignored state stored in `resources/rule-data-state.json`.
 
 Avoid `mvn clean` while iterating. The fast Java-only loop reuses previously generated artifacts,
 and `clean` deletes them. Only use `mvn clean install` when you explicitly want to rebuild

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -7,7 +7,13 @@ Run `npm ci` first on a fresh checkout, and again after any `package.json` or lo
 Use `mvn install` for normal development after Node dependencies are installed.
 When generated RSPEC outputs are already present, this reuses them instead of refetching RSPEC.
 
-Avoid `mvn clean` while iterating. The fast Java-only loop reuses previously generated artifacts, and `clean` deletes them. Only use `mvn clean install` when you explicitly want to rebuild generated assets from scratch.
+Rule-data preparation is materialized by `npm run ensure-rule-data`. This command refreshes
+`generate-rule-data:maven` outputs when they are missing or when the checkout no longer matches
+the ignored state stored under `.sonarjs-build-state/`.
+
+Avoid `mvn clean` while iterating. The fast Java-only loop reuses previously generated artifacts,
+and `clean` deletes them. Only use `mvn clean install` when you explicitly want to rebuild
+generated assets from scratch.
 
 ## Common commands
 
@@ -47,6 +53,12 @@ Regenerate rule metadata:
 
 ```bash
 npm run generate-meta
+```
+
+Ensure rule data is prepared for the current checkout:
+
+```bash
+npm run ensure-rule-data
 ```
 
 Validate quickfix declarations:
@@ -94,7 +106,9 @@ It skips:
 Important details:
 
 - `npm run generate-meta` reuses prepared RSPEC outputs when they already exist, and refreshes them when they do not.
-- To force an RSPEC refresh, or to apply a new root `rspec.sha` pin, run `npm run generate-rule-data:maven` or run `mvn clean` before `npm run generate-meta`.
+- To force an RSPEC refresh, or to apply a new root `rspec.sha` pin, run
+  `npm run ensure-rule-data`; `npm run generate-meta` also invokes this check before generating
+  metadata.
 - The `bridge` module still adds `target/generated-sources` to the Java source roots, so an existing generated stub directory can be reused without re-running protobuf generation.
 - This flag is intended for Java-only loops after a previous non-skipped build.
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -42,7 +42,7 @@ Examples:
 
 `npm run generate-meta` first runs `npm run ensure-rule-data`. This reuses prepared RSPEC outputs
 when the generated local rule data directories, per-language `rspec.sha` files, and ignored
-`.sonarjs-build-state/rule-data.json` stamp match the current checkout. On a fresh checkout, after
+`resources/rule-data-state.json` stamp match the current checkout. On a fresh checkout, after
 switching revisions, after changing the ignored root `rspec.sha` pin, or after `mvn clean`, it runs
 Maven first and uses either your GitHub CLI auth or `GITHUB_TOKEN` to fetch from `SonarSource/rspec`.
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -40,11 +40,22 @@ Examples:
    source ~/.zshenv
    ```
 
-`npm run generate-meta` reuses prepared RSPEC outputs when the generated local rule data directories and per-language `rspec.sha` files are already present. On a fresh checkout, or after `mvn clean`, it runs Maven first and uses either your GitHub CLI auth or `GITHUB_TOKEN` to fetch from `SonarSource/rspec`.
+`npm run generate-meta` first runs `npm run ensure-rule-data`. This reuses prepared RSPEC outputs
+when the generated local rule data directories, per-language `rspec.sha` files, and ignored
+`.sonarjs-build-state/rule-data.json` stamp match the current checkout. On a fresh checkout, after
+switching revisions, after changing the ignored root `rspec.sha` pin, or after `mvn clean`, it runs
+Maven first and uses either your GitHub CLI auth or `GITHUB_TOKEN` to fetch from `SonarSource/rspec`.
 
-To pin all rule data generation to an exact RSPEC revision, write the commit SHA to `rspec.sha` at the repository root and run `npm run generate-rule-data:maven`. If you want to use `npm run generate-meta`, run it after `mvn clean` (or otherwise remove the prepared rule data) so the Maven wrapper is invoked. When the ignored root pin is present, the Maven wrapper passes it to `rspec-maven-plugin` for both JavaScript and CSS.
+To pin all rule data generation to an exact RSPEC revision, write the commit SHA to `rspec.sha` at
+the repository root and run `npm run ensure-rule-data`. When the ignored root pin is present, the
+Maven wrapper passes it to `rspec-maven-plugin` for both JavaScript and CSS.
 
-Prepared rule data keeps separate generated pins in `sonar-plugin/javascript-checks/src/main/resources/rspec.sha` and `sonar-plugin/css/src/main/resources/rspec.sha`. If there is no root pin, the Maven wrapper falls back to these per-language generated pins when they are present. For direct Maven commands that generate rule data, pass `-Drspec.sha=<commit-sha>` to pin both languages, or `-Drspec.javascript.sha=<commit-sha>` and `-Drspec.css.sha=<commit-sha>` to pin them independently.
+Prepared rule data keeps separate generated pins in
+`sonar-plugin/javascript-checks/src/main/resources/rspec.sha` and
+`sonar-plugin/css/src/main/resources/rspec.sha`. If there is no root pin, the Maven wrapper falls
+back to these per-language generated pins when they are present. For direct Maven commands that
+generate rule data, pass `-Drspec.sha=<commit-sha>` to pin both languages, or
+`-Drspec.javascript.sha=<commit-sha>` and `-Drspec.css.sha=<commit-sha>` to pin them independently.
 
 You can also use Docker container defined in `./.cirrus/nodejs.Dockerfile` which bundles all required dependencies and is used for our CI pipeline.
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -56,6 +56,8 @@ Prepared rule data keeps separate generated pins in
 back to these per-language generated pins when they are present. For direct Maven commands that
 generate rule data, pass `-Drspec.sha=<commit-sha>` to pin both languages, or
 `-Drspec.javascript.sha=<commit-sha>` and `-Drspec.css.sha=<commit-sha>` to pin them independently.
+When `npm run ensure-rule-data` detects stale state without a root pin, it clears the generated
+per-language pins before regenerating so pins from another checkout are not reused.
 
 You can also use Docker container defined in `./.cirrus/nodejs.Dockerfile` which bundles all required dependencies and is used for our CI pipeline.
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -63,10 +63,10 @@ Prepared rule data keeps separate generated pins in
 `sonar-plugin/javascript-checks/src/main/resources/rspec.sha` and
 `sonar-plugin/css/src/main/resources/rspec.sha`. If there is no root pin, the Maven wrapper falls
 back to these per-language generated pins when they are present. For direct Maven commands that
-generate rule data, pass `-Drspec.sha=<commit-sha>` to pin both languages, or
-`-Drspec.javascript.sha=<commit-sha>` and `-Drspec.css.sha=<commit-sha>` to pin them independently.
-When `npm run ensure-rule-data` detects stale state without a root pin, it clears the generated
-per-language pins before regenerating so pins from another checkout are not reused.
+generate rule data, use Direct Maven pinning: pass `-Drspec.sha=<commit-sha>` to pin both languages,
+or `-Drspec.javascript.sha=<commit-sha>` and `-Drspec.css.sha=<commit-sha>` to pin them
+independently. When `npm run ensure-rule-data` detects stale state without a root pin, it clears the
+generated per-language pins before regenerating so pins from another checkout are not reused.
 
 You can also use Docker container defined in `./.cirrus/nodejs.Dockerfile` which bundles all
 required dependencies and is used for our CI pipeline.

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -11,12 +11,20 @@ To work on this project, it is required to have the following tools installed:
 
 ### RSPEC Access
 
-The build fetches rule metadata from the private `SonarSource/rspec` repository through `rspec-maven-plugin`.
-The generated RSPEC rule metadata JSON published under `sonar-plugin/*/src/main/resources/**/rules/*/` is tracked in Git. The generated HTML files and per-language `rspec.sha` files remain build artifacts and are not tracked.
+For the full RSPEC sync and lifecycle model, including the distinction between
+`resources/rule-data-state.json`, root `rspec.sha`, and generated per-language `rspec.sha`, see
+[RSPEC Rule-Data Lifecycle](./rule-data-lifecycle.md).
 
-For local development, the Maven flow can reuse your existing GitHub CLI login. Running `gh auth login` is enough on a fresh checkout or after `mvn clean`.
+The build fetches rule metadata from the private `SonarSource/rspec` repository through
+`rspec-maven-plugin`. The generated RSPEC rule metadata JSON published under
+`sonar-plugin/*/src/main/resources/**/rules/*/` is tracked in Git. The generated HTML files and
+per-language `rspec.sha` files remain build artifacts and are not tracked.
 
-If you already have a token with read access to `SonarSource/rspec`, exporting `GITHUB_TOKEN` still works as well.
+For local development, the Maven flow can reuse your existing GitHub CLI login. Running
+`gh auth login` is enough on a fresh checkout or after `mvn clean`.
+
+If you already have a token with read access to `SonarSource/rspec`, exporting `GITHUB_TOKEN` still
+works as well.
 
 In CI, the token is provided from Vault-managed secrets and passed explicitly to the Maven plugin.
 
@@ -44,7 +52,8 @@ Examples:
 when the generated local rule data directories, per-language `rspec.sha` files, and ignored
 `resources/rule-data-state.json` stamp match the current checkout. On a fresh checkout, after
 switching revisions, after changing the ignored root `rspec.sha` pin, or after `mvn clean`, it runs
-Maven first and uses either your GitHub CLI auth or `GITHUB_TOKEN` to fetch from `SonarSource/rspec`.
+Maven first and uses either your GitHub CLI auth or `GITHUB_TOKEN` to fetch from
+`SonarSource/rspec`.
 
 To pin all rule data generation to an exact RSPEC revision, write the commit SHA to `rspec.sha` at
 the repository root and run `npm run ensure-rule-data`. When the ignored root pin is present, the
@@ -59,7 +68,8 @@ generate rule data, pass `-Drspec.sha=<commit-sha>` to pin both languages, or
 When `npm run ensure-rule-data` detects stale state without a root pin, it clears the generated
 per-language pins before regenerating so pins from another checkout are not reused.
 
-You can also use Docker container defined in `./.cirrus/nodejs.Dockerfile` which bundles all required dependencies and is used for our CI pipeline.
+You can also use Docker container defined in `./.cirrus/nodejs.Dockerfile` which bundles all
+required dependencies and is used for our CI pipeline.
 
 ## Build and run unit tests
 
@@ -86,7 +96,8 @@ First make sure the submodules are checked out:
 
 ### Plugin Tests
 
-The "Plugin Test" is an integration test which verifies plugin features such as metric calculation, coverage etc.
+The "Plugin Test" is an integration test which verifies plugin features such as metric calculation,
+coverage etc.
 
 ```sh
 cd its/plugin
@@ -95,7 +106,11 @@ mvn clean install
 
 ### Ruling Tests
 
-The "Ruling Test" is an integration test which launches the analysis of a large code base of third-party projects (stored as submodules), saves the issues created by the plugin in report files, and then compares those results to the set of expected issues (stored as JSON files). This test gives you the opportunity to examine the issues created by each rule and make sure that they are what you expect.
+The "Ruling Test" is an integration test which launches the analysis of a large code base of
+third-party projects (stored as submodules), saves the issues created by the plugin in report files,
+and then compares those results to the set of expected issues (stored as JSON files). This test
+gives you the opportunity to examine the issues created by each rule and make sure that they are
+what you expect.
 
 #### JS/TS
 
@@ -103,8 +118,8 @@ The "Ruling Test" is an integration test which launches the analysis of a large 
 npm run ruling
 ```
 
-The generated issues are written under `packages/ruling/actual/<project>/`.
-The expected issues are stored under `its/ruling/src/test/expected/<project>/`.
+The generated issues are written under `packages/ruling/actual/<project>/`. The expected issues are
+stored under `its/ruling/src/test/expected/<project>/`.
 
 From the project root, run: `npm run ruling-sync`
 
@@ -117,25 +132,35 @@ cd its/ruling
 mvn verify -Dtest=RulingTest -Dmaven.test.redirectTestOutputToFile=false
 ```
 
-To review the Ruling difference in SonarQube UI, put the breakpoint on `assertThat(...)` in `RulingTest.java` and open in the browser the orchestrated local SonarQube.
-Note that you can fix the port in `orchestrator.properties files`, e.g. `orchestrator.container.port=9100`.
+To review the Ruling difference in SonarQube UI, put the breakpoint on `assertThat(...)` in
+`RulingTest.java` and open in the browser the orchestrated local SonarQube. Note that you can fix
+the port in `orchestrator.properties files`, e.g. `orchestrator.container.port=9100`.
 
-If everything looks good to you, you can copy the file with the actual issues located at `its/ruling/target/actual/`
-into the directory with the expected issues `its/ruling/src/test/expected/`.
+If everything looks good to you, you can copy the file with the actual issues located at
+`its/ruling/target/actual/` into the directory with the expected issues
+`its/ruling/src/test/expected/`.
 
-You can review the Ruling difference by running `diff -rq src/test/expected target/actual` from `its/ruling`.
+You can review the Ruling difference by running `diff -rq src/test/expected target/actual` from
+`its/ruling`.
 
-> :warning: Please note that running ruling tests will remove `node_modules` from the root to avoid affecting the results. Run `npm ci` to put them back.
+> :warning: Please note that running ruling tests will remove `node_modules` from the root to avoid
+> affecting the results. Run `npm ci` to put them back.
 
 ### Debug `node` process during scan
 
-You can run your own Node.js process manually and set the environment variable `SONARJS_EXISTING_NODE_PROCESS_PORT` with the value of the port where your process is listening to. When set, SonarJS will not start a new Node process and will send the analysis requests to the specified port instead.
+You can run your own Node.js process manually and set the environment variable
+`SONARJS_EXISTING_NODE_PROCESS_PORT` with the value of the port where your process is listening to.
+When set, SonarJS will not start a new Node process and will send the analysis requests to the
+specified port instead.
 
-When using this for the ruling tests, make sure that you run them in series (and not in parallel), by removing `@Execution(ExecutionMode.CONCURRENT)` from the ruling test.
+When using this for the ruling tests, make sure that you run them in series (and not in parallel),
+by removing `@Execution(ExecutionMode.CONCURRENT)` from the ruling test.
 
 ## Testing in VS Code SonarLint
 
-To patch a local VS Code SonarLint or SonarQube for IDE installation with the latest SonarJS master build from Repox, see [Testing VS Code SonarLint with the latest SonarJS master build](./vscode-sonarlint-master-build.md).
+To patch a local VS Code SonarLint or SonarQube for IDE installation with the latest SonarJS master
+build from Repox, see
+[Testing VS Code SonarLint with the latest SonarJS master build](./vscode-sonarlint-master-build.md).
 
 ## Adding a rule
 
@@ -143,31 +168,29 @@ To patch a local VS Code SonarLint or SonarQube for IDE installation with the la
 
 1. Create a PR with a rule description in the RSPEC repo as described in the
    [RSPEC create-or-modify-a-rule guide](https://github.com/SonarSource/rspec#create-or-modify-a-rule)
-   - Tag the RSPEC with `type-dependent` if the rule relies partially or fully
-     on type information.
-     - In practice, this means the implementation uses TypeScript parser
-       services, either directly or through shared helpers or wrappers.
-     - Direct signals are code paths using
-       `context.sourceCode.parserServices`, `isRequiredParserServices(...)`,
-       `services.program.getTypeChecker()`, or ESTree/TypeScript node maps such
-       as `services.esTreeNodeToTSNodeMap`.
+   - Tag the RSPEC with `type-dependent` if the rule relies partially or fully on type information.
+     - In practice, this means the implementation uses TypeScript parser services, either directly
+       or through shared helpers or wrappers.
+     - Direct signals are code paths using `context.sourceCode.parserServices`,
+       `isRequiredParserServices(...)`, `services.program.getTypeChecker()`, or ESTree/TypeScript
+       node maps such as `services.esTreeNodeToTSNodeMap`.
      - Indirect signals include helpers that wrap the type checker such as
-       `getTypeFromTreeNode(...)`, regex rules built with
-       `createRegExpRule(...)`, and wrapped `@typescript-eslint` rules whose
-       implementation requires typed services.
-     - Do not use `type-dependent` for rules that only inspect TypeScript
-       syntax and never query typed parser services.
-   - Add a field `dependencies` if your rule should only be executed if it
-     relies on a specific import (example: 'react' or 'jest').
-   - Add a field `compatibleLanguages` with an array including which languages
-     you support (`js` and/or `ts`).
+       `getTypeFromTreeNode(...)`, regex rules built with `createRegExpRule(...)`, and wrapped
+       `@typescript-eslint` rules whose implementation requires typed services.
+     - Do not use `type-dependent` for rules that only inspect TypeScript syntax and never query
+       typed parser services.
+   - Add a field `dependencies` if your rule should only be executed if it relies on a specific
+     import (example: 'react' or 'jest').
+   - Add a field `compatibleLanguages` with an array including which languages you support (`js`
+     and/or `ts`).
 
 2. Link this RSPEC PR to the implementation issue in this repo
 3. Make sure the implementation issue title contains the RSPEC number and name
 
 ### Implementing a rule
 
-1. Generate other files required for a new rule. Just choose your options in the prompt of the `new-rule` script
+1. Generate other files required for a new rule. Just choose your options in the prompt of the
+   `new-rule` script
 
 ```sh
 npm run new-rule
@@ -189,25 +212,43 @@ It will also update some files which are not tracked by Git as they are automati
 - updates the `AllRules.java` to include the new rule
 
 2. Update generated files
-   - Make sure annotations in the Java class specify languages to cover (`@JavaScriptRule` and/or `@TypeScriptRule`)
-   - If your rule has configurations, or you are using some from an ESLint rule, override the `configurations()` method of the Java check class
-     - You can use a `MyRuleCheckTest.java` test case to verify how the configurations will be serialized to JSON as shown [here](https://github.com/SonarSource/SonarJS/blob/master/sonar-plugin/javascript-checks/src/test/java/org/sonar/javascript/checks/NoEmptyClassCheckTest.java#L30)
-   - If writing a rule for the test files, replace `extends Check` with `extends TestFileCheck` in the Java class. This will be done by the `new-rule` script, but make sure you are extending the right base class.
+   - Make sure annotations in the Java class specify languages to cover (`@JavaScriptRule` and/or
+     `@TypeScriptRule`)
+   - If your rule has configurations, or you are using some from an ESLint rule, override the
+     `configurations()` method of the Java check class
+     - You can use a `MyRuleCheckTest.java` test case to verify how the configurations will be
+       serialized to JSON as shown
+       [here](https://github.com/SonarSource/SonarJS/blob/master/sonar-plugin/javascript-checks/src/test/java/org/sonar/javascript/checks/NoEmptyClassCheckTest.java#L30)
+   - If writing a rule for the test files, replace `extends Check` with `extends TestFileCheck` in
+     the Java class. This will be done by the `new-rule` script, but make sure you are extending the
+     right base class.
 3. Implement the rule logic in `S1234/rule.ts`
-   - Prefer using `meta.messages` to specify messages through `messageId`s. Message can be part of the RSPEC description, like [here](https://sonarsource.github.io/rspec/#/rspec/S4036/javascript#message).
-   - If writing a regex rule, use [createRegExpRule](https://github.com/SonarSource/SonarJS/blob/master/src/linting/eslint/rules/helpers/regex/rule-template.ts#L52)
+   - Prefer using `meta.messages` to specify messages through `messageId`s. Message can be part of
+     the RSPEC description, like
+     [here](https://sonarsource.github.io/rspec/#/rspec/S4036/javascript#message).
+   - If writing a regex rule, use
+     [createRegExpRule](https://github.com/SonarSource/SonarJS/blob/master/src/linting/eslint/rules/helpers/regex/rule-template.ts#L52)
 
 4. If possible, implement quick fixes for the rule:
-   - If the ESLint fix is at the root of the report (and not in a suggestion), add the message for the quick fix in `rules/SXXXX/meta.ts`.
-   - Add a code fixture that should provide a quickfix in `tests/linter/fixtures/wrapper/quickfixes/<ESLint-style rulekey>.{js,ts}`. The [following test](https://github.com/SonarSource/SonarJS/blob/a99fd9614c4ee3052f8da1cfecbfc05ef16e95d1/tests/linting/eslint/linter/wrapper.test.ts#L334) asserts that the quickfix is enabled.
+   - If the ESLint fix is at the root of the report (and not in a suggestion), add the message for
+     the quick fix in `rules/SXXXX/meta.ts`.
+   - Add a code fixture that should provide a quickfix in
+     `tests/linter/fixtures/wrapper/quickfixes/<ESLint-style rulekey>.{js,ts}`. The
+     [following test](https://github.com/SonarSource/SonarJS/blob/a99fd9614c4ee3052f8da1cfecbfc05ef16e95d1/tests/linting/eslint/linter/wrapper.test.ts#L334)
+     asserts that the quickfix is enabled.
 
 ## Testing a rule
 
-We support 2 kinds of rule unit-tests: ESLint's [RuleTester](https://eslint.org/docs/developer-guide/nodejs-api#ruletester) or our comment-based tests.
+We support 2 kinds of rule unit-tests: ESLint's
+[RuleTester](https://eslint.org/docs/developer-guide/nodejs-api#ruletester) or our comment-based
+tests.
 
 ### Comment-based testing
 
-These tests are located in the rule folder and they **MUST** be named `*.fixture.*` (where the extension could be one of `js`, `ts`, `jsx`, `tsx`, `vue`). If options are to be passed to the tested rule, add a JSON file to the same directory named `cb.options.json`. The file must contain the array of options.
+These tests are located in the rule folder and they **MUST** be named `*.fixture.*` (where the
+extension could be one of `js`, `ts`, `jsx`, `tsx`, `vue`). If options are to be passed to the
+tested rule, add a JSON file to the same directory named `cb.options.json`. The file must contain
+the array of options.
 
 The contents of the test code have the following structure:
 
@@ -225,10 +266,11 @@ The contents of the options file must be a valid JSON array:
 
 ```javascript
 // brace-style.json
-['1tbs', { allowSingleLine: true }];
+["1tbs", { allowSingleLine: true }];
 ```
 
-If your rule depends on a dependency declared in the `package.json` file, you can add the following clause to your test:
+If your rule depends on a dependency declared in the `package.json` file, you can add the following
+clause to your test:
 
 ```js
 process.chdir(__dirname); // change current working dir to avoid the package.json lookup to up in the tree
@@ -245,16 +287,20 @@ You can find an example at [the bottom of this document](#examples).
 
 #### Tests syntax
 
-Given the above test snippet, issue messages (`{{...}}`) and quick fixes (if the rule provides them) are mandatory. The issue primary location (`// ^^^^`) and secondary location(s) (`// ^^^<`) are optional.
+Given the above test snippet, issue messages (`{{...}}`) and quick fixes (if the rule provides them)
+are mandatory. The issue primary location (`// ^^^^`) and secondary location(s) (`// ^^^<`) are
+optional.
 
-`Noncompliant` lines will be associated by default to the line of code where they are written. The syntax `@line_number` allows for an issue to be associated to another line:
+`Noncompliant` lines will be associated by default to the line of code where they are written. The
+syntax `@line_number` allows for an issue to be associated to another line:
 
 ```javascript
 // Noncompliant@2 [[qf1,qf2,...]] {{Optional message to assert}}
 some.faulty.code();
 ```
 
-Another option is to use relative line increments (`@+line_increment`) or decrements (`@-line_decrement`):
+Another option is to use relative line increments (`@+line_increment`) or decrements
+(`@-line_decrement`):
 
 ```javascript
 // Noncompliant@+1
@@ -267,7 +313,11 @@ another.faulty.code();
 
 #### Secondary locations
 
-Secondary locations are part of [Sonar issues](https://docs.sonarqube.org/latest/user-guide/issues/). They provide additional context to the raised issue. In order to use them, you must call the [toEncodedMessage()](https://github.com/SonarSource/SonarJS/blob/382fd7d4dad2a085ca5ac6d004cb38fe52720cca/src/linting/eslint/rules/helpers/location.ts#L44) function when reporting the issue message like this:
+Secondary locations are part of
+[Sonar issues](https://docs.sonarqube.org/latest/user-guide/issues/). They provide additional
+context to the raised issue. In order to use them, you must call the
+[toEncodedMessage()](https://github.com/SonarSource/SonarJS/blob/382fd7d4dad2a085ca5ac6d004cb38fe52720cca/src/linting/eslint/rules/helpers/location.ts#L44)
+function when reporting the issue message like this:
 
 ```javascript
 context.report({
@@ -276,26 +326,49 @@ context.report({
 });
 ```
 
-In order to indicate secondary locations, you must use either `// ^^^^^<` or `// ^^^^>`, the arrow indicating whether the matching main location is either before or after the secondary one.
+In order to indicate secondary locations, you must use either `// ^^^^^<` or `// ^^^^>`, the arrow
+indicating whether the matching main location is either before or after the secondary one.
 
 As stated before, the message is optional.
 
-\*\*/!\*\* If you have used a secondary location in your test file, you must always report error messages using [toEncodedMessage()](https://github.com/SonarSource/SonarJS/blob/382fd7d4dad2a085ca5ac6d004cb38fe52720cca/src/linting/eslint/rules/helpers/location.ts#L44) in your rule, as it will be expecting it.
+\*\*/!\*\* If you have used a secondary location in your test file, you must always report error
+messages using
+[toEncodedMessage()](https://github.com/SonarSource/SonarJS/blob/382fd7d4dad2a085ca5ac6d004cb38fe52720cca/src/linting/eslint/rules/helpers/location.ts#L44)
+in your rule, as it will be expecting it.
 
 #### Quick fixes
 
-Quick fixes refer to both ESLint [Suggestions](https://eslint.org/docs/latest/developer-guide/working-with-rules#providing-suggestions) and [Fixes](https://eslint.org/docs/latest/developer-guide/working-with-rules#applying-fixes). In our comment-based framework both use the same syntax, with the difference that a quick fix ID followed by an exclamation mark (`!`) will be internally treated as a `fix` with ESLint instead of as a suggestion. Please note that rules providing fixes **MUST** be tested always with fixes, otherwise the test will fail with the following error: `The rule fixed the code. Please add 'output' property.`. On the other side, it is optional to check against rule suggestions, meaning that even if a rule provides them, the tests can choose not to test their contents.
+Quick fixes refer to both ESLint
+[Suggestions](https://eslint.org/docs/latest/developer-guide/working-with-rules#providing-suggestions)
+and [Fixes](https://eslint.org/docs/latest/developer-guide/working-with-rules#applying-fixes). In
+our comment-based framework both use the same syntax, with the difference that a quick fix ID
+followed by an exclamation mark (`!`) will be internally treated as a `fix` with ESLint instead of
+as a suggestion. Please note that rules providing fixes **MUST** be tested always with fixes,
+otherwise the test will fail with the following error:
+`The rule fixed the code. Please add 'output' property.`. On the other side, it is optional to check
+against rule suggestions, meaning that even if a rule provides them, the tests can choose not to
+test their contents.
 
-The `fix@` comment referring to a quick fix provides the suggestion description and is optional. Eslint fixes do not support descriptions, meaning a quick fix ID declared with an exclamation mark (i.e. `qf1!`) must **NOT** have a `fix@` matching comment (i.e. `fix@qf1`).
+The `fix@` comment referring to a quick fix provides the suggestion description and is optional.
+Eslint fixes do not support descriptions, meaning a quick fix ID declared with an exclamation mark
+(i.e. `qf1!`) must **NOT** have a `fix@` matching comment (i.e. `fix@qf1`).
 
-Each quick fix can have multiple editions associated to it. There are three different kind of operations to edit the code with quick fixes. Given a quick fix ID `qf`, these are the syntaxes used for each operation:
+Each quick fix can have multiple editions associated to it. There are three different kind of
+operations to edit the code with quick fixes. Given a quick fix ID `qf`, these are the syntaxes used
+for each operation:
 
 - `add@qf {{code to add}}` Add the string between the double brackets to a new line in the code.
 - `del@qf` Remove the line
-- `edit@qf1 [[sc=1;ec=5]] {{text to replace the range }}` Edit the line from start column `sc` to end column `ec` (both 0-based) with the provided string between the double brackets. Alternatively, one can conveniently use only `sc` or `ec`. also optional, meaning this syntax can be used too:
+- `edit@qf1 [[sc=1;ec=5]] {{text to replace the range }}` Edit the line from start column `sc` to
+  end column `ec` (both 0-based) with the provided string between the double brackets.
+  Alternatively, one can conveniently use only `sc` or `ec`. also optional, meaning this syntax can
+  be used too:
   - `edit@qf1 {{text to replace the whole line -do not include //Noncompliant comment- }}`
 
-The line affected in each of these operations will be the line of the issue to which the quick fix is linked to. It is possible to use the line modifier syntax (`@[+|-]?line`). When using line increments/decrements, keep in mind the base number is the issue line number, not the line of the quick fix edit comment. Example for rule `brace-style`:
+The line affected in each of these operations will be the line of the issue to which the quick fix
+is linked to. It is possible to use the line modifier syntax (`@[+|-]?line`). When using line
+increments/decrements, keep in mind the base number is the issue line number, not the line of the
+quick fix edit comment. Example for rule `brace-style`:
 
 ```javascript
 //Noncompliant@+1 [[qf!]]
@@ -317,13 +390,22 @@ if (condition) {
 Let's go through the syntax used in this example:
 
 - The test provides a fix (note the `!` after the ID `qf`).
-- The line `//Noncompliant@+1 [[qf!]]` means that in the following (`@+1`) line there is an issue for which we provide a quick fix.
-- The line `// edit@qf [[sc=16]] {{}}` is providing an edit to the same line of the issue, replacing the contents after column 16 (`sc=16`) by an empty string (`{{}}`). An alternative with the same effect would be `// edit@qf {{if (condition) {}}`, which would replace the whole line by `if (condition) {`.
-- Lastly, the line `// add@qf@+1 {{ doSomething()}}` will add a new line just after the issue line (`@+1`) with the contents `&nbsp;doSomething()`
+- The line `//Noncompliant@+1 [[qf!]]` means that in the following (`@+1`) line there is an issue
+  for which we provide a quick fix.
+- The line `// edit@qf [[sc=16]] {{}}` is providing an edit to the same line of the issue, replacing
+  the contents after column 16 (`sc=16`) by an empty string (`{{}}`). An alternative with the same
+  effect would be `// edit@qf {{if (condition) {}}`, which would replace the whole line by
+  `if (condition) {`.
+- Lastly, the line `// add@qf@+1 {{ doSomething()}}` will add a new line just after the issue line
+  (`@+1`) with the contents `&nbsp;doSomething()`
 
-Note that the length of the list of quick fixes cannot surpass the number of issues declared by `N` or the number of expected messages unless their matching issue is reassigned (see below).
+Note that the length of the list of quick fixes cannot surpass the number of issues declared by `N`
+or the number of expected messages unless their matching issue is reassigned (see below).
 
-Quick fixes IDs can be any `string`, they don't have to follow the `qfN` convention. The order of the list is important, as they will be assigned to the message in the matching position. If one provides 3 messages and 2 quick fixes which are not to be matched against first and second message, there are two options:
+Quick fixes IDs can be any `string`, they don't have to follow the `qfN` convention. The order of
+the list is important, as they will be assigned to the message in the matching position. If one
+provides 3 messages and 2 quick fixes which are not to be matched against first and second message,
+there are two options:
 
 - A _dummy_ quick fix can be used as placeholder:
 
@@ -334,7 +416,8 @@ some.faulty.code(); // Noncompliant [[qf1,qf2,qf3]] {{message1}} {{message2}} {{
 // qf2 is declared but never used --> ignored by the engine
 ```
 
-- Explicitly set the index (0-based) of the message to which the quick fix refers to with the syntax `=index` next to the quick fix ID:
+- Explicitly set the index (0-based) of the message to which the quick fix refers to with the syntax
+  `=index` next to the quick fix ID:
 
 ```javascript
 some.faulty.code(); // Noncompliant [[qf1,qf3=2]] {{message1}} {{message2}} {{message3}}
@@ -354,7 +437,8 @@ some.faulty.code(); // Noncompliant [[qf1,qf2=0]]
 
 #### Ruling
 
-Make sure to run [Ruling ITs](#ruling-tests) for the new or updated rule (don't forget to rebuild the jar before that!).
+Make sure to run [Ruling ITs](#ruling-tests) for the new or updated rule (don't forget to rebuild
+the jar before that!).
 
 If your rule does not raise any issue, you should write your own code that triggers your rule in:
 
@@ -367,13 +451,19 @@ You can simply copy and paste compliant and non-compliant examples from your RSP
 
 - Security Hotspot implementation: [PR](https://github.com/SonarSource/SonarJS/pull/3148)
 - Quality rule implemented with quickfix: [PR](https://github.com/SonarSource/SonarJS/pull/3141)
-- Adding a rule already covered by ESLint or its plugins: [PR](https://github.com/SonarSource/SonarJS/pull/3134)
-- Adding a quickfix for rule covered by ESLint or its plugins: [PR](https://github.com/SonarSource/SonarJS/pull/3058)
-- Adding a rule covered by ESLint with an ESLint "fix" quick fix: [PR](https://github.com/SonarSource/SonarJS/pull/3751)
+- Adding a rule already covered by ESLint or its plugins:
+  [PR](https://github.com/SonarSource/SonarJS/pull/3134)
+- Adding a quickfix for rule covered by ESLint or its plugins:
+  [PR](https://github.com/SonarSource/SonarJS/pull/3058)
+- Adding a rule covered by ESLint with an ESLint "fix" quick fix:
+  [PR](https://github.com/SonarSource/SonarJS/pull/3751)
 - Decorate a rule covered by ESLint: [PR](https://github.com/SonarSource/SonarJS/pull/3514)
-- Merge 2 ESLint rules: [PR](https://github.com/SonarSource/SonarJS/pull/4387/files#diff-0bbe92c0a507bd02fb792be5df80db2ad9d66b30ce7b11b7925ed29121c3b233R22-R44)
-- Use comment-based tests with `package.json` dependencies dependent rule: [PR](<[TBD](https://github.com/SonarSource/SonarJS/pull/4443/files#diff-92d7c68b7e4cc945d0f128acbd458648eb8021903587c1ee7025243f2fae89d2)>)
-- Use ESLint's Rule tester with `package.json` dependencies dependent rule: [PR](<[TBD](https://github.com/SonarSource/SonarJS/commit/dc9435738093286869edff742c90d17d74e39b1c#diff-55f5136cfbed4170ed04f718f78f46015d6bb1f78c26403e036136211a333425R154-R213)>)
+- Merge 2 ESLint rules:
+  [PR](https://github.com/SonarSource/SonarJS/pull/4387/files#diff-0bbe92c0a507bd02fb792be5df80db2ad9d66b30ce7b11b7925ed29121c3b233R22-R44)
+- Use comment-based tests with `package.json` dependencies dependent rule:
+  [PR](<[TBD](https://github.com/SonarSource/SonarJS/pull/4443/files#diff-92d7c68b7e4cc945d0f128acbd458648eb8021903587c1ee7025243f2fae89d2)>)
+- Use ESLint's Rule tester with `package.json` dependencies dependent rule:
+  [PR](<[TBD](https://github.com/SonarSource/SonarJS/commit/dc9435738093286869edff742c90d17d74e39b1c#diff-55f5136cfbed4170ed04f718f78f46015d6bb1f78c26403e036136211a333425R154-R213)>)
 
 ## Rule Options Architecture
 
@@ -401,7 +491,8 @@ External Client → gRPC → transformers.ts → analyzeProject() → ESLint Lin
                    string params to typed values
 ```
 
-The key difference is that SonarQube's Java side sends already-typed values via `configurations()`, while the gRPC endpoint receives string key-value pairs that need type parsing.
+The key difference is that SonarQube's Java side sends already-typed values via `configurations()`,
+while the gRPC endpoint receives string key-value pairs that need type parsing.
 
 Each rule can have configurable options defined in several places that serve different purposes.
 
@@ -422,40 +513,42 @@ The `implementation` field in `meta.ts` determines how a rule is structured:
 
 #### `original`
 
-Rules written from scratch for SonarJS. If the rule accepts options, it defines its own JSON Schema in `meta.ts`. Rules without options don't need a schema or config.ts:
+Rules written from scratch for SonarJS. If the rule accepts options, it defines its own JSON Schema
+in `meta.ts`. Rules without options don't need a schema or config.ts:
 
 ```typescript
 // S100/meta.ts
-export const implementation = 'original';
-export const eslintId = 'function-name';
-export * from './config.js';
-import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
+export const implementation = "original";
+export const eslintId = "function-name";
+export * from "./config.js";
+import type { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
 export const schema = {
-  type: 'array',
-  items: [{ type: 'object', properties: { format: { type: 'string' } } }],
+  type: "array",
+  items: [{ type: "object", properties: { format: { type: "string" } } }],
 } as const satisfies JSONSchema4;
 ```
 
 #### `decorated`
 
-Rules that wrap/extend an existing ESLint rule, adding SonarJS-specific behavior. They may optionally define a `schema` if needed:
+Rules that wrap/extend an existing ESLint rule, adding SonarJS-specific behavior. They may
+optionally define a `schema` if needed:
 
 ```typescript
 // S109/meta.ts - no schema, uses external rule's schema at runtime
-export const implementation = 'decorated';
-export const eslintId = 'no-magic-numbers';
+export const implementation = "decorated";
+export const eslintId = "no-magic-numbers";
 export const externalRules = [
-  { externalPlugin: 'typescript-eslint', externalRule: 'no-magic-numbers' },
+  { externalPlugin: "typescript-eslint", externalRule: "no-magic-numbers" },
 ];
-export * from './config.js';
+export * from "./config.js";
 ```
 
 ```typescript
 // S107/meta.ts - explicit schema (when customization is needed)
-export const implementation = 'decorated';
-export const eslintId = 'max-params';
-export const externalRules = [{ externalPlugin: 'eslint', externalRule: 'max-params' }];
-export * from './config.js';
+export const implementation = "decorated";
+export const eslintId = "max-params";
+export const externalRules = [{ externalPlugin: "eslint", externalRule: "max-params" }];
+export * from "./config.js";
 export const schema = {
   /* ... */
 } as const satisfies JSONSchema4;
@@ -463,14 +556,16 @@ export const schema = {
 
 #### `external`
 
-Rules that directly use an ESLint rule without modification. The schema is inherited from the external rule at runtime. Some external rules expose user-configurable options via `config.ts` (e.g., S103, S139, S1441):
+Rules that directly use an ESLint rule without modification. The schema is inherited from the
+external rule at runtime. Some external rules expose user-configurable options via `config.ts`
+(e.g., S103, S139, S1441):
 
 ```typescript
 // S106/meta.ts
-export const implementation = 'external';
-export const eslintId = 'no-console';
-export const externalPlugin = 'eslint';
-export * from './config.js';
+export const implementation = "external";
+export const eslintId = "no-console";
+export const externalPlugin = "eslint";
+export * from "./config.js";
 ```
 
 ### The `fields` Array (`config.ts`)
@@ -487,9 +582,9 @@ The `fields` array is the **source of truth** for rule options. It defines:
 export const fields = [
   [
     {
-      field: 'max', // ESLint option name
-      displayName: 'maximumFunctionParameters', // SonarQube UI name (optional)
-      description: 'Maximum authorized...', // Shows in SQ UI
+      field: "max", // ESLint option name
+      displayName: "maximumFunctionParameters", // SonarQube UI name (optional)
+      description: "Maximum authorized...", // Shows in SQ UI
       default: 7, // Default value & type inference
     },
   ],
@@ -527,8 +622,8 @@ Fields without `description` are internal-only defaults that users cannot config
 // S109/config.ts - NO descriptions, so not exposed in SQ
 export const fields = [
   [
-    { field: 'ignore', default: [0, 1, -1, 24, 60] }, // Internal only
-    { field: 'ignoreDefaultValues', default: true }, // Internal only
+    { field: "ignore", default: [0, 1, -1, 24, 60] }, // Internal only
+    { field: "ignoreDefaultValues", default: true }, // Internal only
   ],
 ] as const satisfies ESLintConfiguration;
 ```
@@ -540,10 +635,10 @@ export const fields = [
 export const fields = [
   [
     {
-      field: 'passwordWords',
-      items: { type: 'string' },
-      description: 'Comma separated list of words identifying potential passwords.',
-      default: ['password', 'pwd', 'passwd', 'passphrase'],
+      field: "passwordWords",
+      items: { type: "string" },
+      description: "Comma separated list of words identifying potential passwords.",
+      default: ["password", "pwd", "passwd", "passphrase"],
     },
   ],
 ] as const satisfies ESLintConfiguration;
@@ -569,7 +664,10 @@ The transformation layer (`packages/grpc/src/transformers.ts`) handles this mapp
 | **Required for** | `original` rules with options | All rules with options                |
 | **Defines**      | Structure & constraints       | Defaults, descriptions, SQ keys       |
 
-**Important:** The schema is for ESLint validation. The `fields` array provides default values and metadata for SonarQube integration. For `original` rules with options, both schema and fields must be kept in sync manually. For `decorated`/`external` rules, the schema is inherited from the external rule at runtime.
+**Important:** The schema is for ESLint validation. The `fields` array provides default values and
+metadata for SonarQube integration. For `original` rules with options, both schema and fields must
+be kept in sync manually. For `decorated`/`external` rules, the schema is inherited from the
+external rule at runtime.
 
 ### `defaultOptions` in `generated-meta.ts`
 
@@ -580,7 +678,7 @@ The `npm run generate-meta` script reads `fields` and generates `defaultOptions`
 export const meta = {
   // ...
   defaultOptions: [
-    { format: '^[_a-z][a-zA-Z0-9]*$' }, // From fields[0][0].default
+    { format: "^[_a-z][a-zA-Z0-9]*$" }, // From fields[0][0].default
   ],
 };
 ```
@@ -591,12 +689,14 @@ This is extracted using the `defaultOptions()` helper from `helpers/configs.ts`.
 
 #### SonarQube workflow (gRPC)
 
-1. **Java Side**: `@RuleProperty` fields are read, `configurations()` returns typed `List<Object>` (e.g., `Map.of("max", 7)`)
-2. **Transport**: `AnalyzeProjectMessages` converts those Java values to protobuf `Struct`/`Value` while preserving their types
+1. **Java Side**: `@RuleProperty` fields are read, `configurations()` returns typed `List<Object>`
+   (e.g., `Map.of("max", 7)`)
+2. **Transport**: `AnalyzeProjectMessages` converts those Java values to protobuf `Struct`/`Value`
+   while preserving their types
 3. **Linter**: `linter.ts:createRulesRecord()` merges defaults with user config:
    ```typescript
    rules[`sonarjs/${rule.key}`] = [
-     'error',
+     "error",
      ...merge(defaultOptions(ruleMeta.fields), rule.configurations),
    ];
    ```
@@ -604,12 +704,14 @@ This is extracted using the `defaultOptions()` helper from `helpers/configs.ts`.
 #### gRPC workflow (external clients)
 
 1. **Client**: Sends rule params as string key-value pairs via proto3
-2. **Transformer**: `transformers.ts` maps SQ keys → ESLint keys and parses string values to proper types
+2. **Transformer**: `transformers.ts` maps SQ keys → ESLint keys and parses string values to proper
+   types
 3. **Linter**: Same merging as above
 
 ### Type Parsing from Strings (gRPC only)
 
-The gRPC workflow receives all param values as strings. The transformer parses them based on the `default` value type in `fields`:
+The gRPC workflow receives all param values as strings. The transformer parses them based on the
+`default` value type in `fields`:
 
 | Default Type | Input String | Parsed Result     |
 | ------------ | ------------ | ----------------- |
@@ -635,8 +737,8 @@ The gRPC workflow receives all param values as strings. The transformer parses t
 // config.ts
 export const fields = [
   [
-    { field: 'max', description: '...', default: 7 },
-    { field: 'ignoreIIFE', description: '...', default: false },
+    { field: "max", description: "...", default: 7 },
+    { field: "ignoreIIFE", description: "...", default: false },
   ],
 ] as const satisfies ESLintConfiguration;
 
@@ -648,7 +750,7 @@ export const fields = [
 ```typescript
 // config.ts
 export const fields = [
-  { default: '^[a-z]+$' }, // Single non-array element
+  { default: "^[a-z]+$" }, // Single non-array element
 ] as const satisfies ESLintConfiguration;
 
 // ESLint receives: ['^[a-z]+$']
@@ -661,10 +763,10 @@ export const fields = [
 export const fields = [
   [
     {
-      field: 'passwordWords',
-      items: { type: 'string' }, // Required for Java codegen
-      description: 'Comma separated list...',
-      default: ['password', 'pwd'],
+      field: "passwordWords",
+      items: { type: "string" }, // Required for Java codegen
+      description: "Comma separated list...",
+      default: ["password", "pwd"],
     },
   ],
 ] as const satisfies ESLintConfiguration;
@@ -676,13 +778,16 @@ export const fields = [
 ## Misc
 
 - Use issue number for a branch name, e.g. `issue-1234`
-- You can use [AST explorer](https://astexplorer.net/) to explore the tree share. Use the `regexpp` parser when implementing a Regex rule.
+- You can use [AST explorer](https://astexplorer.net/) to explore the tree share. Use the `regexpp`
+  parser when implementing a Regex rule.
 - [ESlint's working with rules](https://eslint.org/docs/developer-guide/working-with-rules)
 
 ## Issue tracking
 
 ### Working on a rule
 
-You don't need to make separate Jira tickets for RSPEC and rule implementation, a single one is good enough.
+You don't need to make separate Jira tickets for RSPEC and rule implementation, a single one is good
+enough.
 
-Add a link to the RSPEC PR from the SonarJS PR as shown in [this example](https://github.com/SonarSource/SonarJS/pull/4802#issue-2505105904).
+Add a link to the RSPEC PR from the SonarJS PR as shown in
+[this example](https://github.com/SonarSource/SonarJS/pull/4802#issue-2505105904).

--- a/docs/rule-data-lifecycle.md
+++ b/docs/rule-data-lifecycle.md
@@ -1,0 +1,173 @@
+# RSPEC Rule-Data Lifecycle
+
+This document explains how SonarJS prepares, reuses, and refreshes generated RSPEC rule data. It
+focuses on the moving pieces that are easy to confuse in a reused workspace:
+
+- `resources/rule-data-state.json`
+- root `rspec.sha`
+- generated per-language `sonar-plugin/*/src/main/resources/rspec.sha`
+
+## Files and roles
+
+### `resources/rule-data-state.json`
+
+This ignored file is the lifecycle stamp written by `npm run ensure-rule-data`.
+
+It records:
+
+- the lifecycle version
+- the generation step name
+- the current SonarJS `HEAD`
+- the current root `rspec.sha` value, if any
+
+Its job is to answer:
+
+> Do the prepared rule-data outputs belong to this checkout and this root RSPEC pin?
+
+If the answer is yes, `ensure-rule-data` can skip regeneration. If the answer is no, it refreshes
+rule data and writes a new stamp.
+
+### Root `rspec.sha`
+
+`rspec.sha` at the repository root is the explicit shared input pin.
+
+If present, it means:
+
+> Generate rule data from this exact RSPEC commit.
+
+`ensure-rule-data` and the Maven wrapper treat this file as authoritative. It applies to both
+JavaScript and CSS unless a direct Maven command overrides the per-language properties itself.
+
+### Generated per-language `rspec.sha`
+
+Prepared rule data also keeps generated pins in:
+
+- `sonar-plugin/javascript-checks/src/main/resources/rspec.sha`
+- `sonar-plugin/css/src/main/resources/rspec.sha`
+
+These files record which RSPEC commit produced the prepared JavaScript and CSS rule data.
+
+They are primarily outputs and provenance markers. They are not committed, and they can survive
+branch switches because they are ignored build artifacts.
+
+## Commands and responsibilities
+
+### `npm run ensure-rule-data`
+
+This is the SonarJS-owned lifecycle entrypoint.
+
+It:
+
+1. checks whether prepared rule data exists
+2. compares it with `resources/rule-data-state.json`
+3. regenerates when the prepared data is missing or stale
+4. writes the refreshed lifecycle stamp
+
+Use this command when you want rule data prepared for the current checkout.
+
+### `npm run generate-meta`
+
+This command now runs:
+
+1. `npm run ensure-rule-data`
+2. `npm run generate-meta:raw`
+
+That means metadata generation always goes through the same rule-data freshness check first.
+
+### `npm run generate-rule-data:maven`
+
+This is the Maven wrapper that actually performs RSPEC generation and deployment.
+
+It can still be useful directly, especially for explicit Maven pinning workflows, but ordinary
+SonarJS lifecycle handling should go through `npm run ensure-rule-data`.
+
+## Reuse and refresh rules
+
+Prepared rule data is reused only when all of these line up:
+
+- the JavaScript rule-data directory exists
+- the CSS rule-data directory exists
+- the generated per-language `rspec.sha` files exist
+- the lifecycle stamp matches the current checkout `HEAD`
+- the lifecycle stamp matches the current root `rspec.sha` value
+
+If any of those conditions stop matching, `ensure-rule-data` regenerates the rule data.
+
+## Pin precedence
+
+Pin precedence is:
+
+1. root `rspec.sha`
+2. generated per-language `rspec.sha`
+3. default RSPEC branch behavior from Maven configuration
+
+In other words:
+
+- root `rspec.sha` is the intentional shared pin
+- generated per-language pins are fallback inputs when no root pin is present
+
+## Why stale generated pins are dangerous
+
+The generated per-language pins are ignored files, so they may remain in the workspace after a
+branch switch or revision change.
+
+If stale generated pins are reused as inputs for a new checkout, rule data can be regenerated from
+an old RSPEC revision and then incorrectly treated as current for the new SonarJS `HEAD`.
+
+To avoid that, `ensure-rule-data` clears generated per-language pins before regenerating only when
+all of these are true:
+
+- there is an existing lifecycle stamp
+- that stamp is stale for the current checkout
+- there is no root `rspec.sha`
+
+This keeps the stale-checkout cleanup path while preserving legacy or direct Maven pinned outputs
+that do not have a lifecycle stamp yet.
+
+## Common scenarios
+
+### Fresh checkout
+
+There is no prepared rule data and no lifecycle stamp.
+
+`npm run ensure-rule-data` regenerates rule data and writes a new `resources/rule-data-state.json`.
+
+### Reused checkout on the same revision
+
+Prepared rule data and the lifecycle stamp match the current checkout.
+
+`npm run ensure-rule-data` skips regeneration.
+
+### Switched branch or revision
+
+Prepared rule data may still exist, but the lifecycle stamp no longer matches the current `HEAD`.
+
+`npm run ensure-rule-data` regenerates rule data and writes a new stamp.
+
+### Root RSPEC pin changed
+
+The root `rspec.sha` value is part of the lifecycle stamp.
+
+Changing that file makes the stamp stale, so `npm run ensure-rule-data` regenerates rule data for
+the new explicit pin.
+
+### Direct Maven per-language pinning
+
+If rule data was prepared outside `ensure-rule-data`, for example with direct Maven
+`-Drspec.javascript.sha=...` or `-Drspec.css.sha=...`, the generated per-language pins may exist
+without a lifecycle stamp.
+
+In that case `ensure-rule-data` does not delete those pins just because the stamp is absent. That
+preserves legacy and directly pinned prepared outputs until SonarJS itself stamps a lifecycle state.
+
+## CI artifact handoff
+
+CI now prepares RSPEC rule data through `npm run ensure-rule-data` and uploads:
+
+- prepared JavaScript rule data
+- prepared CSS rule data
+- generated per-language `rspec.sha`
+- `resources/rule-data-state.json`
+
+Downstream jobs download that artifact at the repository root so the prepared paths and lifecycle
+stamp are restored exactly where `ensure-rule-data` and `generate-meta` expect them.

--- a/docs/rule-data-lifecycle.md
+++ b/docs/rule-data-lifecycle.md
@@ -5,7 +5,96 @@ focuses on the moving pieces that are easy to confuse in a reused workspace:
 
 - `resources/rule-data-state.json`
 - root `rspec.sha`
+- Direct Maven pinning
 - generated per-language `sonar-plugin/*/src/main/resources/rspec.sha`
+
+## Lifecycle at a glance
+
+### Input / Output
+
+```text
+          normal SonarJS path                    advanced/manual path
+        +---------------------------+          +---------------------------+
+        | root rspec.sha            |          | Direct Maven pinning      |
+        | - shared explicit pin     |          | - explicit advanced       |
+        |                           |          |   pinning                 |
+        |                           |          |                           |
+        +-------------+-------------+          +-------------+-------------+
+                      |                                      |
+                      v                                      v
+        +---------------------------+          +---------------------------+
+        | ensure-rule-data /        |          | direct mvn generation     |
+        | generate-rule-data:maven  |          |                           |
+        +-------------+-------------+          +-------------+-------------+
+                      |                                      |
+                      +------------------+-------------------+
+                                         |
+                                         v
+        +-----------------------------------------+
+        | prepared rule-data outputs              |
+        | - sonar-plugin/**/rules/**/*.json       |
+        | - sonar-plugin/**/rules/**/*.html       |
+        | - generated per-language rspec.sha      |
+        +-------------------+---------------------+
+                            |
+                            v
+        +-----------------------------------------+
+        | resources/rule-data-state.json          |
+        | - version                               |
+        | - step                                  |
+        | - head                                  |
+        | - rootRspecSha                          |
+        +-----------------------------------------+
+```
+
+### State Graph
+
+```text
+                    +------------------------------+
+                    | no prepared rule data        |
+                    +--------------+---------------+
+                                   |
+                                   | ensure-rule-data
+                                   v
+                    +------------------------------+
+                    | regenerate rule data         |
+                    +--------------+---------------+
+                                   |
+                                   | write state stamp
+                                   v
+              +--------------------------------------------------+
+              | prepared rule data exists and is consistent      |
+              +----------------------+---------------------------+
+                                     |
+            +------------------------+------------------------+
+            |                                                 |
+            | same HEAD + same root pin                       | HEAD changed
+            | outputs still present                           | or root pin changed
+            |                                                 | or outputs missing
+            v                                                 v
+    +---------------------+                         +------------------------------+
+    | reuse / skip        |                         | stale                        |
+    +----------+----------+                         +--------------+---------------+
+               |                                                   |
+               | ensure-rule-data                                  | ensure-rule-data
+               |                                                   |
+               |                                                   | if stale stamp exists
+               |                                                   | and no root rspec.sha:
+               |                                                   | clear generated
+               |                                                   | per-language pins
+               |                                                   v
+               |                                    +------------------------------+
+               +----------------------------------->| regenerate rule data         |
+                                                    +--------------+---------------+
+                                                                   |
+                                                                   | normal refresh uses:
+                                                                   | - root rspec.sha
+                                                                   | - generated pin fallback
+                                                                   v
+              +--------------------------------------------------+
+              | prepared rule data exists and is consistent      |
+              +--------------------------------------------------+
+```
 
 ## Files and roles
 
@@ -37,6 +126,37 @@ If present, it means:
 
 `ensure-rule-data` and the Maven wrapper treat this file as authoritative. It applies to both
 JavaScript and CSS unless a direct Maven command overrides the per-language properties itself.
+
+This file is intentionally different from `resources/rule-data-state.json`:
+
+- `rspec.sha` expresses requested input: "build from this RSPEC revision"
+- `rule-data-state.json` expresses observed freshness: "these prepared outputs match this checkout
+  and this root pin"
+
+The state file can tell SonarJS whether outputs are current, but it is not meant to replace the
+user-controlled pin. Keeping those roles separate avoids mixing "what was requested" with "what was
+last prepared".
+
+### Direct Maven pinning
+
+Direct Maven pinning means generating rule data by passing explicit Maven properties instead of
+creating a root `rspec.sha` file.
+
+Examples:
+
+```bash
+-Drspec.sha=<commit-sha>
+```
+
+or, for separate JavaScript and CSS revisions:
+
+```bash
+-Drspec.javascript.sha=<commit-sha>
+-Drspec.css.sha=<commit-sha>
+```
+
+This is a supported advanced/manual workflow. It is not the normal GitHub CI path. It is supported
+through the Maven profiles in `sonar-plugin/javascript-checks/pom.xml`.
 
 ### Generated per-language `rspec.sha`
 
@@ -78,8 +198,11 @@ That means metadata generation always goes through the same rule-data freshness 
 
 This is the Maven wrapper that actually performs RSPEC generation and deployment.
 
-It can still be useful directly, especially for explicit Maven pinning workflows, but ordinary
-SonarJS lifecycle handling should go through `npm run ensure-rule-data`.
+It can still be useful directly for the normal SonarJS workflow, but ordinary SonarJS lifecycle
+handling should go through `npm run ensure-rule-data`.
+
+Direct Maven pinning is a separate advanced/manual workflow that bypasses `ensure-rule-data` and
+invokes Maven with explicit `-Drspec...` properties.
 
 ## Reuse and refresh rules
 
@@ -95,7 +218,7 @@ If any of those conditions stop matching, `ensure-rule-data` regenerates the rul
 
 ## Pin precedence
 
-Pin precedence is:
+Within the normal SonarJS lifecycle, pin precedence is:
 
 1. root `rspec.sha`
 2. generated per-language `rspec.sha`
@@ -105,6 +228,29 @@ In other words:
 
 - root `rspec.sha` is the intentional shared pin
 - generated per-language pins are fallback inputs when no root pin is present
+
+Direct Maven pinning sits outside that precedence chain because it bypasses the normal SonarJS
+wrapper and passes explicit Maven properties directly.
+
+## Why the root pin and state file both exist
+
+It may be tempting to collapse root `rspec.sha` into `resources/rule-data-state.json`, but they
+serve different responsibilities:
+
+- root `rspec.sha` is an input chosen by the user or workflow
+- `rule-data-state.json` is a derived stamp written by SonarJS after preparation
+
+In practice, that means:
+
+- deleting the state file should only force SonarJS to re-check or regenerate prepared outputs
+- changing root `rspec.sha` should deliberately change which RSPEC revision is used
+
+As long as SonarJS supports an explicit shared RSPEC pin, the root `rspec.sha` file remains useful
+even though the lifecycle stamp also records its current value.
+
+The generated per-language `rspec.sha` files are a different story: they are primarily build
+artifacts and Maven-facing fallback inputs. Those are more likely candidates for future
+simplification than the root pin itself.
 
 ## Why stale generated pins are dangerous
 
@@ -151,11 +297,10 @@ The root `rspec.sha` value is part of the lifecycle stamp.
 Changing that file makes the stamp stale, so `npm run ensure-rule-data` regenerates rule data for
 the new explicit pin.
 
-### Direct Maven per-language pinning
+### Direct Maven pinning
 
-If rule data was prepared outside `ensure-rule-data`, for example with direct Maven
-`-Drspec.javascript.sha=...` or `-Drspec.css.sha=...`, the generated per-language pins may exist
-without a lifecycle stamp.
+If rule data was prepared outside `ensure-rule-data` with Direct Maven pinning, the generated
+per-language pins may exist without a lifecycle stamp.
 
 In that case `ensure-rule-data` does not delete those pins just because the stamp is absent. That
 preserves legacy and directly pinned prepared outputs until SonarJS itself stamps a lifecycle state.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "new-rule": "tsx tools/new-rule.mts",
     "generate-meta": "node tools/generate-meta.mjs",
     "generate-meta:raw": "npm run grpc:generate-proto && tsx tools/generate-meta.ts",
+    "ensure-rule-data": "node tools/ensure-rule-data.mjs",
     "generate-rule-data:maven": "node tools/generate-rule-data.mjs",
     "validate-quickfix": "tsx tools/validate-quickfix.ts",
     "generate-java-rule-classes": "tsx tools/generate-java-rule-classes.ts",

--- a/tools/ensure-rule-data.mjs
+++ b/tools/ensure-rule-data.mjs
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 const statePath = join('resources', 'rule-data-state.json');
@@ -52,15 +52,24 @@ const preparedRuleDataPaths = [
   join('sonar-plugin', 'css', 'src', 'main', 'resources', 'rspec.sha'),
 ];
 
+const actualState = readRuleDataState();
+const preparedRuleData = hasPreparedRuleData();
+const rootRspecSha = readRootRspecSha();
+const head = gitHead();
 const desiredState = {
   version: stateVersion,
   step: stepName,
-  head: gitHead(),
-  rootRspecSha: readRootRspecSha(),
+  head,
+  rootRspecSha,
 };
 
-if (hasPreparedRuleData() && isCurrentState(readRuleDataState(), desiredState)) {
-  console.log(`Rule data is already prepared for ${desiredState.head}`);
+if (preparedRuleData && isCurrentState(actualState, desiredState)) {
+  console.log(`Rule data is already prepared for ${displayHead(head)}`);
+  process.exit(0);
+}
+
+if (preparedRuleData && head === null && isPreparedStateForUnknownHead(actualState, desiredState)) {
+  console.log('Rule data is already prepared; skipping because git HEAD is unavailable');
   process.exit(0);
 }
 
@@ -68,7 +77,27 @@ runNpmScript(stepName);
 writeRuleDataState(desiredState);
 
 function hasPreparedRuleData() {
-  return preparedRuleDataPaths.every(path => existsSync(path));
+  return (
+    preparedRuleDataPaths.every(path => existsSync(path)) &&
+    directoryContainsRuleFiles(
+      join(
+        'sonar-plugin',
+        'javascript-checks',
+        'src',
+        'main',
+        'resources',
+        'org',
+        'sonar',
+        'l10n',
+        'javascript',
+        'rules',
+        'javascript',
+      ),
+    ) &&
+    directoryContainsRuleFiles(
+      join('sonar-plugin', 'css', 'src', 'main', 'resources', 'org', 'sonar', 'l10n', 'css', 'rules', 'css'),
+    )
+  );
 }
 
 function isCurrentState(actual, expected) {
@@ -76,6 +105,14 @@ function isCurrentState(actual, expected) {
     actual?.version === expected.version &&
     actual?.step === expected.step &&
     actual?.head === expected.head &&
+    actual?.rootRspecSha === expected.rootRspecSha
+  );
+}
+
+function isPreparedStateForUnknownHead(actual, expected) {
+  return (
+    actual?.version === expected.version &&
+    actual?.step === expected.step &&
     actual?.rootRspecSha === expected.rootRspecSha
   );
 }
@@ -108,14 +145,21 @@ function gitHead() {
   const result = spawnSync('git', ['rev-parse', 'HEAD'], {
     encoding: 'utf8',
   });
-  if (result.error !== undefined) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    process.stderr.write(result.stderr);
-    process.exit(result.status ?? 1);
+  if (result.error !== undefined || result.status !== 0) {
+    return null;
   }
   return result.stdout.trim();
+}
+
+function directoryContainsRuleFiles(path) {
+  return readdirSync(path, { withFileTypes: true }).some(
+    entry =>
+      entry.isFile() && (entry.name.endsWith('.json') || entry.name.endsWith('.html')),
+  );
+}
+
+function displayHead(head) {
+  return head ?? 'an unknown head';
 }
 
 function runNpmScript(script) {

--- a/tools/ensure-rule-data.mjs
+++ b/tools/ensure-rule-data.mjs
@@ -15,12 +15,16 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 const statePath = join('resources', 'rule-data-state.json');
 const stateVersion = 1;
 const stepName = 'generate-rule-data:maven';
+const generatedRspecShaPaths = [
+  join('sonar-plugin', 'javascript-checks', 'src', 'main', 'resources', 'rspec.sha'),
+  join('sonar-plugin', 'css', 'src', 'main', 'resources', 'rspec.sha'),
+];
 const preparedRuleDataPaths = [
   join(
     'sonar-plugin',
@@ -48,8 +52,7 @@ const preparedRuleDataPaths = [
     'rules',
     'css',
   ),
-  join('sonar-plugin', 'javascript-checks', 'src', 'main', 'resources', 'rspec.sha'),
-  join('sonar-plugin', 'css', 'src', 'main', 'resources', 'rspec.sha'),
+  ...generatedRspecShaPaths,
 ];
 
 const actualState = readRuleDataState();
@@ -62,6 +65,10 @@ const desiredState = {
   head,
   rootRspecSha,
 };
+const stateIsKnownStale =
+  actualState !== undefined &&
+  !isCurrentState(actualState, desiredState) &&
+  !(head === null && isPreparedStateForUnknownHead(actualState, desiredState));
 
 if (preparedRuleData && isCurrentState(actualState, desiredState)) {
   console.log(`Rule data is already prepared for ${displayHead(head)}`);
@@ -71,6 +78,10 @@ if (preparedRuleData && isCurrentState(actualState, desiredState)) {
 if (preparedRuleData && head === null && isPreparedStateForUnknownHead(actualState, desiredState)) {
   console.log('Rule data is already prepared; skipping because git HEAD is unavailable');
   process.exit(0);
+}
+
+if (stateIsKnownStale && rootRspecSha === null) {
+  clearGeneratedRspecShaPins();
 }
 
 runNpmScript(stepName);
@@ -95,7 +106,19 @@ function hasPreparedRuleData() {
       ),
     ) &&
     directoryContainsRuleFiles(
-      join('sonar-plugin', 'css', 'src', 'main', 'resources', 'org', 'sonar', 'l10n', 'css', 'rules', 'css'),
+      join(
+        'sonar-plugin',
+        'css',
+        'src',
+        'main',
+        'resources',
+        'org',
+        'sonar',
+        'l10n',
+        'css',
+        'rules',
+        'css',
+      ),
     )
   );
 }
@@ -133,6 +156,12 @@ function writeRuleDataState(state) {
   writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
 }
 
+function clearGeneratedRspecShaPins() {
+  for (const path of generatedRspecShaPaths) {
+    rmSync(path, { force: true });
+  }
+}
+
 function readRootRspecSha() {
   if (!existsSync('rspec.sha')) {
     return null;
@@ -153,8 +182,7 @@ function gitHead() {
 
 function directoryContainsRuleFiles(path) {
   return readdirSync(path, { withFileTypes: true }).some(
-    entry =>
-      entry.isFile() && (entry.name.endsWith('.json') || entry.name.endsWith('.html')),
+    entry => entry.isFile() && (entry.name.endsWith('.json') || entry.name.endsWith('.html')),
   );
 }
 

--- a/tools/ensure-rule-data.mjs
+++ b/tools/ensure-rule-data.mjs
@@ -1,0 +1,146 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const statePath = join('.sonarjs-build-state', 'rule-data.json');
+const stateVersion = 1;
+const stepName = 'generate-rule-data:maven';
+const preparedRuleDataPaths = [
+  join(
+    'sonar-plugin',
+    'javascript-checks',
+    'src',
+    'main',
+    'resources',
+    'org',
+    'sonar',
+    'l10n',
+    'javascript',
+    'rules',
+    'javascript',
+  ),
+  join(
+    'sonar-plugin',
+    'css',
+    'src',
+    'main',
+    'resources',
+    'org',
+    'sonar',
+    'l10n',
+    'css',
+    'rules',
+    'css',
+  ),
+  join('sonar-plugin', 'javascript-checks', 'src', 'main', 'resources', 'rspec.sha'),
+  join('sonar-plugin', 'css', 'src', 'main', 'resources', 'rspec.sha'),
+];
+
+const desiredState = {
+  version: stateVersion,
+  step: stepName,
+  head: gitHead(),
+  rootRspecSha: readRootRspecSha(),
+};
+
+if (hasPreparedRuleData() && isCurrentState(readRuleDataState(), desiredState)) {
+  console.log(`Rule data is already prepared for ${desiredState.head}`);
+  process.exit(0);
+}
+
+runNpmScript(stepName);
+writeRuleDataState(desiredState);
+
+function hasPreparedRuleData() {
+  return preparedRuleDataPaths.every(path => existsSync(path));
+}
+
+function isCurrentState(actual, expected) {
+  return (
+    actual?.version === expected.version &&
+    actual?.step === expected.step &&
+    actual?.head === expected.head &&
+    actual?.rootRspecSha === expected.rootRspecSha
+  );
+}
+
+function readRuleDataState() {
+  if (!existsSync(statePath)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(readFileSync(statePath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function writeRuleDataState(state) {
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function readRootRspecSha() {
+  if (!existsSync('rspec.sha')) {
+    return null;
+  }
+  const sha = readFileSync('rspec.sha', 'utf8').trim();
+  return sha.length === 0 ? null : sha;
+}
+
+function gitHead() {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+  });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+  return result.stdout.trim();
+}
+
+function runNpmScript(script) {
+  const command =
+    process.env.npm_execpath === undefined
+      ? process.platform === 'win32'
+        ? 'npm.cmd'
+        : 'npm'
+      : process.execPath;
+  const commandArguments =
+    process.env.npm_execpath === undefined
+      ? ['run', script]
+      : [process.env.npm_execpath, 'run', script];
+  const shouldUseShell = process.platform === 'win32' && command.toLowerCase().endsWith('.cmd');
+  const result = spawnSync(command, commandArguments, {
+    shell: shouldUseShell,
+    stdio: 'inherit',
+  });
+
+  if (result.error !== undefined) {
+    console.error(result.error);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/tools/ensure-rule-data.mjs
+++ b/tools/ensure-rule-data.mjs
@@ -18,7 +18,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
-const statePath = join('.sonarjs-build-state', 'rule-data.json');
+const statePath = join('resources', 'rule-data-state.json');
 const stateVersion = 1;
 const stepName = 'generate-rule-data:maven';
 const preparedRuleDataPaths = [

--- a/tools/ensure-rule-data.test.mjs
+++ b/tools/ensure-rule-data.test.mjs
@@ -16,14 +16,7 @@
  */
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -31,6 +24,15 @@ import { fileURLToPath } from 'node:url';
 
 const scriptPath = fileURLToPath(new URL('./ensure-rule-data.mjs', import.meta.url));
 const statePath = join('resources', 'rule-data-state.json');
+const javascriptRspecShaPath = join(
+  'sonar-plugin',
+  'javascript-checks',
+  'src',
+  'main',
+  'resources',
+  'rspec.sha',
+);
+const cssRspecShaPath = join('sonar-plugin', 'css', 'src', 'main', 'resources', 'rspec.sha');
 
 test('skips rule data generation when the visible state is current', () => {
   const fixture = createFixture();
@@ -84,16 +86,48 @@ test('regenerates rule data when the root rspec pin changes', () => {
     const result = runEnsureRuleData(fixture);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(
-      readFileSync(fixture.commandLog, 'utf8'),
-      'npm run generate-rule-data:maven\n',
-    );
+    assert.equal(readFileSync(fixture.commandLog, 'utf8'), 'npm run generate-rule-data:maven\n');
     assert.deepEqual(readRuleDataState(fixture.repoRoot), {
       version: 1,
       step: 'generate-rule-data:maven',
       head: fixture.head,
       rootRspecSha: 'new-rspec-pin',
     });
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test('clears generated rspec pins before regenerating stale unpinned rule data', () => {
+  const fixture = createFixture({ failWhenNpmSeesGeneratedPins: true });
+  try {
+    writeRuleDataState(fixture.repoRoot, {
+      version: 1,
+      step: 'generate-rule-data:maven',
+      head: 'old-head',
+      rootRspecSha: null,
+    });
+
+    const result = runEnsureRuleData(fixture);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(readFileSync(fixture.commandLog, 'utf8'), 'npm run generate-rule-data:maven\n');
+    assert.equal(existsSync(join(fixture.repoRoot, javascriptRspecShaPath)), false);
+    assert.equal(existsSync(join(fixture.repoRoot, cssRspecShaPath)), false);
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test('preserves generated rspec pins when prepared rule data has no state stamp yet', () => {
+  const fixture = createFixture({ failWhenNpmDoesNotSeeGeneratedPins: true });
+  try {
+    const result = runEnsureRuleData(fixture);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(readFileSync(fixture.commandLog, 'utf8'), 'npm run generate-rule-data:maven\n');
+    assert.equal(readFileSync(join(fixture.repoRoot, javascriptRspecShaPath), 'utf8'), 'js\n');
+    assert.equal(readFileSync(join(fixture.repoRoot, cssRspecShaPath), 'utf8'), 'css\n');
   } finally {
     cleanupFixture(fixture);
   }
@@ -112,10 +146,7 @@ test('regenerates rule data when generated output directories are empty', () => 
     const result = runEnsureRuleData(fixture);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(
-      readFileSync(fixture.commandLog, 'utf8'),
-      'npm run generate-rule-data:maven\n',
-    );
+    assert.equal(readFileSync(fixture.commandLog, 'utf8'), 'npm run generate-rule-data:maven\n');
   } finally {
     cleanupFixture(fixture);
   }
@@ -134,10 +165,7 @@ test('regenerates rule data when generated outputs are missing', () => {
     const result = runEnsureRuleData(fixture);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(
-      readFileSync(fixture.commandLog, 'utf8'),
-      'npm run generate-rule-data:maven\n',
-    );
+    assert.equal(readFileSync(fixture.commandLog, 'utf8'), 'npm run generate-rule-data:maven\n');
   } finally {
     cleanupFixture(fixture);
   }
@@ -149,16 +177,19 @@ test('uses the PATH npm stub even when parent npm_execpath is set', () => {
     const result = withTemporaryNpmEnvironment(fixture, () => runEnsureRuleData(fixture));
 
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(
-      readFileSync(fixture.commandLog, 'utf8'),
-      'npm run generate-rule-data:maven\n',
-    );
+    assert.equal(readFileSync(fixture.commandLog, 'utf8'), 'npm run generate-rule-data:maven\n');
   } finally {
     cleanupFixture(fixture);
   }
 });
 
-function createFixture({ createRuleDataOutputs = true, createRuleFiles = true, createGitBinary = true } = {}) {
+function createFixture({
+  createRuleDataOutputs = true,
+  createRuleFiles = true,
+  createGitBinary = true,
+  failWhenNpmSeesGeneratedPins = false,
+  failWhenNpmDoesNotSeeGeneratedPins = false,
+} = {}) {
   const repoRoot = mkdtempSync(join(tmpdir(), 'sonarjs-rule-data-'));
   const binDir = join(repoRoot, 'bin');
   const commandLog = join(repoRoot, 'commands.log');
@@ -186,6 +217,14 @@ exit 1
     join(binDir, 'npm'),
     `#!/bin/sh
 set -eu
+if ${failWhenNpmSeesGeneratedPins ? 'true' : 'false'} && { [ -e '${join(repoRoot, javascriptRspecShaPath)}' ] || [ -e '${join(repoRoot, cssRspecShaPath)}' ]; }; then
+  printf 'generated rspec pins were still present\\n' >&2
+  exit 42
+fi
+if ${failWhenNpmDoesNotSeeGeneratedPins ? 'true' : 'false'} && { ! [ -e '${join(repoRoot, javascriptRspecShaPath)}' ] || ! [ -e '${join(repoRoot, cssRspecShaPath)}' ]; }; then
+  printf 'generated rspec pins were missing\\n' >&2
+  exit 43
+fi
 printf 'npm %s\\n' "$*" >> '${commandLog}'
 exit 0
 `,
@@ -209,11 +248,14 @@ function createPreparedRuleDataOutputs(repoRoot, { createRuleFiles }) {
     repoRoot,
     'sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript',
   );
-  const cssRulesDir = join(repoRoot, 'sonar-plugin/css/src/main/resources/org/sonar/l10n/css/rules/css');
+  const cssRulesDir = join(
+    repoRoot,
+    'sonar-plugin/css/src/main/resources/org/sonar/l10n/css/rules/css',
+  );
   mkdirSync(javascriptRulesDir, { recursive: true });
   mkdirSync(cssRulesDir, { recursive: true });
-  writeFileSync(join(repoRoot, 'sonar-plugin/javascript-checks/src/main/resources/rspec.sha'), 'js\n');
-  writeFileSync(join(repoRoot, 'sonar-plugin/css/src/main/resources/rspec.sha'), 'css\n');
+  writeFileSync(join(repoRoot, javascriptRspecShaPath), 'js\n');
+  writeFileSync(join(repoRoot, cssRspecShaPath), 'css\n');
   if (createRuleFiles) {
     writeFileSync(join(javascriptRulesDir, 'S0001.json'), '{}\n');
     writeFileSync(join(cssRulesDir, 'S0002.json'), '{}\n');

--- a/tools/ensure-rule-data.test.mjs
+++ b/tools/ensure-rule-data.test.mjs
@@ -146,10 +146,7 @@ test('regenerates rule data when generated outputs are missing', () => {
 test('uses the PATH npm stub even when parent npm_execpath is set', () => {
   const fixture = createFixture({ createRuleDataOutputs: false });
   try {
-    const result = runEnsureRuleData(fixture, {
-      npm_execpath: '/tmp/fake-npm-cli.js',
-      npm_config_user_agent: 'npm/test',
-    });
+    const result = withTemporaryNpmEnvironment(fixture, () => runEnsureRuleData(fixture));
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
@@ -191,6 +188,12 @@ exit 1
 set -eu
 printf 'npm %s\\n' "$*" >> '${commandLog}'
 exit 0
+`,
+  );
+  writeFileSync(
+    join(repoRoot, 'fake-npm-cli.js'),
+    `import { appendFileSync } from 'node:fs';
+appendFileSync(${JSON.stringify(commandLog)}, 'npm_execpath run ' + process.argv.slice(2).join(' ') + '\\n');
 `,
   );
 
@@ -258,4 +261,25 @@ function createChildEnv(fixture, injectedEnv = {}) {
     ...env,
     PATH: `${fixture.binDir}:${process.env.PATH}`,
   };
+}
+
+function withTemporaryNpmEnvironment(fixture, callback) {
+  const previousNpmExecPath = process.env.npm_execpath;
+  const previousUserAgent = process.env.npm_config_user_agent;
+  process.env.npm_execpath = join(fixture.repoRoot, 'fake-npm-cli.js');
+  process.env.npm_config_user_agent = 'npm/test';
+  try {
+    return callback();
+  } finally {
+    restoreProcessEnv('npm_execpath', previousNpmExecPath);
+    restoreProcessEnv('npm_config_user_agent', previousUserAgent);
+  }
+}
+
+function restoreProcessEnv(key, value) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
 }

--- a/tools/ensure-rule-data.test.mjs
+++ b/tools/ensure-rule-data.test.mjs
@@ -1,3 +1,19 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import {
@@ -18,6 +34,25 @@ const statePath = join('resources', 'rule-data-state.json');
 
 test('skips rule data generation when the visible state is current', () => {
   const fixture = createFixture();
+  try {
+    writeRuleDataState(fixture.repoRoot, {
+      version: 1,
+      step: 'generate-rule-data:maven',
+      head: fixture.head,
+      rootRspecSha: null,
+    });
+
+    const result = runEnsureRuleData(fixture);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(fixture.commandLog), false);
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test('skips rule data generation when git is unavailable but prepared data is current', () => {
+  const fixture = createFixture({ createGitBinary: false });
   try {
     writeRuleDataState(fixture.repoRoot, {
       version: 1,
@@ -64,6 +99,28 @@ test('regenerates rule data when the root rspec pin changes', () => {
   }
 });
 
+test('regenerates rule data when generated output directories are empty', () => {
+  const fixture = createFixture({ createRuleFiles: false });
+  try {
+    writeRuleDataState(fixture.repoRoot, {
+      version: 1,
+      step: 'generate-rule-data:maven',
+      head: fixture.head,
+      rootRspecSha: null,
+    });
+
+    const result = runEnsureRuleData(fixture);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      readFileSync(fixture.commandLog, 'utf8'),
+      'npm run generate-rule-data:maven\n',
+    );
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
 test('regenerates rule data when generated outputs are missing', () => {
   const fixture = createFixture({ createRuleDataOutputs: false });
   try {
@@ -86,7 +143,25 @@ test('regenerates rule data when generated outputs are missing', () => {
   }
 });
 
-function createFixture({ createRuleDataOutputs = true } = {}) {
+test('uses the PATH npm stub even when parent npm_execpath is set', () => {
+  const fixture = createFixture({ createRuleDataOutputs: false });
+  try {
+    const result = runEnsureRuleData(fixture, {
+      npm_execpath: '/tmp/fake-npm-cli.js',
+      npm_config_user_agent: 'npm/test',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      readFileSync(fixture.commandLog, 'utf8'),
+      'npm run generate-rule-data:maven\n',
+    );
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+function createFixture({ createRuleDataOutputs = true, createRuleFiles = true, createGitBinary = true } = {}) {
   const repoRoot = mkdtempSync(join(tmpdir(), 'sonarjs-rule-data-'));
   const binDir = join(repoRoot, 'bin');
   const commandLog = join(repoRoot, 'commands.log');
@@ -97,9 +172,10 @@ function createFixture({ createRuleDataOutputs = true } = {}) {
     join(repoRoot, 'package.json'),
     '{"scripts":{"generate-rule-data:maven":"echo"}}\n',
   );
-  writeExecutable(
-    join(binDir, 'git'),
-    `#!/bin/sh
+  if (createGitBinary) {
+    writeExecutable(
+      join(binDir, 'git'),
+      `#!/bin/sh
 set -eu
 if [ "$1 $2" = "rev-parse HEAD" ]; then
   printf '${head}\\n'
@@ -107,7 +183,8 @@ if [ "$1 $2" = "rev-parse HEAD" ]; then
 fi
 exit 1
 `,
-  );
+    );
+  }
   writeExecutable(
     join(binDir, 'npm'),
     `#!/bin/sh
@@ -118,35 +195,32 @@ exit 0
   );
 
   if (createRuleDataOutputs) {
-    createPreparedRuleDataOutputs(repoRoot);
+    createPreparedRuleDataOutputs(repoRoot, { createRuleFiles });
   }
 
   return { repoRoot, binDir, commandLog, head };
 }
 
-function createPreparedRuleDataOutputs(repoRoot) {
-  mkdirSync(
-    join(
-      repoRoot,
-      'sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript',
-    ),
-    { recursive: true },
+function createPreparedRuleDataOutputs(repoRoot, { createRuleFiles }) {
+  const javascriptRulesDir = join(
+    repoRoot,
+    'sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript',
   );
-  mkdirSync(
-    join(repoRoot, 'sonar-plugin/css/src/main/resources/org/sonar/l10n/css/rules/css'),
-    { recursive: true },
-  );
+  const cssRulesDir = join(repoRoot, 'sonar-plugin/css/src/main/resources/org/sonar/l10n/css/rules/css');
+  mkdirSync(javascriptRulesDir, { recursive: true });
+  mkdirSync(cssRulesDir, { recursive: true });
   writeFileSync(join(repoRoot, 'sonar-plugin/javascript-checks/src/main/resources/rspec.sha'), 'js\n');
   writeFileSync(join(repoRoot, 'sonar-plugin/css/src/main/resources/rspec.sha'), 'css\n');
+  if (createRuleFiles) {
+    writeFileSync(join(javascriptRulesDir, 'S0001.json'), '{}\n');
+    writeFileSync(join(cssRulesDir, 'S0002.json'), '{}\n');
+  }
 }
 
-function runEnsureRuleData(fixture) {
+function runEnsureRuleData(fixture, injectedEnv = {}) {
   return spawnSync(process.execPath, [scriptPath], {
     cwd: fixture.repoRoot,
-    env: {
-      ...process.env,
-      PATH: `${fixture.binDir}:${process.env.PATH}`,
-    },
+    env: createChildEnv(fixture, injectedEnv),
     text: true,
     encoding: 'utf8',
   });
@@ -167,4 +241,21 @@ function writeRuleDataState(repoRoot, state) {
 
 function writeExecutable(path, content) {
   writeFileSync(path, content, { mode: 0o755 });
+}
+
+function createChildEnv(fixture, injectedEnv = {}) {
+  const env = {
+    ...process.env,
+    ...injectedEnv,
+  };
+  delete env.npm_execpath;
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('npm_config_')) {
+      delete env[key];
+    }
+  }
+  return {
+    ...env,
+    PATH: `${fixture.binDir}:${process.env.PATH}`,
+  };
 }

--- a/tools/ensure-rule-data.test.mjs
+++ b/tools/ensure-rule-data.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(new URL('./ensure-rule-data.mjs', import.meta.url));
+
+test('skips rule data generation when the visible state is current', () => {
+  const fixture = createFixture();
+  try {
+    writeRuleDataState(fixture.repoRoot, {
+      version: 1,
+      step: 'generate-rule-data:maven',
+      head: fixture.head,
+      rootRspecSha: null,
+    });
+
+    const result = runEnsureRuleData(fixture);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(fixture.commandLog), false);
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test('regenerates rule data when the root rspec pin changes', () => {
+  const fixture = createFixture();
+  try {
+    writeFileSync(join(fixture.repoRoot, 'rspec.sha'), 'new-rspec-pin\n');
+    writeRuleDataState(fixture.repoRoot, {
+      version: 1,
+      step: 'generate-rule-data:maven',
+      head: fixture.head,
+      rootRspecSha: 'old-rspec-pin',
+    });
+
+    const result = runEnsureRuleData(fixture);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      readFileSync(fixture.commandLog, 'utf8'),
+      'npm run generate-rule-data:maven\n',
+    );
+    assert.deepEqual(readRuleDataState(fixture.repoRoot), {
+      version: 1,
+      step: 'generate-rule-data:maven',
+      head: fixture.head,
+      rootRspecSha: 'new-rspec-pin',
+    });
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test('regenerates rule data when generated outputs are missing', () => {
+  const fixture = createFixture({ createRuleDataOutputs: false });
+  try {
+    writeRuleDataState(fixture.repoRoot, {
+      version: 1,
+      step: 'generate-rule-data:maven',
+      head: fixture.head,
+      rootRspecSha: null,
+    });
+
+    const result = runEnsureRuleData(fixture);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      readFileSync(fixture.commandLog, 'utf8'),
+      'npm run generate-rule-data:maven\n',
+    );
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+function createFixture({ createRuleDataOutputs = true } = {}) {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'sonarjs-rule-data-'));
+  const binDir = join(repoRoot, 'bin');
+  const commandLog = join(repoRoot, 'commands.log');
+  const head = 'abc123';
+
+  mkdirSync(binDir);
+  writeFileSync(
+    join(repoRoot, 'package.json'),
+    '{"scripts":{"generate-rule-data:maven":"echo"}}\n',
+  );
+  writeExecutable(
+    join(binDir, 'git'),
+    `#!/bin/sh
+set -eu
+if [ "$1 $2" = "rev-parse HEAD" ]; then
+  printf '${head}\\n'
+  exit 0
+fi
+exit 1
+`,
+  );
+  writeExecutable(
+    join(binDir, 'npm'),
+    `#!/bin/sh
+set -eu
+printf 'npm %s\\n' "$*" >> '${commandLog}'
+exit 0
+`,
+  );
+
+  if (createRuleDataOutputs) {
+    createPreparedRuleDataOutputs(repoRoot);
+  }
+
+  return { repoRoot, binDir, commandLog, head };
+}
+
+function createPreparedRuleDataOutputs(repoRoot) {
+  mkdirSync(
+    join(
+      repoRoot,
+      'sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript',
+    ),
+    { recursive: true },
+  );
+  mkdirSync(
+    join(repoRoot, 'sonar-plugin/css/src/main/resources/org/sonar/l10n/css/rules/css'),
+    { recursive: true },
+  );
+  writeFileSync(join(repoRoot, 'sonar-plugin/javascript-checks/src/main/resources/rspec.sha'), 'js\n');
+  writeFileSync(join(repoRoot, 'sonar-plugin/css/src/main/resources/rspec.sha'), 'css\n');
+}
+
+function runEnsureRuleData(fixture) {
+  return spawnSync(process.execPath, [scriptPath], {
+    cwd: fixture.repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${fixture.binDir}:${process.env.PATH}`,
+    },
+    text: true,
+    encoding: 'utf8',
+  });
+}
+
+function cleanupFixture(fixture) {
+  rmSync(fixture.repoRoot, { recursive: true, force: true });
+}
+
+function readRuleDataState(repoRoot) {
+  return JSON.parse(readFileSync(join(repoRoot, '.sonarjs-build-state/rule-data.json'), 'utf8'));
+}
+
+function writeRuleDataState(repoRoot, state) {
+  mkdirSync(join(repoRoot, '.sonarjs-build-state'), { recursive: true });
+  writeFileSync(
+    join(repoRoot, '.sonarjs-build-state/rule-data.json'),
+    `${JSON.stringify(state, null, 2)}\n`,
+  );
+}
+
+function writeExecutable(path, content) {
+  writeFileSync(path, content, { mode: 0o755 });
+}

--- a/tools/ensure-rule-data.test.mjs
+++ b/tools/ensure-rule-data.test.mjs
@@ -14,6 +14,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const scriptPath = fileURLToPath(new URL('./ensure-rule-data.mjs', import.meta.url));
+const statePath = join('resources', 'rule-data-state.json');
 
 test('skips rule data generation when the visible state is current', () => {
   const fixture = createFixture();
@@ -156,15 +157,12 @@ function cleanupFixture(fixture) {
 }
 
 function readRuleDataState(repoRoot) {
-  return JSON.parse(readFileSync(join(repoRoot, '.sonarjs-build-state/rule-data.json'), 'utf8'));
+  return JSON.parse(readFileSync(join(repoRoot, statePath), 'utf8'));
 }
 
 function writeRuleDataState(repoRoot, state) {
-  mkdirSync(join(repoRoot, '.sonarjs-build-state'), { recursive: true });
-  writeFileSync(
-    join(repoRoot, '.sonarjs-build-state/rule-data.json'),
-    `${JSON.stringify(state, null, 2)}\n`,
-  );
+  mkdirSync(join(repoRoot, 'resources'), { recursive: true });
+  writeFileSync(join(repoRoot, statePath), `${JSON.stringify(state, null, 2)}\n`);
 }
 
 function writeExecutable(path, content) {

--- a/tools/generate-meta.mjs
+++ b/tools/generate-meta.mjs
@@ -14,41 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { join } from 'node:path';
-
-const preparedRuleDataPaths = [
-  join(
-    'sonar-plugin',
-    'javascript-checks',
-    'src',
-    'main',
-    'resources',
-    'org',
-    'sonar',
-    'l10n',
-    'javascript',
-    'rules',
-    'javascript',
-  ),
-  join(
-    'sonar-plugin',
-    'css',
-    'src',
-    'main',
-    'resources',
-    'org',
-    'sonar',
-    'l10n',
-    'css',
-    'rules',
-    'css',
-  ),
-  join('sonar-plugin', 'javascript-checks', 'src', 'main', 'resources', 'rspec.sha'),
-  join('sonar-plugin', 'css', 'src', 'main', 'resources', 'rspec.sha'),
-];
-const hasPreparedRuleData = preparedRuleDataPaths.every(path => existsSync(path));
 
 const command =
   process.env.npm_execpath === undefined
@@ -59,9 +25,7 @@ const command =
 const commandArgumentsPrefix =
   process.env.npm_execpath === undefined ? [] : [process.env.npm_execpath];
 const shouldUseShell = process.platform === 'win32' && command.toLowerCase().endsWith('.cmd');
-const scripts = hasPreparedRuleData
-  ? ['generate-meta:raw']
-  : ['generate-rule-data:maven', 'generate-meta:raw'];
+const scripts = ['ensure-rule-data', 'generate-meta:raw'];
 
 for (const script of scripts) {
   const result = spawnSync(command, [...commandArgumentsPrefix, 'run', script], {

--- a/tools/generate-meta.test.mjs
+++ b/tools/generate-meta.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(new URL('./generate-meta.mjs', import.meta.url));
+
+test('runs rule-data freshness check before raw metadata generation', () => {
+  const fixture = createFixture();
+  try {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: fixture.repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}:${process.env.PATH}`,
+      },
+      text: true,
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(
+      readFileSync(fixture.commandLog, 'utf8').trimEnd().split('\n'),
+      ['npm run ensure-rule-data', 'npm run generate-meta:raw'],
+    );
+  } finally {
+    rmSync(fixture.repoRoot, { recursive: true, force: true });
+  }
+});
+
+function createFixture() {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'sonarjs-generate-meta-'));
+  const binDir = join(repoRoot, 'bin');
+  const commandLog = join(repoRoot, 'commands.log');
+
+  mkdirSync(binDir);
+  writeExecutable(
+    join(binDir, 'npm'),
+    `#!/bin/sh
+set -eu
+printf 'npm %s\\n' "$*" >> '${commandLog}'
+exit 0
+`,
+  );
+
+  return { repoRoot, binDir, commandLog };
+}
+
+function writeExecutable(path, content) {
+  writeFileSync(path, content, { mode: 0o755 });
+}

--- a/tools/generate-meta.test.mjs
+++ b/tools/generate-meta.test.mjs
@@ -1,3 +1,19 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import {
@@ -17,14 +33,24 @@ const scriptPath = fileURLToPath(new URL('./generate-meta.mjs', import.meta.url)
 test('runs rule-data freshness check before raw metadata generation', () => {
   const fixture = createFixture();
   try {
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: fixture.repoRoot,
-      env: {
-        ...process.env,
-        PATH: `${fixture.binDir}:${process.env.PATH}`,
-      },
-      text: true,
-      encoding: 'utf8',
+    const result = runGenerateMeta(fixture);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(
+      readFileSync(fixture.commandLog, 'utf8').trimEnd().split('\n'),
+      ['npm run ensure-rule-data', 'npm run generate-meta:raw'],
+    );
+  } finally {
+    rmSync(fixture.repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('uses the PATH npm stub even when parent npm_execpath is set', () => {
+  const fixture = createFixture();
+  try {
+    const result = runGenerateMeta(fixture, {
+      npm_execpath: '/tmp/fake-npm-cli.js',
+      npm_config_user_agent: 'npm/test',
     });
 
     assert.equal(result.status, 0, result.stderr);
@@ -55,6 +81,32 @@ exit 0
   return { repoRoot, binDir, commandLog };
 }
 
+function runGenerateMeta(fixture, injectedEnv = {}) {
+  return spawnSync(process.execPath, [scriptPath], {
+    cwd: fixture.repoRoot,
+    env: createChildEnv(fixture, injectedEnv),
+    text: true,
+    encoding: 'utf8',
+  });
+}
+
 function writeExecutable(path, content) {
   writeFileSync(path, content, { mode: 0o755 });
+}
+
+function createChildEnv(fixture, injectedEnv = {}) {
+  const env = {
+    ...process.env,
+    ...injectedEnv,
+  };
+  delete env.npm_execpath;
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('npm_config_')) {
+      delete env[key];
+    }
+  }
+  return {
+    ...env,
+    PATH: `${fixture.binDir}:${process.env.PATH}`,
+  };
 }

--- a/tools/generate-meta.test.mjs
+++ b/tools/generate-meta.test.mjs
@@ -48,10 +48,7 @@ test('runs rule-data freshness check before raw metadata generation', () => {
 test('uses the PATH npm stub even when parent npm_execpath is set', () => {
   const fixture = createFixture();
   try {
-    const result = runGenerateMeta(fixture, {
-      npm_execpath: '/tmp/fake-npm-cli.js',
-      npm_config_user_agent: 'npm/test',
-    });
+    const result = withTemporaryNpmEnvironment(fixture, () => runGenerateMeta(fixture));
 
     assert.equal(result.status, 0, result.stderr);
     assert.deepEqual(
@@ -75,6 +72,12 @@ function createFixture() {
 set -eu
 printf 'npm %s\\n' "$*" >> '${commandLog}'
 exit 0
+`,
+  );
+  writeFileSync(
+    join(repoRoot, 'fake-npm-cli.js'),
+    `import { appendFileSync } from 'node:fs';
+appendFileSync(${JSON.stringify(commandLog)}, 'npm_execpath run ' + process.argv.slice(2).join(' ') + '\\n');
 `,
   );
 
@@ -109,4 +112,25 @@ function createChildEnv(fixture, injectedEnv = {}) {
     ...env,
     PATH: `${fixture.binDir}:${process.env.PATH}`,
   };
+}
+
+function withTemporaryNpmEnvironment(fixture, callback) {
+  const previousNpmExecPath = process.env.npm_execpath;
+  const previousUserAgent = process.env.npm_config_user_agent;
+  process.env.npm_execpath = join(fixture.repoRoot, 'fake-npm-cli.js');
+  process.env.npm_config_user_agent = 'npm/test';
+  try {
+    return callback();
+  } finally {
+    restoreProcessEnv('npm_execpath', previousNpmExecPath);
+    restoreProcessEnv('npm_config_user_agent', previousUserAgent);
+  }
+}
+
+function restoreProcessEnv(key, value) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
 }


### PR DESCRIPTION
## Summary

Adds `npm run ensure-rule-data` as the SonarJS-owned entrypoint for preparing generated RSPEC rule data. The command reuses prepared outputs only when the rule data, per-language `rspec.sha` files, current checkout, root `rspec.sha` pin, and ignored `resources/rule-data-state.json` stamp line up.

`npm run generate-meta` now runs this freshness check before `generate-meta:raw`, and CI prepares RSPEC rule data through the same command. The prepared artifact now includes the state stamp and is downloaded at the repository root so the generated paths are restored consistently.

The lifecycle also guards RSPEC pins: stale stamped, unpinned data clears generated per-language pins before regeneration to avoid reusing pins from another checkout, while prepared data with no state stamp preserves those pins for legacy or direct Maven pinned outputs.

## Why

External automation and local metadata generation need an idempotent SonarJS command that can prepare rule data without keeping separate hidden state. Making the stamp visible in the checkout also lets downstream jobs and later `generate-meta` calls tell when prepared RSPEC data belongs to the current revision and root pin.

## Validation

- `node --test tools/ensure-rule-data.test.mjs tools/generate-meta.test.mjs`
- `npm exec --yes --package=prettier@3.8.4 -- prettier --no-config --print-width 100 --trailing-comma all --single-quote --arrow-parens avoid --end-of-line lf --check tools/ensure-rule-data.mjs tools/ensure-rule-data.test.mjs docs/DEV.md`
- `git diff --check`
