### PR TITLE
JS-2005 Fix S6594: prefer RegExp.exec() over String.match() in patch.ts

### DIFF
--- a/packages/analysis/src/jsts/embedded/builder/patch.ts
+++ b/packages/analysis/src/jsts/embedded/builder/patch.ts
@@ -158,7 +158,7 @@ export function patchParsingErrorMessage(
 ): string {
   /* Extracts location information of the form `(<line>:<column>)` */
   const regex = /((?<line>\d+):(?<column>\d+))/;
-  const found = message.match(regex);
+  const found = regex.exec(message);
   if (found?.groups) {
     const line = found.groups.line;
     const column = Number(found.groups.column);


### PR DESCRIPTION
## What

Addresses SonarQube issue `typescript:S6594` — *"RegExp.exec()" should be preferred over "String.match()"* — at `packages/analysis/src/jsts/embedded/builder/patch.ts:161`.

```diff
  const regex = /((?<line>\d+):(?<column>\d+))/;
- const found = message.match(regex);
+ const found = regex.exec(message);
```

## Why it's behavior-preserving

- The regex has **no global `g` flag**, so `String.match()` and `RegExp.exec()` return the identical first-match array, including the named `groups` (`line`, `column`) the code relies on.
- The regex is a fresh literal created on each call, so there is no `lastIndex` statefulness concern from reuse.

Only the maintainability rule is satisfied; runtime behavior is unchanged.

## Testing

`packages/analysis/tests/yaml/builder/patch.test.ts` passes (6/6), including *"should patch parsing error messages"* which directly exercises `patchParsingErrorMessage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
