### PR TITLE
JS-2006 Fix S8786: remove superlinear regex backtracking in patchParsingErrorMessage

### DIFF
--- a/packages/analysis/src/jsts/embedded/builder/patch.ts
+++ b/packages/analysis/src/jsts/embedded/builder/patch.ts
@@ -157,7 +157,7 @@ export function patchParsingErrorMessage(
   embeddedJS: EmbeddedJS,
 ): string {
   /* Extracts location information of the form `(<line>:<column>)` */
-  const regex = /((?<line>\d+):(?<column>\d+))/;
+  const regex = /\((?<line>\d+):(?<column>\d+)\)/;
   const found = regex.exec(message);
   if (found?.groups) {
     const line = found.groups.line;


### PR DESCRIPTION
## What

Fixes SonarQube issue `typescript:S8786` (MAJOR) — *"Regular expressions should not cause non-linear backtracking"* — at `packages/analysis/src/jsts/embedded/builder/patch.ts:160`.

```diff
- const regex = /((?<line>\d+):(?<column>\d+))/;
+ const regex = /\((?<line>\d+):(?<column>\d+)\)/;
```

## Why it's a problem

The original pattern `/((?<line>\d+):(?<column>\d+))/` has an outer redundant capturing group and no anchor. Without an anchor, the regex engine retries `\d+` at every position in the string — when the pattern doesn't match, this yields polynomial (O(n²)) backtracking on large inputs.

## Why the fix is safe

- The input messages have the form `Unexpected token ','. (7:22)`, so the location is always wrapped in literal parentheses. Matching on `\(` and `\)` directly is more precise and semantically equivalent.
- The named capture groups `line` and `column` are unchanged — `found.groups.line` / `found.groups.column` still work identically.
- `found[0]` is never used by the code (only `found.groups`), so the change to the full match value is irrelevant.
- The `message.replace(`(${line}:${column})`, ...)` on the next line already uses literal parens, so it is unaffected.

## Testing

`packages/analysis/tests/yaml/builder/patch.test.ts` passes (6/6), including *"should patch parsing error messages"* which directly exercises `patchParsingErrorMessage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
