### PR TITLE
JS-1972: Remove type assertions from rule S8784

### DIFF
--- a/its/ruling/src/test/expected/vitest/typescript-S8784.json
+++ b/its/ruling/src/test/expected/vitest/typescript-S8784.json
@@ -4,11 +4,5 @@
 ],
 "vitest:test/core/test/hoisted-async-simple.test.ts": [
 21
-],
-"vitest:test/typescript/failing/fail.test-d.ts": [
-15
-],
-"vitest:test/typescript/test-d/test.test-d.ts": [
-49
 ]
 }

--- a/packages/analysis/src/jsts/rules/S8784/fixtures/expect-type.fixture.js
+++ b/packages/analysis/src/jsts/rules/S8784/fixtures/expect-type.fixture.js
@@ -1,0 +1,20 @@
+const { describe, it, expect } = require('vitest');
+const { expectTypeOf } = require('expect-type');
+
+// NOT flagged: expectTypeOf from the standalone `expect-type` package is a
+// compile-time type check with no runtime behaviour. It must not be treated
+// as a misplaced assertion even when a runner-bound library (vitest) is also
+// present and the rule is active.
+expectTypeOf(value).toEqualTypeOf(); // Compliant
+
+// runner-bound vitest assertions are still flagged at the top level
+expect(value).toBe(1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
+
+describe('suite', () => {
+  expectTypeOf(value).toEqualTypeOf(); // Compliant
+
+  it('test', () => {
+    expectTypeOf(value).toEqualTypeOf(); // Compliant
+    expect(value).toBe(1); // Compliant
+  });
+});

--- a/packages/analysis/src/jsts/rules/S8784/fixtures/no-test-structure.fixture.js
+++ b/packages/analysis/src/jsts/rules/S8784/fixtures/no-test-structure.fixture.js
@@ -31,9 +31,13 @@ supertest(app).get('/').expect(200); // Compliant
 // --- runner-bound: still flagged ---
 expect(value).toBe(1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
 cy.get('.status').should('be.visible'); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
-// other known global expect entry points (rxjs marble, vitest type assertions)
+// other known global expect entry points (rxjs marble)
 expectObservable(source$).toBe('a-b'); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
-expectTypeOf(value).toEqualTypeOf(); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
+
+// --- type-level: never flagged ---
+// expectTypeOf is a compile-time Vitest construct (static type check, never executed
+// at runtime), so placing it at the top level is not a misplaced assertion.
+expectTypeOf(value).toEqualTypeOf(); // Compliant
 
 // --- `expect`-prefixed identifiers that are NOT assertion entry points: not flagged ---
 // Matching is by exact name, not an `expect` prefix, so ordinary production code

--- a/packages/analysis/src/jsts/rules/S8784/fixtures/no-test-structure.fixture.js
+++ b/packages/analysis/src/jsts/rules/S8784/fixtures/no-test-structure.fixture.js
@@ -33,11 +33,9 @@ expect(value).toBe(1); // Noncompliant {{Move this assertion into a test case or
 cy.get('.status').should('be.visible'); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
 // other known global expect entry points (rxjs marble)
 expectObservable(source$).toBe('a-b'); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
-
-// --- type-level: never flagged ---
-// expectTypeOf is a compile-time Vitest construct (static type check, never executed
-// at runtime), so placing it at the top level is not a misplaced assertion.
-expectTypeOf(value).toEqualTypeOf(); // Compliant
+// `expectTypeOf` is only exempt when imported from vitest (FQN check); an unimported
+// name-alike (e.g. from the `expect-type` package) is still runner-bound.
+expectTypeOf(value).toEqualTypeOf(); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
 
 // --- `expect`-prefixed identifiers that are NOT assertion entry points: not flagged ---
 // Matching is by exact name, not an `expect` prefix, so ordinary production code

--- a/packages/analysis/src/jsts/rules/S8784/fixtures/vitest.fixture.js
+++ b/packages/analysis/src/jsts/rules/S8784/fixtures/vitest.fixture.js
@@ -1,14 +1,18 @@
-const { describe, it, expect, beforeEach, expectTypeOf } = require('vitest');
+const { describe, it, expect, beforeEach, expectTypeOf, assertType } = require('vitest');
 
 // flagged: vitest assertion at module top level. The inner `expect()` and
 // the outer `.toBe()` are both detected, but the statement is reported once.
 expect(value).toBe(1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
 
-// flagged: `expect.soft` / `expect.poll` / `expect.element` / `expectTypeOf` are
-// real assertion entry points, so they are still detected at module top level.
+// flagged: `expect.soft` / `expect.poll` / `expect.element` are runner-bound assertions.
 expect.soft(value).toBe(1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
 expect.element(value).toBeVisible(); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
-expectTypeOf(value).toBeString(); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
+
+// NOT flagged: `expectTypeOf` and `assertType` are compile-time / type-level constructs.
+// Vitest processes these files statically; they are never executed at runtime.
+// Placing them outside a test() block is idiomatic in .test-d.ts type-test files.
+expectTypeOf(value).toBeString(); // Compliant
+assertType(value); // Compliant
 
 // NOT flagged: `expect.*` configuration / setup methods are not assertions
 // (they register matchers or serializers), so they are never reported.
@@ -19,6 +23,10 @@ expect.addEqualityTesters([() => true]); // Compliant
 describe('vitest', () => {
   // flagged: directly in the describe body
   expect(value).toBe(1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
+
+  // NOT flagged: type-level assertions are fine even in describe bodies
+  expectTypeOf(value).toBeString(); // Compliant
+  assertType(value); // Compliant
 
   it('asserts', () => {
     expect(value).toBe(1); // Compliant

--- a/packages/analysis/src/jsts/rules/S8784/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8784/rule.ts
@@ -30,8 +30,8 @@ import {
   hasSupportedAssertionLibrary,
   isAssertion,
   isScriptCapableAssertion,
+  isTypeLevelAssertion,
 } from '../helpers/assertion-detection.js';
-import { isTypeLevelAssertion } from '../helpers/vitest.js';
 import * as meta from './generated-meta.js';
 
 const messages = {

--- a/packages/analysis/src/jsts/rules/S8784/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8784/rule.ts
@@ -31,7 +31,7 @@ import {
   isAssertion,
   isScriptCapableAssertion,
 } from '../helpers/assertion-detection.js';
-import { getFullyQualifiedName } from '../helpers/module.js';
+import { isTypeLevelAssertion } from '../helpers/vitest.js';
 import * as meta from './generated-meta.js';
 
 const messages = {
@@ -70,7 +70,7 @@ export const rule: Rule.RuleModule = {
         if (!isAssertion(context, node)) {
           return;
         }
-        if (isVitestTypeLevelAssertion(context, node)) {
+        if (isTypeLevelAssertion(context, node)) {
           return;
         }
         const statement = findEnclosingExpressionStatement(context, node);
@@ -222,39 +222,4 @@ function findEnclosingFunctionIndex(ancestors: estree.Node[]): number {
     }
   }
   return -1;
-}
-
-// Vitest's `expectTypeOf` and `assertType` are compile-time type checks, not runtime
-// assertions — Vitest's type-checking pipeline passes these files to `tsc` for static
-// analysis and never executes them. Placing them outside `test()` is idiomatic in
-// `.test-d.ts` files, so S8784 must not flag them.
-const VITEST_TYPE_LEVEL_ROOTS = ['vitest.expectTypeOf', 'vitest.assertType'];
-const VITEST_TYPE_LEVEL_CALLEE_NAMES = new Set(['expectTypeOf', 'assertType']);
-
-function isVitestTypeLevelAssertion(
-  context: Rule.RuleContext,
-  node: estree.CallExpression,
-): boolean {
-  // FQN-based: covers imported/destructured `expectTypeOf`/`assertType` from vitest.
-  const fqn = getFullyQualifiedName(context, node);
-  if (
-    fqn !== null &&
-    VITEST_TYPE_LEVEL_ROOTS.some(root => fqn === root || fqn.startsWith(`${root}.`))
-  ) {
-    return true;
-  }
-  // Name-based: covers global/unimported usage in chains like `expectTypeOf(x).toBeString()`.
-  // The outer chained call is what `isAssertion` matched; we walk to the innermost call.
-  if (node.callee.type !== 'MemberExpression') {
-    return false;
-  }
-  let current: estree.Expression | estree.Super = node.callee.object;
-  while (current.type === 'MemberExpression') {
-    current = current.object;
-  }
-  return (
-    current.type === 'CallExpression' &&
-    current.callee.type === 'Identifier' &&
-    VITEST_TYPE_LEVEL_CALLEE_NAMES.has(current.callee.name)
-  );
 }

--- a/packages/analysis/src/jsts/rules/S8784/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8784/rule.ts
@@ -31,6 +31,7 @@ import {
   isAssertion,
   isScriptCapableAssertion,
 } from '../helpers/assertion-detection.js';
+import { getFullyQualifiedName } from '../helpers/module.js';
 import * as meta from './generated-meta.js';
 
 const messages = {
@@ -67,6 +68,9 @@ export const rule: Rule.RuleModule = {
           hasTestStructure = true;
         }
         if (!isAssertion(context, node)) {
+          return;
+        }
+        if (isVitestTypeLevelAssertion(context, node)) {
           return;
         }
         const statement = findEnclosingExpressionStatement(context, node);
@@ -218,4 +222,39 @@ function findEnclosingFunctionIndex(ancestors: estree.Node[]): number {
     }
   }
   return -1;
+}
+
+// Vitest's `expectTypeOf` and `assertType` are compile-time type checks, not runtime
+// assertions — Vitest's type-checking pipeline passes these files to `tsc` for static
+// analysis and never executes them. Placing them outside `test()` is idiomatic in
+// `.test-d.ts` files, so S8784 must not flag them.
+const VITEST_TYPE_LEVEL_ROOTS = ['vitest.expectTypeOf', 'vitest.assertType'];
+const VITEST_TYPE_LEVEL_CALLEE_NAMES = new Set(['expectTypeOf', 'assertType']);
+
+function isVitestTypeLevelAssertion(
+  context: Rule.RuleContext,
+  node: estree.CallExpression,
+): boolean {
+  // FQN-based: covers imported/destructured `expectTypeOf`/`assertType` from vitest.
+  const fqn = getFullyQualifiedName(context, node);
+  if (
+    fqn !== null &&
+    VITEST_TYPE_LEVEL_ROOTS.some(root => fqn === root || fqn.startsWith(`${root}.`))
+  ) {
+    return true;
+  }
+  // Name-based: covers global/unimported usage in chains like `expectTypeOf(x).toBeString()`.
+  // The outer chained call is what `isAssertion` matched; we walk to the innermost call.
+  if (node.callee.type !== 'MemberExpression') {
+    return false;
+  }
+  let current: estree.Expression | estree.Super = node.callee.object;
+  while (current.type === 'MemberExpression') {
+    current = current.object;
+  }
+  return (
+    current.type === 'CallExpression' &&
+    current.callee.type === 'Identifier' &&
+    VITEST_TYPE_LEVEL_CALLEE_NAMES.has(current.callee.name)
+  );
 }

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -215,6 +215,26 @@ export function isScriptCapableAssertion(context: Rule.RuleContext, node: estree
   return SCRIPT_CAPABLE_DETECTORS.some(detect => detect(context, node));
 }
 
+// All FQN roots whose calls are compile-time-only type checks: Vitest's
+// `expectTypeOf`/`assertType` and the standalone `expect-type` package's
+// `expectTypeOf` (which Vitest uses internally and may be imported directly).
+const TYPE_LEVEL_ASSERTION_ROOTS = [...Vitest.TYPE_LEVEL_ROOTS, 'expect-type.expectTypeOf'];
+
+/**
+ * Whether `node` is a compile-time-only type check that must not be flagged for
+ * placement outside a test case.
+ */
+export function isTypeLevelAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+  const fqn = getFullyQualifiedName(context, node);
+  return (
+    fqn !== null &&
+    TYPE_LEVEL_ASSERTION_ROOTS.some(root => fqn === root || fqn.startsWith(`${root}.`))
+  );
+}
+
 /**
  * Incomplete Chai `foo.should` property chains are not assertions on their own.
  * We exclude them so S2699 does not treat an unfinished `should` chain as an assertion

--- a/packages/analysis/src/jsts/rules/helpers/vitest.ts
+++ b/packages/analysis/src/jsts/rules/helpers/vitest.ts
@@ -36,7 +36,7 @@ export function isTSAssertion(services: ParserServicesWithTypeInformation, node:
 
 // Vitest's compile-time type checks: never executed at runtime, idiomatic at top
 // level in .test-d.ts files, so rules about assertion placement must not flag them.
-const TYPE_LEVEL_ROOTS = ['vitest.expectTypeOf', 'vitest.assertType'];
+export const TYPE_LEVEL_ROOTS = ['vitest.expectTypeOf', 'vitest.assertType'];
 
 // The set of valid matchers is open (custom matchers, matchers called on a stored
 // result), so we cannot enumerate them. Instead, we match anything under these
@@ -83,17 +83,4 @@ function extractFQNforCallExpression(context: Rule.RuleContext, node: estree.Nod
     return undefined;
   }
   return getFullyQualifiedName(context, node);
-}
-
-/**
- * Whether `node` is a Vitest compile-time type check (`expectTypeOf` / `assertType`).
- * These are processed by `tsc`, never executed at runtime, so placement outside a
- * test case is idiomatic and must not be flagged.
- */
-export function isTypeLevelAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
-  const fqn = extractFQNforCallExpression(context, node);
-  if (!fqn) {
-    return false;
-  }
-  return TYPE_LEVEL_ROOTS.some(root => fqn === root || fqn.startsWith(`${root}.`));
 }

--- a/packages/analysis/src/jsts/rules/helpers/vitest.ts
+++ b/packages/analysis/src/jsts/rules/helpers/vitest.ts
@@ -34,10 +34,14 @@ export function isTSAssertion(services: ParserServicesWithTypeInformation, node:
   return isFQNAssertion(fqn);
 }
 
+// Vitest's compile-time type checks: never executed at runtime, idiomatic at top
+// level in .test-d.ts files, so rules about assertion placement must not flag them.
+const TYPE_LEVEL_ROOTS = ['vitest.expectTypeOf', 'vitest.assertType'];
+
 // The set of valid matchers is open (custom matchers, matchers called on a stored
 // result), so we cannot enumerate them. Instead, we match anything under these
 // roots and then exclude the few non-assertion members below.
-const ASSERTION_ROOTS = ['vitest.expect', 'vitest.expectTypeOf', 'vitest.assertType'];
+const ASSERTION_ROOTS = ['vitest.expect', ...TYPE_LEVEL_ROOTS];
 
 // Static helpers on `expect` that share the `vitest.expect` root but configure or
 // declare rather than assert. This set IS closed, so we carve it out by name.
@@ -79,4 +83,17 @@ function extractFQNforCallExpression(context: Rule.RuleContext, node: estree.Nod
     return undefined;
   }
   return getFullyQualifiedName(context, node);
+}
+
+/**
+ * Whether `node` is a Vitest compile-time type check (`expectTypeOf` / `assertType`).
+ * These are processed by `tsc`, never executed at runtime, so placement outside a
+ * test case is idiomatic and must not be flagged.
+ */
+export function isTypeLevelAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
+  const fqn = extractFQNforCallExpression(context, node);
+  if (!fqn) {
+    return false;
+  }
+  return TYPE_LEVEL_ROOTS.some(root => fqn === root || fqn.startsWith(`${root}.`));
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule update:**
  - Modified rule `S8784` to ignore Vitest's compile-time type assertions `expectTypeOf` and `assertType`.
  - Implemented `isVitestTypeLevelAssertion` to distinguish these static type checks from runtime test assertions.

<sub>This will update automatically on new commits.</sub>