### PR TITLE
CLP-25 Add the ToggleLockBranch GH workflow

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -1,0 +1,28 @@
+name: Toggle lock branch
+
+on:
+  workflow_dispatch:    # Triggered manually from the GitHub UI / Actions
+    inputs:
+      additional-message:
+        description: 'Additional Slack message text'
+        required: false
+
+jobs:
+  ToggleLockBranch_job:
+    name: Toggle lock branch
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+    steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-lock token | lock_token;
+            development/kv/data/slack token | slack_api_token;
+      - uses: sonarsource/gh-action-lt-backlog/ToggleLockBranch@v2
+        with:
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
+          slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
+          additional-message: ${{ github.event.inputs.additional-message }}
+          slack-channel: squad-corelang-notifs


### PR DESCRIPTION
Part of [CLP-13](https://sonarsource.atlassian.net/browse/CLP-13).


[CLP-13]: https://sonarsource.atlassian.net/browse/CLP-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **New GitHub Workflow:**
  - Added `ToggleLockBranch.yml` to support manual branch locking via `workflow_dispatch`.
  - Integrated `vault-action-wrapper` to fetch `lock_token` and `slack_api_token` for the workflow.

<sub>This will update automatically on new commits.</sub>