### PR TITLE
JS-1987 Use squad Renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:languages-tooling"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
   "enabledManagers": [
     "github-actions",
@@ -57,14 +57,6 @@
         "rollback"
       ],
       "enabled": false
-    },
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": false
     },
     {
       "description": "@typescript/native-preview - dev builds update daily, limit to weekly",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>SonarSource/renovate-config:languages-team"],
+  "extends": ["local>SonarSource/core-languages-tooling-public:renovate-config"],
   "configMigration": true,
+  "addLabels": ["dependencies"],
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   "enabledManagers": ["github-actions", "maven", "npm"],
   "dockerfile": {
     "enabled": true
@@ -24,11 +26,6 @@
       "matchCurrentVersion": "/-SNAPSHOT$/",
       "enabled": false,
       "matchDepNames": ["/^org\\.sonarsource\\.javascript:/"]
-    },
-    {
-      "description": "Don't group updates by default",
-      "matchPackageNames": ["*"],
-      "groupName": null
     },
     {
       "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
@@ -64,6 +61,5 @@
     }
   ],
   "autoApprove": true,
-  "prCreation": "immediate",
-  "rebaseWhen": "never"
+  "prCreation": "immediate"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>SonarSource/core-languages-tooling-public:renovate-config"],
-  "configMigration": true,
-  "addLabels": ["dependencies"],
-  "minimumReleaseAgeBehaviour": "timestamp-required",
-  "enabledManagers": ["github-actions", "maven", "npm"],
+  "extends": [
+    "local>SonarSource/core-languages-tooling-public:languages-tooling"
+  ],
+  "enabledManagers": [
+    "github-actions",
+    "maven",
+    "npm"
+  ],
   "dockerfile": {
     "enabled": true
   },
@@ -22,35 +25,55 @@
   "packageRules": [
     {
       "description": "Ignore project revision property - managed by CI during release",
-      "matchManagers": ["maven"],
+      "matchManagers": [
+        "maven"
+      ],
       "matchCurrentVersion": "/-SNAPSHOT$/",
       "enabled": false,
-      "matchDepNames": ["/^org\\.sonarsource\\.javascript:/"]
+      "matchDepNames": [
+        "/^org\\.sonarsource\\.javascript:/"
+      ]
     },
     {
       "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
-      "matchManagers": ["npm"],
+      "matchManagers": [
+        "npm"
+      ],
       "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
       "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
     },
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "pinDigests": false
     },
     {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["pin", "rollback"],
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "pin",
+        "rollback"
+      ],
       "enabled": false
     },
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "matchCurrentVersion": "!/^0/",
       "automerge": false
     },
     {
       "description": "@typescript/native-preview - dev builds update daily, limit to weekly",
-      "matchPackageNames": ["@typescript/native-preview"],
-      "extends": ["schedule:weekly"]
+      "matchPackageNames": [
+        "@typescript/native-preview"
+      ],
+      "extends": [
+        "schedule:weekly"
+      ]
     }
   ],
   "hostRules": [
@@ -59,7 +82,5 @@
       "matchHost": "https://repox.jfrog.io/artifactory/api/npm/npm/",
       "token": "{{ secrets.REPOX_TOKEN }}"
     }
-  ],
-  "autoApprove": true,
-  "prCreation": "immediate"
+  ]
 }


### PR DESCRIPTION
## Summary
- switch this repository to the squad Renovate preset
- keep only repo-specific Renovate behavior in the repository

## Effective Delta After Merge
<!-- codex-effective-delta:start -->
- minimumReleaseAgeBehaviour: timestamp-required -> timestamp-optional
- configMigration: true -> unset
- autoApprove: true -> unset
- packageRules removed: {"matchManagers":["regex"],"versioning":"regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"}; minor/patch for !/^0/
- regexManagers: 1 -> 0
<!-- codex-effective-delta:end -->
