### PR TITLE
JS-1929 Clarify S8927 method import message

### DIFF
--- a/packages/analysis/src/jsts/rules/S8927/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8927/rule.ts
@@ -28,7 +28,7 @@ import * as meta from './generated-meta.js';
 const messages = {
   useNamedImports: 'Use named imports from "{{library}}" instead of a default import.',
   useMethodImports:
-    'Import used {{library}} methods from method-level subpaths such as "{{example}}".',
+    'Import {{library}} methods from subpaths such as "{{example}}" to avoid importing more code than needed.',
 };
 
 type LibraryRecommendation =

--- a/packages/analysis/src/jsts/rules/S8927/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8927/unit.test.ts
@@ -211,4 +211,24 @@ import validator from 'validator';
       ],
     });
   });
+
+  it('explains why method-level imports are preferred', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+
+    ruleTester.run('no-default-utility-imports', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: `import lodash from 'lodash';`,
+          filename: path.join(fixtures, 'supported', 'file.js'),
+          errors: [
+            {
+              message:
+                'Import lodash methods from subpaths such as "lodash/map" to avoid importing more code than needed.',
+            },
+          ],
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- clarify the S8927 method-import issue text so it explains why subpath imports are preferred
- add a focused unit test that asserts the rendered rationale-driven message

## Test Plan
- `PATH=/Users/nathan.soufflet/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsx --tsconfig packages/tsconfig.test.json --test --test-reporter=spec packages/analysis/src/jsts/rules/S8927/unit.test.ts`