### PR TITLE
JS-1971: Extend S8785 coverage

### DIFF
--- a/packages/analysis/src/jsts/rules/S8785/async-analysis.ts
+++ b/packages/analysis/src/jsts/rules/S8785/async-analysis.ts
@@ -1,0 +1,140 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { Rule, SourceCode } from 'eslint';
+import type estree from 'estree';
+import { childrenOf } from '../helpers/ancestor.js';
+import { isFunctionNode } from '../helpers/ast.js';
+import { getMochaCalleeParts } from '../helpers/mocha-style-test-frameworks.js';
+
+/** Any function-like node, including named declarations used as async helpers. */
+export type FunctionLike =
+  | estree.FunctionDeclaration
+  | estree.FunctionExpression
+  | estree.ArrowFunctionExpression;
+
+/** Type guard for any function-like node, including named function declarations used as helpers. */
+export function isFunctionLike(node: estree.Node): node is FunctionLike {
+  return (
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionDeclaration'
+  );
+}
+
+/**
+ * If `awaitNode` is an `AwaitExpression` whose argument is a `CallExpression`, returns that
+ * `CallExpression`; otherwise returns `undefined`.
+ */
+export function getAwaitedCall(awaitNode: estree.Node): estree.CallExpression | undefined {
+  if (awaitNode.type === 'AwaitExpression' && awaitNode.argument.type === 'CallExpression') {
+    return awaitNode.argument;
+  }
+  return undefined;
+}
+
+/**
+ * Finds the earliest `await` (or `for await...of`) that runs directly in the function's body,
+ * i.e. not nested inside another function. Returns `undefined` when there is none.
+ */
+export function findFirstTopLevelAwait(
+  context: Rule.RuleContext,
+  callback: FunctionLike,
+): estree.Node | undefined {
+  if (callback.body === null) {
+    return undefined;
+  }
+  const { sourceCode } = context;
+  const stack: estree.Node[] = [callback.body as estree.Node];
+  let earliest: estree.Node | undefined;
+  let earliestStart = Infinity;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined || isFunctionNode(current)) {
+      // A nested function has its own execution context; its awaits are not top-level here.
+      continue;
+    }
+    if (isTopLevelAwait(current)) {
+      const start = sourceCode.getRange(current)[0];
+      if (start < earliestStart) {
+        earliest = current;
+        earliestStart = start;
+      }
+    }
+    stack.push(...childrenOf(current, sourceCode.visitorKeys));
+  }
+  return earliest;
+}
+
+function isTopLevelAwait(node: estree.Node): boolean {
+  return (
+    node.type === 'AwaitExpression' ||
+    (node.type === 'ForOfStatement' && (node as estree.ForOfStatement & { await: boolean }).await)
+  );
+}
+
+/**
+ * Collects the test/suite registrations declared in the function body after the given await node.
+ * Returns the callee of each such call, to be used as a secondary location.
+ *
+ * The walk descends into nested blocks (`if`, `try`, loops, ...) because a registration there is
+ * dropped just like a top-level one: once the callback suspends on the await, everything that runs
+ * afterwards does so too late to be registered. It stops at nested function boundaries — a test
+ * inside a dropped nested suite's own callback belongs to that suite's registration, not to a
+ * separate dropped registration, so only the nested suite's callee is collected.
+ */
+export function findTestsRegisteredAfter(
+  sourceCode: SourceCode,
+  callback: FunctionLike,
+  awaitNode: estree.Node,
+  testAndSuiteNames: Set<string>,
+): estree.Node[] {
+  if (callback.body?.type !== 'BlockStatement') {
+    return [];
+  }
+  // The offset at which the callback suspends. A `for await...of` suspends at the loop itself (the
+  // first `iterator.next()` call, even for a synchronous iterable), so its entire body is dropped
+  // too — use the loop's start. A plain `await` only drops what follows it — use the await's end.
+  const suspendOffset =
+    awaitNode.type === 'ForOfStatement'
+      ? sourceCode.getRange(awaitNode)[0]
+      : sourceCode.getRange(awaitNode)[1];
+  const tests: estree.Node[] = [];
+  const stack: estree.Node[] = [...childrenOf(callback.body, sourceCode.visitorKeys)];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined || isFunctionNode(current)) {
+      continue;
+    }
+    if (
+      current.type === 'ExpressionStatement' &&
+      current.expression.type === 'CallExpression' &&
+      sourceCode.getRange(current)[0] >= suspendOffset
+    ) {
+      const parts = getMochaCalleeParts(current.expression.callee);
+      if (parts && testAndSuiteNames.has(parts.base.name)) {
+        tests.push(current.expression.callee);
+        // Don't descend into the registered call: its own callback is a function boundary and any
+        // tests it contains belong to its registration, not to a separate dropped one.
+        continue;
+      }
+    }
+    stack.push(...childrenOf(current, sourceCode.visitorKeys));
+  }
+  // The stack-based walk yields nodes out of source order; sort so secondary locations are emitted
+  // deterministically (asserted in unit tests, dumped in ruling).
+  return tests.sort((a, b) => sourceCode.getRange(a)[0] - sourceCode.getRange(b)[0]);
+}

--- a/packages/analysis/src/jsts/rules/S8785/async-analysis.ts
+++ b/packages/analysis/src/jsts/rules/S8785/async-analysis.ts
@@ -101,6 +101,7 @@ export function findTestsRegisteredAfter(
   callback: FunctionLike,
   awaitNode: estree.Node,
   testAndSuiteNames: Set<string>,
+  beforeNode?: estree.Node,
 ): estree.Node[] {
   if (callback.body?.type !== 'BlockStatement') {
     return [];
@@ -112,6 +113,7 @@ export function findTestsRegisteredAfter(
     awaitNode.type === 'ForOfStatement'
       ? sourceCode.getRange(awaitNode)[0]
       : sourceCode.getRange(awaitNode)[1];
+  const endOffset = beforeNode !== undefined ? sourceCode.getRange(beforeNode)[0] : Infinity;
   const tests: estree.Node[] = [];
   const stack: estree.Node[] = [...childrenOf(callback.body, sourceCode.visitorKeys)];
   while (stack.length > 0) {
@@ -119,10 +121,12 @@ export function findTestsRegisteredAfter(
     if (current === undefined || isFunctionNode(current)) {
       continue;
     }
+    const nodeStart = sourceCode.getRange(current)[0];
     if (
       current.type === 'ExpressionStatement' &&
       current.expression.type === 'CallExpression' &&
-      sourceCode.getRange(current)[0] >= suspendOffset
+      nodeStart >= suspendOffset &&
+      nodeStart < endOffset
     ) {
       const parts = getMochaCalleeParts(current.expression.callee);
       if (parts && testAndSuiteNames.has(parts.base.name)) {

--- a/packages/analysis/src/jsts/rules/S8785/call-to-declaration.ts
+++ b/packages/analysis/src/jsts/rules/S8785/call-to-declaration.ts
@@ -18,6 +18,7 @@ import type estree from 'estree';
 import type { TSESTree } from '@typescript-eslint/utils';
 import ts from 'typescript';
 import type { RequiredParserServices } from '../helpers/parser-services.js';
+import { getSignatureFromCallee } from '../helpers/type.js';
 
 function normalizeToFunctionLikeDeclaration(
   declaration: ts.Declaration | undefined,
@@ -50,11 +51,7 @@ export function followCallToDeclaration(
   call: estree.CallExpression,
   services: RequiredParserServices,
 ): ts.SignatureDeclaration | undefined {
-  const tsCall = services.esTreeNodeToTSNodeMap.get(call as unknown as TSESTree.Node);
-  const signature = services.program
-    .getTypeChecker()
-    .getResolvedSignature(tsCall as ts.CallLikeExpression);
-  return normalizeToFunctionLikeDeclaration(signature?.declaration);
+  return normalizeToFunctionLikeDeclaration(getSignatureFromCallee(call, services)?.declaration);
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S8785/call-to-declaration.ts
+++ b/packages/analysis/src/jsts/rules/S8785/call-to-declaration.ts
@@ -1,0 +1,84 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type estree from 'estree';
+import type { TSESTree } from '@typescript-eslint/utils';
+import ts from 'typescript';
+import type { RequiredParserServices } from '../helpers/parser-services.js';
+
+function normalizeToFunctionLikeDeclaration(
+  declaration: ts.Declaration | undefined,
+): ts.SignatureDeclaration | undefined {
+  if (declaration === undefined) {
+    return undefined;
+  }
+  if (ts.isFunctionLike(declaration)) {
+    return declaration;
+  }
+  if (
+    ts.isVariableDeclaration(declaration) &&
+    declaration.initializer !== undefined &&
+    ts.isFunctionLike(declaration.initializer)
+  ) {
+    return declaration.initializer;
+  }
+  return undefined;
+}
+
+/**
+ * Resolves a call expression to the function-like declaration it targets, using the TypeScript
+ * type checker's `getResolvedSignature`. Returns `undefined` when the callee does not resolve to
+ * a known function declaration (e.g. built-ins, overloads with no single declaration, or
+ * cross-package symbols without source).
+ *
+ * Only one hop is followed: the directly called function. Deeper call chains are not resolved.
+ */
+export function followCallToDeclaration(
+  call: estree.CallExpression,
+  services: RequiredParserServices,
+): ts.SignatureDeclaration | undefined {
+  const tsCall = services.esTreeNodeToTSNodeMap.get(call as unknown as TSESTree.Node);
+  const signature = services.program
+    .getTypeChecker()
+    .getResolvedSignature(tsCall as ts.CallLikeExpression);
+  return normalizeToFunctionLikeDeclaration(signature?.declaration);
+}
+
+/**
+ * Resolves an identifier reference to the directly referenced function-like declaration.
+ *
+ * Only one indirection is followed: a direct function declaration or a variable whose initializer
+ * is a function expression / arrow function. Aliases such as `const cb = setup; describe(..., cb)`
+ * intentionally return `undefined`.
+ */
+export function followReferenceToDeclaration(
+  node: estree.Identifier,
+  services: RequiredParserServices,
+): ts.SignatureDeclaration | undefined {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node as unknown as TSESTree.Node);
+  const checker = services.program.getTypeChecker();
+  let symbol = checker.getSymbolAtLocation(tsNode);
+  if (symbol === undefined) {
+    return undefined;
+  }
+  if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    symbol = checker.getAliasedSymbol(symbol);
+  }
+  if (symbol.declarations?.length !== 1) {
+    return undefined;
+  }
+  return normalizeToFunctionLikeDeclaration(symbol.declarations[0]);
+}

--- a/packages/analysis/src/jsts/rules/S8785/call-to-declaration.ts
+++ b/packages/analysis/src/jsts/rules/S8785/call-to-declaration.ts
@@ -15,10 +15,9 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import type estree from 'estree';
-import type { TSESTree } from '@typescript-eslint/utils';
 import ts from 'typescript';
 import type { RequiredParserServices } from '../helpers/parser-services.js';
-import { getSignatureFromCallee } from '../helpers/type.js';
+import { getSignatureFromCallee, getSymbolAtLocation } from '../helpers/type.js';
 
 function normalizeToFunctionLikeDeclaration(
   declaration: ts.Declaration | undefined,
@@ -65,14 +64,12 @@ export function followReferenceToDeclaration(
   node: estree.Identifier,
   services: RequiredParserServices,
 ): ts.SignatureDeclaration | undefined {
-  const tsNode = services.esTreeNodeToTSNodeMap.get(node as unknown as TSESTree.Node);
-  const checker = services.program.getTypeChecker();
-  let symbol = checker.getSymbolAtLocation(tsNode);
+  let symbol = getSymbolAtLocation(node, services);
   if (symbol === undefined) {
     return undefined;
   }
   if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
-    symbol = checker.getAliasedSymbol(symbol);
+    symbol = services.program.getTypeChecker().getAliasedSymbol(symbol);
   }
   if (symbol.declarations?.length !== 1) {
     return undefined;

--- a/packages/analysis/src/jsts/rules/S8785/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8785/rule.ts
@@ -181,12 +181,17 @@ function tryReportAwaitedAsyncHelperCall(
     return undefined;
   }
 
+  const nextDescribeAwait =
+    callback.body?.type === 'BlockStatement'
+      ? findNextTopLevelAwaitAfter(context.sourceCode, callback.body, topLevelAwait)
+      : undefined;
   const reported = reportAsyncHelperCall(
     context,
     parserServices,
     awaitedCall,
     callback,
     topLevelAwait,
+    nextDescribeAwait,
   );
   if (!reported) {
     return undefined;
@@ -376,8 +381,19 @@ function reportUnawaitedAsyncHelperCalls(
       stack.push(...childrenOf(current, sourceCode.visitorKeys));
       continue;
     }
+    const nextDescribeAwait =
+      body.type === 'BlockStatement'
+        ? findNextTopLevelAwaitAfter(sourceCode, body, expr)
+        : undefined;
     reported =
-      reportAsyncHelperExpression(context, services, expr, callback, skipAwait) || reported;
+      reportAsyncHelperExpression(
+        context,
+        services,
+        expr,
+        callback,
+        skipAwait,
+        nextDescribeAwait,
+      ) || reported;
   }
   return reported;
 }
@@ -388,6 +404,7 @@ function reportAsyncHelperExpression(
   expr: estree.Expression,
   callback: FunctionLike,
   skipAwait?: estree.Node,
+  nextDescribeAwait?: estree.Node,
 ): boolean {
   // Unawaited call: helper() / () => helper()
   if (expr.type === 'CallExpression' && !shouldSkipHelperResolution(context, expr)) {
@@ -401,9 +418,34 @@ function reportAsyncHelperExpression(
     expr.argument.type === 'CallExpression' &&
     !shouldSkipHelperResolution(context, expr.argument)
   ) {
-    return reportAsyncHelperCall(context, services, expr.argument, callback, expr);
+    return reportAsyncHelperCall(
+      context,
+      services,
+      expr.argument,
+      callback,
+      expr,
+      nextDescribeAwait,
+    );
   }
   return false;
+}
+
+function findNextTopLevelAwaitAfter(
+  sourceCode: Rule.RuleContext['sourceCode'],
+  body: estree.BlockStatement,
+  afterNode: estree.Node,
+): estree.Node | undefined {
+  const afterEnd = sourceCode.getRange(afterNode)[1];
+  for (const stmt of body.body) {
+    if (
+      stmt.type === 'ExpressionStatement' &&
+      stmt.expression.type === 'AwaitExpression' &&
+      sourceCode.getRange(stmt)[0] >= afterEnd
+    ) {
+      return stmt.expression;
+    }
+  }
+  return undefined;
 }
 
 function shouldSkipHelperResolution(
@@ -431,6 +473,7 @@ function reportAsyncHelperCall(
   callNode: estree.CallExpression,
   describeCallback: FunctionLike,
   awaitNode?: estree.Node,
+  nextDescribeAwait?: estree.Node,
 ): boolean {
   const decl = followCallToDeclaration(callNode, services);
   if (!decl) {
@@ -467,13 +510,15 @@ function reportAsyncHelperCall(
   }
 
   // If the call is awaited inside the describe callback, also collect tests dropped in the
-  // describe body after the await expression.
+  // describe body after the await expression, up to the next top-level await (if any) to avoid
+  // overlapping secondaries when multiple sequential awaited helpers are reported.
   const droppedInDescribe = awaitNode
     ? findTestsRegisteredAfter(
         context.sourceCode,
         describeCallback,
         awaitNode,
         TEST_AND_SUITE_NAMES,
+        nextDescribeAwait,
       )
     : [];
 

--- a/packages/analysis/src/jsts/rules/S8785/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8785/rule.ts
@@ -20,6 +20,7 @@ import type { Rule } from 'eslint';
 import type estree from 'estree';
 import ts from 'typescript';
 import { childrenOf } from '../helpers/ancestor.js';
+import { isAssertion } from '../helpers/assertion-detection.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { report, toSecondaryLocation } from '../helpers/location.js';
 import { importsOrDependsOnModule, getFullyQualifiedName } from '../helpers/module.js';
@@ -33,6 +34,7 @@ import {
   isRequiredParserServices,
   type RequiredParserServices,
 } from '../helpers/parser-services.js';
+import { TEST_FRAMEWORK_STRUCTURE_FUNCTIONS } from '../helpers/test-frameworks.js';
 import * as meta from './generated-meta.js';
 import {
   findFirstTopLevelAwait,
@@ -346,7 +348,7 @@ function reportUnawaitedAsyncHelperCalls(
   callback: FunctionLike,
   skipAwait?: estree.Node,
 ): boolean {
-  if (callback.body.type !== 'BlockStatement') {
+  if (callback.body?.type !== 'BlockStatement') {
     return false;
   }
   const { sourceCode } = context;
@@ -360,7 +362,7 @@ function reportUnawaitedAsyncHelperCalls(
     if (current.type === 'ExpressionStatement') {
       const expr = current.expression;
       // Unawaited call: ExpressionStatement → CallExpression
-      if (expr.type === 'CallExpression') {
+      if (expr.type === 'CallExpression' && !shouldSkipHelperResolution(context, expr)) {
         reported = reportAsyncHelperCall(context, services, expr, callback) || reported;
       }
       // Awaited call: ExpressionStatement → AwaitExpression → CallExpression
@@ -368,7 +370,8 @@ function reportUnawaitedAsyncHelperCalls(
       if (
         expr.type === 'AwaitExpression' &&
         expr !== skipAwait &&
-        expr.argument.type === 'CallExpression'
+        expr.argument.type === 'CallExpression' &&
+        !shouldSkipHelperResolution(context, expr.argument)
       ) {
         reported =
           reportAsyncHelperCall(context, services, expr.argument, callback, expr) || reported;
@@ -377,6 +380,16 @@ function reportUnawaitedAsyncHelperCalls(
     stack.push(...childrenOf(current, sourceCode.visitorKeys));
   }
   return reported;
+}
+
+function shouldSkipHelperResolution(
+  context: Rule.RuleContext,
+  call: estree.CallExpression,
+): boolean {
+  const calleeParts = getMochaCalleeParts(call.callee);
+  const isKnownFrameworkRegistration =
+    calleeParts !== undefined && TEST_FRAMEWORK_STRUCTURE_FUNCTIONS.has(calleeParts.base.name);
+  return isKnownFrameworkRegistration || isAssertion(context, call);
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S8785/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8785/rule.ts
@@ -348,38 +348,62 @@ function reportUnawaitedAsyncHelperCalls(
   callback: FunctionLike,
   skipAwait?: estree.Node,
 ): boolean {
-  if (callback.body?.type !== 'BlockStatement') {
+  const body = callback.body;
+  if (!body) {
     return false;
   }
   const { sourceCode } = context;
   let reported = false;
-  const stack: estree.Node[] = [...childrenOf(callback.body, sourceCode.visitorKeys)];
+  // Block body: seed the stack with direct statement children.
+  // Concise-body arrow (`() => expr`): seed with the qexpression itself so it falls through the
+  // while loop below. The expression is identified inside the loop by `current === body`.
+  const stack: estree.Node[] =
+    body.type === 'BlockStatement'
+      ? [...childrenOf(body, sourceCode.visitorKeys)]
+      : [body as estree.Node];
   while (stack.length > 0) {
     const current = stack.pop();
     if (!current || isFunctionNode(current)) {
       continue;
     }
+    let expr: estree.Expression | null = null;
     if (current.type === 'ExpressionStatement') {
-      const expr = current.expression;
-      // Unawaited call: ExpressionStatement → CallExpression
-      if (expr.type === 'CallExpression' && !shouldSkipHelperResolution(context, expr)) {
-        reported = reportAsyncHelperCall(context, services, expr, callback) || reported;
-      }
-      // Awaited call: ExpressionStatement → AwaitExpression → CallExpression
-      // Skip if this is the top-level-await already handled by the outer detection branch.
-      if (
-        expr.type === 'AwaitExpression' &&
-        expr !== skipAwait &&
-        expr.argument.type === 'CallExpression' &&
-        !shouldSkipHelperResolution(context, expr.argument)
-      ) {
-        reported =
-          reportAsyncHelperCall(context, services, expr.argument, callback, expr) || reported;
-      }
+      expr = current.expression;
+    } else if (body.type !== 'BlockStatement' && current === body) {
+      expr = body as estree.Expression;
     }
-    stack.push(...childrenOf(current, sourceCode.visitorKeys));
+    if (expr === null) {
+      stack.push(...childrenOf(current, sourceCode.visitorKeys));
+      continue;
+    }
+    reported =
+      reportAsyncHelperExpression(context, services, expr, callback, skipAwait) || reported;
   }
   return reported;
+}
+
+function reportAsyncHelperExpression(
+  context: Rule.RuleContext,
+  services: RequiredParserServices,
+  expr: estree.Expression,
+  callback: FunctionLike,
+  skipAwait?: estree.Node,
+): boolean {
+  // Unawaited call: helper() / () => helper()
+  if (expr.type === 'CallExpression' && !shouldSkipHelperResolution(context, expr)) {
+    return reportAsyncHelperCall(context, services, expr, callback);
+  }
+  // Awaited call: await helper() / async () => await helper()
+  // Skip if this is the top-level-await already handled by the outer detection branch.
+  if (
+    expr.type === 'AwaitExpression' &&
+    expr !== skipAwait &&
+    expr.argument.type === 'CallExpression' &&
+    !shouldSkipHelperResolution(context, expr.argument)
+  ) {
+    return reportAsyncHelperCall(context, services, expr.argument, callback, expr);
+  }
+  return false;
 }
 
 function shouldSkipHelperResolution(

--- a/packages/analysis/src/jsts/rules/S8785/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8785/rule.ts
@@ -16,19 +16,32 @@
  */
 // https://sonarsource.github.io/rspec/#/rspec/S8785/javascript
 
-import type { Rule, SourceCode } from 'eslint';
+import type { Rule } from 'eslint';
 import type estree from 'estree';
+import ts from 'typescript';
+import { childrenOf } from '../helpers/ancestor.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { report, toSecondaryLocation } from '../helpers/location.js';
 import { importsOrDependsOnModule, getFullyQualifiedName } from '../helpers/module.js';
-import { childrenOf } from '../helpers/ancestor.js';
 import { getVariableFromScope, isFunctionNode } from '../helpers/ast.js';
 import {
   getMochaCalleeParts,
   SUITE_FUNCTION_NAMES,
   TEST_FUNCTION_NAMES,
 } from '../helpers/mocha-style-test-frameworks.js';
+import {
+  isRequiredParserServices,
+  type RequiredParserServices,
+} from '../helpers/parser-services.js';
 import * as meta from './generated-meta.js';
+import {
+  findFirstTopLevelAwait,
+  findTestsRegisteredAfter,
+  getAwaitedCall,
+  isFunctionLike,
+  type FunctionLike,
+} from './async-analysis.js';
+import { followCallToDeclaration, followReferenceToDeclaration } from './call-to-declaration.js';
 
 /**
  * Frameworks that run a suite's callback synchronously during the discovery phase. Vitest is
@@ -55,13 +68,30 @@ const RAISING_MODIFIERS = new Set(['only', 'each']);
 /** Test- and suite-registering identifiers, used to detect the tests dropped after an `await`. */
 const TEST_AND_SUITE_NAMES = new Set([...TEST_FUNCTION_NAMES, ...SUITE_FUNCTION_NAMES]);
 
+type RaisingSuiteCallback =
+  | {
+      callback: estree.FunctionExpression | estree.ArrowFunctionExpression;
+      byReference: false;
+    }
+  | {
+      callback: FunctionLike;
+      byReference: true;
+    };
+
+type AsyncSuiteOutcome =
+  | { kind: 'noTopLevelAwait' }
+  | { kind: 'awaitedHelperReported'; skipAwait: estree.Node }
+  | { kind: 'asyncSuiteReported' };
+
 const messages = {
   removeAsync:
     'Remove the "async" keyword from this test suite callback; a test suite callback must be synchronous.',
   asyncSuiteCallback:
-    'Make this test suite callback synchronous; any test declared after this await is silently dropped.',
+    'Move this async setup into a lifecycle hook or a test callback; any test declared after this "await" is silently dropped.',
   removeAsyncQuickFix: 'Remove the "async" keyword',
   droppedTest: 'This test is declared after the await and is never registered.',
+  asyncHelperCall:
+    'This async helper silently drops tests; remove its "async" keyword and move async setup into a lifecycle hook or a test callback.',
 };
 
 export const rule: Rule.RuleModule = {
@@ -71,16 +101,120 @@ export const rule: Rule.RuleModule = {
       return {};
     }
 
+    const parserServices = context.sourceCode.parserServices;
+
     return {
       CallExpression(node: estree.CallExpression) {
-        const callback = getRaisingSuiteCallback(context, node);
-        if (callback?.async) {
-          reportAsyncCallback(context, callback);
+        const raisingSuiteCallback = getRaisingSuiteCallback(context, node, parserServices);
+        if (!raisingSuiteCallback) {
+          return;
         }
+        visitRaisingSuiteCallback(context, parserServices, raisingSuiteCallback);
       },
     };
   },
 };
+
+function visitRaisingSuiteCallback(
+  context: Rule.RuleContext,
+  parserServices: Rule.RuleContext['sourceCode']['parserServices'],
+  raisingSuiteCallback: RaisingSuiteCallback,
+): void {
+  const { callback, byReference } = raisingSuiteCallback;
+  const asyncSuiteOutcome = callback.async
+    ? analyzeAsyncSuiteCallback(context, parserServices, callback)
+    : undefined;
+
+  if (asyncSuiteOutcome?.kind === 'noTopLevelAwait') {
+    // Async callback, no top-level await: remove the misleading async keyword.
+    reportRemoveAsync(context, callback, !byReference);
+  }
+
+  if (isRequiredParserServices(parserServices)) {
+    reportUnawaitedAsyncHelperCalls(
+      context,
+      parserServices,
+      callback,
+      asyncSuiteOutcome?.kind === 'awaitedHelperReported' ? asyncSuiteOutcome.skipAwait : undefined,
+    );
+  }
+}
+
+function analyzeAsyncSuiteCallback(
+  context: Rule.RuleContext,
+  parserServices: Rule.RuleContext['sourceCode']['parserServices'],
+  callback: FunctionLike,
+): AsyncSuiteOutcome {
+  const topLevelAwait = findFirstTopLevelAwait(context, callback);
+  if (!topLevelAwait) {
+    return { kind: 'noTopLevelAwait' };
+  }
+
+  const awaitedHelperOutcome = tryReportAwaitedAsyncHelperCall(
+    context,
+    parserServices,
+    callback,
+    topLevelAwait,
+  );
+  if (awaitedHelperOutcome) {
+    return awaitedHelperOutcome;
+  }
+
+  reportAsyncSuiteCallback(context, callback, topLevelAwait);
+  return { kind: 'asyncSuiteReported' };
+}
+
+function tryReportAwaitedAsyncHelperCall(
+  context: Rule.RuleContext,
+  parserServices: Rule.RuleContext['sourceCode']['parserServices'],
+  callback: FunctionLike,
+  topLevelAwait: estree.Node,
+): AsyncSuiteOutcome | undefined {
+  if (!isRequiredParserServices(parserServices)) {
+    return undefined;
+  }
+
+  const awaitedCall = getAwaitedCall(topLevelAwait);
+  if (!awaitedCall) {
+    return undefined;
+  }
+
+  const reported = reportAsyncHelperCall(
+    context,
+    parserServices,
+    awaitedCall,
+    callback,
+    topLevelAwait,
+  );
+  if (!reported) {
+    return undefined;
+  }
+
+  return { kind: 'awaitedHelperReported', skipAwait: topLevelAwait };
+}
+
+function reportAsyncSuiteCallback(
+  context: Rule.RuleContext,
+  callback: FunctionLike,
+  topLevelAwait: estree.Node,
+): void {
+  const secondaryLocations = findTestsRegisteredAfter(
+    context.sourceCode,
+    callback,
+    topLevelAwait,
+    TEST_AND_SUITE_NAMES,
+  ).map(test => toSecondaryLocation(test, messages.droppedTest));
+
+  report(
+    context,
+    {
+      messageId: 'asyncSuiteCallback',
+      message: messages.asyncSuiteCallback,
+      node: topLevelAwait,
+    },
+    secondaryLocations,
+  );
+}
 
 /**
  * Returns the function callback of `node` when `node` is a supported suite form that runs its
@@ -91,7 +225,8 @@ export const rule: Rule.RuleModule = {
 function getRaisingSuiteCallback(
   context: Rule.RuleContext,
   node: estree.CallExpression,
-): estree.FunctionExpression | estree.ArrowFunctionExpression | undefined {
+  parserServices: Rule.RuleContext['sourceCode']['parserServices'],
+): RaisingSuiteCallback | undefined {
   const parts = getMochaCalleeParts(node.callee);
   if (parts === undefined || !SUITE_BASE_NAMES.has(parts.base.name)) {
     return undefined;
@@ -102,11 +237,31 @@ function getRaisingSuiteCallback(
   if (!isSupportedFrameworkConstruct(context, parts.base)) {
     return undefined;
   }
-  // The callback is the function literal among the arguments. A callback passed by reference
-  // (an identifier, a call, etc.) is not a literal and is intentionally not reported.
-  return node.arguments.find(isSuiteCallback);
+  const inlineCallback = node.arguments.find(isSuiteCallback);
+  if (inlineCallback) {
+    return { callback: inlineCallback, byReference: false };
+  }
+  if (!isRequiredParserServices(parserServices)) {
+    return undefined;
+  }
+  for (const argument of node.arguments) {
+    if (argument.type !== 'Identifier') {
+      continue;
+    }
+    const decl = followReferenceToDeclaration(argument, parserServices);
+    if (!decl) {
+      continue;
+    }
+    const esTreeDecl = parserServices.tsNodeToESTreeNodeMap.get(decl) as estree.Node | undefined;
+    if (!esTreeDecl || !isFunctionLike(esTreeDecl)) {
+      continue;
+    }
+    return { callback: esTreeDecl, byReference: true };
+  }
+  return undefined;
 }
 
+/** Type guard for inline function callbacks (the describe callback is always an expression). */
 function isSuiteCallback(
   node: estree.Node,
 ): node is estree.FunctionExpression | estree.ArrowFunctionExpression {
@@ -140,144 +295,163 @@ function isSupportedFrameworkConstruct(
   return true;
 }
 
-function reportAsyncCallback(
+function reportRemoveAsync(
   context: Rule.RuleContext,
-  callback: estree.FunctionExpression | estree.ArrowFunctionExpression,
+  callback: FunctionLike,
+  withQuickFix: boolean,
 ): void {
-  const topLevelAwait = findFirstTopLevelAwait(context, callback);
-  if (topLevelAwait === undefined) {
-    // No top-level await: every test still registers, but the `async` keyword is misleading and
-    // makes the callback return a promise the framework silently ignores. A quick fix removes it.
-    const asyncToken = context.sourceCode.getFirstToken(callback);
-    if (asyncToken?.value !== 'async') {
-      return;
-    }
-    const tokenAfterAsync = context.sourceCode.getTokenAfter(asyncToken);
-    // This rule declares `hasSecondaries`, so the linter decodes every issue message of S8785 as
-    // an encoded payload. Route this report through the `report` helper too (with no secondary
-    // locations) so its message is encoded consistently; a raw `context.report` would emit a plain
-    // string that the decoder fails to `JSON.parse`.
-    report(context, {
-      loc: asyncToken.loc,
-      messageId: 'removeAsync',
-      message: messages.removeAsync,
-      suggest: [
-        {
-          messageId: 'removeAsyncQuickFix',
-          fix: fixer =>
-            fixer.removeRange([
-              asyncToken.range[0],
-              tokenAfterAsync?.range[0] ?? asyncToken.range[1],
-            ]),
-        },
-      ],
-    });
+  const asyncToken = context.sourceCode.getFirstToken(callback);
+  if (asyncToken?.value !== 'async') {
     return;
   }
-
-  // A top-level await: the framework registers whatever was scheduled before it and moves on, so
-  // tests declared afterwards are silently dropped. No safe automated fix exists.
-  const secondaryLocations = findTestsRegisteredAfter(
-    context.sourceCode,
-    callback,
-    topLevelAwait,
-  ).map(test => toSecondaryLocation(test, messages.droppedTest));
-  report(
-    context,
-    {
-      messageId: 'asyncSuiteCallback',
-      message: messages.asyncSuiteCallback,
-      node: topLevelAwait,
-    },
-    secondaryLocations,
-  );
+  const tokenAfterAsync = context.sourceCode.getTokenAfter(asyncToken);
+  // This rule declares `hasSecondaries`, so the linter decodes every issue message of S8785 as
+  // an encoded payload. Route this report through the `report` helper too (with no secondary
+  // locations) so its message is encoded consistently; a raw `context.report` would emit a plain
+  // string that the decoder fails to `JSON.parse`.
+  report(context, {
+    loc: asyncToken.loc,
+    messageId: 'removeAsync',
+    message: messages.removeAsync,
+    ...(withQuickFix
+      ? {
+          suggest: [
+            {
+              messageId: 'removeAsyncQuickFix',
+              fix: fixer =>
+                fixer.removeRange([
+                  asyncToken.range[0],
+                  tokenAfterAsync?.range[0] ?? asyncToken.range[1],
+                ]),
+            },
+          ],
+        }
+      : {}),
+  });
 }
 
 /**
- * Finds the earliest `await` (or `for await...of`) that runs directly in the callback's body,
- * i.e. not nested inside another function. Returns `undefined` when there is none.
- */
-function findFirstTopLevelAwait(
-  context: Rule.RuleContext,
-  callback: estree.FunctionExpression | estree.ArrowFunctionExpression,
-): estree.Node | undefined {
-  const { sourceCode } = context;
-  const stack: estree.Node[] = [callback.body];
-  let earliest: estree.Node | undefined;
-  let earliestStart = Infinity;
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (current === undefined || isFunctionNode(current)) {
-      // A nested function has its own execution context; its awaits are not top-level here.
-      continue;
-    }
-    if (isTopLevelAwait(current)) {
-      const start = sourceCode.getRange(current)[0];
-      if (start < earliestStart) {
-        earliest = current;
-        earliestStart = start;
-      }
-    }
-    stack.push(...childrenOf(current, sourceCode.visitorKeys));
-  }
-  return earliest;
-}
-
-function isTopLevelAwait(node: estree.Node): boolean {
-  return (
-    node.type === 'AwaitExpression' ||
-    (node.type === 'ForOfStatement' && (node as estree.ForOfStatement & { await: boolean }).await)
-  );
-}
-
-/**
- * Collects the test/suite registrations declared in the callback body after the given await node.
- * Returns the callee of each such call, to be used as a secondary location.
+ * Walks the top-level statements of `callback`'s body (not crossing function boundaries) and
+ * reports `asyncHelperCall` for each `CallExpression` statement whose target is an async function
+ * with at least one test registered after a top-level `await` inside it.
  *
- * The walk descends into nested blocks (`if`, `try`, loops, ...) because a registration there is
- * dropped just like a top-level one: once the callback suspends on the await, everything that runs
- * afterwards does so too late to be registered. It stops at nested function boundaries — a test
- * inside a dropped nested suite's own callback belongs to that suite's registration, not to a
- * separate dropped registration, so only the nested suite's callee is collected.
+ * `skipAwait` is an optional `AwaitExpression` node already handled by the caller (the top-level
+ * await of the describe callback). Any statement whose expression IS that node is skipped.
+ *
+ * Returns `true` if at least one issue was reported.
  */
-function findTestsRegisteredAfter(
-  sourceCode: SourceCode,
-  callback: estree.FunctionExpression | estree.ArrowFunctionExpression,
-  awaitNode: estree.Node,
-): estree.Node[] {
+function reportUnawaitedAsyncHelperCalls(
+  context: Rule.RuleContext,
+  services: RequiredParserServices,
+  callback: FunctionLike,
+  skipAwait?: estree.Node,
+): boolean {
   if (callback.body.type !== 'BlockStatement') {
-    return [];
+    return false;
   }
-  // The offset at which the callback suspends. A `for await...of` suspends at the loop itself (the
-  // first `iterator.next()` call, even for a synchronous iterable), so its entire body is dropped
-  // too — use the loop's start. A plain `await` only drops what follows it — use the await's end.
-  const suspendOffset =
-    awaitNode.type === 'ForOfStatement'
-      ? sourceCode.getRange(awaitNode)[0]
-      : sourceCode.getRange(awaitNode)[1];
-  const tests: estree.Node[] = [];
+  const { sourceCode } = context;
+  let reported = false;
   const stack: estree.Node[] = [...childrenOf(callback.body, sourceCode.visitorKeys)];
   while (stack.length > 0) {
     const current = stack.pop();
-    if (current === undefined || isFunctionNode(current)) {
+    if (!current || isFunctionNode(current)) {
       continue;
     }
-    if (
-      current.type === 'ExpressionStatement' &&
-      current.expression.type === 'CallExpression' &&
-      sourceCode.getRange(current)[0] >= suspendOffset
-    ) {
-      const parts = getMochaCalleeParts(current.expression.callee);
-      if (parts && TEST_AND_SUITE_NAMES.has(parts.base.name)) {
-        tests.push(current.expression.callee);
-        // Don't descend into the registered call: its own callback is a function boundary and any
-        // tests it contains belong to its registration, not to a separate dropped one.
-        continue;
+    if (current.type === 'ExpressionStatement') {
+      const expr = current.expression;
+      // Unawaited call: ExpressionStatement → CallExpression
+      if (expr.type === 'CallExpression') {
+        reported = reportAsyncHelperCall(context, services, expr, callback) || reported;
+      }
+      // Awaited call: ExpressionStatement → AwaitExpression → CallExpression
+      // Skip if this is the top-level-await already handled by the outer detection branch.
+      if (
+        expr.type === 'AwaitExpression' &&
+        expr !== skipAwait &&
+        expr.argument.type === 'CallExpression'
+      ) {
+        reported =
+          reportAsyncHelperCall(context, services, expr.argument, callback, expr) || reported;
       }
     }
     stack.push(...childrenOf(current, sourceCode.visitorKeys));
   }
-  // The stack-based walk yields nodes out of source order; sort so secondary locations are emitted
-  // deterministically (asserted in unit tests, dumped in ruling).
-  return tests.sort((a, b) => sourceCode.getRange(a)[0] - sourceCode.getRange(b)[0]);
+  return reported;
+}
+
+/**
+ * Checks whether `callNode` targets an async function that drops tests after its first top-level
+ * `await`. If so, reports `asyncHelperCall` on `callNode` with the dropped tests as secondaries.
+ *
+ * When `awaitNode` is provided, the call is awaited at `awaitNode` inside the describe callback,
+ * so tests dropped in the describe body after `awaitNode` are also collected as secondaries.
+ *
+ * Returns `true` if an issue was reported.
+ */
+function reportAsyncHelperCall(
+  context: Rule.RuleContext,
+  services: RequiredParserServices,
+  callNode: estree.CallExpression,
+  describeCallback: FunctionLike,
+  awaitNode?: estree.Node,
+): boolean {
+  const decl = followCallToDeclaration(callNode, services);
+  if (!decl) {
+    return false;
+  }
+
+  // Only flag async functions.
+  if (!(ts.getCombinedModifierFlags(decl) & ts.ModifierFlags.Async)) {
+    return false;
+  }
+
+  // Get the ESTree equivalent — skip cross-file declarations (no ESTree nodes available for
+  // secondary locations, and we cannot confirm dropped tests without the body).
+  const esTreeDecl = services.tsNodeToESTreeNodeMap.get(decl) as estree.Node | undefined;
+  if (!esTreeDecl || !isFunctionLike(esTreeDecl)) {
+    return false;
+  }
+
+  // Find the first top-level await inside the helper.
+  const helperAwait = findFirstTopLevelAwait(context, esTreeDecl);
+  if (!helperAwait) {
+    return false;
+  }
+
+  // Require at least one test dropped after the await inside the helper.
+  const droppedInHelper = findTestsRegisteredAfter(
+    context.sourceCode,
+    esTreeDecl,
+    helperAwait,
+    TEST_AND_SUITE_NAMES,
+  );
+  if (droppedInHelper.length === 0) {
+    return false;
+  }
+
+  // If the call is awaited inside the describe callback, also collect tests dropped in the
+  // describe body after the await expression.
+  const droppedInDescribe = awaitNode
+    ? findTestsRegisteredAfter(
+        context.sourceCode,
+        describeCallback,
+        awaitNode,
+        TEST_AND_SUITE_NAMES,
+      )
+    : [];
+
+  const secondaryLocations = [...droppedInHelper, ...droppedInDescribe].map(test =>
+    toSecondaryLocation(test, messages.droppedTest),
+  );
+
+  report(
+    context,
+    {
+      messageId: 'asyncHelperCall',
+      message: messages.asyncHelperCall,
+      node: callNode,
+    },
+    secondaryLocations,
+  );
+  return true;
 }

--- a/packages/analysis/src/jsts/rules/S8785/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8785/rule.ts
@@ -454,7 +454,9 @@ function shouldSkipHelperResolution(
 ): boolean {
   const calleeParts = getMochaCalleeParts(call.callee);
   const isKnownFrameworkRegistration =
-    calleeParts !== undefined && TEST_FRAMEWORK_STRUCTURE_FUNCTIONS.has(calleeParts.base.name);
+    calleeParts !== undefined &&
+    TEST_FRAMEWORK_STRUCTURE_FUNCTIONS.has(calleeParts.base.name) &&
+    isSupportedFrameworkConstruct(context, calleeParts.base);
   return isKnownFrameworkRegistration || isAssertion(context, call);
 }
 

--- a/packages/analysis/src/jsts/rules/S8785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8785/unit.test.ts
@@ -14,7 +14,10 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { DefaultParserRuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  RuleTester,
+} from '../../../../tests/jsts/tools/testers/rule-tester.js';
 import { rule } from './rule.js';
 import { describe, it } from 'node:test';
 import path from 'node:path';
@@ -29,7 +32,8 @@ describe('S8785', () => {
     const mochaGlobals = fixture('mocha-globals');
     const cypressGlobals = fixture('cypress-globals');
 
-    ruleTester.run('Test suite callbacks should be synchronous functions', rule, {
+    const RULE_NAME = 'Test suite callbacks should be synchronous functions';
+    ruleTester.run(RULE_NAME, rule, {
       valid: [
         {
           // synchronous arrow / function callbacks
@@ -285,7 +289,7 @@ context('group', async () => { await b(); });
               data: {
                 sonarRuntimeData: JSON.stringify({
                   message:
-                    'Make this test suite callback synchronous; any test declared after this await is silently dropped.',
+                    'Move this async setup into a lifecycle hook or a test callback; any test declared after this "await" is silently dropped.',
                   secondaryLocations: [
                     {
                       message: 'This test is declared after the await and is never registered.',
@@ -321,7 +325,7 @@ context('group', async () => { await b(); });
               data: {
                 sonarRuntimeData: JSON.stringify({
                   message:
-                    'Make this test suite callback synchronous; any test declared after this await is silently dropped.',
+                    'Move this async setup into a lifecycle hook or a test callback; any test declared after this "await" is silently dropped.',
                   secondaryLocations: [
                     {
                       message: 'This test is declared after the await and is never registered.',
@@ -361,7 +365,7 @@ context('group', async () => { await b(); });
               data: {
                 sonarRuntimeData: JSON.stringify({
                   message:
-                    'Make this test suite callback synchronous; any test declared after this await is silently dropped.',
+                    'Move this async setup into a lifecycle hook or a test callback; any test declared after this "await" is silently dropped.',
                   secondaryLocations: [
                     {
                       message: 'This test is declared after the await and is never registered.',
@@ -411,6 +415,260 @@ context('group', async () => { await b(); });
 });`,
                 },
               ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const typedRuleTester = new RuleTester();
+    typedRuleTester.run(RULE_NAME, rule, {
+      valid: [
+        {
+          // sync helper is never async — no issue
+          code: `import { describe } from 'mocha';
+function setup() { return 42; }
+describe('suite', () => { setup(); });`,
+        },
+        {
+          // async helper has no tests after its await — nothing dropped
+          code: `import { describe } from 'mocha';
+async function setup() { await Promise.resolve(); }
+describe('suite', () => { setup(); });`,
+        },
+        {
+          // async helper has tests but BEFORE its await — nothing dropped
+          code: `import { describe } from 'mocha';
+async function setup() {
+  it('before', () => {});
+  await Promise.resolve();
+}
+describe('suite', () => { setup(); });`,
+        },
+        {
+          // only one hop is followed for referenced suite callbacks
+          code: `import { describe } from 'mocha';
+async function setup() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+const register = setup;
+describe('suite', register);`,
+        },
+        {
+          // cross-file helper via declare: no ESTree body available — skip
+          code: `import { describe } from 'mocha';
+declare function asyncHelper(): Promise<void>;
+describe('suite', () => { asyncHelper(); });`,
+        },
+      ],
+      invalid: [
+        {
+          // async callback passed by reference to a named function: report on the declaration,
+          // but do not auto-fix because the function may be reused elsewhere
+          code: `import { describe } from 'mocha';
+async function register() {
+  it('registered', () => {});
+}
+describe('suite', register);`,
+          errors: [{ messageId: 'removeAsync' }],
+        },
+        {
+          // async callback passed by reference through a variable initializer is also resolved
+          code: `import { describe } from 'mocha';
+const register = async () => {
+  await Promise.resolve();
+  it('dropped', () => {});
+};
+describe('suite', register);`,
+          errors: [{ messageId: 'asyncSuiteCallback' }],
+        },
+        {
+          // one-hop resolution also catches named async function declarations with dropped tests
+          code: `import { describe } from 'mocha';
+async function register() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', register);`,
+          errors: [{ messageId: 'asyncSuiteCallback' }],
+        },
+        {
+          // the callback can still be found when the suite title is itself passed by reference
+          code: `import { describe } from 'mocha';
+const title = 'suite';
+async function register() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe(title, register);`,
+          errors: [{ messageId: 'asyncSuiteCallback' }],
+        },
+        {
+          // Sync describe + unawaited async helper with dropped tests
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', () => {
+  testing();
+});`,
+          errors: [{ messageId: 'asyncHelperCall' }],
+        },
+        {
+          // top-level await inside a variable initializer still drops later tests in the helper
+          code: `import { describe } from 'mocha';
+async function testing() {
+  const value = await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', () => {
+  testing();
+});`,
+          errors: [{ messageId: 'asyncHelperCall' }],
+        },
+        {
+          // Async describe (no top-level await) + unawaited async helper
+          // removeAsync (with QF) + asyncHelperCall both fire
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', async () => {
+  testing();
+});`,
+          errors: [
+            {
+              messageId: 'removeAsync',
+              suggestions: [
+                {
+                  messageId: 'removeAsyncQuickFix',
+                  output: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', () => {
+  testing();
+});`,
+                },
+              ],
+            },
+            { messageId: 'asyncHelperCall' },
+          ],
+        },
+        {
+          // Async describe + top-level await that IS the async helper
+          // asyncHelperCall fires, asyncSuiteCallback suppressed
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped in helper', () => {});
+}
+describe('suite', async () => {
+  await testing();
+});`,
+          errors: [{ messageId: 'asyncHelperCall' }],
+        },
+        {
+          // Tests dropped in both the helper body and the describe body
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped in helper', () => {});
+}
+describe('suite', async () => {
+  await testing();
+  it('dropped in describe', () => {});
+});`,
+          errors: [{ messageId: 'asyncHelperCall' }],
+        },
+        {
+          // Async describe + non-helper top-level await + unawaited async helper
+          // asyncSuiteCallback + asyncHelperCall both fire independently
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped in helper', () => {});
+}
+describe('suite', async () => {
+  await Promise.resolve();
+  it('dropped in describe', () => {});
+  testing();
+});`,
+          errors: [{ messageId: 'asyncSuiteCallback' }, { messageId: 'asyncHelperCall' }],
+        },
+        {
+          // sonarRuntime — asyncHelperCall secondary locations: tests inside the helper
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', () => {
+  testing();
+});`,
+          settings: { sonarRuntime: true },
+          errors: [
+            {
+              messageId: 'sonarRuntime',
+              data: {
+                sonarRuntimeData: JSON.stringify({
+                  message:
+                    'This async helper silently drops tests; remove its "async" keyword and move async setup into a lifecycle hook or a test callback.',
+                  secondaryLocations: [
+                    {
+                      message: 'This test is declared after the await and is never registered.',
+                      column: 2,
+                      line: 4,
+                      endColumn: 4,
+                      endLine: 4,
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        },
+        {
+          // sonarRuntime — awaited async helper: secondaries from helper body + describe body
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped in helper', () => {});
+}
+describe('suite', async () => {
+  await testing();
+  it('dropped in describe', () => {});
+});`,
+          settings: { sonarRuntime: true },
+          errors: [
+            {
+              messageId: 'sonarRuntime',
+              data: {
+                sonarRuntimeData: JSON.stringify({
+                  message:
+                    'This async helper silently drops tests; remove its "async" keyword and move async setup into a lifecycle hook or a test callback.',
+                  secondaryLocations: [
+                    {
+                      message: 'This test is declared after the await and is never registered.',
+                      column: 2,
+                      line: 4,
+                      endColumn: 4,
+                      endLine: 4,
+                    },
+                    {
+                      message: 'This test is declared after the await and is never registered.',
+                      column: 2,
+                      line: 8,
+                      endColumn: 4,
+                      endLine: 8,
+                    },
+                  ],
+                }),
+              },
             },
           ],
         },

--- a/packages/analysis/src/jsts/rules/S8785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8785/unit.test.ts
@@ -523,6 +523,20 @@ describe('suite', () => {
           errors: [{ messageId: 'asyncHelperCall' }],
         },
         {
+          // User-defined async helper named after a framework hook (e.g. 'before') must be
+          // reported — the bare-name match against TEST_FRAMEWORK_STRUCTURE_FUNCTIONS must not
+          // exempt it without verifying import provenance.
+          code: `import { describe } from 'mocha';
+async function before() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', () => {
+  before();
+});`,
+          errors: [{ messageId: 'asyncHelperCall' }],
+        },
+        {
           // top-level await inside a variable initializer still drops later tests in the helper
           code: `import { describe } from 'mocha';
 async function testing() {

--- a/packages/analysis/src/jsts/rules/S8785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8785/unit.test.ts
@@ -698,6 +698,78 @@ describe('suite', async () => {
             },
           ],
         },
+        {
+          // sonarRuntime — two sequential awaited helpers: each reports only its own dropped tests,
+          // with no overlap between their secondary locations.
+          code: `import { describe } from 'mocha';
+async function helperA() {
+  await Promise.resolve();
+  it('dropped in helperA', () => {});
+}
+async function helperB() {
+  await Promise.resolve();
+  it('dropped in helperB', () => {});
+}
+describe('suite', async () => {
+  await helperA();
+  it('dropped after helperA', () => {});
+  await helperB();
+  it('dropped after helperB', () => {});
+});`,
+          settings: { sonarRuntime: true },
+          errors: [
+            {
+              messageId: 'sonarRuntime',
+              data: {
+                sonarRuntimeData: JSON.stringify({
+                  message:
+                    'This async helper silently drops tests; remove its "async" keyword and move async setup into a lifecycle hook or a test callback.',
+                  secondaryLocations: [
+                    {
+                      message: 'This test is declared after the await and is never registered.',
+                      column: 2,
+                      line: 4,
+                      endColumn: 4,
+                      endLine: 4,
+                    },
+                    {
+                      message: 'This test is declared after the await and is never registered.',
+                      column: 2,
+                      line: 12,
+                      endColumn: 4,
+                      endLine: 12,
+                    },
+                  ],
+                }),
+              },
+            },
+            {
+              messageId: 'sonarRuntime',
+              data: {
+                sonarRuntimeData: JSON.stringify({
+                  message:
+                    'This async helper silently drops tests; remove its "async" keyword and move async setup into a lifecycle hook or a test callback.',
+                  secondaryLocations: [
+                    {
+                      message: 'This test is declared after the await and is never registered.',
+                      column: 2,
+                      line: 8,
+                      endColumn: 4,
+                      endLine: 8,
+                    },
+                    {
+                      message: 'This test is declared after the await and is never registered.',
+                      column: 2,
+                      line: 14,
+                      endColumn: 4,
+                      endLine: 14,
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        },
       ],
     });
   });

--- a/packages/analysis/src/jsts/rules/S8785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8785/unit.test.ts
@@ -456,6 +456,12 @@ const register = setup;
 describe('suite', register);`,
         },
         {
+          // concise-body arrow with sync helper — no issue
+          code: `import { describe } from 'mocha';
+function syncHelper() { return 42; }
+describe('suite', () => syncHelper());`,
+        },
+        {
           // cross-file helper via declare: no ESTree body available — skip
           code: `import { describe } from 'mocha';
 declare function asyncHelper(): Promise<void>;
@@ -631,6 +637,26 @@ describe('suite', () => {
               },
             },
           ],
+        },
+        {
+          // concise-body arrow: () => helper() — unawaited async helper
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', () => testing());`,
+          errors: [{ messageId: 'asyncHelperCall' }],
+        },
+        {
+          // concise-body arrow: async () => await helper() — awaited async helper
+          code: `import { describe } from 'mocha';
+async function testing() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+describe('suite', async () => await testing());`,
+          errors: [{ messageId: 'asyncHelperCall' }],
         },
         {
           // sonarRuntime — awaited async helper: secondaries from helper body + describe body

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6582.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S6582.json
@@ -2,7 +2,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "MEDIUM"
+      "MAINTAINABILITY": "LOW"
     },
     "attribute": "CLEAR"
   },
@@ -15,7 +15,7 @@
     "type-dependent",
     "editable-source"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-6582",
   "sqKey": "S6582",
   "scope": "Main",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S8785.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S8785.json
@@ -1,5 +1,5 @@
 {
-  "title": "Test suite callbacks should be synchronous functions",
+  "title": "Tests should not be registered asynchronously in suite callbacks",
   "type": "BUG",
   "status": "ready",
   "remediation": {
@@ -20,7 +20,7 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "covered",
+  "quickfix": "partial",
   "code": {
     "impacts": {
       "RELIABILITY": "MEDIUM",

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S8785.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S8785.json
@@ -20,7 +20,7 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "partial",
+  "quickfix": "covered",
   "code": {
     "impacts": {
       "RELIABILITY": "MEDIUM",


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule S8785 enhancements:**
  - Extended detection to `async` helper functions that silently drop tests when called within test suites.
  - Added TypeScript-based resolution for callbacks passed by reference to identify async declarations.
- **Refactored analysis logic:**
  - Extracted analysis logic into `async-analysis.ts` and `call-to-declaration.ts` for improved maintainability.
  - Updated `rule.ts` to orchestrate detection of both top-level `await` and unawaited `async` helper calls.
- **Rule metadata updates:**
  - Renamed rule title to "Tests should not be registered asynchronously in suite callbacks" and updated quick-fix status.
  - Adjusted `S5914` and `S6582` rule metadata (titles, severity, and quick-fix indicators).

<sub>This will update automatically on new commits.</sub>