### PR TITLE
JS-1994 Fix S8780 false positive on done-callback tests

### DIFF
--- a/packages/analysis/src/jsts/rules/S8780/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8780/rule.ts
@@ -123,6 +123,10 @@ export const rule: Rule.RuleModule = {
           return;
         }
 
+        if (usesDoneCallback(callback)) {
+          return;
+        }
+
         forEachExpressionStatement(callback.body, statement => {
           const assertionNode = getAsyncAssertionNode(context, statement.expression, frameworks);
           if (assertionNode) {
@@ -161,6 +165,18 @@ function extractSupportedTestCallback(
 
 function isFunctionArgument(node: estree.Node | estree.SpreadElement): node is FunctionArgument {
   return node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression';
+}
+
+/**
+ * Jest/Jasmine/Vitest pass a `done` callback whenever the test function declares a parameter
+ * (arity-based, regardless of its name). Mixing that with an awaited/returned assertion makes
+ * the runtime throw ("cannot both take a 'done' callback and return something"), so the fix this
+ * rule suggests doesn't apply to such tests. Playwright's fixtures parameter is always a
+ * destructuring pattern, never a plain identifier, so it isn't mistaken for a done callback.
+ */
+function usesDoneCallback(callback: estree.Function): boolean {
+  const [firstParam] = callback.params;
+  return firstParam?.type === 'Identifier';
 }
 
 function forEachExpressionStatement(
@@ -363,7 +379,9 @@ function isNamedCall(
   return importedNames.includes(fqn ?? '') || isIdentifier(call.callee, globalName);
 }
 
-function unwrapChainExpression<T extends estree.Node | estree.Super>(node: T): T | estree.Expression {
+function unwrapChainExpression<T extends estree.Node | estree.Super>(
+  node: T,
+): T | estree.Expression {
   return node.type === 'ChainExpression' ? node.expression : node;
 }
 

--- a/packages/analysis/src/jsts/rules/S8780/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8780/unit.test.ts
@@ -125,6 +125,29 @@ describe('S8780', () => {
             });
           `,
         },
+        {
+          code: `
+            import { expect, test } from '@jest/globals';
+
+            test('should log errors and mark job as failed', (done) => {
+              failingJob.once('error', () => {
+                expect(failingJob.status).toBe('FAILED');
+                done();
+              });
+              expect(failingJob.run()).rejects.toThrow('Processor error');
+            });
+          `,
+        },
+        {
+          code: `
+            import { expect, it } from 'vitest';
+
+            it('ignores done-style callbacks', function (done) {
+              expect(fetchUser(1)).resolves.toHaveProperty('name');
+              done();
+            });
+          `,
+        },
       ],
       invalid: [
         {


### PR DESCRIPTION
## Summary

- Fix a false positive in S8780 ("Async test assertions should be awaited or returned") for test callbacks that use a `done`-style completion parameter (e.g. `it('...', (done) => {...})`).
- In that pattern, Jest/Jasmine/Vitest determine test completion by the callback's arity, not by the returned/awaited value — mixing `done` with an awaited or returned assertion makes the runtime throw `Test functions cannot both take a 'done' callback and return something`, so the rule's own suggested fix doesn't apply to these tests.
- Locally verified with jest 30.4.1 that a failing assertion in this pattern is not silently swallowed either (unlike the scenario the rule targets) — it surfaces as an unhandled rejection that crashes the worker and exits non-zero.
- `usesDoneCallback` skips analysis when the test callback's first parameter is a plain identifier, while leaving Playwright's destructured fixtures parameter (`({ page })`) unaffected, since it's never a plain identifier.
- Added regression tests covering the reported pattern (Jest) and a Vitest done-callback variant.

## Links

- Jira: https://sonarsource.atlassian.net/browse/JS-1994
