### PR TITLE
JS-1982 Guard S6819 menuitem suggestions

### DIFF
--- a/packages/analysis/src/jsts/rules/S6819/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6819/decorator.ts
@@ -83,6 +83,13 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
         return;
       }
 
+      const suggestedTag = (
+        reportDescriptor as Rule.ReportDescriptor & { data?: { tag?: unknown } }
+      ).data?.tag;
+      if (typeof suggestedTag === 'string' && suggestedTag.startsWith('<menuitem')) {
+        return;
+      }
+
       if (isValidAriaPattern(node)) {
         // Suppress for valid ARIA patterns
         return;

--- a/packages/analysis/src/jsts/rules/S6819/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6819/unit.test.ts
@@ -14,7 +14,9 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
+import type { Rule } from 'eslint';
 import { rule } from './index.js';
+import { decorate } from './decorator.js';
 import { rules } from '../external/a11y.js';
 import { NoTypeCheckingRuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
@@ -86,6 +88,99 @@ describe('S6819', () => {
       ],
       invalid: [],
     });
+  });
+
+  it('should not flag deprecated menuitem role suggestions', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+
+    ruleTester.run('prefer-tag-over-role - deprecated menuitem roles', rule, {
+      valid: [
+        {
+          code: `<li role="menuitem" onClick={handleClick}>Save</li>`,
+        },
+        {
+          code: `<li role="menuitemcheckbox" aria-checked="true">Autosave</li>`,
+        },
+        {
+          code: `<li role="menuitemradio" aria-checked="false">Compact</li>`,
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  it('should suppress non-conforming menuitem replacements without hiding valid ones', () => {
+    const ruleTester = new NoTypeCheckingRuleTester();
+    const mockPreferTagOverRoleRule: Rule.RuleModule = {
+      meta: { schema: [] },
+      create(context) {
+        return {
+          JSXOpeningElement(node) {
+            const roleAttribute = node.attributes.find(
+              attribute =>
+                attribute.type === 'JSXAttribute' &&
+                attribute.name.type === 'JSXIdentifier' &&
+                attribute.name.name === 'role' &&
+                attribute.value?.type === 'Literal' &&
+                typeof attribute.value.value === 'string',
+            );
+
+            if (!roleAttribute || roleAttribute.value?.type !== 'Literal') {
+              return;
+            }
+
+            const roleValue = roleAttribute.value.value.toLowerCase();
+            const tag =
+              roleValue === 'menuitemcheckbox'
+                ? '<menuitem type="checkbox">'
+                : roleValue === 'menuitemradio'
+                  ? '<menuitem type="radio">'
+                  : roleValue === 'menuitem'
+                    ? '<menuitem>'
+                    : '<button>';
+
+            context.report({
+              node,
+              message:
+                'Use {{tag}} instead of the "{{role}}" role to ensure accessibility across all devices.',
+              data: {
+                tag,
+                role: roleValue,
+              },
+            });
+          },
+        };
+      },
+    };
+
+    ruleTester.run(
+      'prefer-tag-over-role - non-conforming menuitem replacement',
+      decorate(mockPreferTagOverRoleRule),
+      {
+        valid: [
+          {
+            code: `<li role="menuitem">Save</li>`,
+          },
+          {
+            code: `<li role="menuitemcheckbox">Autosave</li>`,
+          },
+          {
+            code: `<li role="menuitemradio">Compact</li>`,
+          },
+        ],
+        invalid: [
+          {
+            code: `<div role="button">Save</div>`,
+            errors: [
+              {
+                message:
+                  'Use <button> instead of the "button" role to ensure accessibility across all devices.',
+              },
+            ],
+          },
+        ],
+      },
+    );
   });
 
   // Test for JS-1101: role="img" flagged on non-image visual content and containers


### PR DESCRIPTION
## Summary
This adds a local S6819 guard that suppresses suggestions pointing to obsolete `<menuitem>` tags if an upstream prefer-tag-over-role report reintroduces them.
It also adds regression coverage for the real rule behavior and for the decorator-level guard that keeps valid replacements intact.

## Changes
- Suppress any S6819 report whose suggested replacement starts with `<menuitem`
- Add regression tests for `menuitem`, `menuitemcheckbox`, and `menuitemradio`
- Add a focused decorator test that still reports valid replacements such as `<button>`

## Functional Validation
Artifact: [JS-1982-fv.zip](https://github.com/user-attachments/files/29588505/JS-1982-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "suggestions.jsx"...
Results:
    - Rule "S6819" -> L.1: Use <menuitem> instead of the "menuitem" role to ensure accessibility across all devices.
    - Rule "S6819" -> L.2: Use <menuitem type="checkbox"> instead of the "menuitemcheckbox" role to ensure accessibility across all devices.
    - Rule "S6819" -> L.3: Use <menuitem type="radio"> instead of the "menuitemradio" role to ensure accessibility across all devices.
    - Rule "S6819" -> L.4: Use <button> instead of the "button" role to ensure accessibility across all devices.

****** Branch "fix/js-1982-s6819-menuitem-suggestion" ******
Analyzing "suggestions.jsx"...
Results:
    - Rule "S6819" -> L.4: Use <button> instead of the "button" role to ensure accessibility across all devices.
```


