### PR TITLE
JS-2004 Document agent handling for baseline CI mismatches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,14 +55,10 @@ See `/build` for the full build pipeline reference.
 
 - The guidance in this section applies to any automated coding agent working in this repository, not
   only Claude Code.
-- If CI fails with `Mismatch between RSPEC metadata and implementation for fixable attribute in rule
-  ...`, first verify whether the failing rule is unrelated to the pull request diff.
-- If the failure is unrelated, rebase once on the latest `origin/master` to confirm the mismatch is
-  not already fixed upstream.
-- If the same failure persists after that rebase and still points to files outside the pull request
-  scope, stop and report it as a baseline/environment blocker instead of patching unrelated rules in
-  the pull request.
-- See [`docs/BUILD.md`](docs/BUILD.md) for the detailed RSPEC and build guidance behind this rule.
+- For RSPEC-related baseline CI failures, follow
+  [`docs/BUILD.md#baseline-ci-mismatches`](docs/BUILD.md#baseline-ci-mismatches).
+- Do not patch unrelated rules or commit unrelated refreshed RSPEC metadata just to make a pull
+  request green.
 
 ## Important Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,19 @@ See `/build` for the full build pipeline reference.
 
 - Always add `SonarSource/quality-web-squad` as a reviewer when creating PRs
 
+## Repo-wide agent guidance
+
+- The guidance in this section applies to any automated coding agent working in this repository, not
+  only Claude Code.
+- If CI fails with `Mismatch between RSPEC metadata and implementation for fixable attribute in rule
+  ...`, first verify whether the failing rule is unrelated to the pull request diff.
+- If the failure is unrelated, rebase once on the latest `origin/master` to confirm the mismatch is
+  not already fixed upstream.
+- If the same failure persists after that rebase and still points to files outside the pull request
+  scope, stop and report it as a baseline/environment blocker instead of patching unrelated rules in
+  the pull request.
+- See [`docs/BUILD.md`](docs/BUILD.md) for the detailed RSPEC and build guidance behind this rule.
+
 ## Important Notes
 
 - `generated-meta.ts` files are auto-generated from RSPEC — do not edit manually

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -114,27 +114,68 @@ npm run validate-quickfix
 
 ## Baseline CI mismatches
 
-One recurring repository-wide failure mode is:
+Local builds and CI do not consume RSPEC data the same way:
+
+- Normal local workflows such as `npm run bbf`, `npm run generate-meta`, and `mvn install` reuse
+  the tracked JavaScript rule JSON already present in the checkout unless you explicitly run
+  `npm run rspec:refresh`.
+- In GitHub Actions, `prepare_rspec_rule_data` refreshes RSPEC first and uploads an
+  `rspec-rule-data-${github.sha}` artifact. Downstream jobs use that refreshed artifact instead of
+  the tracked JSON from the branch.
+- The nightly `generated_files_freshness` workflow keeps the tracked JSON on `master` reasonably
+  fresh, but pull request CI does not wait for those tracked files to be updated.
+
+Because of that, pull request CI can fail even when the tracked JSON in the branch still looks
+consistent.
+
+In other words, CI is validating against freshly refreshed RSPEC data, not only against the metadata
+tracked in Git.
+
+One recurring failure class is temporary drift between freshly refreshed RSPEC metadata and the
+SonarJS implementation. This can happen in either direction when RSPEC and SonarJS changes merge in
+different orders, so `master` can temporarily go red until the lagging side catches up.
+
+One common symptom is:
 
 ```text
 Mismatch between RSPEC metadata and implementation for fixable attribute in rule ...
 ```
 
-This means the tracked RSPEC-derived rule metadata and the SonarJS rule implementation are
-temporarily out of sync for some rule.
+That error is thrown later in the build when a rule module calls `generateMeta(...)`. Another common
+surface is `npm run validate-quickfix`, which can fail with messages such as:
 
-When this appears in CI:
+- `RSPEC declares quickfix='covered' but rule has neither fixable nor hasSuggestions`
+- `Rule has fixable or hasSuggestions but RSPEC doesn't declare quickfix='covered'`
+- `Rule is fixable but meta.ts doesn't export quickFixMessage`
 
-- Check whether the failing rule is part of the pull request diff.
-- If the failing rule is unrelated to the pull request, treat it as a baseline/environment blocker
-  rather than as work to absorb into that pull request.
-- Rebase once on the latest `origin/master` to confirm the mismatch is not already fixed upstream.
-- If the same mismatch persists after rebasing and it still points outside the pull request scope,
-  stop and report the blocker instead of patching unrelated rules or committing unrelated refreshed
-  RSPEC metadata in the pull request.
+When one of these failures appears in CI:
 
-This guidance is especially important for automated agents, because RSPEC refreshes can update
-tracked metadata for rules that have nothing to do with the requested change.
+1. Identify the failing rule and check whether your pull request actually changes that rule.
+2. Rebase once on the latest `origin/master` to confirm the mismatch is not already fixed upstream.
+3. If the same failure persists after rebasing and the rule is still unrelated to your change,
+   treat it as a baseline blocker rather than as work to absorb into your pull request.
+4. Determine which side is behind:
+   - If RSPEC now says `quickfix='covered'` but the SonarJS rule has neither `fixable` nor
+     `hasSuggestions`, the SonarJS implementation usually still needs to catch up.
+   - If the SonarJS rule already has `fixable` or `hasSuggestions` but RSPEC does not declare
+     `quickfix='covered'`, the RSPEC metadata usually still needs to catch up.
+   - If the rule is fixable but `quickFixMessage` is missing, SonarJS metadata still needs to catch
+     up.
+5. Fix the lagging repository, or wait for the already-merged fix to reach the branch you are
+   building.
+6. Do not patch unrelated rules or commit unrelated refreshed RSPEC metadata just to make the pull
+   request green.
+
+Concrete examples:
+
+- `S5914` started failing in CI after refreshed RSPEC metadata declared `quickfix='covered'` before
+  the matching SonarJS implementation change had merged. That was fixed on the SonarJS side in
+  [#7435](https://github.com/SonarSource/SonarJS/pull/7435).
+- `S7743` and `S7761` failed in `validate-quickfix` during an unrelated SonarJS update because the
+  RSPEC quickfix metadata was lagging. That was fixed on the RSPEC side in
+  [SonarSource/rspec#7088](https://github.com/SonarSource/rspec/pull/7088).
+
+This guidance applies to humans and automated agents alike.
 
 ## Reactor order
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -166,6 +166,18 @@ When one of these failures appears in CI:
 6. Do not patch unrelated rules or commit unrelated refreshed RSPEC metadata just to make the pull
    request green.
 
+When the mismatch is intentional because your SonarJS pull request depends on an RSPEC change that
+is not yet merged on the default RSPEC branch, make that dependency explicit:
+
+- create or update the matching RSPEC pull request
+- point the root `rspec.sha` file in the SonarJS branch to a commit from that RSPEC branch
+- let CI refresh against that exact RSPEC revision while the two pull requests move together
+
+This is the normal workflow both when adding quickfix support and needing RSPEC to start declaring
+`quickfix='covered'`, and when removing quickfix support and needing RSPEC to stop declaring it.
+Remove the temporary root `rspec.sha` before merging to `master` once the RSPEC change has landed on
+the intended default branch.
+
 Concrete examples:
 
 - `S5914` started failing in CI after refreshed RSPEC metadata declared `quickfix='covered'` before

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -112,6 +112,30 @@ Validate quickfix declarations:
 npm run validate-quickfix
 ```
 
+## Baseline CI mismatches
+
+One recurring repository-wide failure mode is:
+
+```text
+Mismatch between RSPEC metadata and implementation for fixable attribute in rule ...
+```
+
+This means the tracked RSPEC-derived rule metadata and the SonarJS rule implementation are
+temporarily out of sync for some rule.
+
+When this appears in CI:
+
+- Check whether the failing rule is part of the pull request diff.
+- If the failing rule is unrelated to the pull request, treat it as a baseline/environment blocker
+  rather than as work to absorb into that pull request.
+- Rebase once on the latest `origin/master` to confirm the mismatch is not already fixed upstream.
+- If the same mismatch persists after rebasing and it still points outside the pull request scope,
+  stop and report the blocker instead of patching unrelated rules or committing unrelated refreshed
+  RSPEC metadata in the pull request.
+
+This guidance is especially important for automated agents, because RSPEC refreshes can update
+tracked metadata for rules that have nothing to do with the requested change.
+
 ## Reactor order
 
 The `sonar-plugin` reactor builds modules in this order:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -108,6 +108,11 @@ On a fresh checkout, or whenever you want the latest RSPEC rule data instead of 
 already present in the repository, run `npm run rspec:refresh` before the Maven build commands
 below.
 
+If CI starts failing after an RSPEC refresh even though your branch still looks consistent locally,
+see [BUILD.md](BUILD.md#baseline-ci-mismatches). Pull request CI validates against freshly refreshed
+RSPEC rule data, so temporary merge-order drift between RSPEC and SonarJS can make `master`
+temporarily red until the lagging side catches up.
+
 To build the plugin and run its unit tests, execute this command from the project's root directory:
 
 ```sh

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -64,6 +64,18 @@ To pin rule data generation to an exact RSPEC revision for branch-local work, wr
 to `rspec.sha` at the repository root and run `npm run rspec:refresh`. The root `rspec.sha` file is
 a temporary local workflow input and must never be committed to `master`.
 
+This is also the standard way to keep a SonarJS pull request aligned with an RSPEC pull request
+that is not yet merged on the default RSPEC branch. For example:
+
+- you add a quickfix in SonarJS and need RSPEC to declare `quickfix='covered'`
+- you remove quickfix capability in SonarJS and need RSPEC to stop declaring it
+
+In that situation, point the root `rspec.sha` file to the commit on the RSPEC branch that contains
+the intended metadata and keep that file in the SonarJS pull request while the dependency is still
+unmerged. CI will then refresh against that exact RSPEC revision instead of the default branch.
+Remove the temporary root `rspec.sha` before merging to `master` once the RSPEC change has landed on
+the intended default branch.
+
 When no SHA pin is active, the refresh uses the configured default RSPEC branch. In the current
 SonarJS wiring that default is `dogfood-automerge`.
 


### PR DESCRIPTION
## Summary

- document how automated agents should handle unrelated RSPEC metadata/implementation CI mismatches
- add a repo-visible short policy in CLAUDE.md and detailed build guidance in docs/BUILD.md

## Validation

- git diff --check
