### PR TITLE
JS-1916 S6268: reduce false positives via local constant propagation

### DIFF
--- a/packages/analysis/src/jsts/rules/S6268/rule.ts
+++ b/packages/analysis/src/jsts/rules/S6268/rule.ts
@@ -19,7 +19,13 @@
 import type { Rule } from 'eslint';
 import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
-import { isLiteral, isMemberWithProperty } from '../helpers/ast.js';
+import {
+  getProperty,
+  getUniqueWriteUsageOrNode,
+  getValueOfExpression,
+  isLiteral,
+  isMemberWithProperty,
+} from '../helpers/ast.js';
 import * as meta from './generated-meta.js';
 
 const bypassMethods = [
@@ -44,7 +50,7 @@ export const rule: Rule.RuleModule = {
         if (
           isMemberWithProperty(callee, ...bypassMethods) &&
           args.length === 1 &&
-          !isHardcodedLiteral(args[0])
+          !isHardcodedLiteral(args[0], context)
         ) {
           context.report({
             messageId: 'checkAngularBypass',
@@ -56,10 +62,29 @@ export const rule: Rule.RuleModule = {
   },
 };
 
-function isHardcodedLiteral(node: estree.Node) {
+function isHardcodedLiteral(node: estree.Node, context: Rule.RuleContext): boolean {
   if (node.type === 'TemplateLiteral') {
     return node.expressions.length === 0;
-  } else {
-    return isLiteral(node);
   }
+  if (isLiteral(node)) {
+    return true;
+  }
+  // Identifier with a single write site: trace to the assigned value
+  if (node.type === 'Identifier') {
+    const resolved = getUniqueWriteUsageOrNode(context, node, true);
+    if (resolved !== node) {
+      return isHardcodedLiteral(resolved, context);
+    }
+  }
+  // obj.prop where obj resolves to an object literal with a literal property value
+  if (node.type === 'MemberExpression' && !node.computed && node.property.type === 'Identifier') {
+    const obj = getValueOfExpression(context, node.object, 'ObjectExpression', true);
+    if (obj) {
+      const prop = getProperty(obj, node.property.name, context);
+      if (prop) {
+        return isHardcodedLiteral(prop.value as estree.Node, context);
+      }
+    }
+  }
+  return false;
 }

--- a/packages/analysis/src/jsts/rules/S6268/rule.ts
+++ b/packages/analysis/src/jsts/rules/S6268/rule.ts
@@ -62,7 +62,15 @@ export const rule: Rule.RuleModule = {
   },
 };
 
-function isHardcodedLiteral(node: estree.Node, context: Rule.RuleContext): boolean {
+function isHardcodedLiteral(
+  node: estree.Node,
+  context: Rule.RuleContext,
+  visited: Set<estree.Node> = new Set(),
+): boolean {
+  if (visited.has(node)) {
+    return false;
+  }
+  visited.add(node);
   if (node.type === 'TemplateLiteral') {
     return node.expressions.length === 0;
   }
@@ -73,7 +81,7 @@ function isHardcodedLiteral(node: estree.Node, context: Rule.RuleContext): boole
   if (node.type === 'Identifier') {
     const resolved = getUniqueWriteUsageOrNode(context, node, true);
     if (resolved !== node) {
-      return isHardcodedLiteral(resolved, context);
+      return isHardcodedLiteral(resolved, context, visited);
     }
   }
   // obj.prop where obj resolves to an object literal with a literal property value
@@ -82,7 +90,7 @@ function isHardcodedLiteral(node: estree.Node, context: Rule.RuleContext): boole
     if (obj) {
       const prop = getProperty(obj, node.property.name, context);
       if (prop) {
-        return isHardcodedLiteral(prop.value as estree.Node, context);
+        return isHardcodedLiteral(prop.value as estree.Node, context, visited);
       }
     }
   }

--- a/packages/analysis/src/jsts/rules/S6268/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6268/unit.test.ts
@@ -87,6 +87,39 @@ describe('S6268', () => {
             },
           ],
         },
+        {
+          code: `
+      // identifier assigned a non-literal (function call)
+      const html = getHtml();
+      sanitizer.bypassSecurityTrustHtml(html);
+      `,
+          errors: 1,
+        },
+        {
+          code: `
+      // identifier with multiple write sites — no unique write usage
+      let html = '<b>safe</b>';
+      html = getHtml();
+      sanitizer.bypassSecurityTrustHtml(html);
+      `,
+          errors: 1,
+        },
+        {
+          code: `
+      // object property value is a non-literal
+      const config = { content: getHtml() };
+      sanitizer.bypassSecurityTrustHtml(config.content);
+      `,
+          errors: 1,
+        },
+        {
+          code: `
+      // computed member access is not tracked
+      const config = { content: '<b>safe</b>' };
+      sanitizer.bypassSecurityTrustHtml(config['content']);
+      `,
+          errors: 1,
+        },
       ],
     });
   });

--- a/packages/analysis/src/jsts/rules/S6268/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6268/unit.test.ts
@@ -41,6 +41,14 @@ describe('S6268', () => {
       sanitizer.bypassSecurityTrustHtml('input');
       sanitizer.bypassSecurityTrustHtml("input");
       sanitizer.bypassSecurityTrustHtml(\`input\`);
+
+      // identifier assigned a string literal
+      const html = '<b>safe</b>';
+      sanitizer.bypassSecurityTrustHtml(html);
+
+      // member expression on a locally defined object literal
+      const config = { content: '<b>safe</b>' };
+      sanitizer.bypassSecurityTrustHtml(config.content);
       `,
         },
       ],


### PR DESCRIPTION
## Why

S6268 was generating noise on projects using `bypassSecurityTrust*` with provably compile-time constant values. During a noise-reduction investigation, sample files were downloaded and found to contain false positives. The rule's existing check only suppressed direct inline literals — any variable or object property access, even when assigned a hardcoded string in the same file, was incorrectly flagged.

## What

Extend hardcoded-literal detection to two additional patterns via local constant propagation:

1. An identifier with a single write site that resolves to a string literal
2. A static member expression (`obj.prop`) where the object resolves to a locally-defined object literal with a literal property value

## How

Uses existing AST helpers (`getUniqueWriteUsageOrNode`, `getValueOfExpression`, `getProperty`) — no new dependencies. Change is isolated to `isHardcodedLiteral` in `rule.ts`.

**Before (both flagged as FP):**
```typescript
const trustedHtml = '<b>Hello</b>';
sanitizer.bypassSecurityTrustHtml(trustedHtml); // FP

const config = { content: '<svg>...</svg>' };
sanitizer.bypassSecurityTrustHtml(config.content); // FP
```

**After (neither flagged):**
```typescript
const trustedHtml = '<b>Hello</b>';
sanitizer.bypassSecurityTrustHtml(trustedHtml); // OK

const config = { content: '<svg>...</svg>' };
sanitizer.bypassSecurityTrustHtml(config.content); // OK
```

**Out of scope:** Callback parameters (e.g. `array.map(item => sanitizer.bypassSecurityTrustHtml(item.content))`) and cross-file tracking are not covered by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)