### PR TITLE
JS-2008 Automate SQAA release handoff

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -18,6 +18,10 @@ on:
         description: "Integrate into SQS"
         type: boolean
         default: true
+      sqaa-integration:
+        description: "Integrate into SQAA"
+        type: boolean
+        default: true
       branch:
         description: "Branch from which to do the release"
         required: true
@@ -53,8 +57,8 @@ jobs:
       new-version: ${{ github.event.inputs.new-version }}
       sqc-integration: ${{ github.event.inputs.sqc-integration == 'true' }}
       sqs-integration: ${{ github.event.inputs.sqs-integration == 'true' }}
-      # SonarJS SQAA releases are handled manually from the dedicated SQAA workflow
-      # and then handed off through sonar-analysis-as-a-service.
+      # SonarJS uses a custom SQAA workflow that builds the Docker image from the
+      # release tag and updates analysis/js_ts_image_tag in sonar-analysis-as-a-service.
       sqaa-integration: false
       create-slvs-ticket: true
       create-slvscode-ticket: true
@@ -69,9 +73,28 @@ jobs:
       use-jira-sandbox: false
       is-draft-release: false
 
+  sqaa_release:
+    name: Release SQAA
+    needs: release
+    if: ${{ needs.release.result == 'success' && github.event.inputs.sqc-integration == 'true' && github.event.inputs.sqaa-integration == 'true' }}
+    uses: ./.github/workflows/sqaa-release.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      ref: refs/tags/${{ needs.release.outputs.release-version }}
+      release-version: ${{ needs.release.outputs.release-version }}
+      ticket-url: ${{ needs.release.outputs.sqc-ticket-url }}
+      create-aaas-pr: true
+      reviewers: ${{ github.actor }}
+      release-automation-secret-name: "SonarJS-release-automation"
+
   bump_versions:
     name: Bump versions
-    needs: release
+    needs:
+      - release
+      - sqaa_release
+    if: ${{ needs.release.result == 'success' && (needs.sqaa_release.result == 'success' || needs.sqaa_release.result == 'skipped') }}
     uses: ./.github/workflows/bump-versions.yml
     permissions:
       contents: write

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -84,6 +84,7 @@ jobs:
     with:
       ref: refs/tags/${{ needs.release.outputs.release-version }}
       release-version: ${{ needs.release.outputs.release-version }}
+      publish-to-release-repo: true
       ticket-url: ${{ needs.release.outputs.sqc-ticket-url }}
       create-aaas-pr: true
       reviewers: ${{ github.actor }}

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -76,7 +76,7 @@ jobs:
   derive_sqaa_build_number:
     name: Derive SQAA build number
     needs: release
-    if: ${{ needs.release.result == 'success' && github.event.inputs.sqc-integration == 'true' && github.event.inputs.sqaa-integration == 'true' }}
+    if: ${{ needs.release.result == 'success' && github.event.inputs.sqaa-integration == 'true' }}
     runs-on: github-ubuntu-latest-s
     outputs:
       build-number: ${{ steps.derive.outputs.build-number }}
@@ -98,7 +98,7 @@ jobs:
     needs:
       - release
       - derive_sqaa_build_number
-    if: ${{ needs.release.result == 'success' && needs.derive_sqaa_build_number.result == 'success' && github.event.inputs.sqc-integration == 'true' && github.event.inputs.sqaa-integration == 'true' }}
+    if: ${{ needs.release.result == 'success' && needs.derive_sqaa_build_number.result == 'success' && github.event.inputs.sqaa-integration == 'true' }}
     uses: ./.github/workflows/sqaa-release.yml
     permissions:
       id-token: write
@@ -108,7 +108,7 @@ jobs:
       release-version: ${{ needs.release.outputs.release-version }}
       build-number: ${{ needs.derive_sqaa_build_number.outputs.build-number }}
       publish-to-release-repo: true
-      ticket-url: ${{ needs.release.outputs.sqc-ticket-url }}
+      ticket-url: ${{ needs.release.outputs.sqc-ticket-url || needs.release.outputs.release-ticket-url }}
       create-aaas-pr: true
       reviewers: ${{ github.actor }}
       release-automation-secret-name: "SonarJS-release-automation"
@@ -118,7 +118,7 @@ jobs:
     needs:
       - release
       - sqaa_release
-    if: ${{ needs.release.result == 'success' && (needs.sqaa_release.result == 'success' || needs.sqaa_release.result == 'skipped') }}
+    if: ${{ needs.release.result == 'success' && (github.event.inputs.sqaa-integration != 'true' || needs.sqaa_release.result == 'success') }}
     uses: ./.github/workflows/bump-versions.yml
     permissions:
       contents: write

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -73,10 +73,32 @@ jobs:
       use-jira-sandbox: false
       is-draft-release: false
 
-  sqaa_release:
-    name: Release SQAA
+  derive_sqaa_build_number:
+    name: Derive SQAA build number
     needs: release
     if: ${{ needs.release.result == 'success' && github.event.inputs.sqc-integration == 'true' && github.event.inputs.sqaa-integration == 'true' }}
+    runs-on: github-ubuntu-latest-s
+    outputs:
+      build-number: ${{ steps.derive.outputs.build-number }}
+    steps:
+      - name: Derive build number from released version
+        id: derive
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.release-version }}
+        run: |
+          if [[ -z "$RELEASE_VERSION" ]]; then
+            echo "::error::Missing release-version output from the automated release workflow."
+            exit 1
+          fi
+          echo "build-number=${RELEASE_VERSION##*.}" >> "$GITHUB_OUTPUT"
+
+  sqaa_release:
+    name: Release SQAA
+    needs:
+      - release
+      - derive_sqaa_build_number
+    if: ${{ needs.release.result == 'success' && needs.derive_sqaa_build_number.result == 'success' && github.event.inputs.sqc-integration == 'true' && github.event.inputs.sqaa-integration == 'true' }}
     uses: ./.github/workflows/sqaa-release.yml
     permissions:
       id-token: write
@@ -84,6 +106,7 @@ jobs:
     with:
       ref: refs/tags/${{ needs.release.outputs.release-version }}
       release-version: ${{ needs.release.outputs.release-version }}
+      build-number: ${{ needs.derive_sqaa_build_number.outputs.build-number }}
       publish-to-release-repo: true
       ticket-url: ${{ needs.release.outputs.sqc-ticket-url }}
       create-aaas-pr: true

--- a/.github/workflows/docker-sqaa.yml
+++ b/.github/workflows/docker-sqaa.yml
@@ -4,108 +4,32 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to build from'
+        description: 'Branch or tag to build from'
         required: true
         type: string
         default: master
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  DOCKER_REPOX_BUILDS_REGISTRY: repox-sonarsource-docker-builds.jfrog.io
-  # The registry repository still uses the historical a3s prefix.
-  DOCKER_IMAGE: "a3s/analysis/javascript"
+      build-number:
+        description: 'Optional build number to reuse for the Docker tag'
+        required: false
+        type: string
+      publish-to-release-repo:
+        description: 'Publish the same Docker tag to the durable Repox release registry'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  get_build_number:
-    runs-on: warp-custom-ubuntu-24-04
-    name: Get build number
-    permissions:
-      id-token: write
-      contents: read
-    outputs:
-      BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
-    steps:
-      - uses: SonarSource/ci-github-actions/get-build-number@master
-        id: get-build-number
-
   build_and_publish:
     name: Build and publish Docker image
-    runs-on: warp-custom-ubuntu-24-04
-    needs: get_build_number
     permissions:
       id-token: write
       contents: read
-    env:
-      BUILD_NUMBER: ${{ needs.get_build_number.outputs.BUILD_NUMBER }}
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          ref: ${{ inputs.branch || github.ref }}
-
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-        with:
-          version: 2025.11.2
-          mise_toml: |
-            [tools]
-            java = "21.0"
-            maven = "3.9"
-            node = "24.11.0"
-
-      - name: Configure Maven
-        uses: SonarSource/ci-github-actions/config-maven@master
-        with:
-          artifactory-reader-role: private-reader
-          disable-caching: 'true'
-
-      - uses: SonarSource/ci-github-actions/config-npm@v1
-
-      - name: Access vault secrets
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer access_token | ARTIFACTORY_DEPLOY_PASSWORD;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer username | ARTIFACTORY_DEPLOY_USERNAME;
-            development/github/token/{REPO_OWNER_NAME_DASH}-rspec token | RSPEC_GITHUB_TOKEN;
-
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - uses: ./.github/actions/rule-api-cache
-
-      - name: Refresh RSPEC rule data
-        env:
-          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).RSPEC_GITHUB_TOKEN }}
-        run: npm run rspec:refresh
-
-      - name: Build bundle for Docker
-        run: npm run grpc:build
-
-      - name: Docker login to Repox registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
-        with:
-          registry: ${{ env.DOCKER_REPOX_BUILDS_REGISTRY }}
-          username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
-          password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
-
-      - name: Setup Docker image
-        shell: bash
-        id: docker-image-setup
-        run: |
-          DOCKER_IMAGE_BUILD_NUMBER="${DOCKER_REPOX_BUILDS_REGISTRY}/${DOCKER_IMAGE}:${BUILD_NUMBER}"
-          echo "docker-image=${DOCKER_IMAGE_BUILD_NUMBER}" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-
-      - name: Build and push Docker image
-        shell: bash
-        env:
-          DOCKER_IMAGE_BUILD_NUMBER: ${{ steps.docker-image-setup.outputs.docker-image }}
-        run: |
-          docker buildx build --platform linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
+    uses: ./.github/workflows/sqaa-release.yml
+    with:
+      ref: ${{ inputs.branch || github.ref }}
+      build-number: ${{ inputs.build-number }}
+      publish-to-release-repo: ${{ inputs.publish-to-release-repo == true }}

--- a/.github/workflows/sqaa-release.yml
+++ b/.github/workflows/sqaa-release.yml
@@ -156,16 +156,20 @@ jobs:
           artifactory-reader-role: private-reader
           disable-caching: 'true'
 
-      - uses: SonarSource/ci-github-actions/config-npm@v1
-
       - name: Access vault secrets
         id: secrets
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer access_token | ARTIFACTORY_DEPLOY_PASSWORD;
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer username | ARTIFACTORY_DEPLOY_USERNAME;
             development/github/token/{REPO_OWNER_NAME_DASH}-rspec token | RSPEC_GITHUB_TOKEN;
+
+      - name: Configure npm registry
+        run: |
+          npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+          npm config set registry https://repox.jfrog.io/artifactory/api/npm/npm/
 
       - name: Install NPM dependencies
         run: npm ci

--- a/.github/workflows/sqaa-release.yml
+++ b/.github/workflows/sqaa-release.yml
@@ -1,0 +1,281 @@
+name: SQAA Release
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to build from
+        required: true
+        type: string
+      release-version:
+        description: Released version in major.minor.patch.build format
+        required: false
+        type: string
+      build-number:
+        description: Build number to reuse for the Docker image tag
+        required: false
+        type: string
+      ticket-url:
+        description: Jira ticket URL used for the sonar-analysis-as-a-service PR
+        required: false
+        type: string
+      create-aaas-pr:
+        description: Create the sonar-analysis-as-a-service PR after pushing the image
+        required: false
+        type: boolean
+        default: false
+      aaas-base-branch:
+        description: Base branch for the sonar-analysis-as-a-service PR
+        required: false
+        type: string
+        default: master
+      reviewers:
+        description: Comma-separated list of GitHub reviewers for the sonar-analysis-as-a-service PR
+        required: false
+        type: string
+      draft:
+        description: Create the sonar-analysis-as-a-service PR as draft
+        required: false
+        type: boolean
+        default: false
+      release-automation-secret-name:
+        description: Vault secret name for a GitHub token with sonar-analysis-as-a-service access
+        required: false
+        type: string
+        default: SonarJS-release-automation
+      runner:
+        description: GitHub runner to use
+        required: false
+        type: string
+        default: warp-custom-ubuntu-24-04
+    outputs:
+      build-number:
+        description: Docker image build number
+        value: ${{ jobs.resolve_build_number.outputs.build-number }}
+      pull-request-url:
+        description: URL of the created sonar-analysis-as-a-service pull request
+        value: ${{ jobs.handoff_to_analysis_as_a_service.outputs.pull-request-url }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  DOCKER_REPOX_BUILDS_REGISTRY: repox-sonarsource-docker-builds.jfrog.io
+  # The registry repository still uses the historical a3s prefix.
+  DOCKER_IMAGE: "a3s/analysis/javascript"
+
+jobs:
+  resolve_build_number:
+    name: Resolve build number
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      build-number: ${{ steps.finalize.outputs.build-number }}
+      ticket-key: ${{ steps.finalize.outputs.ticket-key }}
+    steps:
+      - name: Derive build metadata from inputs
+        id: derive
+        shell: bash
+        env:
+          INPUT_BUILD_NUMBER: ${{ inputs.build-number }}
+          RELEASE_VERSION: ${{ inputs.release-version }}
+          TICKET_URL: ${{ inputs.ticket-url }}
+        run: |
+          if [[ -n "$INPUT_BUILD_NUMBER" ]]; then
+            echo "build-number=$INPUT_BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          elif [[ -n "$RELEASE_VERSION" ]]; then
+            echo "build-number=${RELEASE_VERSION##*.}" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ -n "$TICKET_URL" ]]; then
+            ticket_key="${TICKET_URL##*/}"
+            ticket_key="${ticket_key%%\?*}"
+            echo "ticket-key=$ticket_key" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get build number
+        if: ${{ steps.derive.outputs.build-number == '' }}
+        id: get-build-number
+        uses: SonarSource/ci-github-actions/get-build-number@master
+
+      - name: Finalize build metadata
+        id: finalize
+        shell: bash
+        env:
+          DERIVED_BUILD_NUMBER: ${{ steps.derive.outputs.build-number }}
+          GENERATED_BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+          DERIVED_TICKET_KEY: ${{ steps.derive.outputs.ticket-key }}
+          CREATE_AAAS_PR: ${{ inputs.create-aaas-pr == true && 'true' || 'false' }}
+        run: |
+          build_number="${DERIVED_BUILD_NUMBER:-$GENERATED_BUILD_NUMBER}"
+          if [[ -z "$build_number" ]]; then
+            echo "::error::Could not resolve the SQAA build number."
+            exit 1
+          fi
+          echo "build-number=$build_number" >> "$GITHUB_OUTPUT"
+
+          if [[ "$CREATE_AAAS_PR" == "true" && -z "$DERIVED_TICKET_KEY" ]]; then
+            echo "::error::ticket-url is required when create-aaas-pr is true."
+            exit 1
+          fi
+          echo "ticket-key=$DERIVED_TICKET_KEY" >> "$GITHUB_OUTPUT"
+
+  build_and_publish:
+    name: Build and publish Docker image
+    runs-on: ${{ inputs.runner }}
+    needs: resolve_build_number
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      BUILD_NUMBER: ${{ needs.resolve_build_number.outputs.build-number }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: jdx/mise-action@v4.2.0
+        with:
+          version: 2025.11.2
+          mise_toml: |
+            [tools]
+            java = "21.0"
+            maven = "3.9"
+            node = "24.11.0"
+
+      - name: Configure Maven
+        uses: SonarSource/ci-github-actions/config-maven@master
+        with:
+          artifactory-reader-role: private-reader
+          disable-caching: 'true'
+
+      - uses: SonarSource/ci-github-actions/config-npm@v1
+
+      - name: Access vault secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer access_token | ARTIFACTORY_DEPLOY_PASSWORD;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer username | ARTIFACTORY_DEPLOY_USERNAME;
+            development/github/token/{REPO_OWNER_NAME_DASH}-rspec token | RSPEC_GITHUB_TOKEN;
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - uses: ./.github/actions/rule-api-cache
+
+      - name: Refresh RSPEC rule data
+        env:
+          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).RSPEC_GITHUB_TOKEN }}
+        run: npm run rspec:refresh
+
+      - name: Build bundle for Docker
+        run: npm run grpc:build
+
+      - name: Docker login to Repox registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ${{ env.DOCKER_REPOX_BUILDS_REGISTRY }}
+          username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
+
+      - name: Setup Docker image
+        shell: bash
+        id: docker-image-setup
+        run: |
+          DOCKER_IMAGE_BUILD_NUMBER="${DOCKER_REPOX_BUILDS_REGISTRY}/${DOCKER_IMAGE}:${BUILD_NUMBER}"
+          echo "docker-image=${DOCKER_IMAGE_BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+
+      - name: Build and push Docker image
+        shell: bash
+        env:
+          DOCKER_IMAGE_BUILD_NUMBER: ${{ steps.docker-image-setup.outputs.docker-image }}
+        run: |
+          docker buildx build --platform linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
+
+  handoff_to_analysis_as_a_service:
+    name: Update sonar-analysis-as-a-service
+    if: ${{ inputs.create-aaas-pr }}
+    runs-on: ${{ inputs.runner }}
+    needs:
+      - resolve_build_number
+      - build_and_publish
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      pull-request-url: ${{ steps.create_pr.outputs.pull-request-url }}
+    env:
+      BUILD_NUMBER: ${{ needs.resolve_build_number.outputs.build-number }}
+      TICKET_KEY: ${{ needs.resolve_build_number.outputs.ticket-key }}
+    steps:
+      - name: Access vault secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/github/token/SonarSource-${{ inputs.release-automation-secret-name }} token | GITHUB_TOKEN;
+
+      - name: Set commit prefix
+        id: setup_env
+        shell: bash
+        env:
+          DRAFT: ${{ inputs.draft == true && 'true' || 'false' }}
+          TICKET_KEY: ${{ env.TICKET_KEY }}
+        run: |
+          if [[ "$DRAFT" == "true" ]]; then
+            echo "commit-prefix=[DO NOT MERGE]" >> "$GITHUB_OUTPUT"
+          else
+            echo "commit-prefix=$TICKET_KEY" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request body
+        id: pull_request_body
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.release-version }}
+          BUILD_NUMBER: ${{ env.BUILD_NUMBER }}
+        run: |
+          release_label="${RELEASE_VERSION:-build ${BUILD_NUMBER}}"
+          {
+            echo "body<<EOF"
+            echo "Update \`analysis/js_ts_image_tag\` to \`${BUILD_NUMBER}\` for SonarJS release \`${release_label}\`."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout sonar-analysis-as-a-service
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: SonarSource/sonar-analysis-as-a-service
+          ref: ${{ inputs.aaas-base-branch }}
+          sparse-checkout: analysis/js_ts_image_tag
+          sparse-checkout-cone-mode: false
+          fetch-depth: 0
+          path: sonar-analysis-as-a-service
+          token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+
+      - name: Update JS/TS image tag
+        shell: bash
+        run: |
+          echo "${BUILD_NUMBER}" > sonar-analysis-as-a-service/analysis/js_ts_image_tag
+
+      - name: Create Pull Request
+        id: create_pr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+          path: sonar-analysis-as-a-service
+          add-paths: analysis/js_ts_image_tag
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          commit-message: '${{ steps.setup_env.outputs.commit-prefix }} Update JSTS analyzer to ${{ env.BUILD_NUMBER }}'
+          title: '${{ steps.setup_env.outputs.commit-prefix }} Update JSTS analyzer to ${{ env.BUILD_NUMBER }}'
+          body: ${{ steps.pull_request_body.outputs.body }}
+          branch: javascript/update-sqaa-${{ env.BUILD_NUMBER }}
+          base: ${{ inputs.aaas-base-branch }}
+          draft: ${{ inputs.draft }}
+          reviewers: ${{ inputs.reviewers }}

--- a/.github/workflows/sqaa-release.yml
+++ b/.github/workflows/sqaa-release.yml
@@ -15,6 +15,11 @@ on:
         description: Build number to reuse for the Docker image tag
         required: false
         type: string
+      publish-to-release-repo:
+        description: Publish the same Docker tag to the Repox release registry
+        required: false
+        type: boolean
+        default: false
       ticket-url:
         description: Jira ticket URL used for the sonar-analysis-as-a-service PR
         required: false
@@ -59,6 +64,7 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   DOCKER_REPOX_BUILDS_REGISTRY: repox-sonarsource-docker-builds.jfrog.io
+  DOCKER_REPOX_RELEASES_REGISTRY: repox-sonarsource-docker-releases.jfrog.io
   # The registry repository still uses the historical a3s prefix.
   DOCKER_IMAGE: "a3s/analysis/javascript"
 
@@ -181,12 +187,31 @@ jobs:
           username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
 
+      - name: Access vault release registry secrets
+        if: ${{ inputs.publish-to-release-repo }}
+        id: release-secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release access_token | ARTIFACTORY_RELEASE_PASSWORD;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release username | ARTIFACTORY_RELEASE_USERNAME;
+
+      - name: Docker login to Repox release registry
+        if: ${{ inputs.publish-to-release-repo }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ${{ env.DOCKER_REPOX_RELEASES_REGISTRY }}
+          username: ${{ fromJSON(steps.release-secrets.outputs.vault).ARTIFACTORY_RELEASE_USERNAME }}
+          password: ${{ fromJSON(steps.release-secrets.outputs.vault).ARTIFACTORY_RELEASE_PASSWORD }}
+
       - name: Setup Docker image
         shell: bash
         id: docker-image-setup
         run: |
           DOCKER_IMAGE_BUILD_NUMBER="${DOCKER_REPOX_BUILDS_REGISTRY}/${DOCKER_IMAGE}:${BUILD_NUMBER}"
-          echo "docker-image=${DOCKER_IMAGE_BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          DOCKER_IMAGE_RELEASE_NUMBER="${DOCKER_REPOX_RELEASES_REGISTRY}/${DOCKER_IMAGE}:${BUILD_NUMBER}"
+          echo "docker-image-build=${DOCKER_IMAGE_BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "docker-image-release=${DOCKER_IMAGE_RELEASE_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
@@ -194,9 +219,15 @@ jobs:
       - name: Build and push Docker image
         shell: bash
         env:
-          DOCKER_IMAGE_BUILD_NUMBER: ${{ steps.docker-image-setup.outputs.docker-image }}
+          DOCKER_IMAGE_BUILD_NUMBER: ${{ steps.docker-image-setup.outputs.docker-image-build }}
+          DOCKER_IMAGE_RELEASE_NUMBER: ${{ steps.docker-image-setup.outputs.docker-image-release }}
+          PUBLISH_TO_RELEASE_REPO: ${{ inputs.publish-to-release-repo == true && 'true' || 'false' }}
         run: |
-          docker buildx build --platform linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
+          docker_args=(--platform linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}")
+          if [[ "$PUBLISH_TO_RELEASE_REPO" == "true" ]]; then
+            docker_args+=(--tag "${DOCKER_IMAGE_RELEASE_NUMBER}")
+          fi
+          docker buildx build "${docker_args[@]}" --push .
 
   handoff_to_analysis_as_a_service:
     name: Update sonar-analysis-as-a-service

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -135,8 +135,10 @@ Run `.github/workflows/docker-sqaa.yml` manually when you need an SQAA-only buil
 
 This workflow does the following:
 
-1. Get a SonarJS build number with `SonarSource/ci-github-actions/get-build-number@master`.
-2. Check out the requested branch.
+1. Resolve the Docker tag:
+   - use the explicit `build-number` input when provided
+   - otherwise get a SonarJS build number with `SonarSource/ci-github-actions/get-build-number@master`
+2. Check out the requested branch or tag.
 3. Install toolchains with `jdx/mise-action@v4.2.0`:
    - Java 21
    - Maven 3.9
@@ -150,7 +152,8 @@ This workflow does the following:
 8. Refresh RSPEC rule data with `npm run rspec:refresh`.
 9. Run `npm run grpc:build`.
 10. Log in to `repox-sonarsource-docker-builds.jfrog.io`.
-11. Build and push the Docker image with:
+11. If `publish-to-release-repo` is enabled, also log in to `repox-sonarsource-docker-releases.jfrog.io`.
+12. Build and push the Docker image with:
 
 ```bash
 docker buildx build --platform linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
@@ -162,6 +165,12 @@ The image is pushed to:
 repox-sonarsource-docker-builds.jfrog.io/a3s/analysis/javascript:<build_number>
 ```
 
+When `publish-to-release-repo=true`, the same tag is also pushed to:
+
+```text
+repox-sonarsource-docker-releases.jfrog.io/a3s/analysis/javascript:<build_number>
+```
+
 The `a3s` repository segment is still intentional legacy naming. Do not change it during a routine SQAA release.
 
 ### SQAA automation from the standard release
@@ -171,7 +180,8 @@ When SQAA automation is enabled in `.github/workflows/automated-release.yml`:
 1. The standard release produces a version in the format `X.Y.Z.BuildNumber`.
 2. SonarJS reuses that exact `.BuildNumber` suffix for the SQAA Docker tag.
 3. The SQAA image is built from the release tag `refs/tags/<release-version>`, not from the moving branch head.
-4. The same run opens the `sonar-analysis-as-a-service` PR that updates `analysis/js_ts_image_tag`.
+4. The same Docker tag is published to the durable Repox release registry `repox-sonarsource-docker-releases.jfrog.io`.
+5. The same run opens the `sonar-analysis-as-a-service` PR that updates `analysis/js_ts_image_tag`.
 
 This keeps the Java artifacts and the SQAA Docker image on the same released commit and build number.
 
@@ -194,14 +204,15 @@ In `SonarSource/sonar-analysis-as-a-service`:
 
 1. `.github/workflows/build.yml` reads `analysis/js_ts_image_tag`.
 2. It calls `.github/workflows/pull-and-push-analyzer-image.yml`.
-3. That reusable workflow pulls:
+3. That reusable workflow must pull the official release image from the durable release registry:
 
 ```text
-repox-sonarsource-docker-builds.jfrog.io/a3s/analysis/javascript:${source_tag}
+repox-sonarsource-docker-releases.jfrog.io/a3s/analysis/javascript:${source_tag}
 ```
 
-4. It re-tags that image with the `sonar-analysis-as-a-service` build number and pushes it to ECR.
-5. The merge to `master` also triggers `.github/workflows/master-deployment.yml`, which starts the deployment workflow for the environments.
+4. This pull-source switch is implemented in `SonarSource/sonar-analysis-as-a-service`, not in SonarJS.
+5. It then re-tags that image with the `sonar-analysis-as-a-service` build number and pushes it to ECR.
+6. The merge to `master` also triggers `.github/workflows/master-deployment.yml`, which starts the deployment workflow for the environments.
 
 ### Important warning
 
@@ -214,6 +225,7 @@ That generic action updates `gradle/sonar-plugins.versions.toml` in `sonar-analy
 1. For the normal release path, run `.github/workflows/automated-release.yml` with `sqaa-integration` enabled.
 2. For a manual SQAA-only path, run `.github/workflows/docker-sqaa.yml`.
 3. Note the SonarJS build number used as the Docker tag.
-4. If the flow was manual, open a PR in `SonarSource/sonar-analysis-as-a-service` and update `analysis/js_ts_image_tag` to that build number.
-5. Merge the PR to `master`.
-6. Let `sonar-analysis-as-a-service` build and deployment workflows roll out the new image.
+4. If the flow was a manual rerun for an official release, pass the original release build number and enable `publish-to-release-repo`.
+5. If the flow was manual, open a PR in `SonarSource/sonar-analysis-as-a-service` and update `analysis/js_ts_image_tag` to that build number.
+6. Merge the PR to `master`.
+7. Let `sonar-analysis-as-a-service` build and deployment workflows roll out the new image.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,10 +2,10 @@
 
 SonarJS currently has two distinct release targets:
 
-| Target                      | Artifact                                   | Main workflow                             | Notes                                                |
-| --------------------------- | ------------------------------------------ | ----------------------------------------- | ---------------------------------------------------- |
-| Standard SonarQube analyzer | Maven/JAR release artifacts                | `.github/workflows/automated-release.yml` | This is the normal SonarJS release flow.             |
-| SQAA (previously A3S)       | Docker image for `LanguageAnalyzerService` | `.github/workflows/docker-sqaa.yml`       | This is separate from the standard analyzer release. |
+| Target                      | Artifact                                   | Main workflow                             | Notes                                      |
+| --------------------------- | ------------------------------------------ | ----------------------------------------- | ------------------------------------------ |
+| Standard SonarQube analyzer | Maven/JAR release artifacts                | `.github/workflows/automated-release.yml` | This is the normal SonarJS release flow.   |
+| SQAA (previously A3S)       | Docker image for `LanguageAnalyzerService` | `.github/workflows/docker-sqaa.yml`       | Manual SQAA-only entry point and fallback. |
 
 ## Terminology
 
@@ -17,7 +17,7 @@ SonarJS currently has two distinct release targets:
 
 ## Standard SonarQube Analyzer Release
 
-This is the regular SonarJS analyzer release. It is the release that produces the standard SonarQube analyzer artifacts. It does **not** build or roll out the SQAA Docker image.
+This is the regular SonarJS analyzer release. It produces the standard SonarQube analyzer artifacts and can also automate the SQAA handoff using the same build number.
 
 ### Entry points
 
@@ -33,8 +33,9 @@ The SonarJS workflow is a thin wrapper around `SonarSource/release-github-action
 - plugin name `javascript`
 - Jira project `JS`
 - optional SQC and SQS integration PRs
+- optional SQAA integration, enabled in the SonarJS wrapper and implemented by a custom local workflow
 - SLVS, SLVSCODE, SLE, and SLI integration tickets enabled
-- SQAA integration explicitly disabled in SonarJS, because SQAA is released manually
+- the generic `release-github-actions` SQAA integration explicitly disabled, because SonarJS uses `analysis/js_ts_image_tag` instead of `gradle/sonar-plugins.versions.toml`
 
 The reusable workflow performs the following steps:
 
@@ -49,6 +50,16 @@ The reusable workflow performs the following steps:
 9. Release the Jira version, create the next Jira version, and move the REL ticket to `Technical Release Done`.
 10. Create integration tickets.
 11. Open analyzer update PRs for SQS and SQC.
+
+After that reusable workflow succeeds, SonarJS runs a custom `sqaa_release` job that:
+
+1. Reuses the released `X.Y.Z.BuildNumber` version from the standard release.
+2. Extracts the Docker tag from the final `.BuildNumber` suffix.
+3. Checks out the release tag `refs/tags/<release-version>` so the SQAA image is built from the exact released commit.
+4. Runs the SQAA Docker build and push flow.
+5. Opens the `sonar-analysis-as-a-service` PR that updates `analysis/js_ts_image_tag`.
+
+The `Prepare next development iteration` PR waits for this SonarJS-specific SQAA automation to finish, so a failed SQAA handoff blocks the end of the automated release run.
 
 ### What `publish-github-release` does in practice
 
@@ -94,13 +105,18 @@ SonarJS does **not** use the generic `release-github-actions` version bump actio
 1. Run `.github/workflows/automated-release.yml`, usually from `master`.
 2. Monitor the GitHub release publication kicked off through `.github/workflows/release.yml`.
 3. Verify the REL ticket and Jira release were updated.
-4. Merge the `Prepare next development iteration` PR.
-5. Merge the SQS and SQC integration PRs created by the release automation.
-6. Do **not** expect a SQAA Docker image from this flow.
+4. If `sqaa-integration` was enabled, verify the SQAA Docker image was built from the release tag and that the `sonar-analysis-as-a-service` PR was created.
+5. Merge the `Prepare next development iteration` PR.
+6. Merge the SQS, SQC, and SQAA integration PRs created by the release automation.
 
 ## SQAA Release
 
-SQAA (previously A3S) is released separately from the standard analyzer. The SonarJS side only builds and publishes the Docker image to Repox. The deployment handoff happens afterwards in `SonarSource/sonar-analysis-as-a-service`.
+SQAA (previously A3S) can be released in two ways:
+
+- automatically from `.github/workflows/automated-release.yml`, reusing the standard release build number and release tag
+- manually from `.github/workflows/docker-sqaa.yml` for SQAA-only rebuilds or exceptional reruns
+
+In both cases, the SonarJS side only builds and publishes the Docker image to Repox. The deployment handoff happens afterwards in `SonarSource/sonar-analysis-as-a-service`.
 
 ### Artifact
 
@@ -115,7 +131,7 @@ Relevant implementation details:
 
 ### SonarJS workflow
 
-Run `.github/workflows/docker-sqaa.yml` manually.
+Run `.github/workflows/docker-sqaa.yml` manually when you need an SQAA-only build outside the standard automated release.
 
 This workflow does the following:
 
@@ -148,12 +164,23 @@ repox-sonarsource-docker-builds.jfrog.io/a3s/analysis/javascript:<build_number>
 
 The `a3s` repository segment is still intentional legacy naming. Do not change it during a routine SQAA release.
 
+### SQAA automation from the standard release
+
+When SQAA automation is enabled in `.github/workflows/automated-release.yml`:
+
+1. The standard release produces a version in the format `X.Y.Z.BuildNumber`.
+2. SonarJS reuses that exact `.BuildNumber` suffix for the SQAA Docker tag.
+3. The SQAA image is built from the release tag `refs/tags/<release-version>`, not from the moving branch head.
+4. The same run opens the `sonar-analysis-as-a-service` PR that updates `analysis/js_ts_image_tag`.
+
+This keeps the Java artifacts and the SQAA Docker image on the same released commit and build number.
+
 ### Handoff to `sonar-analysis-as-a-service`
 
 After the SonarJS workflow succeeds:
 
 1. Take the SonarJS build number from the SQAA workflow run.
-2. Open a PR in `SonarSource/sonar-analysis-as-a-service`.
+2. Open a PR in `SonarSource/sonar-analysis-as-a-service`, or let the automated release create it for you.
 3. Update only `analysis/js_ts_image_tag` to that new build number.
 
 Example:
@@ -180,13 +207,13 @@ repox-sonarsource-docker-builds.jfrog.io/a3s/analysis/javascript:${source_tag}
 
 Do **not** use the generic `SonarSource/release-github-actions/update-analysis-as-a-service` action for the SonarJS SQAA release.
 
-That generic action updates `gradle/sonar-plugins.versions.toml` in `sonar-analysis-as-a-service`. The current JS/TS SQAA rollout does **not** use that file. The real SonarJS handoff is the manual PR that updates `analysis/js_ts_image_tag`.
+That generic action updates `gradle/sonar-plugins.versions.toml` in `sonar-analysis-as-a-service`. The current JS/TS SQAA rollout does **not** use that file. The real SonarJS handoff is the PR that updates `analysis/js_ts_image_tag`, whether that PR is created automatically or manually.
 
 ### SQAA release checklist
 
-1. Run `.github/workflows/docker-sqaa.yml`.
-2. Note the SonarJS build number used as the Docker tag.
-3. Open a PR in `SonarSource/sonar-analysis-as-a-service`.
-4. Update `analysis/js_ts_image_tag` to that build number.
+1. For the normal release path, run `.github/workflows/automated-release.yml` with `sqaa-integration` enabled.
+2. For a manual SQAA-only path, run `.github/workflows/docker-sqaa.yml`.
+3. Note the SonarJS build number used as the Docker tag.
+4. If the flow was manual, open a PR in `SonarSource/sonar-analysis-as-a-service` and update `analysis/js_ts_image_tag` to that build number.
 5. Merge the PR to `master`.
 6. Let `sonar-analysis-as-a-service` build and deployment workflows roll out the new image.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -144,7 +144,7 @@ This workflow does the following:
    - Maven 3.9
    - Node 24.11.0
 4. Configure Maven with `SonarSource/ci-github-actions/config-maven@master`.
-5. Configure npm with `SonarSource/ci-github-actions/config-npm@v1`.
+5. Configure the npm registry for Repox with the Artifactory private-reader token.
 6. Read Vault secrets:
    - Repox QA deployer credentials
    - RSPEC GitHub token


### PR DESCRIPTION
## Summary
- automate the SonarJS SQAA handoff from the standard release flow while reusing the same release build number as the Java artifacts
- publish official SQAA release images to the durable Repox release registry so they do not expire after 90 days
- keep `.github/workflows/docker-sqaa.yml` as the manual SQAA-only entry point, with inputs that allow rerunning an official release with the original build number

## What Changed
### `.github/workflows/automated-release.yml`
- add a SonarJS-level `sqaa-integration` input
- keep the generic `release-github-actions` SQAA integration disabled because SonarJS does not use `gradle/sonar-plugins.versions.toml`
- run a local `sqaa_release` job after the standard release succeeds
- derive the SQAA Docker tag explicitly from the released `X.Y.Z.BuildNumber` before calling the local SQAA workflow
- build SQAA from `refs/tags/<release-version>` so the Docker image comes from the exact released commit
- let SQAA depend only on `sqaa-integration`, not on `sqc-integration`
- fall back to `release-ticket-url` when no SQC ticket is created
- pass `publish-to-release-repo: true` so official release images are also pushed to `repox-sonarsource-docker-releases.jfrog.io`
- make `bump_versions` wait for a successful SQAA handoff whenever `sqaa-integration` is enabled, so derive or handoff failures block the next-dev PR

### `.github/workflows/sqaa-release.yml`
- add a reusable workflow for SQAA builds and handoff
- resolve the Docker tag from an explicit `build-number` input, or the `.BuildNumber` suffix of `release-version`, or a fresh `get-build-number` call for manual non-release runs
- build and push the image to `repox-sonarsource-docker-builds.jfrog.io/a3s/analysis/javascript:<build_number>`
- optionally also push the same tag to `repox-sonarsource-docker-releases.jfrog.io/a3s/analysis/javascript:<build_number>` when `publish-to-release-repo=true`
- align npm registry setup with the current `build.yml` flow by configuring Repox manually with the Artifactory private-reader token instead of `config-npm@v1`
- create the `sonar-analysis-as-a-service` PR automatically by updating `analysis/js_ts_image_tag`

### `.github/workflows/docker-sqaa.yml`
- turn the manual workflow into a thin wrapper over the reusable SQAA workflow
- allow building from a branch or a tag
- add an optional `build-number` input so an official release can be rerun with the original tag
- add `publish-to-release-repo` so manual reruns of official releases can republish the durable release image

### `docs/RELEASE.md`
- document the shared build-number behavior between the standard release and SQAA
- document the durable Repox release-registry publication
- document the manual rerun procedure for official releases
- document that `sonar-analysis-as-a-service` must switch its pull source to the release registry

## Expected Behavior After This PR
### Standard release path
- the standard SonarJS release produces `X.Y.Z.BuildNumber`
- the SQAA image reuses that same `BuildNumber`
- the SQAA image is built from the release tag, not the moving branch head
- the official release tag is published to both `repox-sonarsource-docker-builds.jfrog.io` and `repox-sonarsource-docker-releases.jfrog.io`
- the `sonar-analysis-as-a-service` PR is created automatically by updating `analysis/js_ts_image_tag`
- the next-dev bump PR is blocked if the requested SQAA handoff fails

### Manual rerun path for an official release
Run `.github/workflows/docker-sqaa.yml` with:
- `branch`: the release tag
- `build-number`: the original released build number
- `publish-to-release-repo`: `true`

This avoids minting a new Docker tag and republishes the official image to the durable release registry.

## Design Assessment

SonarJS intentionally does not use the generic SQAA integration from `release-github-actions`:

- most JVM analyzers publish plugin JARs to Repox, and the generic integration updates `gradle/sonar-plugins.versions.toml` so `sonar-analysis-as-a-service` can rebuild its shared analyzer image
- .NET publishes analyzer and service packages that are assembled into a Docker image by `sonar-analysis-as-a-service`
- SonarJS, like the custom Jasmin/Armor path, owns a self-contained gRPC Docker image and is integrated through an image-tag file rather than a plugin version catalog

For SonarJS, keeping the Docker build in this repository and updating `analysis/js_ts_image_tag` is therefore simpler and more accurate than introducing AAAS-side Gradle or packaging scaffolding. Reusing the standard release build number also gives the Java artifacts and Docker image one release identity, while publishing to the Docker release registry removes the 90-day retention problem of the builds registry.

### Known tradeoff: release-time rebuild

The SQAA image is rebuilt during the release from the exact release tag. This guarantees the same source commit and build number, but it is not strict "build once, use everywhere": the workflow reruns `npm ci`, `rspec:refresh`, and `grpc:build` instead of promoting an image produced by the original `build.yml` run. In particular, refreshed RSPEC data could change between the validated build and the release-time Docker build.

The stronger long-term model is to build and publish the SQAA image to the Docker builds registry during `build.yml`, using the same build number and prepared RSPEC artifact as the standard analyzer build. The release workflow would then promote or copy that exact image digest to the Docker releases registry before opening the AAAS PR.

This PR deliberately keeps that larger build-pipeline refactor out of scope. It automates the current custom-image release model while improving traceability, failure gating, and artifact durability.
## Follow-up Outside This PR

1. `SonarSource/sonar-analysis-as-a-service` must pull the JS/TS analyzer image from:

   ```text
   repox-sonarsource-docker-releases.jfrog.io/a3s/analysis/javascript:${source_tag}
   ```

   instead of the expiring `repox-sonarsource-docker-builds.jfrog.io` source.

2. For strict build reproducibility, move SQAA image creation into `build.yml` and make the release workflow promote the already validated image digest rather than rebuilding it.
## Verification
- `git diff --check`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/sqaa-release.yml').read_text())"`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/automated-release.yml').read_text())"`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/docker-sqaa.yml').read_text())"`

## Notes
- I did not run the workflows themselves from this environment.
- I did not verify the Vault secret contents for `development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release`; the workflow assumes that token exists with permission to push to the Repox release registry.