### PR TITLE
JS-1975 Implement private assertion layer for assertions-in-tests

### DIFF
--- a/packages/analysis/src/jsts/rules/S2699/assertion-detectors.ts
+++ b/packages/analysis/src/jsts/rules/S2699/assertion-detectors.ts
@@ -1,0 +1,44 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { Rule } from 'eslint';
+import type estree from 'estree';
+import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
+import ts from 'typescript';
+
+// Test-only placeholder proving S2699 can extend assertion detection privately.
+const TEST_ONLY_ASSERTION_NAME = '__sonarPrivateAssertionForTestsOnly';
+
+export function isAdditionalAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
+  void context;
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === TEST_ONLY_ASSERTION_NAME
+  );
+}
+
+export function isAdditionalTSAssertion(
+  services: ParserServicesWithTypeInformation,
+  node: ts.Node,
+): boolean {
+  void services;
+  return (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === TEST_ONLY_ASSERTION_NAME
+  );
+}

--- a/packages/analysis/src/jsts/rules/S2699/assertion-detectors.ts
+++ b/packages/analysis/src/jsts/rules/S2699/assertion-detectors.ts
@@ -19,59 +19,27 @@ import type estree from 'estree';
 import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
 import ts from 'typescript';
 
-type AdditionalAssertionDetector = (context: Rule.RuleContext, node: estree.Node) => boolean;
-type AdditionalTSAssertionDetector = (
+export type AdditionalAssertionDetector = (context: Rule.RuleContext, node: estree.Node) => boolean;
+export type AdditionalTSAssertionDetector = (
   services: ParserServicesWithTypeInformation,
   node: ts.Node,
 ) => boolean;
 
-const additionalAssertionDetectors: AdditionalAssertionDetector[] = [];
-const additionalTSAssertionDetectors: AdditionalTSAssertionDetector[] = [];
+const defaultAdditionalAssertionDetectors: AdditionalAssertionDetector[] = [];
+const defaultAdditionalTSAssertionDetectors: AdditionalTSAssertionDetector[] = [];
 
-export function isAdditionalAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
-  return additionalAssertionDetectors.some(detector => detector(context, node));
+export function isAdditionalAssertion(
+  context: Rule.RuleContext,
+  node: estree.Node,
+  detectors: AdditionalAssertionDetector[] = defaultAdditionalAssertionDetectors,
+): boolean {
+  return detectors.some(detector => detector(context, node));
 }
 
 export function isAdditionalTSAssertion(
   services: ParserServicesWithTypeInformation,
   node: ts.Node,
+  detectors: AdditionalTSAssertionDetector[] = defaultAdditionalTSAssertionDetectors,
 ): boolean {
-  return additionalTSAssertionDetectors.some(detector => detector(services, node));
-}
-
-export function withAdditionalAssertionDetectorsForTesting<T>(
-  detectors: {
-    assertionDetectors?: AdditionalAssertionDetector[];
-    tsAssertionDetectors?: AdditionalTSAssertionDetector[];
-  },
-  callback: () => T,
-): T {
-  const previousAssertionDetectors = [...additionalAssertionDetectors];
-  const previousTSAssertionDetectors = [...additionalTSAssertionDetectors];
-
-  additionalAssertionDetectors.splice(
-    0,
-    additionalAssertionDetectors.length,
-    ...(detectors.assertionDetectors ?? []),
-  );
-  additionalTSAssertionDetectors.splice(
-    0,
-    additionalTSAssertionDetectors.length,
-    ...(detectors.tsAssertionDetectors ?? []),
-  );
-
-  try {
-    return callback();
-  } finally {
-    additionalAssertionDetectors.splice(
-      0,
-      additionalAssertionDetectors.length,
-      ...previousAssertionDetectors,
-    );
-    additionalTSAssertionDetectors.splice(
-      0,
-      additionalTSAssertionDetectors.length,
-      ...previousTSAssertionDetectors,
-    );
-  }
+  return detectors.some(detector => detector(services, node));
 }

--- a/packages/analysis/src/jsts/rules/S2699/assertion-detectors.ts
+++ b/packages/analysis/src/jsts/rules/S2699/assertion-detectors.ts
@@ -19,26 +19,59 @@ import type estree from 'estree';
 import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
 import ts from 'typescript';
 
-// Test-only placeholder proving S2699 can extend assertion detection privately.
-const TEST_ONLY_ASSERTION_NAME = '__sonarPrivateAssertionForTestsOnly';
+type AdditionalAssertionDetector = (context: Rule.RuleContext, node: estree.Node) => boolean;
+type AdditionalTSAssertionDetector = (
+  services: ParserServicesWithTypeInformation,
+  node: ts.Node,
+) => boolean;
+
+const additionalAssertionDetectors: AdditionalAssertionDetector[] = [];
+const additionalTSAssertionDetectors: AdditionalTSAssertionDetector[] = [];
 
 export function isAdditionalAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
-  void context;
-  return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'Identifier' &&
-    node.callee.name === TEST_ONLY_ASSERTION_NAME
-  );
+  return additionalAssertionDetectors.some(detector => detector(context, node));
 }
 
 export function isAdditionalTSAssertion(
   services: ParserServicesWithTypeInformation,
   node: ts.Node,
 ): boolean {
-  void services;
-  return (
-    ts.isCallExpression(node) &&
-    ts.isIdentifier(node.expression) &&
-    node.expression.text === TEST_ONLY_ASSERTION_NAME
+  return additionalTSAssertionDetectors.some(detector => detector(services, node));
+}
+
+export function withAdditionalAssertionDetectorsForTesting<T>(
+  detectors: {
+    assertionDetectors?: AdditionalAssertionDetector[];
+    tsAssertionDetectors?: AdditionalTSAssertionDetector[];
+  },
+  callback: () => T,
+): T {
+  const previousAssertionDetectors = [...additionalAssertionDetectors];
+  const previousTSAssertionDetectors = [...additionalTSAssertionDetectors];
+
+  additionalAssertionDetectors.splice(
+    0,
+    additionalAssertionDetectors.length,
+    ...(detectors.assertionDetectors ?? []),
   );
+  additionalTSAssertionDetectors.splice(
+    0,
+    additionalTSAssertionDetectors.length,
+    ...(detectors.tsAssertionDetectors ?? []),
+  );
+
+  try {
+    return callback();
+  } finally {
+    additionalAssertionDetectors.splice(
+      0,
+      additionalAssertionDetectors.length,
+      ...previousAssertionDetectors,
+    );
+    additionalTSAssertionDetectors.splice(
+      0,
+      additionalTSAssertionDetectors.length,
+      ...previousTSAssertionDetectors,
+    );
+  }
 }

--- a/packages/analysis/src/jsts/rules/S2699/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2699/rule.ts
@@ -34,6 +34,7 @@ import {
   isAssertion,
   isTSAssertion,
 } from '../helpers/assertion-detection.js';
+import { isAdditionalAssertion, isAdditionalTSAssertion } from './assertion-detectors.js';
 import * as meta from './generated-meta.js';
 import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
 import ts from 'typescript';
@@ -223,7 +224,7 @@ class TestCaseAssertionVisitor {
       return visitedTSNodes.get(node)!;
     }
     visitedTSNodes.set(node, false);
-    if (isTSAssertion(services, node)) {
+    if (isTSAssertion(services, node) || isAdditionalTSAssertion(services, node)) {
       visitedTSNodes.set(node, true);
       return true;
     }
@@ -262,7 +263,7 @@ class TestCaseAssertionVisitor {
       return visitedNodes.get(node)!;
     }
     visitedNodes.set(node, false);
-    if (isAssertion(context, node)) {
+    if (isAssertion(context, node) || isAdditionalAssertion(context, node)) {
       visitedNodes.set(node, true);
       return true;
     }

--- a/packages/analysis/src/jsts/rules/S2699/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2699/rule.ts
@@ -34,34 +34,59 @@ import {
   isAssertion,
   isTSAssertion,
 } from '../helpers/assertion-detection.js';
-import { isAdditionalAssertion, isAdditionalTSAssertion } from './assertion-detectors.js';
+import {
+  isAdditionalAssertion,
+  isAdditionalTSAssertion,
+  type AdditionalAssertionDetector,
+  type AdditionalTSAssertionDetector,
+} from './assertion-detectors.js';
 import * as meta from './generated-meta.js';
 import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
 import ts from 'typescript';
+
+type AdditionalAssertionLayer = {
+  assertionDetectors?: AdditionalAssertionDetector[];
+  tsAssertionDetectors?: AdditionalTSAssertionDetector[];
+};
 
 /**
  * We assume that the user is using a single assertion library per file,
  * this is why we are not saving if an assertion has been performed for
  * libX and the imported library was libY.
  */
-export const rule: Rule.RuleModule = {
-  meta: generateMeta(meta),
-  create(context: Rule.RuleContext) {
-    if (!hasSupportedAssertionLibrary(context)) {
-      return {};
-    }
-    const visitedNodes: Map<estree.Node, boolean> = new Map();
-    const visitedTSNodes: Map<ts.Node, boolean> = new Map();
-    return {
-      'CallExpression:exit': (node: estree.Node) => {
-        const testCase = Mocha.extractTestCase(node);
-        if (testCase !== null) {
-          checkAssertions(testCase, context, visitedNodes, visitedTSNodes);
-        }
-      },
-    };
-  },
-};
+export function createRule(
+  additionalAssertionLayer: AdditionalAssertionLayer = {},
+): Rule.RuleModule {
+  const { assertionDetectors = [], tsAssertionDetectors = [] } = additionalAssertionLayer;
+
+  return {
+    meta: generateMeta(meta),
+    create(context: Rule.RuleContext) {
+      if (!hasSupportedAssertionLibrary(context)) {
+        return {};
+      }
+      const visitedNodes: Map<estree.Node, boolean> = new Map();
+      const visitedTSNodes: Map<ts.Node, boolean> = new Map();
+      return {
+        'CallExpression:exit': (node: estree.Node) => {
+          const testCase = Mocha.extractTestCase(node);
+          if (testCase !== null) {
+            checkAssertions(
+              testCase,
+              context,
+              visitedNodes,
+              visitedTSNodes,
+              assertionDetectors,
+              tsAssertionDetectors,
+            );
+          }
+        },
+      };
+    },
+  };
+}
+
+export const rule: Rule.RuleModule = createRule();
 
 /**
  * Checks if a test uses the Mocha done callback as an assertion mechanism.
@@ -186,6 +211,8 @@ function checkAssertions(
   context: Rule.RuleContext,
   visitedNodes: Map<estree.Node, boolean>,
   visitedTSNodes: Map<ts.Node, boolean>,
+  assertionDetectors: AdditionalAssertionDetector[],
+  tsAssertionDetectors: AdditionalTSAssertionDetector[],
 ) {
   const { node, callback } = testCase;
 
@@ -194,7 +221,7 @@ function checkAssertions(
     return;
   }
 
-  const visitor = new TestCaseAssertionVisitor(context);
+  const visitor = new TestCaseAssertionVisitor(context, assertionDetectors, tsAssertionDetectors);
   const parserServices = context.sourceCode.parserServices;
   let hasAssertions = false;
   if (isRequiredParserServices(parserServices)) {
@@ -211,7 +238,11 @@ function checkAssertions(
 class TestCaseAssertionVisitor {
   private readonly visitorKeys: SourceCode.VisitorKeys;
 
-  constructor(private readonly context: Rule.RuleContext) {
+  constructor(
+    private readonly context: Rule.RuleContext,
+    private readonly assertionDetectors: AdditionalAssertionDetector[],
+    private readonly tsAssertionDetectors: AdditionalTSAssertionDetector[],
+  ) {
     this.visitorKeys = context.sourceCode.visitorKeys;
   }
 
@@ -224,7 +255,10 @@ class TestCaseAssertionVisitor {
       return visitedTSNodes.get(node)!;
     }
     visitedTSNodes.set(node, false);
-    if (isTSAssertion(services, node) || isAdditionalTSAssertion(services, node)) {
+    if (
+      isTSAssertion(services, node) ||
+      isAdditionalTSAssertion(services, node, this.tsAssertionDetectors)
+    ) {
       visitedTSNodes.set(node, true);
       return true;
     }
@@ -263,7 +297,10 @@ class TestCaseAssertionVisitor {
       return visitedNodes.get(node)!;
     }
     visitedNodes.set(node, false);
-    if (isAssertion(context, node) || isAdditionalAssertion(context, node)) {
+    if (
+      isAssertion(context, node) ||
+      isAdditionalAssertion(context, node, this.assertionDetectors)
+    ) {
       visitedNodes.set(node, true);
       return true;
     }

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -18,6 +18,8 @@ import {
   DefaultParserRuleTester,
   RuleTester,
 } from '../../../../tests/jsts/tools/testers/rule-tester.js';
+import type { Rule } from 'eslint';
+import { isAssertion } from '../helpers/assertion-detection.js';
 import { rule } from './rule.js';
 import { describe, it } from 'node:test';
 
@@ -53,6 +55,16 @@ const chai = require('chai');
 describe('global expect', () => {
   it('expect', () => {
     expect(5).toEqual(4);
+  });
+});
+          `,
+        },
+        {
+          code: `
+const chai = require('chai');
+describe('private assertion layer', () => {
+  it('accepts the rule-local placeholder assertion', () => {
+    __sonarPrivateAssertionForTestsOnly();
   });
 });
           `,
@@ -320,7 +332,20 @@ describe('RxJS marble testing with types', () => {
     expectSubscriptions(subscriptions).toBe(['^ !']);
   });
 });
-`,
+          `,
+        },
+        {
+          code: `
+import { expect } from 'chai';
+
+declare function __sonarPrivateAssertionForTestsOnly(): void;
+
+describe('private assertion layer with types', () => {
+  it('accepts the rule-local placeholder assertion', () => {
+    __sonarPrivateAssertionForTestsOnly();
+  });
+});
+          `,
         },
         // expectTypeOf in TypeScript
         {
@@ -413,6 +438,44 @@ describe('Observable error handling with object syntax', () => {
         },
       ],
       invalid: [],
+    });
+  });
+
+  it('keeps private placeholder assertions out of shared detection', () => {
+    const ruleTester = new DefaultParserRuleTester();
+    const probeRule: Rule.RuleModule = {
+      meta: {
+        messages: {
+          detected: 'detected',
+        },
+      },
+      create(context) {
+        return {
+          CallExpression(node) {
+            if (isAssertion(context, node)) {
+              context.report({ node, messageId: 'detected' });
+            }
+          },
+        };
+      },
+    };
+
+    ruleTester.run('Shared assertion detection stays unchanged', probeRule, {
+      valid: [
+        {
+          code: `
+__sonarPrivateAssertionForTestsOnly();
+          `,
+        },
+      ],
+      invalid: [
+        {
+          code: `
+expect(1).toEqual(1);
+          `,
+          errors: 1,
+        },
+      ],
     });
   });
 });

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -349,8 +349,9 @@ describe('RxJS marble testing with types', () => {
     expectSubscriptions(subscriptions).toBe(['^ !']);
   });
 });
-          `,
+`,
         },
+        // expectTypeOf in TypeScript
         {
           code: `
 import { expect } from 'chai';

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -20,8 +20,36 @@ import {
 } from '../../../../tests/jsts/tools/testers/rule-tester.js';
 import type { Rule } from 'eslint';
 import { isAssertion } from '../helpers/assertion-detection.js';
+import { withAdditionalAssertionDetectorsForTesting } from './assertion-detectors.js';
 import { rule } from './rule.js';
 import { describe, it } from 'node:test';
+import ts from 'typescript';
+
+const PRIVATE_ASSERTION_NAME = '__sonarPrivateAssertionForTestsOnly';
+
+function isPrivateAssertion(node: unknown): boolean {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    'type' in node &&
+    node.type === 'CallExpression' &&
+    'callee' in node &&
+    typeof node.callee === 'object' &&
+    node.callee !== null &&
+    'type' in node.callee &&
+    node.callee.type === 'Identifier' &&
+    'name' in node.callee &&
+    node.callee.name === PRIVATE_ASSERTION_NAME
+  );
+}
+
+function isPrivateTSAssertion(node: ts.Node): boolean {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === PRIVATE_ASSERTION_NAME
+  );
+}
 
 describe('S2699', () => {
   it('S2699', () => {
@@ -55,16 +83,6 @@ const chai = require('chai');
 describe('global expect', () => {
   it('expect', () => {
     expect(5).toEqual(4);
-  });
-});
-          `,
-        },
-        {
-          code: `
-const chai = require('chai');
-describe('private assertion layer', () => {
-  it('accepts the rule-local placeholder assertion', () => {
-    __sonarPrivateAssertionForTestsOnly();
   });
 });
           `,
@@ -338,20 +356,6 @@ describe('RxJS marble testing with types', () => {
           code: `
 import { expect } from 'chai';
 
-declare function __sonarPrivateAssertionForTestsOnly(): void;
-
-describe('private assertion layer with types', () => {
-  it('accepts the rule-local placeholder assertion', () => {
-    __sonarPrivateAssertionForTestsOnly();
-  });
-});
-          `,
-        },
-        // expectTypeOf in TypeScript
-        {
-          code: `
-import { expect } from 'chai';
-
 declare function expectTypeOf<T>(value: T): { toEqualTypeOf: <U>() => void; toBe: () => void };
 
 describe('Type testing with expectTypeOf', () => {
@@ -441,6 +445,63 @@ describe('Observable error handling with object syntax', () => {
     });
   });
 
+  it('uses the private assertion layer in JavaScript mode', () => {
+    const ruleTester = new DefaultParserRuleTester();
+
+    withAdditionalAssertionDetectorsForTesting(
+      {
+        assertionDetectors: [(_context, node) => isPrivateAssertion(node)],
+      },
+      () => {
+        ruleTester.run(`Test cases must have assertions`, rule, {
+          valid: [
+            {
+              code: `
+const chai = require('chai');
+describe('private assertion layer', () => {
+  it('accepts the rule-local private detector', () => {
+    __sonarPrivateAssertionForTestsOnly();
+  });
+});
+              `,
+            },
+          ],
+          invalid: [],
+        });
+      },
+    );
+  });
+
+  it('uses the private assertion layer in type-aware mode', () => {
+    const typedRuleTester = new RuleTester();
+
+    withAdditionalAssertionDetectorsForTesting(
+      {
+        tsAssertionDetectors: [(_services, node) => isPrivateTSAssertion(node)],
+      },
+      () => {
+        typedRuleTester.run('Test cases must have assertions', rule, {
+          valid: [
+            {
+              code: `
+import { expect } from 'chai';
+
+declare function __sonarPrivateAssertionForTestsOnly(): void;
+
+describe('private assertion layer with types', () => {
+  it('accepts the rule-local private detector', () => {
+    __sonarPrivateAssertionForTestsOnly();
+  });
+});
+              `,
+            },
+          ],
+          invalid: [],
+        });
+      },
+    );
+  });
+
   it('keeps private placeholder assertions out of shared detection', () => {
     const ruleTester = new DefaultParserRuleTester();
     const probeRule: Rule.RuleModule = {
@@ -464,7 +525,7 @@ describe('Observable error handling with object syntax', () => {
       valid: [
         {
           code: `
-__sonarPrivateAssertionForTestsOnly();
+${PRIVATE_ASSERTION_NAME}();
           `,
         },
       ],

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -20,8 +20,7 @@ import {
 } from '../../../../tests/jsts/tools/testers/rule-tester.js';
 import type { Rule } from 'eslint';
 import { isAssertion } from '../helpers/assertion-detection.js';
-import { withAdditionalAssertionDetectorsForTesting } from './assertion-detectors.js';
-import { rule } from './rule.js';
+import { createRule, rule } from './rule.js';
 import { describe, it } from 'node:test';
 import ts from 'typescript';
 
@@ -447,43 +446,37 @@ describe('Observable error handling with object syntax', () => {
 
   it('uses the private assertion layer in JavaScript mode', () => {
     const ruleTester = new DefaultParserRuleTester();
+    const ruleWithPrivateAssertionDetector = createRule({
+      assertionDetectors: [(_context, node) => isPrivateAssertion(node)],
+    });
 
-    withAdditionalAssertionDetectorsForTesting(
-      {
-        assertionDetectors: [(_context, node) => isPrivateAssertion(node)],
-      },
-      () => {
-        ruleTester.run(`Test cases must have assertions`, rule, {
-          valid: [
-            {
-              code: `
+    ruleTester.run(`Test cases must have assertions`, ruleWithPrivateAssertionDetector, {
+      valid: [
+        {
+          code: `
 const chai = require('chai');
 describe('private assertion layer', () => {
   it('accepts the rule-local private detector', () => {
     __sonarPrivateAssertionForTestsOnly();
   });
 });
-              `,
-            },
-          ],
-          invalid: [],
-        });
-      },
-    );
+          `,
+        },
+      ],
+      invalid: [],
+    });
   });
 
   it('uses the private assertion layer in type-aware mode', () => {
     const typedRuleTester = new RuleTester();
+    const ruleWithPrivateAssertionDetector = createRule({
+      tsAssertionDetectors: [(_services, node) => isPrivateTSAssertion(node)],
+    });
 
-    withAdditionalAssertionDetectorsForTesting(
-      {
-        tsAssertionDetectors: [(_services, node) => isPrivateTSAssertion(node)],
-      },
-      () => {
-        typedRuleTester.run('Test cases must have assertions', rule, {
-          valid: [
-            {
-              code: `
+    typedRuleTester.run('Test cases must have assertions', ruleWithPrivateAssertionDetector, {
+      valid: [
+        {
+          code: `
 import { expect } from 'chai';
 
 declare function __sonarPrivateAssertionForTestsOnly(): void;
@@ -493,13 +486,11 @@ describe('private assertion layer with types', () => {
     __sonarPrivateAssertionForTestsOnly();
   });
 });
-              `,
-            },
-          ],
-          invalid: [],
-        });
-      },
-    );
+          `,
+        },
+      ],
+      invalid: [],
+    });
   });
 
   it('keeps private placeholder assertions out of shared detection', () => {


### PR DESCRIPTION
## Summary
- add a private assertion detector layer for S2699 without changing shared assertion detection
- prove S2699 accepts the rule-local placeholder in both JS and TS paths
- add a regression test showing the shared detector still ignores the private placeholder

## Validation
- npx tsx --tsconfig packages/tsconfig.test.json --test --test-concurrency=1 --test-reporter=spec --test-reporter-destination stdout packages/analysis/src/jsts/rules/S2699/unit.test.ts