### PR TITLE
JS-2010 Remediate SonarJS dependency risks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1461,9 +1461,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1555,9 +1555,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4891,9 +4891,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5753,9 +5753,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6580,9 +6580,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6655,9 +6655,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6803,9 +6803,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6951,9 +6951,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7222,9 +7222,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -9085,9 +9085,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11471,16 +11471,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/protobufjs-cli/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/protobufjs-cli/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
@@ -11544,6 +11534,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/punycode": {
@@ -11670,9 +11670,9 @@
       "license": "MIT"
     },
     "node_modules/read-package-json/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12947,9 +12947,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -144,6 +144,13 @@
     "vue-eslint-parser": "10.4.1",
     "yaml": "2.9.0"
   },
+  "overrides": {
+    "brace-expansion@^1.1.7": "1.1.15",
+    "brace-expansion@^2.0.1": "2.0.3",
+    "brace-expansion@^5.0.5": "5.0.7",
+    "fast-uri@^3.0.1": "3.1.3",
+    "js-yaml@^3.13.1": "3.15.0"
+  },
   "prettier": {
     "printWidth": 100,
     "trailingComma": "all",

--- a/package.json
+++ b/package.json
@@ -144,13 +144,6 @@
     "vue-eslint-parser": "10.4.1",
     "yaml": "2.9.0"
   },
-  "overrides": {
-    "brace-expansion@^1.1.7": "1.1.15",
-    "brace-expansion@^2.0.1": "2.0.3",
-    "brace-expansion@^5.0.5": "5.0.7",
-    "fast-uri@^3.0.1": "3.1.3",
-    "js-yaml@^3.13.1": "3.15.0"
-  },
   "prettier": {
     "printWidth": 100,
     "trailingComma": "all",

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
         <version>${gson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.21.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>


### PR DESCRIPTION
## Summary
Remediate the vulnerable dependency versions resolved on the SonarJS master line by pinning the affected transitive NPM packages and managing jackson-databind from the root Maven build.

## Changes
- add npm overrides for the vulnerable brace-expansion, fast-uri, and js-yaml transitive versions
- refresh package-lock.json so master resolves the patched dependency versions
- manage jackson-databind 2.21.1 in the root pom so Flyway-driven test paths stop resolving 2.19.1

## Functional Validation
Artifact: `dependency-risk-remediation-fv.zip`

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
NPM dependency graph:
sonarjs@1.0.0 /Users/erwan.leforestier/dev/clones/env-1/tmp/dependency-risk-remediation-fv/work/master
├─┬ @istanbuljs/esm-loader-hook@0.3.0
│ ├─┬ @istanbuljs/load-nyc-config@1.1.0
│ │ └── js-yaml@3.14.2
│ └─┬ test-exclude@6.0.0
│   └─┬ minimatch@3.1.5
│     └── brace-expansion@1.1.13
├─┬ dir-compare@5.0.0
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.13
├─┬ eslint-doc-generator@3.6.0
│ ├─┬ ajv@8.20.0
│ │ └── fast-uri@3.1.2
│ ├─┬ cosmiconfig@9.0.2
│ │ └── js-yaml@4.2.0
│ └─┬ table@6.9.0
│   └─┬ ajv@8.18.0
│     └── fast-uri@3.1.2 deduped
├─┬ eslint-plugin-import@2.32.0
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.13
├─┬ eslint-plugin-jsx-a11y@6.10.2
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.13
├─┬ eslint-plugin-react@7.37.5
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.13
├─┬ eslint@9.39.4
│ ├─┬ @eslint/config-array@0.21.2
│ │ └─┬ minimatch@3.1.5
│ │   └── brace-expansion@1.1.13
│ ├─┬ @eslint/eslintrc@3.3.5
│ │ ├── js-yaml@4.2.0
│ │ └─┬ minimatch@3.1.5
│ │   └── brace-expansion@1.1.13
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.13
├─┬ license-checker@25.0.1
│ └─┬ read-installed@4.0.3
│   └─┬ read-package-json@2.1.2
│     └─┬ glob@7.2.3
│       └─┬ minimatch@3.1.5
│         └── brace-expansion@1.1.13
├─┬ minimatch@10.2.5
│ └── brace-expansion@5.0.6
└─┬ protobufjs-cli@2.5.6
  └─┬ glob@8.1.0
    └─┬ minimatch@5.1.9
      └── brace-expansion@2.1.1


Maven dependency graph:
[INFO]          \- com.fasterxml.jackson.core:jackson-databind:jar:2.19.1:test
[INFO]       \- com.fasterxml.jackson.core:jackson-databind:jar:2.19.1:test
[INFO]             \- com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test
[INFO]    |           \- (com.fasterxml.jackson.core:jackson-databind:jar:2.19.1:test - omitted for conflict with 2.20.1)
[INFO]          +- com.fasterxml.jackson.core:jackson-databind:jar:2.20.1:test
[INFO]          |  \- (com.fasterxml.jackson.core:jackson-databind:jar:2.20.1:test - omitted for duplicate)
[INFO]             +- (com.fasterxml.jackson.core:jackson-databind:jar:2.18.3:test - omitted for conflict with 2.20.1)
[INFO]                \- (com.fasterxml.jackson.core:jackson-databind:jar:2.18.3:test - omitted for conflict with 2.20.1)
[INFO]             \- com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test

******************* Branch "fix/remediate-dependency-risks" *******************
NPM dependency graph:
sonarjs@1.0.0 /Users/erwan.leforestier/dev/clones/env-1/tmp/dependency-risk-remediation-fv/work/branch
├─┬ @istanbuljs/esm-loader-hook@0.3.0
│ ├─┬ @istanbuljs/load-nyc-config@1.1.0
│ │ └── js-yaml@3.15.0 overridden
│ └─┬ test-exclude@6.0.0
│   └─┬ minimatch@3.1.5
│     └── brace-expansion@1.1.15 overridden
├─┬ dir-compare@5.0.0
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.15 overridden
├─┬ eslint-doc-generator@3.6.0
│ ├─┬ ajv@8.20.0
│ │ └── fast-uri@3.1.3 overridden
│ ├─┬ cosmiconfig@9.0.2
│ │ └── js-yaml@4.2.0
│ └─┬ table@6.9.0
│   └─┬ ajv@8.18.0
│     └── fast-uri@3.1.3 deduped
├─┬ eslint-plugin-import@2.32.0
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.15 overridden
├─┬ eslint-plugin-jsx-a11y@6.10.2
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.15 overridden
├─┬ eslint-plugin-react@7.37.5
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.15 overridden
├─┬ eslint@9.39.4
│ ├─┬ @eslint/config-array@0.21.2
│ │ └─┬ minimatch@3.1.5
│ │   └── brace-expansion@1.1.15 overridden
│ ├─┬ @eslint/eslintrc@3.3.5
│ │ ├── js-yaml@4.2.0
│ │ └─┬ minimatch@3.1.5
│ │   └── brace-expansion@1.1.15 overridden
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.15 overridden
├─┬ license-checker@25.0.1
│ └─┬ read-installed@4.0.3
│   └─┬ read-package-json@2.1.2
│     └─┬ glob@7.2.3
│       └─┬ minimatch@3.1.5
│         └── brace-expansion@1.1.15 overridden
├─┬ minimatch@10.2.5
│ └── brace-expansion@5.0.7 overridden
└─┬ protobufjs-cli@2.5.6
  └─┬ glob@8.1.0
    └─┬ minimatch@5.1.9
      └── brace-expansion@2.0.3 overridden


Maven dependency graph:
[INFO]          \- com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test (version managed from 2.19.1)
[INFO]       \- com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test (version managed from 2.19.1)
[INFO]             \- com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test (version managed from 2.21.1)
[INFO]    |           \- (com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test - version managed from 2.19.1; omitted for duplicate)
[INFO]          +- com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test (version managed from 2.20.1)
[INFO]          |  \- (com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test - version managed from 2.20.1; omitted for duplicate)
[INFO]             +- (com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test - version managed from 2.18.3; omitted for duplicate)
[INFO]                \- (com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test - version managed from 2.18.3; omitted for duplicate)
[INFO]             \- com.fasterxml.jackson.core:jackson-databind:jar:2.21.1:test (version managed from 2.21.1)

```

:warning::warning: This is not ready for review :warning::warning:
