### PR TITLE
JS-1933 Add S6853 regression coverage

### DIFF
--- a/packages/analysis/src/jsts/rules/S6853/cb.fixture.tsx
+++ b/packages/analysis/src/jsts/rules/S6853/cb.fixture.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react';
+
 function valid() {
   return (
     <label>
@@ -9,6 +11,39 @@ function valid() {
 
 function validCustomComponent() {
   return <label>Surname <CustomComponent /> </label>;
+}
+
+function validUseIdSibling() {
+  const id = useId();
+  return (
+    <>
+      <label htmlFor={id}>Name</label>
+      <input id={id} />
+    </>
+  );
+}
+
+function validUseIdNesting() {
+  const id = useId();
+  return (
+    <label htmlFor={id}>
+      Name
+      <input id={id} />
+    </label>
+  );
+}
+
+function validSplitLabel() {
+  return (
+    <div className="field">
+      <div className="field-label">
+        <label htmlFor="email">Email</label>
+      </div>
+      <div className="field-control">
+        <input id="email" />
+      </div>
+    </div>
+  );
 }
 
 function invalid() {
@@ -25,5 +60,4 @@ function invalidEmptyLabel() {
   return <label></label>; // Noncompliant {{A form label must have accessible text.}}
   //      ^^^^^
 }
-
 


### PR DESCRIPTION
## Summary
Investigated the S6853 false-positive patterns from JS-1933 and added focused regression coverage for them.
This locks in `useId()`-based associations and split-subtree label/control layouts without changing analyzer behavior.

## Changes
- Add a sibling `useId()` association case to the S6853 comment-based fixture
- Add a nested `useId()` association case to the S6853 comment-based fixture
- Add a split-subtree `htmlFor`/`id` association case to the S6853 comment-based fixture

## Functional Validation
Artifact: [JS-1933-fv.zip](https://github.com/user-attachments/files/29295529/JS-1933-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "label-association.fixture.tsx"...
Results:
    (none)

****** Branch "fix/js-1933-improve-s6853" ******
Analyzing "label-association.fixture.tsx"...
Results:
    (none)
```

No difference is expected since it was already handled on master, this is just adding a regression test to make sure it remains covered over time.