### PR TITLE
JS-1981 Expose propNamePattern for S6478

### DIFF
--- a/packages/analysis/src/jsts/rules/S6478/config.ts
+++ b/packages/analysis/src/jsts/rules/S6478/config.ts
@@ -28,7 +28,7 @@ export const fields = [
     },
     {
       field: 'propNamePattern',
-      default: '{render*,*Enhancer,*Render}',
+      default: '{render*,*Enhancer,*Renderer}',
       description:
         'Glob pattern matching prop names whose inline functions should be treated as render props rather than nested components.',
       displayName: 'propNamePattern',

--- a/packages/analysis/src/jsts/rules/S6478/config.ts
+++ b/packages/analysis/src/jsts/rules/S6478/config.ts
@@ -23,7 +23,15 @@ export const fields = [
     {
       field: 'allowAsProps',
       default: false,
-      description: 'Allow React components defined inline when they are passed as props.',
+      description:
+        'Allow React components defined inline when they are passed as props. Use this broad escape hatch when propNamePattern is not precise enough.',
+    },
+    {
+      field: 'propNamePattern',
+      default: 'render*',
+      description:
+        'Glob pattern matching prop names whose inline functions should be treated as render props rather than nested components.',
+      displayName: 'propNamePattern',
     },
   ],
 ] as const satisfies ESLintConfiguration;

--- a/packages/analysis/src/jsts/rules/S6478/config.ts
+++ b/packages/analysis/src/jsts/rules/S6478/config.ts
@@ -28,7 +28,7 @@ export const fields = [
     },
     {
       field: 'propNamePattern',
-      default: 'render*',
+      default: '{render*,*Enhancer,*Render}',
       description:
         'Glob pattern matching prop names whose inline functions should be treated as render props rather than nested components.',
       displayName: 'propNamePattern',

--- a/packages/analysis/src/jsts/rules/S6478/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6478/unit.test.ts
@@ -22,7 +22,7 @@ import { fields } from './config.js';
 import { rule } from './index.js';
 
 describe('S6478', () => {
-  it('should expose allowAsProps as a Sonar configuration field', () => {
+  it('should expose allowAsProps and propNamePattern as Sonar configuration fields', () => {
     assert.ok(Array.isArray(fields));
     assert.ok(
       fields.some(
@@ -32,6 +32,19 @@ describe('S6478', () => {
             option =>
               option.field === 'allowAsProps' &&
               option.default === false &&
+              typeof option.description === 'string',
+          ),
+      ),
+    );
+    assert.ok(
+      fields.some(
+        field =>
+          Array.isArray(field) &&
+          field.some(
+            option =>
+              option.field === 'propNamePattern' &&
+              option.default === 'render*' &&
+              option.displayName === 'propNamePattern' &&
               typeof option.description === 'string',
           ),
       ),
@@ -124,6 +137,70 @@ describe('S6478', () => {
                 return <div />;
               }
               return <Child />;
+            }
+          `,
+          errors: 1,
+        },
+      ],
+    });
+  });
+
+  it('should suppress configured render-prop names with propNamePattern', () => {
+    const ruleTester = new DefaultParserRuleTester();
+
+    ruleTester.run('S6478', rule, {
+      valid: [
+        {
+          options: [{ propNamePattern: 'render*' }],
+          code: `
+            function Parent() {
+              return (
+                <OtherComponent
+                  renderLabel={value => <span>{value}</span>}
+                />
+              );
+            }
+          `,
+        },
+        {
+          options: [{ propNamePattern: '*Enhancer' }],
+          code: `
+            function Parent() {
+              return (
+                <Button
+                  startEnhancer={() => <Icon />}
+                  endEnhancer={() => <OtherIcon />}
+                />
+              );
+            }
+          `,
+        },
+        {
+          options: [{ propNamePattern: '*Render' }],
+          code: `
+            function Parent() {
+              return (
+                <Image
+                  preview={{
+                    imageRender: () => <video muted />,
+                    actionsRender: () => null,
+                  }}
+                />
+              );
+            }
+          `,
+        },
+      ],
+      invalid: [
+        {
+          options: [{ propNamePattern: '*Enhancer' }],
+          code: `
+            function Parent() {
+              return (
+                <OtherComponent
+                  component={() => <div />}
+                />
+              );
             }
           `,
           errors: 1,

--- a/packages/analysis/src/jsts/rules/S6478/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6478/unit.test.ts
@@ -43,7 +43,7 @@ describe('S6478', () => {
           field.some(
             option =>
               option.field === 'propNamePattern' &&
-              option.default === 'render*' &&
+              option.default === '{render*,*Enhancer,*Render}' &&
               option.displayName === 'propNamePattern' &&
               typeof option.description === 'string',
           ),
@@ -56,6 +56,32 @@ describe('S6478', () => {
 
     ruleTester.run('S6478', rule, {
       valid: [
+        {
+          code: `
+            function Parent() {
+              return (
+                <Button
+                  startEnhancer={() => <Icon />}
+                  endEnhancer={() => <OtherIcon />}
+                />
+              );
+            }
+          `,
+        },
+        {
+          code: `
+            function Parent() {
+              return (
+                <Image
+                  preview={{
+                    imageRender: () => <video muted />,
+                    actionsRender: () => null,
+                  }}
+                />
+              );
+            }
+          `,
+        },
         {
           code: `
             function Parent() {
@@ -151,7 +177,7 @@ describe('S6478', () => {
     ruleTester.run('S6478', rule, {
       valid: [
         {
-          options: [{ propNamePattern: 'render*' }],
+          options: [{ propNamePattern: '{render*,*Enhancer,*Render}' }],
           code: `
             function Parent() {
               return (
@@ -163,7 +189,7 @@ describe('S6478', () => {
           `,
         },
         {
-          options: [{ propNamePattern: '*Enhancer' }],
+          options: [{ propNamePattern: '{render*,*Enhancer,*Render}' }],
           code: `
             function Parent() {
               return (
@@ -176,7 +202,7 @@ describe('S6478', () => {
           `,
         },
         {
-          options: [{ propNamePattern: '*Render' }],
+          options: [{ propNamePattern: '{render*,*Enhancer,*Render}' }],
           code: `
             function Parent() {
               return (
@@ -193,7 +219,7 @@ describe('S6478', () => {
       ],
       invalid: [
         {
-          options: [{ propNamePattern: '*Enhancer' }],
+          options: [{ propNamePattern: '{render*,*Enhancer,*Render}' }],
           code: `
             function Parent() {
               return (

--- a/packages/analysis/src/jsts/rules/S6478/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6478/unit.test.ts
@@ -14,43 +14,12 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { DefaultParserRuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
-import { fields } from './config.js';
 import { rule } from './index.js';
 
 describe('S6478', () => {
-  it('should expose allowAsProps and propNamePattern as Sonar configuration fields', () => {
-    assert.ok(Array.isArray(fields));
-    assert.ok(
-      fields.some(
-        field =>
-          Array.isArray(field) &&
-          field.some(
-            option =>
-              option.field === 'allowAsProps' &&
-              option.default === false &&
-              typeof option.description === 'string',
-          ),
-      ),
-    );
-    assert.ok(
-      fields.some(
-        field =>
-          Array.isArray(field) &&
-          field.some(
-            option =>
-              option.field === 'propNamePattern' &&
-              option.default === '{render*,*Enhancer,*Render}' &&
-              option.displayName === 'propNamePattern' &&
-              typeof option.description === 'string',
-          ),
-      ),
-    );
-  });
-
   it('should keep prop-based inline components noncompliant by default', () => {
     const ruleTester = new DefaultParserRuleTester();
 
@@ -74,8 +43,8 @@ describe('S6478', () => {
               return (
                 <Image
                   preview={{
-                    imageRender: () => <video muted />,
-                    actionsRender: () => null,
+                    imageRenderer: () => <video muted />,
+                    actionsRenderer: () => null,
                   }}
                 />
               );
@@ -173,36 +142,24 @@ describe('S6478', () => {
 
   it('should suppress configured render-prop names with propNamePattern', () => {
     const ruleTester = new DefaultParserRuleTester();
+    const propNamePattern = '{*Render,*Slot}';
 
     ruleTester.run('S6478', rule, {
       valid: [
         {
-          options: [{ propNamePattern: '{render*,*Enhancer,*Render}' }],
+          options: [{ propNamePattern }],
           code: `
             function Parent() {
               return (
                 <OtherComponent
-                  renderLabel={value => <span>{value}</span>}
+                  footerSlot={() => <Footer />}
                 />
               );
             }
           `,
         },
         {
-          options: [{ propNamePattern: '{render*,*Enhancer,*Render}' }],
-          code: `
-            function Parent() {
-              return (
-                <Button
-                  startEnhancer={() => <Icon />}
-                  endEnhancer={() => <OtherIcon />}
-                />
-              );
-            }
-          `,
-        },
-        {
-          options: [{ propNamePattern: '{render*,*Enhancer,*Render}' }],
+          options: [{ propNamePattern }],
           code: `
             function Parent() {
               return (
@@ -219,12 +176,25 @@ describe('S6478', () => {
       ],
       invalid: [
         {
-          options: [{ propNamePattern: '{render*,*Enhancer,*Render}' }],
+          options: [{ propNamePattern }],
           code: `
             function Parent() {
               return (
                 <OtherComponent
-                  component={() => <div />}
+                  renderLabel={value => <span>{value}</span>}
+                />
+              );
+            }
+          `,
+          errors: 1,
+        },
+        {
+          options: [{ propNamePattern }],
+          code: `
+            function Parent() {
+              return (
+                <OtherComponent
+                  itemRenderer={() => <div />}
                 />
               );
             }

--- a/sonar-plugin/javascript-checks/src/test/java/org/sonar/javascript/checks/CheckListTest.java
+++ b/sonar-plugin/javascript-checks/src/test/java/org/sonar/javascript/checks/CheckListTest.java
@@ -31,7 +31,7 @@ import org.sonar.plugins.javascript.api.Language;
 
 class CheckListTest {
 
-  private static final int CHECKS_PROPERTIES_COUNT = 41;
+  private static final int CHECKS_PROPERTIES_COUNT = 42;
 
   /**
    * Enforces that each check declared in list.


### PR DESCRIPTION
## Summary
- expose `propNamePattern` alongside `allowAsProps` for S6478
- keep the upstream default glob semantics (`render*`) and describe the option as a prop-name glob
- add focused tests covering `render*`, `*Enhancer`, and `*Render` suppression while keeping non-matching props noncompliant

## Validation
- `npm run generate-meta`
- `npx tsx --test packages/analysis/src/jsts/rules/S6478/**/*.test.ts`

## Notes
- `npm run generate-java-rule-classes` completes with an unrelated `RSPEC metadata not found for rule S8957.` warning in this checkout