### PR TITLE
JS-1950 Fix S5906 ambiguous Jasmine length assertions

### DIFF
--- a/packages/analysis/src/jsts/rules/S5906/fixtures/mixed-jasmine-jest/package.json
+++ b/packages/analysis/src/jsts/rules/S5906/fixtures/mixed-jasmine-jest/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "jasmine-core": "5.7.1",
+    "jest": "30.0.0"
+  }
+}

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -22,7 +22,11 @@ import { minVersion } from 'semver';
 import { extractTestAssertion, type AssertionStyle } from '../helpers/assertions.js';
 import { isIdentifier, isMethodCall } from '../helpers/ast.js';
 import { getDependenciesSanitizePaths } from '../helpers/dependency-manifests/dependencies.js';
-import { getFullyQualifiedName, importsOrDependsOnModule } from '../helpers/module.js';
+import {
+  getFullyQualifiedName,
+  importsModule,
+  importsOrDependsOnModule,
+} from '../helpers/module.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { chaiShouldReceiver, getBooleanExpressionSuggestion } from './assertion-suggestions.js';
 import {
@@ -47,6 +51,10 @@ const messages = {
 };
 
 const PLAYWRIGHT_MODULES = ['@playwright/test'];
+const JEST_LIKE_MODULES = ['vitest', 'bun:test', '@jest/globals'];
+const JEST_LIKE_GLOBAL_MODULES = ['jest'];
+const JASMINE_MODULES = ['jasmine'];
+const JASMINE_GLOBAL_MODULES = ['jasmine', 'jasmine-core', 'jasmine-node', 'karma-jasmine'];
 const MAX_ASSERT_ARGUMENTS_WITH_MESSAGE = 3;
 const CHAI_EQUALITY_MATCHERS = new Set(['equal', 'equals', 'eq', 'eql', 'eqls']);
 const JASMINE_SIZE_DEPENDENCIES = ['jasmine-core', 'jasmine'];
@@ -58,6 +66,7 @@ export const rule: Rule.RuleModule = {
     const sourceCode = context.sourceCode;
     const hasPlaywright = importsOrDependsOnModule(context, PLAYWRIGHT_MODULES, PLAYWRIGHT_MODULES);
     const jasmineSupportsToHaveSize = supportsJasmineToHaveSize(context);
+    const hasAmbiguousJasmineJestGlobalExpect = hasAmbiguousJasmineJestGlobalExpectSignal(context);
     const playwrightLocators = new Set<Scope.Variable>();
 
     function report(node: estree.CallExpression, suggestion: Suggestion) {
@@ -108,6 +117,7 @@ export const rule: Rule.RuleModule = {
           node,
           sourceCode,
           jasmineSupportsToHaveSize,
+          hasAmbiguousJasmineJestGlobalExpect,
         );
         if (suggestion) {
           report(node, suggestion);
@@ -123,9 +133,17 @@ function getSuggestion(
   node: estree.CallExpression,
   sourceCode: SourceCode,
   jasmineSupportsToHaveSize: boolean,
+  hasAmbiguousJasmineJestGlobalExpect: boolean,
 ): Suggestion | null {
   switch (style) {
     case 'jest-like':
+      return getExpectLikeSuggestion(
+        node,
+        sourceCode,
+        'jest',
+        true,
+        hasAmbiguousJasmineJestGlobalExpect,
+      );
     case 'playwright':
       return getExpectLikeSuggestion(node, sourceCode, 'jest');
     case 'jasmine':
@@ -146,6 +164,7 @@ function getExpectLikeSuggestion(
   sourceCode: SourceCode,
   family: 'jest' | 'jasmine',
   jasmineSupportsToHaveSize = true,
+  skipLengthEqualitySuggestions = false,
 ): Suggestion | null {
   if (
     !isMethodCall(node) ||
@@ -180,6 +199,9 @@ function getExpectLikeSuggestion(
     return replacement(`${prefix}.toBeNaN()`, node, sourceCode);
   }
   if (isLengthAccess(actual)) {
+    if (skipLengthEqualitySuggestions) {
+      return null;
+    }
     if (family === 'jasmine' && !jasmineSupportsToHaveSize) {
       return null;
     }
@@ -192,6 +214,9 @@ function getExpectLikeSuggestion(
   }
   const booleanExpected = getBooleanValue(expected);
   if (booleanExpected === undefined) {
+    return null;
+  }
+  if (skipLengthEqualitySuggestions && isLengthEqualityComparison(actual)) {
     return null;
   }
   return getBooleanExpressionSuggestion(
@@ -221,6 +246,26 @@ function supportsJasmineToHaveSize(context: Rule.RuleContext): boolean {
   }
 
   return false;
+}
+
+function hasAmbiguousJasmineJestGlobalExpectSignal(context: Rule.RuleContext): boolean {
+  if (importsModule(context, JEST_LIKE_MODULES) || importsModule(context, JASMINE_MODULES)) {
+    return false;
+  }
+
+  const dependencies = getDependenciesSanitizePaths(context);
+  return (
+    JEST_LIKE_GLOBAL_MODULES.some(dependency => dependencies.has(dependency)) &&
+    JASMINE_GLOBAL_MODULES.some(dependency => dependencies.has(dependency))
+  );
+}
+
+function isLengthEqualityComparison(node: estree.Node): boolean {
+  return (
+    node.type === 'BinaryExpression' &&
+    ['===', '!=='].includes(node.operator) &&
+    (isLengthAccess(node.left) || isLengthAccess(node.right))
+  );
 }
 
 function getChaiBddSuggestion(

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -248,6 +248,8 @@ function supportsJasmineToHaveSize(context: Rule.RuleContext): boolean {
   return false;
 }
 
+// For bare global expect(), mixed Jasmine/Jest dependency signals are ambiguous:
+// there is no import/FQN evidence to choose between toHaveSize() and toHaveLength().
 function hasAmbiguousJasmineJestGlobalExpectSignal(context: Rule.RuleContext): boolean {
   if (importsModule(context, JEST_LIKE_MODULES) || importsModule(context, JASMINE_MODULES)) {
     return false;

--- a/packages/analysis/src/jsts/rules/S5906/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5906/unit.test.ts
@@ -34,6 +34,12 @@ describe('S5906', () => {
       'modern-jasmine',
       'test.ts',
     );
+    const mixedJasmineJestFixture = path.join(
+      import.meta.dirname,
+      'fixtures',
+      'mixed-jasmine-jest',
+      'test.ts',
+    );
     const expectedError = (output: string) => ({
       messageId: 'preferSpecificAssertion',
       suggestions: [{ messageId: 'quickfix', output }],
@@ -118,10 +124,23 @@ describe('S5906', () => {
           `,
         },
         {
+          // https://community.sonarsource.com/t/eslint-prefer-specific-assertions-wants-me-to-use-tohavelength-but-i-cant/184082
           code: `
             expect(items.length).toBe(3);
           `,
           filename: angularJasmineFixture,
+        },
+        {
+          code: `
+            expect(items.length).toBe(3);
+          `,
+          filename: mixedJasmineJestFixture,
+        },
+        {
+          code: `
+            expect(items.length === 2).toBe(true);
+          `,
+          filename: mixedJasmineJestFixture,
         },
       ],
       invalid: [
@@ -174,9 +193,35 @@ describe('S5906', () => {
         },
         {
           code: `
+            import { expect } from 'jasmine';
+
+            expect(items.length).toBe(3);
+          `,
+          filename: mixedJasmineJestFixture,
+          errors: [
+            expectedError(`
+            import { expect } from 'jasmine';
+
+            expect(items).toHaveSize(3);
+          `),
+          ],
+        },
+        {
+          code: `
             expect(error).toBe(null);
           `,
           filename: angularJasmineFixture,
+          errors: [
+            expectedError(`
+            expect(error).toBeNull();
+          `),
+          ],
+        },
+        {
+          code: `
+            expect(error).toBe(null);
+          `,
+          filename: mixedJasmineJestFixture,
           errors: [
             expectedError(`
             expect(error).toBeNull();
@@ -198,6 +243,21 @@ describe('S5906', () => {
             test('uses generic length assertion', () => {
               expect(items).toHaveLength(3);
             });
+          `),
+          ],
+        },
+        {
+          code: `
+            import { expect } from 'vitest';
+
+            expect(items.length).toBe(3);
+          `,
+          filename: mixedJasmineJestFixture,
+          errors: [
+            expectedError(`
+            import { expect } from 'vitest';
+
+            expect(items).toHaveLength(3);
           `),
           ],
         },

--- a/packages/analysis/src/jsts/rules/helpers/assertions.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions.ts
@@ -113,6 +113,36 @@ export function extractTestAssertion(
   context: Rule.RuleContext,
   node: estree.Node,
 ): Assertion | null {
+  // Explicit imports in the current file are more precise than project-wide dependency signals.
+  if (importsModule(context, JEST_LIKE_MODULES)) {
+    const assertion = extractExpectAssertion(node, 'jest-like');
+    if (assertion) {
+      return assertion;
+    }
+  }
+
+  if (importsModule(context, JASMINE_MODULES)) {
+    const assertion = extractExpectAssertion(node, 'jasmine');
+    if (assertion) {
+      return assertion;
+    }
+  }
+
+  if (importsModule(context, PLAYWRIGHT_MODULES)) {
+    const assertion = extractExpectAssertion(node, 'playwright');
+    if (assertion) {
+      return assertion;
+    }
+  }
+
+  if (importsModule(context, CHAI_LIKE_GLOBAL_MODULES)) {
+    const assertion =
+      extractChaiAssertion(context, node, true) ?? extractCypressChainAssertion(node);
+    if (assertion) {
+      return assertion;
+    }
+  }
+
   // covers Jest-like assertion libraries
   if (importsOrDependsOnModule(context, JEST_LIKE_MODULES, JEST_LIKE_GLOBAL_MODULES)) {
     const assertion = extractExpectAssertion(node, 'jest-like');

--- a/packages/analysis/src/jsts/rules/helpers/assertions.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions.ts
@@ -109,76 +109,77 @@ type NodeAssertMethod =
   | 'deepStrictEqual'
   | 'notDeepStrictEqual';
 
+type AssertionLibrary = {
+  imports: string[];
+  dependencies: string[];
+  extract: (context: Rule.RuleContext, node: estree.Node) => Assertion | null;
+};
+
+const ASSERTION_LIBRARIES: AssertionLibrary[] = [
+  {
+    imports: JEST_LIKE_MODULES,
+    dependencies: JEST_LIKE_GLOBAL_MODULES,
+    extract: (_context, node) => extractExpectAssertion(node, 'jest-like'),
+  },
+  {
+    imports: JASMINE_MODULES,
+    dependencies: JASMINE_GLOBAL_MODULES,
+    extract: (_context, node) => extractExpectAssertion(node, 'jasmine'),
+  },
+  {
+    imports: PLAYWRIGHT_MODULES,
+    dependencies: PLAYWRIGHT_MODULES,
+    extract: (_context, node) => extractExpectAssertion(node, 'playwright'),
+  },
+  {
+    imports: CHAI_LIKE_GLOBAL_MODULES,
+    dependencies: CHAI_LIKE_GLOBAL_MODULES,
+    extract: (context, node) =>
+      extractChaiAssertion(context, node, true) ?? extractCypressChainAssertion(node),
+  },
+];
+
 export function extractTestAssertion(
   context: Rule.RuleContext,
   node: estree.Node,
 ): Assertion | null {
   // Explicit imports in the current file are more precise than project-wide dependency signals.
-  if (importsModule(context, JEST_LIKE_MODULES)) {
-    const assertion = extractExpectAssertion(node, 'jest-like');
-    if (assertion) {
-      return assertion;
-    }
+  const importedAssertion = extractAssertionFromLibraries(context, node, library =>
+    importsModule(context, library.imports),
+  );
+  if (importedAssertion) {
+    return importedAssertion;
   }
 
-  if (importsModule(context, JASMINE_MODULES)) {
-    const assertion = extractExpectAssertion(node, 'jasmine');
-    if (assertion) {
-      return assertion;
-    }
-  }
-
-  if (importsModule(context, PLAYWRIGHT_MODULES)) {
-    const assertion = extractExpectAssertion(node, 'playwright');
-    if (assertion) {
-      return assertion;
-    }
-  }
-
-  if (importsModule(context, CHAI_LIKE_GLOBAL_MODULES)) {
-    const assertion =
-      extractChaiAssertion(context, node, true) ?? extractCypressChainAssertion(node);
-    if (assertion) {
-      return assertion;
-    }
-  }
-
-  // covers Jest-like assertion libraries
-  if (importsOrDependsOnModule(context, JEST_LIKE_MODULES, JEST_LIKE_GLOBAL_MODULES)) {
-    const assertion = extractExpectAssertion(node, 'jest-like');
-    if (assertion) {
-      return assertion;
-    }
-  }
-
-  // covers Jasmine's Jest-like assertion shape
-  if (importsOrDependsOnModule(context, JASMINE_MODULES, JASMINE_GLOBAL_MODULES)) {
-    const assertion = extractExpectAssertion(node, 'jasmine');
-    if (assertion) {
-      return assertion;
-    }
-  }
-
-  // covers Playwright's generic `expect(...).toBe()/toEqual()` shape
-  if (importsOrDependsOnModule(context, PLAYWRIGHT_MODULES, PLAYWRIGHT_MODULES)) {
-    const assertion = extractExpectAssertion(node, 'playwright');
-    if (assertion) {
-      return assertion;
-    }
-  }
-
-  // covers Chai-like assertion libraries (including Cypress expect/assert and cy.wrap().should() chains)
-  if (importsOrDependsOnModule(context, CHAI_LIKE_GLOBAL_MODULES, CHAI_LIKE_GLOBAL_MODULES)) {
-    const assertion =
-      extractChaiAssertion(context, node, true) ?? extractCypressChainAssertion(node);
-    if (assertion) {
-      return assertion;
-    }
+  const dependencyAssertion = extractAssertionFromLibraries(context, node, library =>
+    importsOrDependsOnModule(context, library.imports, library.dependencies),
+  );
+  if (dependencyAssertion) {
+    return dependencyAssertion;
   }
 
   // covers Node.js assert
   if (node.type === 'CallExpression' && importsModule(context, NODE_ASSERT_MODULES)) {
     return extractNodeJSAssertion(context, node);
+  }
+
+  return null;
+}
+
+function extractAssertionFromLibraries(
+  context: Rule.RuleContext,
+  node: estree.Node,
+  isAvailable: (library: AssertionLibrary) => boolean,
+): Assertion | null {
+  for (const library of ASSERTION_LIBRARIES) {
+    if (!isAvailable(library)) {
+      continue;
+    }
+
+    const assertion = library.extract(context, node);
+    if (assertion) {
+      return assertion;
+    }
   }
 
   return null;


### PR DESCRIPTION
## Summary
- Prefer explicit assertion-framework imports over project-wide dependency signals.
- Suppress S5906 length-equality suggestions for global expect() when Jasmine and Jest dependency signals are both present.
- Add mixed Jasmine/Jest fixture coverage for ambiguous globals and explicit Jasmine/Vitest imports.

## Community report
- https://community.sonarsource.com/t/eslint-prefer-specific-assertions-wants-me-to-use-tohavelength-but-i-cant/184082

## Verification
- ./node_modules/.bin/tsx --test packages/analysis/src/jsts/rules/S5906/**/*.test.ts
- ./node_modules/.bin/tsc -b packages

Jira: JS-1950