### PR TITLE
JS-2017 Fix JS coverage handoff for Sonar analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,13 +418,12 @@ jobs:
     needs: [setup, populate_npm_cache, prepare_rspec_rule_data]
     permissions: *read_permissions
     steps:
-      - name: Check JS coverage cache
+      - name: Restore JS coverage cache
         id: cache
         uses: SonarSource/gh-action_cache@v1
         with:
           path: coverage/js
           key: js-coverage-${{ needs.setup.outputs.js-files-hash }}
-          lookup-only: true
       - name: Checkout source code
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -456,6 +455,15 @@ jobs:
           npm run generate-meta
           npm run bridge:compile
           npm run bridge:test:cov
+      - name: Upload JS coverage reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: js-coverage-reports-${{ github.sha }}
+          path: |
+            coverage/js/lcov.info
+            coverage/js/test-report.xml
+          if-no-files-found: error
+          retention-days: 1
 
   test_js_win:
     runs-on: github-windows-latest-m
@@ -521,13 +529,12 @@ jobs:
       - *mise
       - *npm_cache
       - *maven_cache
-      - &js_coverage_cache
-        name: Cache JS coverage
-        id: js-coverage-cache
-        uses: SonarSource/gh-action_cache@v1
+      - &download_js_coverage_reports
+        name: Download JS coverage reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          name: js-coverage-reports-${{ github.sha }}
           path: coverage/js
-          key: js-coverage-${{ needs.setup.outputs.js-files-hash }}
       - &download_maven_targets
         name: Download Maven target artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -588,7 +595,7 @@ jobs:
       - *mise
       - *npm_cache
       - *maven_cache
-      - *js_coverage_cache
+      - *download_js_coverage_reports
       - *download_maven_targets
       - *download_jacoco_xml_reports
       - *config_maven

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,6 +455,14 @@ jobs:
           npm run generate-meta
           npm run bridge:compile
           npm run bridge:test:cov
+      - name: Validate JS coverage reports
+        run: |
+          for report in coverage/js/lcov.info coverage/js/test-report.xml; do
+            if [ ! -f "$report" ]; then
+              echo "::error file=$report::Missing JS coverage report"
+              exit 1
+            fi
+          done
       - name: Upload JS coverage reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

This PR fixes the JS coverage handoff in CI.

`test_js` can still reuse an existing `coverage/js` cache to skip rerunning bridge coverage, but the coverage files consumed by `Analyze in SonarQube NEXT` are now passed explicitly as a workflow artifact instead of relying on implicit cache behavior across jobs.

## Root cause

The latent workflow bug was introduced by `16cc127bc27f7968e3bb9e6b3ae5e5000a87db2c` (`JS-943 try bigger machines + windows dependencies (#5909)`, 2025-11-11).

That change split the flow in two jobs:

- `test_js` checked `coverage/js` with `SonarSource/gh-action_cache@v1` and `lookup-only: true`
- `Analyze in SonarQube NEXT` later tried to restore `coverage/js` from the cache using the same `js-files-hash`

This was fragile because `lookup-only: true` means the `test_js` job is not supposed to restore or save anything. The workflow only kept working because the action implementation still ended up saving branch caches as a side effect.

## Why it started failing now

This did not start because of a new SonarJS workflow change. It started because `SonarSource/gh-action_cache@v1` is a floating ref and its behavior changed on 2026-06-30 in `8d5f45db5f8e71b8b09d15d3a8f751576cd33afd` (`BUILD-11220 Skip duplicate S3 cache save when content matches the default-branch fallback`).

Before that update, earlier successful runs on PR #7445 still saved a branch cache from `test_js` after a cold miss, and `Analyze in SonarQube NEXT` restored that branch cache later in the same workflow.

After the update, the action started enforcing lookup-only mode explicitly:

- `mode=lookup`
- `lookup-only input set — no restore, no save`

Earlier successful runs used action SHA `339d9d71cc5210bfa866a831dd8eba8e32c40491` and showed:

- `test_js`: `Cache saved with key: fix/js-1995-s2486-single-statement-try/js-coverage-...`
- `Analyze in SonarQube NEXT`: `Cache restored from key: fix/js-1995-s2486-single-statement-try/js-coverage-...`

The failing run used action SHA `4e40632e780e11a8bbe9b721985ab22b42847cc4` and logged the explicit lookup-only behavior instead.

Once `@v1` advanced, the latent bug became visible. PR #7445 exposed it because changing files under `rules/` changed `js-files-hash`, which forced a cold miss on a new cache key. `test_js` no longer saved coverage for that key, `Analyze in SonarQube NEXT` could not restore anything from the branch or `master`, and the job failed when `coverage/js/test-report.xml` was missing.

## Fix

- keep the cache as an optimization inside `test_js`, but use a normal restore instead of a lookup-only probe
- always upload `coverage/js/lcov.info` and `coverage/js/test-report.xml` from `test_js`
- make the Sonar analysis jobs download those reports explicitly

This removes the hidden dependency on cache side effects while preserving the fast path when the JS coverage cache already exists.
