### PR TITLE
JS-1993 S5906: clarify that length matchers apply beyond collections

### DIFF
--- a/packages/analysis/src/jsts/rules/S5906/assertion-suggestions.ts
+++ b/packages/analysis/src/jsts/rules/S5906/assertion-suggestions.ts
@@ -229,22 +229,36 @@ function buildLengthEqualitySuggestion(
   const actual = sourceCode.getText(actualNode);
   if (family === 'jest' || family === 'jasmine') {
     const matcher = family === 'jasmine' ? 'toHaveSize' : 'toHaveLength';
-    return replacement(`expect(${actual})${negation(same)}.${matcher}(${expected})`, node);
+    return replacement(
+      `expect(${actual})${negation(same)}.${matcher}(${expected})`,
+      node,
+      undefined,
+      'length',
+    );
   }
   if (family === 'assert') {
     return same
-      ? replacement(`${assertObject}.lengthOf(${actual}, ${expected}${extraArguments})`, node)
+      ? replacement(
+          `${assertObject}.lengthOf(${actual}, ${expected}${extraArguments})`,
+          node,
+          undefined,
+          'length',
+        )
       : null;
   }
   if (family === 'chai-should') {
     return replacement(
       `${chaiShouldReceiver(actual, actualNode)}.should${negation(same)}.have.lengthOf(${expected})`,
       node,
+      undefined,
+      'length',
     );
   }
   return replacement(
     `expect(${actual}${extraArguments}).to${negation(same)}.have.lengthOf(${expected})`,
     node,
+    undefined,
+    'length',
   );
 }
 

--- a/packages/analysis/src/jsts/rules/S5906/assertion-suggestions.ts
+++ b/packages/analysis/src/jsts/rules/S5906/assertion-suggestions.ts
@@ -233,7 +233,7 @@ function buildLengthEqualitySuggestion(
       `expect(${actual})${negation(same)}.${matcher}(${expected})`,
       node,
       undefined,
-      'length',
+      'preferSpecificLengthAssertion',
     );
   }
   if (family === 'assert') {
@@ -242,7 +242,7 @@ function buildLengthEqualitySuggestion(
           `${assertObject}.lengthOf(${actual}, ${expected}${extraArguments})`,
           node,
           undefined,
-          'length',
+          'preferSpecificLengthAssertion',
         )
       : null;
   }
@@ -251,14 +251,14 @@ function buildLengthEqualitySuggestion(
       `${chaiShouldReceiver(actual, actualNode)}.should${negation(same)}.have.lengthOf(${expected})`,
       node,
       undefined,
-      'length',
+      'preferSpecificLengthAssertion',
     );
   }
   return replacement(
     `expect(${actual}${extraArguments}).to${negation(same)}.have.lengthOf(${expected})`,
     node,
     undefined,
-    'length',
+    'preferSpecificLengthAssertion',
   );
 }
 

--- a/packages/analysis/src/jsts/rules/S5906/assertion-utils.ts
+++ b/packages/analysis/src/jsts/rules/S5906/assertion-utils.ts
@@ -22,7 +22,7 @@ import { getVariableFromName, isIdentifier, isMethodCall } from '../helpers/ast.
 export type Suggestion = {
   assertion: string;
   replacement?: string;
-  kind?: 'length';
+  messageId?: 'preferSpecificAssertion' | 'preferSpecificLengthAssertion';
 };
 
 const PLAYWRIGHT_LOCATOR_FACTORIES = new Set([
@@ -125,11 +125,11 @@ export function replacement(
   replacementText: string,
   _node: estree.CallExpression,
   _sourceCode?: SourceCode,
-  kind?: Suggestion['kind'],
+  messageId?: Suggestion['messageId'],
 ): Suggestion {
   return {
     assertion: replacementText,
     replacement: replacementText,
-    ...(kind ? { kind } : {}),
+    ...(messageId ? { messageId } : {}),
   };
 }

--- a/packages/analysis/src/jsts/rules/S5906/assertion-utils.ts
+++ b/packages/analysis/src/jsts/rules/S5906/assertion-utils.ts
@@ -22,6 +22,7 @@ import { getVariableFromName, isIdentifier, isMethodCall } from '../helpers/ast.
 export type Suggestion = {
   assertion: string;
   replacement?: string;
+  kind?: 'length';
 };
 
 const PLAYWRIGHT_LOCATOR_FACTORIES = new Set([
@@ -124,9 +125,11 @@ export function replacement(
   replacementText: string,
   _node: estree.CallExpression,
   _sourceCode?: SourceCode,
+  kind?: Suggestion['kind'],
 ): Suggestion {
   return {
     assertion: replacementText,
     replacement: replacementText,
+    ...(kind ? { kind } : {}),
   };
 }

--- a/packages/analysis/src/jsts/rules/S5906/chai-bdd.unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5906/chai-bdd.unit.test.ts
@@ -25,6 +25,10 @@ describe('S5906', () => {
       messageId: 'preferSpecificAssertion',
       suggestions: [{ messageId: 'quickfix', output }],
     });
+    const expectedLengthError = (output: string) => ({
+      messageId: 'preferSpecificLengthAssertion',
+      suggestions: [{ messageId: 'quickfix', output }],
+    });
 
     ruleTester.run('prefer-specific-assertions', rule, {
       valid: [],
@@ -106,7 +110,7 @@ describe('S5906', () => {
             expect(items.length).to.equal(2);
           `,
           errors: [
-            expectedError(`
+            expectedLengthError(`
             import { expect } from 'chai';
 
             expect(items).to.have.lengthOf(2);

--- a/packages/analysis/src/jsts/rules/S5906/integrations.unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5906/integrations.unit.test.ts
@@ -25,6 +25,10 @@ describe('S5906', () => {
       messageId: 'preferSpecificAssertion',
       suggestions: [{ messageId: 'quickfix', output }],
     });
+    const expectedLengthError = (output: string) => ({
+      messageId: 'preferSpecificLengthAssertion',
+      suggestions: [{ messageId: 'quickfix', output }],
+    });
     const expectedErrorWithoutSuggestion = {
       messageId: 'preferSpecificAssertion',
       suggestions: [],
@@ -191,7 +195,7 @@ describe('S5906', () => {
             assert.strictEqual(items.length, 2, 'item count');
           `,
           errors: [
-            expectedError(`
+            expectedLengthError(`
             import { assert } from 'chai';
 
             assert.lengthOf(items, 2, 'item count');

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -48,7 +48,7 @@ const messages = {
   preferSpecificAssertion:
     'Prefer "{{assertion}}" over this generic assertion; dedicated matchers read better and report clearer failures.',
   preferSpecificLengthAssertion:
-    'Prefer "{{assertion}}" over this generic assertion. It also works for any object with a numeric length property.',
+    'Prefer "{{assertion}}" over this generic assertion for better reporting; it works on any object with a numeric length property.',
   quickfix: 'Replace with {{assertion}}.',
 };
 

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -85,10 +85,7 @@ export const rule: Rule.RuleModule = {
 
       context.report({
         node: node.callee,
-        messageId:
-          suggestion.kind === 'length'
-            ? 'preferSpecificLengthAssertion'
-            : 'preferSpecificAssertion',
+        messageId: suggestion.messageId ?? 'preferSpecificAssertion',
         data: { assertion: suggestion.assertion },
         ...(suggest ? { suggest } : {}),
       });
@@ -215,7 +212,7 @@ function getExpectLikeSuggestion(
       `expect(${sourceCode.getText(actual.object)}).${negated ? 'not.' : ''}${lengthMatcher}(${expectedText})`,
       node,
       sourceCode,
-      'length',
+      'preferSpecificLengthAssertion',
     );
   }
   const booleanExpected = getBooleanValue(expected);
@@ -376,7 +373,7 @@ function getChaiAssertSuggestion(
       `${assertText}.lengthOf(${sourceCode.getText(actual.object)}, ${sourceCode.getText(expected)}${trailingArgs})`,
       node,
       sourceCode,
-      'length',
+      'preferSpecificLengthAssertion',
     );
   }
   const booleanExpected = getBooleanValue(expected);
@@ -422,7 +419,7 @@ function getChaiValueSuggestion(
       `expect(${sourceCode.getText(actual.object)}${messageArguments}).to${negated ? '.not' : ''}.have.lengthOf(${sourceCode.getText(expected)})`,
       node,
       sourceCode,
-      'length',
+      'preferSpecificLengthAssertion',
     );
   }
   const booleanExpected = getBooleanValue(expected);
@@ -468,7 +465,7 @@ function getChaiShouldValueSuggestion(
       `${receiver}.should${negated ? '.not' : ''}.have.lengthOf(${sourceCode.getText(expected)})`,
       node,
       sourceCode,
-      'length',
+      'preferSpecificLengthAssertion',
     );
   }
   const booleanExpected = getBooleanValue(expected);

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -47,6 +47,8 @@ import { getPlaywrightLocatorSuggestion } from './playwright-suggestions.js';
 const messages = {
   preferSpecificAssertion:
     'Prefer a more specific assertion instead of this generic one, e.g. "{{assertion}}".',
+  preferSpecificLengthAssertion:
+    'Prefer a more specific assertion instead of this generic one, e.g. "{{assertion}}". This matcher works on any value with a numeric length property, not only arrays or collections.',
   quickfix: 'Replace with {{assertion}}.',
 };
 
@@ -83,7 +85,10 @@ export const rule: Rule.RuleModule = {
 
       context.report({
         node: node.callee,
-        messageId: 'preferSpecificAssertion',
+        messageId:
+          suggestion.kind === 'length'
+            ? 'preferSpecificLengthAssertion'
+            : 'preferSpecificAssertion',
         data: { assertion: suggestion.assertion },
         ...(suggest ? { suggest } : {}),
       });
@@ -210,6 +215,7 @@ function getExpectLikeSuggestion(
       `expect(${sourceCode.getText(actual.object)}).${negated ? 'not.' : ''}${lengthMatcher}(${expectedText})`,
       node,
       sourceCode,
+      'length',
     );
   }
   const booleanExpected = getBooleanValue(expected);
@@ -370,6 +376,7 @@ function getChaiAssertSuggestion(
       `${assertText}.lengthOf(${sourceCode.getText(actual.object)}, ${sourceCode.getText(expected)}${trailingArgs})`,
       node,
       sourceCode,
+      'length',
     );
   }
   const booleanExpected = getBooleanValue(expected);
@@ -415,6 +422,7 @@ function getChaiValueSuggestion(
       `expect(${sourceCode.getText(actual.object)}${messageArguments}).to${negated ? '.not' : ''}.have.lengthOf(${sourceCode.getText(expected)})`,
       node,
       sourceCode,
+      'length',
     );
   }
   const booleanExpected = getBooleanValue(expected);
@@ -460,6 +468,7 @@ function getChaiShouldValueSuggestion(
       `${receiver}.should${negated ? '.not' : ''}.have.lengthOf(${sourceCode.getText(expected)})`,
       node,
       sourceCode,
+      'length',
     );
   }
   const booleanExpected = getBooleanValue(expected);

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -48,7 +48,7 @@ const messages = {
   preferSpecificAssertion:
     'Prefer a more specific assertion instead of this generic one, e.g. "{{assertion}}".',
   preferSpecificLengthAssertion:
-    'Prefer a more specific assertion instead of this generic one, e.g. "{{assertion}}". This matcher works on any value with a numeric length property, not only arrays or collections.',
+    'Prefer "{{assertion}}"; it works for any object with a numeric length property.',
   quickfix: 'Replace with {{assertion}}.',
 };
 

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -48,7 +48,7 @@ const messages = {
   preferSpecificAssertion:
     'Prefer "{{assertion}}" over this generic assertion; dedicated matchers read better and report clearer failures.',
   preferSpecificLengthAssertion:
-    'Prefer "{{assertion}}" over this generic assertion; it reads better, reports clearer failures, and applies to any object with a numeric length property.',
+    'Prefer "{{assertion}}" over this generic assertion. It also works for any object with a numeric length property.',
   quickfix: 'Replace with {{assertion}}.',
 };
 

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -46,7 +46,7 @@ import { getPlaywrightLocatorSuggestion } from './playwright-suggestions.js';
 
 const messages = {
   preferSpecificAssertion:
-    'Prefer a more specific assertion instead of this generic one, e.g. "{{assertion}}".',
+    'Prefer "{{assertion}}" over this generic assertion; dedicated matchers read better and report clearer failures.',
   preferSpecificLengthAssertion:
     'Prefer "{{assertion}}"; it works for any object with a numeric length property.',
   quickfix: 'Replace with {{assertion}}.',

--- a/packages/analysis/src/jsts/rules/S5906/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5906/rule.ts
@@ -48,7 +48,7 @@ const messages = {
   preferSpecificAssertion:
     'Prefer "{{assertion}}" over this generic assertion; dedicated matchers read better and report clearer failures.',
   preferSpecificLengthAssertion:
-    'Prefer "{{assertion}}"; it works for any object with a numeric length property.',
+    'Prefer "{{assertion}}" over this generic assertion; it reads better, reports clearer failures, and applies to any object with a numeric length property.',
   quickfix: 'Replace with {{assertion}}.',
 };
 

--- a/packages/analysis/src/jsts/rules/S5906/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5906/unit.test.ts
@@ -44,6 +44,10 @@ describe('S5906', () => {
       messageId: 'preferSpecificAssertion',
       suggestions: [{ messageId: 'quickfix', output }],
     });
+    const expectedLengthError = (output: string) => ({
+      messageId: 'preferSpecificLengthAssertion',
+      suggestions: [{ messageId: 'quickfix', output }],
+    });
 
     ruleTester.run('prefer-specific-assertions', rule, {
       valid: [
@@ -184,7 +188,7 @@ describe('S5906', () => {
           `,
           filename: modernJasmineFixture,
           errors: [
-            expectedError(`
+            expectedLengthError(`
             import { expect } from 'jasmine';
 
             expect(items).toHaveSize(3);
@@ -199,7 +203,7 @@ describe('S5906', () => {
           `,
           filename: mixedJasmineJestFixture,
           errors: [
-            expectedError(`
+            expectedLengthError(`
             import { expect } from 'jasmine';
 
             expect(items).toHaveSize(3);
@@ -237,7 +241,7 @@ describe('S5906', () => {
             });
           `,
           errors: [
-            expectedError(`
+            expectedLengthError(`
             import { expect, test } from 'vitest';
 
             test('uses generic length assertion', () => {
@@ -254,7 +258,7 @@ describe('S5906', () => {
           `,
           filename: mixedJasmineJestFixture,
           errors: [
-            expectedError(`
+            expectedLengthError(`
             import { expect } from 'vitest';
 
             expect(items).toHaveLength(3);
@@ -338,7 +342,7 @@ describe('S5906', () => {
             expect(items.length === 2).toBe(true);
           `,
           errors: [
-            expectedError(`
+            expectedLengthError(`
             import { expect } from 'vitest';
 
             expect(items).toHaveLength(2);
@@ -352,7 +356,7 @@ describe('S5906', () => {
             expect(items.length === 2).toBe(true);
           `,
           errors: [
-            expectedError(`
+            expectedLengthError(`
             import { expect } from 'jasmine';
 
             expect(items).toHaveSize(2);


### PR DESCRIPTION
## Summary

Reviewers have reported the S5906 rewrite `expect(x.length).toBe(n)` → `expect(x).toHaveLength(n)` (and the Jasmine/Chai equivalents `toHaveSize`/`lengthOf`) as a false positive when `x` isn't literally a collection, e.g. `expect(diagram.length).toBe(1400)` where `diagram` is a rendered string.

These matchers are actually generic: Jest/Vitest's `toHaveLength` and Jasmine's `toHaveSize` pass whenever the tested value exposes a numeric `length`/`size` property with the expected value, whatever that value represents (Vitest's own test suite even asserts `expect({ length: 3 }).toHaveLength(3)`). The rewrite is behaviorally identical regardless of what `x` is, so this isn't a detection bug — it's a communication gap.

This PR:
- Tags length-based suggestions with `kind: 'length'` on the `Suggestion` type (`assertion-utils.ts`), set at every call site that builds a `.length`/`.size` rewrite across `rule.ts` and `assertion-suggestions.ts`.
- Adds a dedicated `preferSpecificLengthAssertion` message that explicitly states the matcher works on any value with a numeric length property, not only arrays or collections, used instead of the generic `preferSpecificAssertion` message for these cases.
- Updates existing length-related test expectations across `unit.test.ts`, `chai-bdd.unit.test.ts`, and `integrations.unit.test.ts` to assert the new message id.

RSPEC companion PR (adds the same clarification plus a string-based example to "Why is this an issue?"): https://github.com/SonarSource/rspec/pull/7279

## Test plan
- [x] `npx tsx --test packages/analysis/src/jsts/rules/S5906/*.test.ts` — all 3 suites pass
- [x] `npx tsc --noEmit` on the analysis package — no new errors
- [x] `npx prettier --check` on changed files