### PR TITLE
JS-1976 Cache sonar-rule-api RSPEC clone in CI

### DIFF
--- a/.github/actions/rule-api-cache/action.yml
+++ b/.github/actions/rule-api-cache/action.yml
@@ -25,8 +25,8 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: ${{ env.RULE_API_CACHE_DIR }}
-        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ github.run_id }}
-        restore-keys: ${{ inputs.key-prefix }}-${{ runner.os }}-
+        key: ${{ inputs.key-prefix }}-${{ github.run_id }}
+        restore-keys: ${{ inputs.key-prefix }}-
 
     # Full cache on default branch (save enabled) - uses run_id for rolling cache because the RSPEC
     # clone contents evolve independently of the SonarJS source tree.
@@ -35,8 +35,8 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ env.RULE_API_CACHE_DIR }}
-        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ github.run_id }}
-        restore-keys: ${{ inputs.key-prefix }}-${{ runner.os }}-
+        key: ${{ inputs.key-prefix }}-${{ github.run_id }}
+        restore-keys: ${{ inputs.key-prefix }}-
 
     - name: Setup Rule API cache directory
       shell: bash

--- a/.github/actions/rule-api-cache/action.yml
+++ b/.github/actions/rule-api-cache/action.yml
@@ -2,9 +2,6 @@ name: Setup Rule API Cache
 description: Sets up sonar-rule-api cache with restore-only behavior on non-default branches
 
 inputs:
-  cache-month:
-    description: 'Month string for cache key rotation (YYYY-MM)'
-    required: true
   key-prefix:
     description: 'Prefix for the cache key (default: rule-api)'
     required: false
@@ -28,8 +25,8 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: ${{ env.RULE_API_CACHE_DIR }}
-        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ inputs.cache-month }}-${{ github.run_id }}
-        restore-keys: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ inputs.cache-month }}-
+        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: ${{ inputs.key-prefix }}-${{ runner.os }}-
 
     # Full cache on default branch (save enabled) - uses run_id for rolling cache because the RSPEC
     # clone contents evolve independently of the SonarJS source tree.
@@ -38,8 +35,8 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ env.RULE_API_CACHE_DIR }}
-        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ inputs.cache-month }}-${{ github.run_id }}
-        restore-keys: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ inputs.cache-month }}-
+        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: ${{ inputs.key-prefix }}-${{ runner.os }}-
 
     - name: Setup Rule API cache directory
       shell: bash

--- a/.github/actions/rule-api-cache/action.yml
+++ b/.github/actions/rule-api-cache/action.yml
@@ -1,0 +1,46 @@
+name: Setup Rule API Cache
+description: Sets up sonar-rule-api cache with restore-only behavior on non-default branches
+
+inputs:
+  cache-month:
+    description: 'Month string for cache key rotation (YYYY-MM)'
+    required: true
+  key-prefix:
+    description: 'Prefix for the cache key (default: rule-api)'
+    required: false
+    default: 'rule-api'
+  save:
+    description: 'Whether to save the cache on the default branch (default: true)'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Set Rule API cache variables
+      shell: bash
+      run: echo "RULE_API_CACHE_DIR=$HOME/.sonar/rule-api" >> $GITHUB_ENV
+
+    # Restore only on branches (no save) - allows branches to read from default branch's cache.
+    # Also used when save is disabled.
+    - name: Restore Rule API cache (restore only)
+      if: github.ref_name != github.event.repository.default_branch || inputs.save != 'true'
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ env.RULE_API_CACHE_DIR }}
+        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ inputs.cache-month }}-${{ github.run_id }}
+        restore-keys: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ inputs.cache-month }}-
+
+    # Full cache on default branch (save enabled) - uses run_id for rolling cache because the RSPEC
+    # clone contents evolve independently of the SonarJS source tree.
+    - name: Cache Rule API data (default branch)
+      if: github.ref_name == github.event.repository.default_branch && inputs.save == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.RULE_API_CACHE_DIR }}
+        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ inputs.cache-month }}-${{ github.run_id }}
+        restore-keys: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ inputs.cache-month }}-
+
+    - name: Setup Rule API cache directory
+      shell: bash
+      run: mkdir -p "$RULE_API_CACHE_DIR"

--- a/.github/actions/rule-api-cache/action.yml
+++ b/.github/actions/rule-api-cache/action.yml
@@ -22,7 +22,7 @@ runs:
     # Also used when save is disabled.
     - name: Restore Rule API cache (restore only)
       if: github.ref_name != github.event.repository.default_branch || inputs.save != 'true'
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: ${{ env.RULE_API_CACHE_DIR }}
         key: ${{ inputs.key-prefix }}-${{ github.run_id }}
@@ -32,7 +32,7 @@ runs:
     # clone contents evolve independently of the SonarJS source tree.
     - name: Cache Rule API data (default branch)
       if: github.ref_name == github.event.repository.default_branch && inputs.save == 'true'
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ${{ env.RULE_API_CACHE_DIR }}
         key: ${{ inputs.key-prefix }}-${{ github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,8 +179,6 @@ jobs:
         with:
           cache-month: ${{ needs.setup.outputs.cache-month }}
           maven-hash: ${{ needs.setup.outputs.maven-hash }}
-      - &rule_api_cache
-        uses: ./.github/actions/rule-api-cache
       - &config_maven
         name: Configure Maven
         id: config-maven
@@ -259,7 +257,7 @@ jobs:
       - *mise
       - *npm_cache
       - *maven_cache
-      - *rule_api_cache
+      - uses: ./.github/actions/rule-api-cache
       - *config_maven
       - id: rspec-secrets
         uses: SonarSource/vault-action-wrapper@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,8 +181,6 @@ jobs:
           maven-hash: ${{ needs.setup.outputs.maven-hash }}
       - &rule_api_cache
         uses: ./.github/actions/rule-api-cache
-        with:
-          cache-month: ${{ needs.setup.outputs.cache-month }}
       - &config_maven
         name: Configure Maven
         id: config-maven

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,10 @@ jobs:
         with:
           cache-month: ${{ needs.setup.outputs.cache-month }}
           maven-hash: ${{ needs.setup.outputs.maven-hash }}
+      - &rule_api_cache
+        uses: ./.github/actions/rule-api-cache
+        with:
+          cache-month: ${{ needs.setup.outputs.cache-month }}
       - &config_maven
         name: Configure Maven
         id: config-maven
@@ -257,6 +261,7 @@ jobs:
       - *mise
       - *npm_cache
       - *maven_cache
+      - *rule_api_cache
       - *config_maven
       - id: rspec-secrets
         uses: SonarSource/vault-action-wrapper@v3


### PR DESCRIPTION
## Summary

- add an explicit cache for `~/.sonar/rule-api`
- restore it on non-default branches without saving, following the repository cache policy
- save it on the default branch with a rolling key so the cached RSPEC clone can evolve independently of SonarJS sources
- apply it only to `prepare_rspec_rule_data`
- keep the cache key simple: `rule-api-${github.run_id}` with `rule-api-` restore fallback

## Why

We already reuse the prepared RSPEC rule-data artifact across jobs inside the same workflow, but the `sonar-rule-api` cache directory is currently recreated from scratch on every workflow run. That means cold-start `rspec:refresh` runs still pay the full RSPEC clone/update cost.

Caching `~/.sonar/rule-api` makes those cold starts cheaper across workflow runs while keeping the current job topology unchanged. Only `prepare_rspec_rule_data` needs this cache because downstream jobs already consume the uploaded RSPEC artifact.

The cache key uses `github.run_id` on the default branch so the cache can keep moving forward even when the SonarJS checkout itself does not change. We intentionally do not rotate this cache monthly because the payload is a Git clone that updates in place rather than an ever-growing dependency store. We also do not split the key by OS because the cache is only used by the Linux `prepare_rspec_rule_data` job.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/rule-api-cache/action.yml"); YAML.load_file(".github/workflows/build.yml")'`
