### PR TITLE
JS-1997 Fix S1848 RegExp validation FP

### DIFF
--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -35,6 +35,8 @@ const DOM_SELECTION_METHODS = [
 ];
 /** jQuery/$ function names */
 const JQUERY_IDENTIFIERS = ['$', 'jQuery'];
+const STATEMENT_ANCESTOR_OFFSET = 1;
+const CONTAINER_ANCESTOR_OFFSET = 2;
 
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta, {
@@ -97,13 +99,17 @@ function isRegExpValidation(node: estree.NewExpression, context: Rule.RuleContex
   }
 
   const nextStatement = getNextSiblingStatement(node, context);
-  if (nextStatement?.type !== 'ReturnStatement' || !nextStatement.argument) {
+  if (nextStatement?.type !== 'ReturnStatement') {
+    return false;
+  }
+
+  const { argument: returnArgument } = nextStatement;
+  if (!returnArgument) {
     return false;
   }
 
   return node.arguments.some(
-    argument =>
-      isIdentifier(argument) && containsReturnedIdentifier(nextStatement.argument!, argument),
+    argument => isIdentifier(argument) && containsReturnedIdentifier(returnArgument, argument),
   );
 }
 
@@ -143,8 +149,8 @@ function getNextSiblingStatement(
   context: Rule.RuleContext,
 ): estree.Statement | undefined {
   const ancestors = context.sourceCode.getAncestors(node);
-  const statement = ancestors.at(-1);
-  const container = ancestors.at(-2);
+  const statement = ancestors.at(-STATEMENT_ANCESTOR_OFFSET);
+  const container = ancestors.at(-CONTAINER_ANCESTOR_OFFSET);
   if (statement?.type !== 'ExpressionStatement') {
     return undefined;
   }

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -21,7 +21,7 @@ import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { getVariableFromIdentifier } from '../helpers/reaching-definitions.js';
-import { isIdentifier } from '../helpers/ast.js';
+import { getVariableFromScope, isIdentifier } from '../helpers/ast.js';
 import * as meta from './generated-meta.js';
 
 /** DOM selection method names commonly used for element selection */
@@ -93,6 +93,19 @@ function isTryable(node: estree.Node, context: Rule.RuleContext) {
   return false;
 }
 
+/**
+ * Suppresses false positives for RegExp validation patterns where the constructor is used only
+ * to validate an input before returning it.
+ *
+ * For example, `new RegExp(pattern)` is intentional in:
+ *
+ * ```js
+ * function validatePattern(pattern) {
+ *   new RegExp(pattern);
+ *   return pattern;
+ * }
+ * ```
+ */
 function isRegExpValidation(node: estree.NewExpression, context: Rule.RuleContext): boolean {
   if (!isBuiltInRegExpConstructor(node, context)) {
     return false;
@@ -118,30 +131,19 @@ function isBuiltInRegExpConstructor(
   context: Rule.RuleContext,
 ): boolean {
   const { callee } = node;
+  const scope = context.sourceCode.getScope(node);
 
   if (isIdentifier(callee, 'RegExp')) {
-    return !isLocallyDefined(callee, context.sourceCode.getScope(node));
+    return !getVariableFromScope(scope, callee.name)?.defs.length;
   }
 
   return (
     callee.type === 'MemberExpression' &&
     !callee.computed &&
     isIdentifier(callee.object, 'globalThis') &&
-    !isLocallyDefined(callee.object, context.sourceCode.getScope(node)) &&
+    !getVariableFromScope(scope, callee.object.name)?.defs.length &&
     isIdentifier(callee.property, 'RegExp')
   );
-}
-
-function isLocallyDefined(identifier: estree.Identifier, scope: Scope.Scope): boolean {
-  let currentScope: Scope.Scope | null = scope;
-  while (currentScope) {
-    const variable = currentScope.variables.find(value => value.name === identifier.name);
-    if (variable) {
-      return variable.defs.length > 0;
-    }
-    currentScope = currentScope.upper;
-  }
-  return false;
 }
 
 function getNextSiblingStatement(

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -107,7 +107,7 @@ function isRegExpValidation(node: estree.NewExpression, context: Rule.RuleContex
     argument =>
       argument.type !== 'SpreadElement' &&
       argument.type !== 'Literal' &&
-      containsEquivalentNode(nextStatement.argument!, argument, context),
+      containsEquivalentValueNode(nextStatement.argument!, argument, context),
   );
 }
 
@@ -131,7 +131,15 @@ function isBuiltInRegExpConstructor(
 }
 
 function isLocallyDefined(identifier: estree.Identifier, scope: Scope.Scope): boolean {
-  return (getVariableFromIdentifier(identifier, scope)?.defs.length ?? 0) > 0;
+  let currentScope: Scope.Scope | null = scope;
+  while (currentScope) {
+    const variable = currentScope.variables.find(value => value.name === identifier.name);
+    if (variable) {
+      return variable.defs.length > 0;
+    }
+    currentScope = currentScope.upper;
+  }
+  return false;
 }
 
 function getNextSiblingStatement(
@@ -164,16 +172,25 @@ function getStatementList(node: estree.Node | undefined): estree.Statement[] | u
   return undefined;
 }
 
-function containsEquivalentNode(
+function containsEquivalentValueNode(
   node: estree.Node,
   expected: estree.Node,
   context: Rule.RuleContext,
 ): boolean {
-  return (
-    areEquivalent(node, expected, context.sourceCode) ||
-    childrenOf(node, context.sourceCode.visitorKeys).some(child =>
-      containsEquivalentNode(child, expected, context),
-    )
+  if (areEquivalent(node, expected, context.sourceCode)) {
+    return true;
+  }
+
+  if (node.type === 'Property') {
+    return containsEquivalentValueNode(node.value as estree.Node, expected, context);
+  }
+
+  if (node.type === 'MemberExpression') {
+    return containsEquivalentValueNode(node.object, expected, context);
+  }
+
+  return childrenOf(node, context.sourceCode.visitorKeys).some(child =>
+    containsEquivalentValueNode(child, expected, context),
   );
 }
 

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -22,8 +22,6 @@ import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { getVariableFromIdentifier } from '../helpers/reaching-definitions.js';
 import { isIdentifier } from '../helpers/ast.js';
-import { childrenOf } from '../helpers/ancestor.js';
-import { areEquivalent } from '../helpers/equivalence.js';
 import * as meta from './generated-meta.js';
 
 /** DOM selection method names commonly used for element selection */
@@ -105,9 +103,7 @@ function isRegExpValidation(node: estree.NewExpression, context: Rule.RuleContex
 
   return node.arguments.some(
     argument =>
-      argument.type !== 'SpreadElement' &&
-      argument.type !== 'Literal' &&
-      containsEquivalentValueNode(nextStatement.argument!, argument, context),
+      isIdentifier(argument) && containsReturnedIdentifier(nextStatement.argument!, argument),
   );
 }
 
@@ -172,26 +168,48 @@ function getStatementList(node: estree.Node | undefined): estree.Statement[] | u
   return undefined;
 }
 
-function containsEquivalentValueNode(
-  node: estree.Node,
-  expected: estree.Node,
-  context: Rule.RuleContext,
-): boolean {
-  if (areEquivalent(node, expected, context.sourceCode)) {
+function containsReturnedIdentifier(node: estree.Node, identifier: estree.Identifier): boolean {
+  if (isIdentifier(node, identifier.name)) {
     return true;
   }
 
-  if (node.type === 'Property') {
-    return containsEquivalentValueNode(node.value as estree.Node, expected, context);
+  if (node.type === 'ObjectExpression') {
+    return node.properties.some(property => {
+      if (property.type === 'Property') {
+        return containsReturnedIdentifier(property.value as estree.Node, identifier);
+      }
+      return containsReturnedIdentifier(property.argument, identifier);
+    });
   }
 
-  if (node.type === 'MemberExpression') {
-    return containsEquivalentValueNode(node.object, expected, context);
+  if (node.type === 'ArrayExpression') {
+    return node.elements.some(element => {
+      if (!element) {
+        return false;
+      }
+      if (element.type === 'SpreadElement') {
+        return containsReturnedIdentifier(element.argument, identifier);
+      }
+      return containsReturnedIdentifier(element, identifier);
+    });
   }
 
-  return childrenOf(node, context.sourceCode.visitorKeys).some(child =>
-    containsEquivalentValueNode(child, expected, context),
-  );
+  if (node.type === 'ConditionalExpression') {
+    return (
+      containsReturnedIdentifier(node.consequent, identifier) ||
+      containsReturnedIdentifier(node.alternate, identifier)
+    );
+  }
+
+  const nodeType = node.type as string;
+  if (nodeType === 'TSAsExpression' || nodeType === 'TSTypeAssertion') {
+    return containsReturnedIdentifier(
+      (node as unknown as { expression: estree.Node }).expression,
+      identifier,
+    );
+  }
+
+  return false;
 }
 
 function reportIssue(

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -22,6 +22,8 @@ import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { getVariableFromIdentifier } from '../helpers/reaching-definitions.js';
 import { isIdentifier } from '../helpers/ast.js';
+import { childrenOf } from '../helpers/ancestor.js';
+import { areEquivalent } from '../helpers/equivalence.js';
 import * as meta from './generated-meta.js';
 
 /** DOM selection method names commonly used for element selection */
@@ -55,6 +57,9 @@ export const rule: Rule.RuleModule = {
         if (hasDomSelectionArgument(node, context)) {
           return;
         }
+        if (isRegExpValidation(node, context)) {
+          return;
+        }
         const { callee } = node;
         if (callee.type === 'Identifier' || callee.type === 'MemberExpression') {
           const calleeText = sourceCode.getText(callee);
@@ -86,6 +91,90 @@ function isTryable(node: estree.Node, context: Rule.RuleContext) {
     child = parent;
   }
   return false;
+}
+
+function isRegExpValidation(node: estree.NewExpression, context: Rule.RuleContext): boolean {
+  if (!isBuiltInRegExpConstructor(node, context)) {
+    return false;
+  }
+
+  const nextStatement = getNextSiblingStatement(node, context);
+  if (nextStatement?.type !== 'ReturnStatement' || !nextStatement.argument) {
+    return false;
+  }
+
+  return node.arguments.some(
+    argument =>
+      argument.type !== 'SpreadElement' &&
+      argument.type !== 'Literal' &&
+      containsEquivalentNode(nextStatement.argument!, argument, context),
+  );
+}
+
+function isBuiltInRegExpConstructor(
+  node: estree.NewExpression,
+  context: Rule.RuleContext,
+): boolean {
+  const { callee } = node;
+
+  if (isIdentifier(callee, 'RegExp')) {
+    return !isLocallyDefined(callee, context.sourceCode.getScope(node));
+  }
+
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    isIdentifier(callee.object, 'globalThis') &&
+    !isLocallyDefined(callee.object, context.sourceCode.getScope(node)) &&
+    isIdentifier(callee.property, 'RegExp')
+  );
+}
+
+function isLocallyDefined(identifier: estree.Identifier, scope: Scope.Scope): boolean {
+  return (getVariableFromIdentifier(identifier, scope)?.defs.length ?? 0) > 0;
+}
+
+function getNextSiblingStatement(
+  node: estree.Node,
+  context: Rule.RuleContext,
+): estree.Statement | undefined {
+  const ancestors = context.sourceCode.getAncestors(node);
+  const statement = ancestors.at(-1);
+  const container = ancestors.at(-2);
+  if (statement?.type !== 'ExpressionStatement') {
+    return undefined;
+  }
+
+  const body = getStatementList(container);
+  if (!body) {
+    return undefined;
+  }
+
+  const statementIndex = body.indexOf(statement);
+  return statementIndex === -1 ? undefined : body[statementIndex + 1];
+}
+
+function getStatementList(node: estree.Node | undefined): estree.Statement[] | undefined {
+  if (node?.type === 'BlockStatement') {
+    return node.body;
+  }
+  if (node?.type === 'SwitchCase') {
+    return node.consequent;
+  }
+  return undefined;
+}
+
+function containsEquivalentNode(
+  node: estree.Node,
+  expected: estree.Node,
+  context: Rule.RuleContext,
+): boolean {
+  return (
+    areEquivalent(node, expected, context.sourceCode) ||
+    childrenOf(node, context.sourceCode.visitorKeys).some(child =>
+      containsEquivalentNode(child, expected, context),
+    )
+  );
 }
 
 function reportIssue(

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -295,10 +295,44 @@ new DragInstance(params, startEvent, eBody);`,
           {
             code: `
       function parseRegExp(regExp) {
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+        return { pattern: "fallback" };
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      function parseRegExp(regExp) {
+        const options = { pattern: "fallback" };
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+        return options.pattern;
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      function parseRegExp(regExp) {
         const RegExp = CustomRegExp;
         const pattern = regExp.slice(1, -1);
         new RegExp(pattern);
         return pattern;
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      const RegExp = CustomRegExp;
+      function parseRegExp(regExp) {
+        if (regExp.startsWith("/")) {
+          const pattern = regExp.slice(1, -1);
+          new RegExp(pattern);
+          return pattern;
+        }
       }
       `,
             errors: 1,
@@ -310,6 +344,19 @@ new DragInstance(params, startEvent, eBody);`,
         const pattern = regExp.slice(1, -1);
         new globalThis.RegExp(pattern);
         return pattern;
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      const globalThis = { RegExp: CustomRegExp };
+      function parseRegExp(regExp) {
+        if (regExp.startsWith("/")) {
+          const pattern = regExp.slice(1, -1);
+          new globalThis.RegExp(pattern);
+          return pattern;
+        }
       }
       `,
             errors: 1,

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -67,6 +67,47 @@ describe('S1848', () => {
           },
           {
             code: `
+      function parsePatternInSwitch(regExp, type) {
+        const pattern = regExp.slice(1, -1);
+        switch (type) {
+          case "pattern":
+            new RegExp(pattern);
+            return pattern;
+          default:
+            return "";
+        }
+      }
+      `,
+          },
+          {
+            code: `
+      function parsePatternCharacters(regExp) {
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+        return [...pattern];
+      }
+      `,
+          },
+          {
+            code: `
+      function parsePatternConditionally(regExp, withPrefix) {
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+        return withPrefix ? \`/\${pattern}/\` : pattern;
+      }
+      `,
+          },
+          {
+            code: `
+      function parsePatternWithAssertion(regExp) {
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+        return pattern as string;
+      }
+      `,
+          },
+          {
+            code: `
       new Notification("hello there");
       `,
           },

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -315,6 +315,25 @@ new DragInstance(params, startEvent, eBody);`,
           },
           {
             code: `
+      function parseRegExp(regExp, items) {
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+        return items.map(pattern => pattern);
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      function parseRegExp() {
+        new RegExp(buildPattern());
+        return buildPattern();
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
       function parseRegExp(regExp) {
         const RegExp = CustomRegExp;
         const pattern = regExp.slice(1, -1);

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -44,6 +44,29 @@ describe('S1848', () => {
           },
           {
             code: `
+      export function parseRegExp(regExp: string): {
+        pattern: string;
+        flags: string;
+      } {
+        const patternEnd = regExp.lastIndexOf("/");
+        const pattern = regExp.slice(1, patternEnd);
+        const flags = regExp.slice(patternEnd + 1);
+        new RegExp(pattern, flags);
+        return { pattern, flags };
+      }
+      `,
+          },
+          {
+            code: `
+      function parsePattern(regExp) {
+        const pattern = regExp.slice(1, -1);
+        new globalThis.RegExp(pattern);
+        return pattern;
+      }
+      `,
+          },
+          {
+            code: `
       new Notification("hello there");
       `,
           },
@@ -247,6 +270,47 @@ new DragInstance(params, startEvent, eBody);`,
             code: `
         import Grid from '@ag-grid-community/core';
         new Grid();
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      function parseRegExp(regExp) {
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      function parseRegExp(regExp) {
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+        return true;
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      function parseRegExp(regExp) {
+        const RegExp = CustomRegExp;
+        const pattern = regExp.slice(1, -1);
+        new RegExp(pattern);
+        return pattern;
+      }
+      `,
+            errors: 1,
+          },
+          {
+            code: `
+      function parseRegExp(regExp) {
+        const globalThis = { RegExp: CustomRegExp };
+        const pattern = regExp.slice(1, -1);
+        new globalThis.RegExp(pattern);
+        return pattern;
+      }
       `,
             errors: 1,
           },


### PR DESCRIPTION
Part of JS-1997

## Summary
- Suppress S1848 for discarded built-in RegExp constructors used as a validation step before returning parsed regex data.
- Keep reporting arbitrary discarded RegExp constructors, unrelated returns, and locally shadowed RegExp/globalThis constructors.
- Add JS/TS-focused unit coverage for the Jira reproducer and guardrails.

## Validation
- npm run generate-meta
- npx tsx --test packages/analysis/src/jsts/rules/S1848/**/*.test.ts
- npm run eslint-plugin:check
- npx prettier --check packages/analysis/src/jsts/rules/S1848/rule.ts packages/analysis/src/jsts/rules/S1848/unit.test.ts