### PR TITLE
JS-1996 Fix SonarQube Next quality gate issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1460,9 +1460,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1554,9 +1554,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4883,9 +4883,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5745,9 +5745,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6572,9 +6572,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6647,9 +6647,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6795,9 +6795,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6911,9 +6911,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7182,9 +7182,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -11617,9 +11617,9 @@
       "license": "MIT"
     },
     "node_modules/read-package-json/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12894,9 +12894,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/analysis/src/css/rules/S125/rule.ts
+++ b/packages/analysis/src/css/rules/S125/rule.ts
@@ -23,6 +23,9 @@ import { parse } from 'postcss';
 
 const ruleName = 'sonar/no-commented-code';
 const messages = { commentedCode: 'Remove this commented out code.' };
+const cssSelectorHead = /^[a-z0-9\s,.\-#:_\[\]"'=()*%>+~|]+$/i;
+const cssDeclarationProperty = /^[a-z-]+$/i;
+const cssAtRule = /^@[a-z-]+(?:\s|$)/i;
 
 const ruleImpl: pkg.RuleBase = () => {
   return (root: PostCSS.Root, result: PostcssResult) => {
@@ -46,20 +49,26 @@ const ruleImpl: pkg.RuleBase = () => {
 };
 
 function isLikelyCss(text: string) {
-  // Regular expression to match CSS selectors, properties, and values
-  // `<selector(s)> '{' <anything> '}'`
-  const ruleRegex = /([a-z0-9\s,.\-#:_]+)\{([^}]*)\}/i;
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
 
-  // Regular expression to match CSS declarations
-  // `<property> ':' <value> ';'`
-  const declRegex = /([a-z-]+)\s*:\s*([^;]+);/i;
+  const firstOpenBrace = trimmed.indexOf('{');
+  if (firstOpenBrace > 0 && trimmed.includes('}', firstOpenBrace + 1)) {
+    const head = trimmed.slice(0, firstOpenBrace).trim();
+    if (cssAtRule.test(head) || cssSelectorHead.test(head)) {
+      return true;
+    }
+  }
 
-  // Regular expression to match CSS at-rules
-  // `'@' <at-rule> '(' <anything> ')'`
-  const atRuleRegex = /@([a-z-]*)\s*([^;{]*)(;|(\{([^}]*)\}))/i;
+  const firstColon = trimmed.indexOf(':');
+  const lastSemicolon = trimmed.lastIndexOf(';');
+  if (firstColon > 0 && lastSemicolon > firstColon + 1) {
+    return cssDeclarationProperty.test(trimmed.slice(0, firstColon).trim());
+  }
 
-  // Test the text against the regular expressions
-  return ruleRegex.test(text) || declRegex.test(text) || atRuleRegex.test(text);
+  return cssAtRule.test(trimmed) && trimmed.includes(';');
 }
 
 export const rule = createPlugin(

--- a/packages/analysis/src/jsts/embedded/builder/patch.ts
+++ b/packages/analysis/src/jsts/embedded/builder/patch.ts
@@ -157,13 +157,12 @@ export function patchParsingErrorMessage(
   embeddedJS: EmbeddedJS,
 ): string {
   /* Extracts location information of the form `(<line>:<column>)` */
-  const regex = /((?<line>\d+):(?<column>\d+))/;
+  const regex = /\((?<line>\d+):(?<column>\d+)\)$/;
   const found = message.match(regex);
   if (found?.groups) {
-    const line = found.groups.line;
     const column = Number(found.groups.column);
     const patchedColumn = embeddedJS.format === 'PLAIN' ? column + embeddedJS.column - 1 : column;
-    return message.replace(`(${line}:${column})`, `(${patchedLine}:${patchedColumn})`);
+    return message.replace(regex, `(${patchedLine}:${patchedColumn})`);
   }
   return message;
 }

--- a/packages/analysis/src/jsts/rules/S3800/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3800/rule.ts
@@ -176,7 +176,7 @@ function prettyPrint(type: ts.Type, checker: ts.TypeChecker): string {
 function isTypedArray(type: ts.Type, checker: ts.TypeChecker) {
   const typeAsString = checker.typeToString(type);
   // Since TS 5.7 typed arrays include the type of the elements in the string, eg. Float32Array<any>
-  return /.*Array(?:<[^>]*>)?$/.test(typeAsString);
+  return /^[^<]*Array(?:<[^>]*>)?$/.test(typeAsString);
 }
 
 function isNullLike(type: ts.Type) {

--- a/packages/analysis/tests/jsts/tools/testers/comment-based/framework.ts
+++ b/packages/analysis/tests/jsts/tools/testers/comment-based/framework.ts
@@ -190,7 +190,7 @@ function editLine(lines: string[], change: Change) {
   if (contents !== undefined) {
     let appendAfterFix = '';
     const line = lines[issueLine - 1];
-    const containsNC = line.search(/\s*\{?\s*(\/\*|\/\/)\s*Noncompliant/);
+    const containsNC = findNoncompliantCommentStart(line);
     if (end === undefined) {
       if (containsNC >= 0) {
         appendAfterFix = line.slice(containsNC);
@@ -206,6 +206,32 @@ function editLine(lines: string[], change: Change) {
     }
     lines[issueLine - 1] = line.slice(0, start || 0) + contents + appendAfterFix;
   }
+}
+
+function findNoncompliantCommentStart(line: string) {
+  const noncompliantIndex = line.indexOf('Noncompliant');
+  if (noncompliantIndex < 0) {
+    return -1;
+  }
+
+  const lineCommentIndex = line.lastIndexOf('//', noncompliantIndex);
+  const blockCommentIndex = line.lastIndexOf('/*', noncompliantIndex);
+  const commentIndex = Math.max(lineCommentIndex, blockCommentIndex);
+  if (commentIndex < 0) {
+    return -1;
+  }
+
+  let start = commentIndex;
+  while (start > 0 && /\s/.test(line[start - 1])) {
+    start--;
+  }
+  if (start > 0 && line[start - 1] === '{') {
+    start--;
+    while (start > 0 && /\s/.test(line[start - 1])) {
+      start--;
+    }
+  }
+  return start;
 }
 
 /**

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -352,13 +352,16 @@ public class BridgeServerImpl implements BridgeServer {
         if (remainingNanos <= 0) {
           return false;
         }
-        startupPortReady.await(
+        boolean stateChanged = startupPortReady.await(
           Math.min(
             TimeUnit.NANOSECONDS.toMillis(remainingNanos),
             STARTUP_PORT_WAIT_POLL_INTERVAL_MS
           ),
           TimeUnit.MILLISECONDS
         );
+        if (!stateChanged) {
+          continue;
+        }
       }
       port = startupPort.get();
       return true;


### PR DESCRIPTION
## Summary

- fix the reliability findings behind the failing SonarQube Next gate by replacing the flagged regexes with linear parsing and by checking the `await(...)` status explicitly
- update `package-lock.json` to move `fast-uri` to `3.1.3` and the vulnerable `brace-expansion` lines to `1.1.15` and `5.0.7`
- keep the diff focused on the gate fix only

## Testing

- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/tests/yaml/builder/patch.test.ts packages/analysis/tests/jsts/tools/testers/comment-based/framework.test.ts packages/analysis/src/css/rules/S125/unit.test.ts packages/analysis/src/jsts/rules/S3800/unit.test.ts`
- `mvn -pl sonar-plugin/bridge -am "-Dlicense.skip=true" "-Dsurefire.failIfNoSpecifiedTests=false" -Dtest=BridgeServerImplTest test`