### PR TITLE
JS-1983 Refine S6819 role=group exception

### DIFF
--- a/its/ruling/src/test/expected/desktop/typescript-S6819.json
+++ b/its/ruling/src/test/expected/desktop/typescript-S6819.json
@@ -1,10 +1,4 @@
 {
-"desktop:app/src/ui/changes/commit-message.tsx": [
-753
-],
-"desktop:app/src/ui/changes/undo-commit.tsx": [
-36
-],
 "desktop:app/src/ui/dialog/header.tsx": [
 67
 ]

--- a/its/ruling/src/test/expected/vuetify/typescript-S6819.json
+++ b/its/ruling/src/test/expected/vuetify/typescript-S6819.json
@@ -1,5 +1,0 @@
-{
-"vuetify:packages/vuetify/src/components/VList/VListGroup.tsx": [
-112
-]
-}

--- a/packages/analysis/src/jsts/rules/S6819/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6819/decorator.ts
@@ -50,9 +50,6 @@ const COMPOSITE_GROUP_OWNER_ROLES = new Set([
 const FIELDSET_FORM_CONTROL_ELEMENTS = new Set(['input', 'select', 'textarea']);
 const NON_GROUPABLE_INPUT_TYPES = new Set(['hidden', 'button', 'submit', 'reset', 'image']);
 
-// A group id resolved either as a static string or as a dynamic expression key.
-type GroupIdReference = { readonly value: string; readonly dynamic: boolean };
-
 // Composite-widget owners per JSX subtree root, so each tree is scanned once.
 const compositeGroupOwnersBySubtree = new WeakMap<
   TSESTree.JSXElement | TSESTree.JSXFragment,
@@ -319,7 +316,7 @@ function hasCompositeGroupOwnerAncestor(node: TSESTree.JSXOpeningElement): boole
  * @return Whether a composite widget owns the group by id reference.
  */
 function hasCompositeGroupOwnerByAriaOwns(node: TSESTree.JSXOpeningElement): boolean {
-  const id = getGroupIdReference((node as JSXOpeningElement).attributes);
+  const id = getNonEmptyStringAttributeValue((node as JSXOpeningElement).attributes, 'id');
   if (id === null) {
     return false;
   }
@@ -569,34 +566,12 @@ function isCompositeGroupOwner(node: TSESTree.JSXOpeningElement): boolean {
 /**
  * Checks whether a composite owner's aria-owns references the group id.
  *
- * Matches static ids by value and dynamic ids by shared expression, so a group
- * and its owner wired through the same `useId()`/prop variable still resolve.
- *
  * @param owner The composite-widget owner opening element.
- * @param id The group id reference to match.
+ * @param id The static group id to match.
  * @return Whether the owner owns the group.
  */
-function ownerReferencesId(owner: TSESTree.JSXOpeningElement, id: GroupIdReference): boolean {
-  const attributes = (owner as JSXOpeningElement).attributes;
-  return id.dynamic
-    ? getAriaOwnsExpressionKey(attributes) === id.value
-    : getAriaOwnsIds(attributes).includes(id.value);
-}
-
-/**
- * Resolves a group's id as a static value or a dynamic expression key.
- *
- * @param attributes The JSX attributes on the group element.
- * @return The id reference, or null when no id is present.
- */
-function getGroupIdReference(attributes: JSXOpeningElement['attributes']): GroupIdReference | null {
-  const staticId = getNonEmptyStringAttributeValue(attributes, 'id');
-  if (staticId !== null) {
-    return { value: staticId, dynamic: false };
-  }
-
-  const key = getAttributeExpressionKey(attributes, 'id');
-  return key === null ? null : { value: key, dynamic: true };
+function ownerReferencesId(owner: TSESTree.JSXOpeningElement, id: string): boolean {
+  return getAriaOwnsIds((owner as JSXOpeningElement).attributes).includes(id);
 }
 
 /**
@@ -608,58 +583,6 @@ function getGroupIdReference(attributes: JSXOpeningElement['attributes']): Group
 function getAriaOwnsIds(attributes: JSXOpeningElement['attributes']): string[] {
   const value = getNonEmptyStringAttributeValue(attributes, 'aria-owns');
   return value === null ? [] : value.split(/\s+/);
-}
-
-/**
- * Gets the dynamic expression key of an aria-owns attribute, if any.
- *
- * @param attributes The JSX attributes on the composite owner.
- * @return The expression key, or null when aria-owns is absent or unresolvable.
- */
-function getAriaOwnsExpressionKey(attributes: JSXOpeningElement['attributes']): string | null {
-  return getAttributeExpressionKey(attributes, 'aria-owns');
-}
-
-/**
- * Builds a stable key for a simple attribute expression (`{x}` or `{x.y}`).
- *
- * @param attributes The JSX attributes to read.
- * @param name The attribute name to resolve.
- * @return The expression key, or null for absent or unsupported expressions.
- */
-function getAttributeExpressionKey(
-  attributes: JSXOpeningElement['attributes'],
-  name: string,
-): string | null {
-  const prop = getProp(attributes, name);
-  if (!prop || prop.value?.type !== 'JSXExpressionContainer') {
-    return null;
-  }
-
-  return getExpressionKey(prop.value.expression as unknown as TSESTree.Node);
-}
-
-/**
- * Builds a key from an identifier or non-computed member expression.
- *
- * @param expression The expression node to key.
- * @return The key, or null for expressions that cannot be compared statically.
- */
-function getExpressionKey(expression: TSESTree.Node): string | null {
-  if (expression.type === 'Identifier') {
-    return expression.name;
-  }
-
-  if (
-    expression.type === 'MemberExpression' &&
-    !expression.computed &&
-    expression.property.type === 'Identifier'
-  ) {
-    const objectKey = getExpressionKey(expression.object);
-    return objectKey === null ? null : `${objectKey}.${expression.property.name}`;
-  }
-
-  return null;
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S6819/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6819/decorator.ts
@@ -377,10 +377,72 @@ function countFormControlsInChildren(children: TSESTree.JSXChild[]): number {
       count += countFormControlsInChildren(child.children);
     } else if (child.type === 'JSXFragment') {
       count += countFormControlsInChildren(child.children);
+    } else if (child.type === 'JSXExpressionContainer') {
+      count += countFormControlsInChildren(getJsxFromExpression(child.expression));
     }
   }
 
   return count;
+}
+
+/**
+ * Extracts the JSX subtrees a `{ ... }` expression container renders.
+ *
+ * Covers the common React render patterns: bare JSX, short-circuit (`&&`/`||`),
+ * conditional (`?:`), arrays, and iteration callbacks such as `.map(...)`. JSX
+ * reached through a variable or an external helper call cannot be resolved
+ * statically and is intentionally left out.
+ *
+ * @param expression The expression wrapped in the container.
+ * @return The JSX subtrees reachable from the expression.
+ */
+function getJsxFromExpression(
+  expression: TSESTree.Expression | TSESTree.JSXEmptyExpression,
+): (TSESTree.JSXElement | TSESTree.JSXFragment)[] {
+  switch (expression.type) {
+    case 'JSXElement':
+    case 'JSXFragment':
+      return [expression];
+    case 'LogicalExpression':
+      return [...getJsxFromExpression(expression.left), ...getJsxFromExpression(expression.right)];
+    case 'ConditionalExpression':
+      return [
+        ...getJsxFromExpression(expression.consequent),
+        ...getJsxFromExpression(expression.alternate),
+      ];
+    case 'ArrayExpression':
+      return expression.elements.flatMap(element =>
+        element === null || element.type === 'SpreadElement' ? [] : getJsxFromExpression(element),
+      );
+    case 'CallExpression':
+      return expression.arguments.flatMap(getJsxFromCallbackArgument);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Extracts JSX returned by a callback argument (e.g. the `.map` mapper).
+ *
+ * @param argument The call argument to inspect.
+ * @return The JSX subtrees returned by the callback body.
+ */
+function getJsxFromCallbackArgument(
+  argument: TSESTree.CallExpressionArgument,
+): (TSESTree.JSXElement | TSESTree.JSXFragment)[] {
+  if (argument.type !== 'ArrowFunctionExpression' && argument.type !== 'FunctionExpression') {
+    return [];
+  }
+
+  if (argument.body.type === 'BlockStatement') {
+    return argument.body.body.flatMap(statement =>
+      statement.type === 'ReturnStatement' && statement.argument != null
+        ? getJsxFromExpression(statement.argument)
+        : [],
+    );
+  }
+
+  return getJsxFromExpression(argument.body);
 }
 
 /**
@@ -460,11 +522,17 @@ function hasCompositeGroupOwnerReference(
     return true;
   }
 
-  return node.children.some(
-    child =>
-      (child.type === 'JSXElement' || child.type === 'JSXFragment') &&
-      hasCompositeGroupOwnerReference(child, id, current),
-  );
+  return node.children.some(child => {
+    if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
+      return hasCompositeGroupOwnerReference(child, id, current);
+    }
+    if (child.type === 'JSXExpressionContainer') {
+      return getJsxFromExpression(child.expression).some(jsx =>
+        hasCompositeGroupOwnerReference(jsx, id, current),
+      );
+    }
+    return false;
+  });
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S6819/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6819/decorator.ts
@@ -37,6 +37,17 @@ const COMPOSITE_CHILD_ROLES = new Set([
   'rowheader',
   'option',
 ]);
+const COMPOSITE_GROUP_OWNER_ROLES = new Set([
+  'tree',
+  'treegrid',
+  'menu',
+  'menubar',
+  'toolbar',
+  'listbox',
+  'tablist',
+  'radiogroup',
+]);
+const FIELDSET_FORM_CONTROL_ELEMENTS = new Set(['input', 'select', 'textarea']);
 
 /**
  * Decorates the prefer-tag-over-role rule to fix false positives.
@@ -51,13 +62,13 @@ const COMPOSITE_CHILD_ROLES = new Set([
  *    - role="radio" with aria-checked
  *    - role="separator" with children (since <hr> is void)
  *    - role="img" on div/span with children or CSS backgroundImage (since <img> is void)
- *    - role="group" on div/span outside form/fieldset contexts
+ *    - role="group" in composite widgets or when the content is not fieldset-like
  *    - ARIA composite widget roles (table, grid, listbox, row, option, etc.) when forming
  *      complete custom widget patterns
  *
  * Note: SVG internal elements like <g> are not in HTML_TAG_NAMES, so they're
- * already filtered out by isHtmlElement. HTML elements with role="group" inside
- * form-related contexts remain true positives since <fieldset> stays appropriate there.
+ * already filtered out by isHtmlElement. HTML elements with role="group" only
+ * remain true positives when they approximate a <fieldset>-style control group.
  */
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
   return interceptReportForReact(
@@ -121,7 +132,7 @@ function isValidAriaPattern(node: TSESTree.JSXOpeningElement): boolean {
     isCustomRadio(role, attributes) ||
     isSeparatorWithChildren(role, node) ||
     isImgRoleWithValidPattern(elementName, role, attributes, node) ||
-    isStandaloneGroupRole(elementName, role, node) ||
+    isValidGroupRolePattern(role, attributes, node) ||
     isCustomCompositeWidget(role, node)
   );
 }
@@ -244,42 +255,263 @@ function isSeparatorWithChildren(role: string, node: TSESTree.JSXOpeningElement)
 }
 
 /**
- * Checks if a generic container uses role="group" outside form-related ancestors.
+ * Checks if role="group" is used in a valid pattern.
  *
- * @param elementName The lower-cased JSX element name.
  * @param role The resolved role attribute value.
+ * @param attributes The JSX attributes on the current element.
  * @param node The JSX opening element being checked.
  * @return Whether the group role should be preserved.
  */
-function isStandaloneGroupRole(
-  elementName: string | null,
+function isValidGroupRolePattern(
   role: string,
+  attributes: JSXOpeningElement['attributes'],
   node: TSESTree.JSXOpeningElement,
 ): boolean {
   return (
     role === 'group' &&
-    (elementName === 'div' || elementName === 'span') &&
-    !hasFormGroupingAncestor(node)
+    (isGroupWithinCompositeWidget(node) || !hasFieldsetEquivalentContent(attributes, node))
   );
 }
 
 /**
- * Checks if the JSX element is nested inside a form or fieldset.
+ * Checks if the group belongs to a larger composite widget structure.
  *
  * @param node The JSX opening element being checked.
- * @return Whether a form-related ancestor exists.
+ * @return Whether the group is structural to a composite widget.
  */
-function hasFormGroupingAncestor(node: TSESTree.JSXOpeningElement): boolean {
+function isGroupWithinCompositeWidget(node: TSESTree.JSXOpeningElement): boolean {
+  return hasCompositeGroupOwnerAncestor(node) || hasCompositeGroupOwnerByAriaOwns(node);
+}
+
+/**
+ * Checks if the group sits below a composite widget ancestor.
+ *
+ * @param node The JSX opening element being checked.
+ * @return Whether a composite widget ancestor exists.
+ */
+function hasCompositeGroupOwnerAncestor(node: TSESTree.JSXOpeningElement): boolean {
   return (
     findFirstMatchingAncestor(node, ancestor => {
       if (ancestor.type !== 'JSXElement') {
         return false;
       }
 
-      const ancestorName = getElementName(ancestor.openingElement);
-      return ancestorName === 'form' || ancestorName === 'fieldset';
+      const role = getJSXElementRole(ancestor);
+      return role !== null && COMPOSITE_GROUP_OWNER_ROLES.has(role);
     }) !== undefined
   );
+}
+
+/**
+ * Checks if a composite widget owns this group via aria-owns.
+ *
+ * @param node The JSX opening element being checked.
+ * @return Whether a composite widget owns the group by id reference.
+ */
+function hasCompositeGroupOwnerByAriaOwns(node: TSESTree.JSXOpeningElement): boolean {
+  const id = getNonEmptyStringAttributeValue((node as JSXOpeningElement).attributes, 'id');
+  if (id === null) {
+    return false;
+  }
+
+  const root = getContainingJsxSubtree(node);
+  return root !== null && hasCompositeGroupOwnerReference(root, id, node);
+}
+
+/**
+ * Checks whether the group content is close to a fieldset-like control grouping.
+ *
+ * @param attributes The JSX attributes on the current element.
+ * @param node The JSX opening element being checked.
+ * @return Whether a fieldset is still a sound replacement.
+ */
+function hasFieldsetEquivalentContent(
+  attributes: JSXOpeningElement['attributes'],
+  node: TSESTree.JSXOpeningElement,
+): boolean {
+  return hasGroupAccessibleName(attributes) && countDescendantFormControls(node) >= 2;
+}
+
+/**
+ * Checks whether the group exposes a shared accessible name.
+ *
+ * @param attributes The JSX attributes on the current element.
+ * @return Whether the group has an accessible name attribute.
+ */
+function hasGroupAccessibleName(attributes: JSXOpeningElement['attributes']): boolean {
+  return (
+    hasAccessibleNameAttribute(attributes, 'aria-label') ||
+    hasAccessibleNameAttribute(attributes, 'aria-labelledby')
+  );
+}
+
+/**
+ * Counts descendant form controls that a fieldset could group.
+ *
+ * @param node The JSX opening element being checked.
+ * @return The number of descendant form controls.
+ */
+function countDescendantFormControls(node: TSESTree.JSXOpeningElement): number {
+  const group = node.parent;
+  if (group?.type !== 'JSXElement') {
+    return 0;
+  }
+
+  return countFormControlsInChildren(group.children);
+}
+
+/**
+ * Counts form controls in a JSX children list.
+ *
+ * @param children The JSX children to inspect.
+ * @return The number of descendant form controls.
+ */
+function countFormControlsInChildren(children: TSESTree.JSXChild[]): number {
+  let count = 0;
+
+  for (const child of children) {
+    if (child.type === 'JSXElement') {
+      if (isFieldsetFormControl(child)) {
+        count++;
+      }
+      count += countFormControlsInChildren(child.children);
+    } else if (child.type === 'JSXFragment') {
+      count += countFormControlsInChildren(child.children);
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Checks whether a JSX element is a form control that a fieldset can group.
+ *
+ * @param element The JSX element being checked.
+ * @return Whether the element is a supported fieldset form control.
+ */
+function isFieldsetFormControl(element: TSESTree.JSXElement): boolean {
+  if (!isHtmlElement(element)) {
+    return false;
+  }
+
+  const elementName = getElementName(element.openingElement);
+  if (elementName === null || !FIELDSET_FORM_CONTROL_ELEMENTS.has(elementName)) {
+    return false;
+  }
+
+  if (elementName !== 'input') {
+    return true;
+  }
+
+  return !isHiddenInput(element.openingElement);
+}
+
+/**
+ * Checks whether an input element is explicitly hidden.
+ *
+ * @param node The JSX opening element being checked.
+ * @return Whether the input type is hidden.
+ */
+function isHiddenInput(node: TSESTree.JSXOpeningElement): boolean {
+  const type = getNonEmptyStringAttributeValue((node as JSXOpeningElement).attributes, 'type');
+  return type?.toLowerCase() === 'hidden';
+}
+
+/**
+ * Finds the outermost local JSX subtree containing the node.
+ *
+ * @param node The JSX opening element being checked.
+ * @return The containing JSX subtree, if any.
+ */
+function getContainingJsxSubtree(
+  node: TSESTree.JSXOpeningElement,
+): TSESTree.JSXElement | TSESTree.JSXFragment | null {
+  let current = node.parent;
+  let root: TSESTree.JSXElement | TSESTree.JSXFragment | null = null;
+
+  while (current != null) {
+    if (current.type === 'JSXElement' || current.type === 'JSXFragment') {
+      root = current;
+    }
+    current = current.parent;
+  }
+
+  return root;
+}
+
+/**
+ * Checks whether a JSX subtree contains a composite owner for the given id.
+ *
+ * @param node The JSX subtree to inspect.
+ * @param id The id owned by the composite widget.
+ * @param current The current group opening element.
+ * @return Whether a composite widget in the subtree owns the id.
+ */
+function hasCompositeGroupOwnerReference(
+  node: TSESTree.JSXElement | TSESTree.JSXFragment,
+  id: string,
+  current: TSESTree.JSXOpeningElement,
+): boolean {
+  if (
+    node.type === 'JSXElement' &&
+    node.openingElement !== current &&
+    isCompositeGroupOwnerReference(node.openingElement, id)
+  ) {
+    return true;
+  }
+
+  return node.children.some(
+    child =>
+      (child.type === 'JSXElement' || child.type === 'JSXFragment') &&
+      hasCompositeGroupOwnerReference(child, id, current),
+  );
+}
+
+/**
+ * Checks whether an element is a composite widget that owns the given id.
+ *
+ * @param node The JSX opening element being checked.
+ * @param id The id owned by the composite widget.
+ * @return Whether the element owns the id.
+ */
+function isCompositeGroupOwnerReference(node: TSESTree.JSXOpeningElement, id: string): boolean {
+  const role = getJSXOpeningElementRole(node);
+  if (role === null || !COMPOSITE_GROUP_OWNER_ROLES.has(role)) {
+    return false;
+  }
+
+  return getAriaOwnsIds((node as JSXOpeningElement).attributes).includes(id);
+}
+
+/**
+ * Gets the whitespace-separated aria-owns ids from a JSX attribute list.
+ *
+ * @param attributes The JSX attributes on the current element.
+ * @return The owned ids.
+ */
+function getAriaOwnsIds(attributes: JSXOpeningElement['attributes']): string[] {
+  const value = getNonEmptyStringAttributeValue(attributes, 'aria-owns');
+  return value === null ? [] : value.split(/\s+/);
+}
+
+/**
+ * Gets a non-empty static string attribute value.
+ *
+ * @param attributes The JSX attributes on the current element.
+ * @param name The attribute name to resolve.
+ * @return The static string value, if any.
+ */
+function getNonEmptyStringAttributeValue(
+  attributes: JSXOpeningElement['attributes'],
+  name: string,
+): string | null {
+  const prop = getProp(attributes, name);
+  if (!prop) {
+    return null;
+  }
+
+  const value = getLiteralPropValue(prop);
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
 }
 
 /**
@@ -401,8 +633,14 @@ function hasCompositeChildRoleInSubtree(node: TSESTree.JSXElement): boolean {
  * Gets the role attribute value from a JSXElement.
  */
 function getJSXElementRole(element: TSESTree.JSXElement): string | null {
-  const openingElement = element.openingElement;
-  const attributes = (openingElement as JSXOpeningElement).attributes;
+  return getJSXOpeningElementRole(element.openingElement);
+}
+
+/**
+ * Gets the role attribute value from a JSXOpeningElement.
+ */
+function getJSXOpeningElementRole(element: TSESTree.JSXOpeningElement): string | null {
+  const attributes = (element as JSXOpeningElement).attributes;
   const roleProp = getProp(attributes, 'role');
   if (!roleProp) {
     return null;

--- a/packages/analysis/src/jsts/rules/S6819/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6819/decorator.ts
@@ -50,6 +50,15 @@ const COMPOSITE_GROUP_OWNER_ROLES = new Set([
 const FIELDSET_FORM_CONTROL_ELEMENTS = new Set(['input', 'select', 'textarea']);
 const NON_GROUPABLE_INPUT_TYPES = new Set(['hidden', 'button', 'submit', 'reset', 'image']);
 
+// A group id resolved either as a static string or as a dynamic expression key.
+type GroupIdReference = { readonly value: string; readonly dynamic: boolean };
+
+// Composite-widget owners per JSX subtree root, so each tree is scanned once.
+const compositeGroupOwnersBySubtree = new WeakMap<
+  TSESTree.JSXElement | TSESTree.JSXFragment,
+  TSESTree.JSXOpeningElement[]
+>();
+
 /**
  * Decorates the prefer-tag-over-role rule to fix false positives.
  *
@@ -310,13 +319,13 @@ function hasCompositeGroupOwnerAncestor(node: TSESTree.JSXOpeningElement): boole
  * @return Whether a composite widget owns the group by id reference.
  */
 function hasCompositeGroupOwnerByAriaOwns(node: TSESTree.JSXOpeningElement): boolean {
-  const id = getNonEmptyStringAttributeValue((node as JSXOpeningElement).attributes, 'id');
+  const id = getGroupIdReference((node as JSXOpeningElement).attributes);
   if (id === null) {
     return false;
   }
 
   const root = getContainingJsxSubtree(node);
-  return root !== null && hasCompositeGroupOwnerReference(root, id, node);
+  return root !== null && getCompositeGroupOwners(root).some(owner => ownerReferencesId(owner, id));
 }
 
 /**
@@ -353,12 +362,7 @@ function hasGroupAccessibleName(attributes: JSXOpeningElement['attributes']): bo
  * @return The number of descendant form controls.
  */
 function countDescendantFormControls(node: TSESTree.JSXOpeningElement): number {
-  const group = node.parent;
-  if (group?.type !== 'JSXElement') {
-    return 0;
-  }
-
-  return countFormControlsInChildren(group.children);
+  return countFormControlsInChildren(node.parent.children);
 }
 
 /**
@@ -506,53 +510,93 @@ function getContainingJsxSubtree(
 }
 
 /**
- * Checks whether a JSX subtree contains a composite owner for the given id.
+ * Collects the composite-widget owner elements within a JSX subtree.
  *
- * @param node The JSX subtree to inspect.
- * @param id The id owned by the composite widget.
- * @param current The current group opening element.
- * @return Whether a composite widget in the subtree owns the id.
+ * The result is memoized per subtree root so a file with many id-bearing
+ * groups scans each tree once instead of once per group.
+ *
+ * @param root The containing JSX subtree.
+ * @return The composite-widget owner opening elements in the subtree.
  */
-function hasCompositeGroupOwnerReference(
-  node: TSESTree.JSXElement | TSESTree.JSXFragment,
-  id: string,
-  current: TSESTree.JSXOpeningElement,
-): boolean {
-  if (
-    node.type === 'JSXElement' &&
-    node.openingElement !== current &&
-    isCompositeGroupOwnerReference(node.openingElement, id)
-  ) {
-    return true;
+function getCompositeGroupOwners(
+  root: TSESTree.JSXElement | TSESTree.JSXFragment,
+): TSESTree.JSXOpeningElement[] {
+  let owners = compositeGroupOwnersBySubtree.get(root);
+  if (owners === undefined) {
+    owners = [];
+    collectCompositeGroupOwners(root, owners);
+    compositeGroupOwnersBySubtree.set(root, owners);
   }
-
-  return node.children.some(child => {
-    if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
-      return hasCompositeGroupOwnerReference(child, id, current);
-    }
-    if (child.type === 'JSXExpressionContainer') {
-      return getJsxFromExpression(child.expression).some(jsx =>
-        hasCompositeGroupOwnerReference(jsx, id, current),
-      );
-    }
-    return false;
-  });
+  return owners;
 }
 
 /**
- * Checks whether an element is a composite widget that owns the given id.
+ * Gathers composite-widget owner opening elements from a JSX subtree.
  *
- * @param node The JSX opening element being checked.
- * @param id The id owned by the composite widget.
- * @return Whether the element owns the id.
+ * @param node The JSX subtree to inspect.
+ * @param owners The accumulator to append owners to.
  */
-function isCompositeGroupOwnerReference(node: TSESTree.JSXOpeningElement, id: string): boolean {
-  const role = getJSXOpeningElementRole(node);
-  if (role === null || !COMPOSITE_GROUP_OWNER_ROLES.has(role)) {
-    return false;
+function collectCompositeGroupOwners(
+  node: TSESTree.JSXElement | TSESTree.JSXFragment,
+  owners: TSESTree.JSXOpeningElement[],
+): void {
+  if (node.type === 'JSXElement' && isCompositeGroupOwner(node.openingElement)) {
+    owners.push(node.openingElement);
   }
 
-  return getAriaOwnsIds((node as JSXOpeningElement).attributes).includes(id);
+  for (const child of node.children) {
+    if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
+      collectCompositeGroupOwners(child, owners);
+    } else if (child.type === 'JSXExpressionContainer') {
+      for (const jsx of getJsxFromExpression(child.expression)) {
+        collectCompositeGroupOwners(jsx, owners);
+      }
+    }
+  }
+}
+
+/**
+ * Checks whether an element carries a composite-widget owner role.
+ *
+ * @param node The JSX opening element being checked.
+ * @return Whether the element is a composite-widget owner.
+ */
+function isCompositeGroupOwner(node: TSESTree.JSXOpeningElement): boolean {
+  const role = getJSXOpeningElementRole(node);
+  return role !== null && COMPOSITE_GROUP_OWNER_ROLES.has(role);
+}
+
+/**
+ * Checks whether a composite owner's aria-owns references the group id.
+ *
+ * Matches static ids by value and dynamic ids by shared expression, so a group
+ * and its owner wired through the same `useId()`/prop variable still resolve.
+ *
+ * @param owner The composite-widget owner opening element.
+ * @param id The group id reference to match.
+ * @return Whether the owner owns the group.
+ */
+function ownerReferencesId(owner: TSESTree.JSXOpeningElement, id: GroupIdReference): boolean {
+  const attributes = (owner as JSXOpeningElement).attributes;
+  return id.dynamic
+    ? getAriaOwnsExpressionKey(attributes) === id.value
+    : getAriaOwnsIds(attributes).includes(id.value);
+}
+
+/**
+ * Resolves a group's id as a static value or a dynamic expression key.
+ *
+ * @param attributes The JSX attributes on the group element.
+ * @return The id reference, or null when no id is present.
+ */
+function getGroupIdReference(attributes: JSXOpeningElement['attributes']): GroupIdReference | null {
+  const staticId = getNonEmptyStringAttributeValue(attributes, 'id');
+  if (staticId !== null) {
+    return { value: staticId, dynamic: false };
+  }
+
+  const key = getAttributeExpressionKey(attributes, 'id');
+  return key === null ? null : { value: key, dynamic: true };
 }
 
 /**
@@ -564,6 +608,58 @@ function isCompositeGroupOwnerReference(node: TSESTree.JSXOpeningElement, id: st
 function getAriaOwnsIds(attributes: JSXOpeningElement['attributes']): string[] {
   const value = getNonEmptyStringAttributeValue(attributes, 'aria-owns');
   return value === null ? [] : value.split(/\s+/);
+}
+
+/**
+ * Gets the dynamic expression key of an aria-owns attribute, if any.
+ *
+ * @param attributes The JSX attributes on the composite owner.
+ * @return The expression key, or null when aria-owns is absent or unresolvable.
+ */
+function getAriaOwnsExpressionKey(attributes: JSXOpeningElement['attributes']): string | null {
+  return getAttributeExpressionKey(attributes, 'aria-owns');
+}
+
+/**
+ * Builds a stable key for a simple attribute expression (`{x}` or `{x.y}`).
+ *
+ * @param attributes The JSX attributes to read.
+ * @param name The attribute name to resolve.
+ * @return The expression key, or null for absent or unsupported expressions.
+ */
+function getAttributeExpressionKey(
+  attributes: JSXOpeningElement['attributes'],
+  name: string,
+): string | null {
+  const prop = getProp(attributes, name);
+  if (!prop || prop.value?.type !== 'JSXExpressionContainer') {
+    return null;
+  }
+
+  return getExpressionKey(prop.value.expression as unknown as TSESTree.Node);
+}
+
+/**
+ * Builds a key from an identifier or non-computed member expression.
+ *
+ * @param expression The expression node to key.
+ * @return The key, or null for expressions that cannot be compared statically.
+ */
+function getExpressionKey(expression: TSESTree.Node): string | null {
+  if (expression.type === 'Identifier') {
+    return expression.name;
+  }
+
+  if (
+    expression.type === 'MemberExpression' &&
+    !expression.computed &&
+    expression.property.type === 'Identifier'
+  ) {
+    const objectKey = getExpressionKey(expression.object);
+    return objectKey === null ? null : `${objectKey}.${expression.property.name}`;
+  }
+
+  return null;
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S6819/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6819/decorator.ts
@@ -488,7 +488,7 @@ function isHiddenInput(node: TSESTree.JSXOpeningElement): boolean {
 function getContainingJsxSubtree(
   node: TSESTree.JSXOpeningElement,
 ): TSESTree.JSXElement | TSESTree.JSXFragment | null {
-  let current = node.parent;
+  let current: TSESTree.Node | undefined = node.parent;
   let root: TSESTree.JSXElement | TSESTree.JSXFragment | null = null;
 
   while (current != null) {

--- a/packages/analysis/src/jsts/rules/S6819/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6819/decorator.ts
@@ -48,6 +48,7 @@ const COMPOSITE_GROUP_OWNER_ROLES = new Set([
   'radiogroup',
 ]);
 const FIELDSET_FORM_CONTROL_ELEMENTS = new Set(['input', 'select', 'textarea']);
+const NON_GROUPABLE_INPUT_TYPES = new Set(['hidden', 'button', 'submit', 'reset', 'image']);
 
 /**
  * Decorates the prefer-tag-over-role rule to fix false positives.
@@ -465,18 +466,21 @@ function isFieldsetFormControl(element: TSESTree.JSXElement): boolean {
     return true;
   }
 
-  return !isHiddenInput(element.openingElement);
+  return !isNonGroupableInput(element.openingElement);
 }
 
 /**
- * Checks whether an input element is explicitly hidden.
+ * Checks whether an input is a type a fieldset would not group.
+ *
+ * Hidden inputs are not user-facing, and command inputs (button, submit, reset,
+ * image) are the `<button>` case rather than data-entry fields.
  *
  * @param node The JSX opening element being checked.
- * @return Whether the input type is hidden.
+ * @return Whether the input type falls outside fieldset grouping.
  */
-function isHiddenInput(node: TSESTree.JSXOpeningElement): boolean {
+function isNonGroupableInput(node: TSESTree.JSXOpeningElement): boolean {
   const type = getNonEmptyStringAttributeValue((node as JSXOpeningElement).attributes, 'type');
-  return type?.toLowerCase() === 'hidden';
+  return type !== null && NON_GROUPABLE_INPUT_TYPES.has(type.toLowerCase());
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S6819/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6819/decorator.ts
@@ -51,12 +51,13 @@ const COMPOSITE_CHILD_ROLES = new Set([
  *    - role="radio" with aria-checked
  *    - role="separator" with children (since <hr> is void)
  *    - role="img" on div/span with children or CSS backgroundImage (since <img> is void)
+ *    - role="group" on div/span outside form/fieldset contexts
  *    - ARIA composite widget roles (table, grid, listbox, row, option, etc.) when forming
  *      complete custom widget patterns
  *
  * Note: SVG internal elements like <g> are not in HTML_TAG_NAMES, so they're
- * already filtered out by isHtmlElement. HTML elements with role="group" remain
- * as true positives since semantic alternatives exist.
+ * already filtered out by isHtmlElement. HTML elements with role="group" inside
+ * form-related contexts remain true positives since <fieldset> stays appropriate there.
  */
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
   return interceptReportForReact(
@@ -120,6 +121,7 @@ function isValidAriaPattern(node: TSESTree.JSXOpeningElement): boolean {
     isCustomRadio(role, attributes) ||
     isSeparatorWithChildren(role, node) ||
     isImgRoleWithValidPattern(elementName, role, attributes, node) ||
+    isStandaloneGroupRole(elementName, role, node) ||
     isCustomCompositeWidget(role, node)
   );
 }
@@ -239,6 +241,45 @@ function isCustomRadio(role: string, attributes: JSXOpeningElement['attributes']
 
 function isSeparatorWithChildren(role: string, node: TSESTree.JSXOpeningElement): boolean {
   return role === 'separator' && hasChildren(node);
+}
+
+/**
+ * Checks if a generic container uses role="group" outside form-related ancestors.
+ *
+ * @param elementName The lower-cased JSX element name.
+ * @param role The resolved role attribute value.
+ * @param node The JSX opening element being checked.
+ * @return Whether the group role should be preserved.
+ */
+function isStandaloneGroupRole(
+  elementName: string | null,
+  role: string,
+  node: TSESTree.JSXOpeningElement,
+): boolean {
+  return (
+    role === 'group' &&
+    (elementName === 'div' || elementName === 'span') &&
+    !hasFormGroupingAncestor(node)
+  );
+}
+
+/**
+ * Checks if the JSX element is nested inside a form or fieldset.
+ *
+ * @param node The JSX opening element being checked.
+ * @return Whether a form-related ancestor exists.
+ */
+function hasFormGroupingAncestor(node: TSESTree.JSXOpeningElement): boolean {
+  return (
+    findFirstMatchingAncestor(node, ancestor => {
+      if (ancestor.type !== 'JSXElement') {
+        return false;
+      }
+
+      const ancestorName = getElementName(ancestor.openingElement);
+      return ancestorName === 'form' || ancestorName === 'fieldset';
+    }) !== undefined
+  );
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S6819/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6819/unit.test.ts
@@ -237,6 +237,32 @@ describe('S6819', () => {
     });
   });
 
+  it('should not treat command inputs as fieldset-groupable form controls', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+
+    ruleTester.run('prefer-tag-over-role - command inputs group', rule, {
+      valid: [
+        {
+          code: `
+            <div role="group" aria-label="Actions">
+              <input type="submit" value="Save" />
+              <input type="reset" value="Cancel" />
+            </div>
+          `,
+        },
+        {
+          code: `
+            <div role="group" aria-label="Search">
+              <input type="text" name="q" />
+              <input type="submit" value="Go" />
+            </div>
+          `,
+        },
+      ],
+      invalid: [],
+    });
+  });
+
   // Test for JS-1101: role="img" flagged on non-image visual content and containers
   // These tests demonstrate false positives that occur when role="img" is used on
   // div/span elements containing children or using CSS background-image.

--- a/packages/analysis/src/jsts/rules/S6819/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6819/unit.test.ts
@@ -149,6 +149,61 @@ describe('S6819', () => {
             </>
           `,
         },
+        // One fieldset-like group per owner role: suppression must come from the
+        // composite owner, not from the content failing the fieldset heuristic.
+        ...['tree', 'treegrid', 'menu', 'menubar', 'tablist', 'radiogroup'].map(ownerRole => ({
+          code: `
+            <div role="${ownerRole}">
+              <div role="group" aria-label="Filters">
+                <input type="checkbox" name="a" />
+                <input type="checkbox" name="b" />
+              </div>
+            </div>
+          `,
+        })),
+      ],
+      invalid: [],
+    });
+  });
+
+  it('should resolve aria-owns ownership across id lists and dynamic ids', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+
+    ruleTester.run('prefer-tag-over-role - aria-owns ownership', rule, {
+      valid: [
+        {
+          code: `
+            <>
+              <div role="toolbar" aria-owns="a b format-actions" />
+              <div role="group" id="format-actions" aria-label="Filters">
+                <input type="checkbox" name="a" />
+                <input type="checkbox" name="b" />
+              </div>
+            </>
+          `,
+        },
+        {
+          code: `
+            <>
+              <div role="toolbar" aria-owns={groupId} />
+              <div role="group" id={groupId} aria-label="Filters">
+                <input type="checkbox" name="a" />
+                <input type="checkbox" name="b" />
+              </div>
+            </>
+          `,
+        },
+        {
+          code: `
+            <>
+              <div role="toolbar" aria-owns={props.groupId} />
+              <div role="group" id={props.groupId} aria-label="Filters">
+                <input type="checkbox" name="a" />
+                <input type="checkbox" name="b" />
+              </div>
+            </>
+          `,
+        },
       ],
       invalid: [],
     });

--- a/packages/analysis/src/jsts/rules/S6819/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6819/unit.test.ts
@@ -154,6 +154,46 @@ describe('S6819', () => {
     });
   });
 
+  it('should resolve controls and composite owners rendered through JSX expressions', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+
+    ruleTester.run('prefer-tag-over-role - jsx expression content', rule, {
+      valid: [
+        {
+          code: `
+            <>
+              {isEditing && <div role="toolbar" aria-owns="format-actions" />}
+              <div role="group" id="format-actions" aria-label="Text formatting">
+                <button type="button">Bold</button>
+                <button type="button">Italic</button>
+              </div>
+            </>
+          `,
+        },
+      ],
+      invalid: [
+        {
+          code: `
+            <div role="group" aria-label="Delivery">
+              <input type="radio" name="delivery" />
+              {express && <input type="radio" name="delivery" />}
+            </div>
+          `,
+          errors: 1,
+        },
+        {
+          code: `
+            <div role="group" aria-label="Toppings">
+              <input type="checkbox" name="cheese" />
+              {toppings.map(t => <input type="checkbox" name={t} key={t} />)}
+            </div>
+          `,
+          errors: 1,
+        },
+      ],
+    });
+  });
+
   it('should keep flagging fieldset-like role="group" patterns', () => {
     const ruleTester = new NoTypeCheckingRuleTester();
 

--- a/packages/analysis/src/jsts/rules/S6819/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6819/unit.test.ts
@@ -55,6 +55,23 @@ describe('S6819 upstream sentinel', () => {
       ],
     });
   });
+
+  it('upstream prefer-tag-over-role raises on standalone group role patterns that decorator suppresses', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+    ruleTester.run('prefer-tag-over-role', upstreamRule, {
+      valid: [],
+      invalid: [
+        {
+          code: `<div role="group" aria-label="Request methods"><button>GET</button><button>POST</button></div>`,
+          errors: 1,
+        },
+        {
+          code: `<span role="group" aria-label="Filter pills"><span>Active</span><span>Archived</span></span>`,
+          errors: 1,
+        },
+      ],
+    });
+  });
 });
 
 describe('S6819', () => {
@@ -85,6 +102,31 @@ describe('S6819', () => {
         },
       ],
       invalid: [],
+    });
+  });
+
+  it('should not flag standalone role="group" outside form contexts', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+
+    ruleTester.run('prefer-tag-over-role - standalone group', rule, {
+      valid: [
+        {
+          code: `<div role="group" aria-label="Request methods"><button>GET</button><button>POST</button></div>`,
+        },
+        {
+          code: `<span role="group" aria-label="Filter pills"><span>Active</span><span>Archived</span></span>`,
+        },
+      ],
+      invalid: [
+        {
+          code: `<form><div role="group" aria-label="Shipping options"><input type="radio" /></div></form>`,
+          errors: 1,
+        },
+        {
+          code: `<fieldset><span role="group" aria-label="Quick toggles"><button type="button">On</button></span></fieldset>`,
+          errors: 1,
+        },
+      ],
     });
   });
 

--- a/packages/analysis/src/jsts/rules/S6819/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6819/unit.test.ts
@@ -166,7 +166,7 @@ describe('S6819', () => {
     });
   });
 
-  it('should resolve aria-owns ownership across id lists and dynamic ids', () => {
+  it('should resolve aria-owns ownership across a whitespace-separated id list', () => {
     const ruleTester = new NoTypeCheckingRuleTester();
 
     ruleTester.run('prefer-tag-over-role - aria-owns ownership', rule, {
@@ -176,28 +176,6 @@ describe('S6819', () => {
             <>
               <div role="toolbar" aria-owns="a b format-actions" />
               <div role="group" id="format-actions" aria-label="Filters">
-                <input type="checkbox" name="a" />
-                <input type="checkbox" name="b" />
-              </div>
-            </>
-          `,
-        },
-        {
-          code: `
-            <>
-              <div role="toolbar" aria-owns={groupId} />
-              <div role="group" id={groupId} aria-label="Filters">
-                <input type="checkbox" name="a" />
-                <input type="checkbox" name="b" />
-              </div>
-            </>
-          `,
-        },
-        {
-          code: `
-            <>
-              <div role="toolbar" aria-owns={props.groupId} />
-              <div role="group" id={props.groupId} aria-label="Filters">
                 <input type="checkbox" name="a" />
                 <input type="checkbox" name="b" />
               </div>

--- a/packages/analysis/src/jsts/rules/S6819/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6819/unit.test.ts
@@ -56,7 +56,7 @@ describe('S6819 upstream sentinel', () => {
     });
   });
 
-  it('upstream prefer-tag-over-role raises on standalone group role patterns that decorator suppresses', () => {
+  it('upstream prefer-tag-over-role raises on role="group" patterns that decorator suppresses', () => {
     const ruleTester = new NoTypeCheckingRuleTester();
     ruleTester.run('prefer-tag-over-role', upstreamRule, {
       valid: [],
@@ -66,7 +66,7 @@ describe('S6819 upstream sentinel', () => {
           errors: 1,
         },
         {
-          code: `<span role="group" aria-label="Filter pills"><span>Active</span><span>Archived</span></span>`,
+          code: `<form><div role="group" aria-label="View mode"><button type="button">Grid</button><button type="button">List</button></div></form>`,
           errors: 1,
         },
       ],
@@ -105,25 +105,92 @@ describe('S6819', () => {
     });
   });
 
-  it('should not flag standalone role="group" outside form contexts', () => {
+  it('should not flag role="group" when the content is not fieldset-like', () => {
     const ruleTester = new NoTypeCheckingRuleTester();
 
-    ruleTester.run('prefer-tag-over-role - standalone group', rule, {
+    ruleTester.run('prefer-tag-over-role - non-fieldset group', rule, {
       valid: [
         {
           code: `<div role="group" aria-label="Request methods"><button>GET</button><button>POST</button></div>`,
         },
         {
-          code: `<span role="group" aria-label="Filter pills"><span>Active</span><span>Archived</span></span>`,
+          code: `<form><div role="group" aria-label="View mode"><button type="button">Grid</button><button type="button">List</button></div></form>`,
+        },
+        {
+          code: `<div role="group"><input type="checkbox" /><input type="checkbox" /></div>`,
+        },
+        {
+          code: `<div role="group" aria-label="Profile fields"><input type="hidden" /><input type="email" /></div>`,
+        },
+        {
+          code: `<div role="group" aria-label="Profile fields"><Input /><Input /></div>`,
         },
       ],
+      invalid: [],
+    });
+  });
+
+  it('should not flag role="group" when it belongs to a composite widget', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+
+    ruleTester.run('prefer-tag-over-role - composite widget group', rule, {
+      valid: [
+        {
+          code: `<div role="listbox"><div role="group" aria-label="Cities"><div role="option">Paris</div></div></div>`,
+        },
+        {
+          code: `
+            <>
+              <div role="toolbar" aria-owns="format-actions" />
+              <div role="group" id="format-actions" aria-label="Text formatting">
+                <button type="button">Bold</button>
+                <button type="button">Italic</button>
+              </div>
+            </>
+          `,
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  it('should keep flagging fieldset-like role="group" patterns', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+
+    ruleTester.run('prefer-tag-over-role - fieldset-like group', rule, {
+      valid: [],
       invalid: [
         {
-          code: `<form><div role="group" aria-label="Shipping options"><input type="radio" /></div></form>`,
+          code: `
+            <div role="group" aria-label="Shipping options">
+              <label>
+                <input type="radio" name="shipping" />
+                Standard
+              </label>
+              <label>
+                <input type="radio" name="shipping" />
+                Express
+              </label>
+            </div>
+          `,
           errors: 1,
         },
         {
-          code: `<fieldset><span role="group" aria-label="Quick toggles"><button type="button">On</button></span></fieldset>`,
+          code: `
+            <form>
+              <div role="group" aria-labelledby="contact-label">
+                <span id="contact-label">Contact details</span>
+                <label>
+                  Email
+                  <input type="email" />
+                </label>
+                <label>
+                  Phone
+                  <input type="tel" />
+                </label>
+              </div>
+            </form>
+          `,
           errors: 1,
         },
       ],


### PR DESCRIPTION
## Summary
Refine the S6819 `role="group"` exception so the rule no longer relies on `<form>` or `<fieldset>` ancestry.
The rule now keeps `group` for composite-widget subgroups and non-fieldset-like content, and only reports when the container looks like a real `<fieldset>` replacement.
RSPEC PR: https://github.com/SonarSource/rspec/pull/7277

## Changes
- Replace the form-ancestor heuristic with a content-based check: shared accessible name plus at least two native form controls
- Suppress composite-widget group substructures, including `aria-owns` ownership
- Refresh focused S6819 tests to show that form ancestry is irrelevant and that fieldset-like groups still report
