### PR TITLE
JS-2013 Align S6842 with the ARIA in HTML conformance table

### DIFF
--- a/its/ruling/src/test/expected/desktop/typescript-S6842.json
+++ b/its/ruling/src/test/expected/desktop/typescript-S6842.json
@@ -1,5 +1,0 @@
-{
-"desktop:app/src/ui/lib/vertical-segmented-control/segmented-item.tsx": [
-71
-]
-}

--- a/packages/analysis/src/jsts/rules/S6842/config.ts
+++ b/packages/analysis/src/jsts/rules/S6842/config.ts
@@ -17,35 +17,30 @@
 // https://sonarsource.github.io/rspec/#/rspec/S6842/javascript
 
 import type { ESLintConfiguration } from '../helpers/configs.js';
-import { getUpstreamRecommendedConfiguration } from '../external/a11y.js';
 
-type Allowlist = Record<string, string[]>;
+// Interactive roles that the ARIA in HTML conformance table
+// (https://w3c.github.io/html-aria/#docconformance) permits per element.
+// "Any role" elements, the context-sensitive elements (li, img, figure, label)
+// and the `toolbar` structure role are handled in decorator.ts.
+const LIST_CONTAINER_ROLES = ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'];
 
-const LIST_CONTAINER_COMPOSITE_ROLES = [
-  'listbox',
-  'menu',
-  'menubar',
-  'radiogroup',
-  'tablist',
-  'toolbar',
-  'tree',
-];
-
-const TABLE_COMPOSITE_ROLES = [...LIST_CONTAINER_COMPOSITE_ROLES, 'grid', 'treegrid'];
-
-const upstreamAllowlist = getUpstreamRecommendedConfiguration(
-  'no-noninteractive-element-to-interactive-role',
-) as Allowlist;
-
-const allowlist: Allowlist = {
-  ...upstreamAllowlist,
-  ul: [...new Set([...upstreamAllowlist.ul, 'toolbar'])],
-  ol: [...new Set([...upstreamAllowlist.ol, 'toolbar'])],
-  table: [...new Set([...upstreamAllowlist.table, ...TABLE_COMPOSITE_ROLES])],
-  menu: LIST_CONTAINER_COMPOSITE_ROLES,
-  tbody: TABLE_COMPOSITE_ROLES,
-  thead: TABLE_COMPOSITE_ROLES,
-  tfoot: TABLE_COMPOSITE_ROLES,
+const allowlist: Record<string, string[]> = {
+  ul: LIST_CONTAINER_ROLES,
+  ol: LIST_CONTAINER_ROLES,
+  menu: LIST_CONTAINER_ROLES,
+  nav: ['menu', 'menubar', 'tablist'],
+  h1: ['tab'],
+  h2: ['tab'],
+  h3: ['tab'],
+  h4: ['tab'],
+  h5: ['tab'],
+  h6: ['tab'],
+  fieldset: ['radiogroup', 'presentation'],
+  td: ['gridcell'],
+  progress: ['progressbar'],
+  // Restricted to `listitem` only when the parent still exposes a list role;
+  // decorator.ts allows any role otherwise.
+  li: [],
 };
 
 export const fields: ESLintConfiguration = [

--- a/packages/analysis/src/jsts/rules/S6842/config.ts
+++ b/packages/analysis/src/jsts/rules/S6842/config.ts
@@ -17,8 +17,40 @@
 // https://sonarsource.github.io/rspec/#/rspec/S6842/javascript
 
 import type { ESLintConfiguration } from '../helpers/configs.js';
-import { getUpstreamRecommendedFields } from '../external/a11y.js';
+import { getUpstreamRecommendedConfiguration } from '../external/a11y.js';
+
+type Allowlist = Record<string, string[]>;
+
+const LIST_CONTAINER_COMPOSITE_ROLES = [
+  'listbox',
+  'menu',
+  'menubar',
+  'radiogroup',
+  'tablist',
+  'toolbar',
+  'tree',
+];
+
+const TABLE_COMPOSITE_ROLES = [...LIST_CONTAINER_COMPOSITE_ROLES, 'grid', 'treegrid'];
+
+const upstreamAllowlist = getUpstreamRecommendedConfiguration(
+  'no-noninteractive-element-to-interactive-role',
+) as Allowlist;
+
+const allowlist: Allowlist = {
+  ...upstreamAllowlist,
+  ul: [...new Set([...upstreamAllowlist.ul, 'toolbar'])],
+  ol: [...new Set([...upstreamAllowlist.ol, 'toolbar'])],
+  table: [...new Set([...upstreamAllowlist.table, ...TABLE_COMPOSITE_ROLES])],
+  menu: LIST_CONTAINER_COMPOSITE_ROLES,
+  tbody: TABLE_COMPOSITE_ROLES,
+  thead: TABLE_COMPOSITE_ROLES,
+  tfoot: TABLE_COMPOSITE_ROLES,
+};
 
 export const fields: ESLintConfiguration = [
-  getUpstreamRecommendedFields('no-noninteractive-element-to-interactive-role'),
+  Object.entries(allowlist).map(([field, defaultValue]) => ({
+    field,
+    default: defaultValue,
+  })),
 ];

--- a/packages/analysis/src/jsts/rules/S6842/config.ts
+++ b/packages/analysis/src/jsts/rules/S6842/config.ts
@@ -21,7 +21,7 @@ import type { ESLintConfiguration } from '../helpers/configs.js';
 // Interactive roles that the ARIA in HTML conformance table
 // (https://w3c.github.io/html-aria/#docconformance) permits per element.
 // "Any role" elements, the context-sensitive elements (li, img, figure, label)
-// and the `toolbar` structure role are handled in decorator.ts.
+// and the list-container `toolbar` structure role are handled in decorator.ts.
 const LIST_CONTAINER_ROLES = ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'];
 
 const allowlist: Record<string, string[]> = {

--- a/packages/analysis/src/jsts/rules/S6842/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6842/decorator.ts
@@ -16,9 +16,9 @@
  */
 import type { Rule } from 'eslint';
 import type { TSESTree } from '@typescript-eslint/utils';
-import type { JSXOpeningElement } from 'estree-jsx';
+import type { JSXAttribute, JSXOpeningElement } from 'estree-jsx';
 import pkg from 'jsx-ast-utils-x';
-const { getProp, getLiteralPropValue } = pkg;
+const { getProp, getLiteralPropValue, getPropValue } = pkg;
 import { interceptReportForReact } from '../helpers/decorators/interceptor.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getElementType } from '../helpers/accessibility.js';
@@ -99,7 +99,7 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
         return;
       }
       const tag = getElementType(context)(opening).toLowerCase();
-      const roleValue = getLiteralPropValue(getProp(attributesOf(opening), 'role'));
+      const roleValue = getLiteralAttributeValue(attributesOf(opening), 'role');
       const role = typeof roleValue === 'string' ? roleValue.toLowerCase() : '';
       if (isRoleAllowedBySpec(context, opening, tag, role)) {
         return;
@@ -111,6 +111,21 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
 
 function attributesOf(opening: TSESTree.JSXOpeningElement): JSXOpeningElement['attributes'] {
   return (opening as unknown as JSXOpeningElement).attributes;
+}
+
+function getAttribute(
+  attributes: JSXOpeningElement['attributes'],
+  name: string,
+): JSXAttribute | undefined {
+  return getProp(attributes, name);
+}
+
+function getLiteralAttributeValue(
+  attributes: JSXOpeningElement['attributes'],
+  name: string,
+): unknown {
+  const attribute = getAttribute(attributes, name);
+  return attribute ? getLiteralPropValue(attribute) : undefined;
 }
 
 function openingElementOf(
@@ -166,7 +181,7 @@ function parentExposesListRole(
     return false;
   }
   const parentOpening = parent.openingElement;
-  const parentRole = getLiteralPropValue(getProp(attributesOf(parentOpening), 'role'));
+  const parentRole = getLiteralAttributeValue(attributesOf(parentOpening), 'role');
   if (typeof parentRole === 'string' && parentRole !== '') {
     return parentRole.toLowerCase() === 'list';
   }
@@ -175,16 +190,46 @@ function parentExposesListRole(
 
 // An img exposes an accessible name via non-empty alt, aria-label or aria-labelledby.
 function hasAccessibleName(opening: TSESTree.JSXOpeningElement): boolean {
+  const attributes = attributesOf(opening);
   return (
-    hasNonEmptyAttribute(opening, 'alt') ||
-    hasNonEmptyAttribute(opening, 'aria-label') ||
-    hasNonEmptyAttribute(opening, 'aria-labelledby')
+    hasAccessibleNameAttribute(attributes, 'alt') ||
+    hasAccessibleNameAttribute(attributes, 'aria-label') ||
+    hasAccessibleNameAttribute(attributes, 'aria-labelledby')
   );
 }
 
-function hasNonEmptyAttribute(opening: TSESTree.JSXOpeningElement, name: string): boolean {
-  const value = getLiteralPropValue(getProp(attributesOf(opening), name));
-  return typeof value === 'string' && value.length > 0;
+function hasAccessibleNameAttribute(
+  attributes: JSXOpeningElement['attributes'],
+  name: string,
+): boolean {
+  const attribute = getAttribute(attributes, name);
+  if (!attribute) {
+    return false;
+  }
+  if (isNonEmptyStringAttribute(attribute)) {
+    return true;
+  }
+
+  // Dynamic expressions are unknown statically, but nullish values should not suppress.
+  return getLiteralPropValue(attribute) === null && getPropValue(attribute) != null;
+}
+
+function isNonEmptyStringAttribute(attribute: JSXAttribute): boolean {
+  if (attribute.value?.type === 'Literal') {
+    return typeof attribute.value.value === 'string' && attribute.value.value.trim() !== '';
+  }
+
+  if (
+    attribute.value?.type === 'JSXExpressionContainer' &&
+    attribute.value.expression.type === 'Literal'
+  ) {
+    return (
+      typeof attribute.value.expression.value === 'string' &&
+      attribute.value.expression.value.trim() !== ''
+    );
+  }
+
+  return false;
 }
 
 // A figure caption must be the first or last child of the figure per the HTML content model.

--- a/packages/analysis/src/jsts/rules/S6842/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6842/decorator.ts
@@ -84,7 +84,7 @@ const LABELABLE_CONTROLS = new Set([
  * the element/role combinations the ARIA in HTML conformance table permits are not
  * reported. config.ts keeps the flat, spec-derived allowlists; this decorator handles
  * what the allowlist cannot express: elements that accept any role, the context-sensitive
- * elements (li, img, figure, label) and the `toolbar` structure role.
+ * elements (li, img, figure, label) and the list-container `toolbar` structure role.
  */
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
   return interceptReportForReact(
@@ -150,9 +150,9 @@ function isRoleAllowedBySpec(
   tag: string,
   role: string,
 ): boolean {
-  // `toolbar` is a structure role, not a widget role.
+  // `toolbar` is a structure role, not a widget role; ARIA in HTML allows it on list containers.
   if (role === 'toolbar') {
-    return true;
+    return LIST_CONTAINER_ELEMENTS.has(tag);
   }
   if (ANY_ROLE_ELEMENTS.has(tag)) {
     return true;

--- a/packages/analysis/src/jsts/rules/S6842/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6842/decorator.ts
@@ -1,0 +1,237 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { Rule } from 'eslint';
+import type { TSESTree } from '@typescript-eslint/utils';
+import type { JSXOpeningElement } from 'estree-jsx';
+import pkg from 'jsx-ast-utils-x';
+const { getProp, getLiteralPropValue } = pkg;
+import { interceptReportForReact } from '../helpers/decorators/interceptor.js';
+import { generateMeta } from '../helpers/generate-meta.js';
+import { getElementType } from '../helpers/accessibility.js';
+import * as meta from './generated-meta.js';
+
+// Elements that the ARIA in HTML conformance table lets take any role.
+const ANY_ROLE_ELEMENTS = new Set([
+  'abbr',
+  'address',
+  'blockquote',
+  'code',
+  'del',
+  'dfn',
+  'em',
+  'ins',
+  'mark',
+  'output',
+  'p',
+  'pre',
+  'ruby',
+  'strong',
+  'sub',
+  'sup',
+  'table',
+  'tbody',
+  'tfoot',
+  'thead',
+  'time',
+]);
+
+// Interactive roles allowed on an <img> that exposes an accessible name.
+const IMG_ROLES = new Set([
+  'button',
+  'checkbox',
+  'link',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'progressbar',
+  'radio',
+  'scrollbar',
+  'slider',
+  'switch',
+  'tab',
+  'treeitem',
+]);
+
+const LIST_CONTAINER_ELEMENTS = new Set(['ul', 'ol', 'menu']);
+
+const LABELABLE_CONTROLS = new Set([
+  'button',
+  'input',
+  'meter',
+  'output',
+  'progress',
+  'select',
+  'textarea',
+]);
+
+/**
+ * Decorates the jsx-a11y `no-noninteractive-element-to-interactive-role` rule so that
+ * the element/role combinations the ARIA in HTML conformance table permits are not
+ * reported. config.ts keeps the flat, spec-derived allowlists; this decorator handles
+ * what the allowlist cannot express: elements that accept any role, the context-sensitive
+ * elements (li, img, figure, label) and the `toolbar` structure role.
+ */
+export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
+  return interceptReportForReact(
+    {
+      ...rule,
+      meta: generateMeta(meta, rule.meta),
+    },
+    (context, reportDescriptor) => {
+      const opening = openingElementOf(reportDescriptor);
+      if (opening === undefined) {
+        context.report(reportDescriptor);
+        return;
+      }
+      const tag = getElementType(context)(opening).toLowerCase();
+      const roleValue = getLiteralPropValue(getProp(attributesOf(opening), 'role'));
+      const role = typeof roleValue === 'string' ? roleValue.toLowerCase() : '';
+      if (isRoleAllowedBySpec(context, opening, tag, role)) {
+        return;
+      }
+      context.report(reportDescriptor);
+    },
+  );
+}
+
+function attributesOf(opening: TSESTree.JSXOpeningElement): JSXOpeningElement['attributes'] {
+  return (opening as unknown as JSXOpeningElement).attributes;
+}
+
+function openingElementOf(
+  reportDescriptor: Rule.ReportDescriptor,
+): TSESTree.JSXOpeningElement | undefined {
+  if (!('node' in reportDescriptor) || !reportDescriptor.node) {
+    return undefined;
+  }
+  const node = reportDescriptor.node as TSESTree.Node;
+  if (node.type === 'JSXAttribute') {
+    return node.parent as TSESTree.JSXOpeningElement;
+  }
+  if (node.type === 'JSXOpeningElement') {
+    return node;
+  }
+  return undefined;
+}
+
+function isRoleAllowedBySpec(
+  context: Rule.RuleContext,
+  opening: TSESTree.JSXOpeningElement,
+  tag: string,
+  role: string,
+): boolean {
+  // `toolbar` is a structure role, not a widget role.
+  if (role === 'toolbar') {
+    return true;
+  }
+  if (ANY_ROLE_ELEMENTS.has(tag)) {
+    return true;
+  }
+  switch (tag) {
+    case 'li':
+      return !parentExposesListRole(context, opening);
+    case 'img':
+      return hasAccessibleName(opening) && IMG_ROLES.has(role);
+    case 'figure':
+      return !hasFigcaptionChild(context, opening);
+    case 'label':
+      return !isAssociatedLabel(context, opening);
+    default:
+      return false;
+  }
+}
+
+// A list item is restricted to listitem only when its parent still exposes the list role.
+function parentExposesListRole(
+  context: Rule.RuleContext,
+  opening: TSESTree.JSXOpeningElement,
+): boolean {
+  const parent = opening.parent?.parent;
+  if (parent?.type !== 'JSXElement') {
+    return false;
+  }
+  const parentOpening = parent.openingElement;
+  const parentRole = getLiteralPropValue(getProp(attributesOf(parentOpening), 'role'));
+  if (typeof parentRole === 'string' && parentRole !== '') {
+    return parentRole.toLowerCase() === 'list';
+  }
+  return LIST_CONTAINER_ELEMENTS.has(getElementType(context)(parentOpening).toLowerCase());
+}
+
+// An img exposes an accessible name via non-empty alt, aria-label or aria-labelledby.
+function hasAccessibleName(opening: TSESTree.JSXOpeningElement): boolean {
+  return (
+    hasNonEmptyAttribute(opening, 'alt') ||
+    hasNonEmptyAttribute(opening, 'aria-label') ||
+    hasNonEmptyAttribute(opening, 'aria-labelledby')
+  );
+}
+
+function hasNonEmptyAttribute(opening: TSESTree.JSXOpeningElement, name: string): boolean {
+  const value = getLiteralPropValue(getProp(attributesOf(opening), name));
+  return typeof value === 'string' && value.length > 0;
+}
+
+// A figure caption must be the first or last child of the figure per the HTML content model.
+function hasFigcaptionChild(
+  context: Rule.RuleContext,
+  opening: TSESTree.JSXOpeningElement,
+): boolean {
+  const element = opening.parent;
+  if (element?.type !== 'JSXElement') {
+    return false;
+  }
+  const elementChildren = element.children.filter(
+    (child): child is TSESTree.JSXElement => child.type === 'JSXElement',
+  );
+  if (elementChildren.length === 0) {
+    return false;
+  }
+  const first = elementChildren[0];
+  const last = elementChildren[elementChildren.length - 1];
+  return isFigcaption(context, first) || isFigcaption(context, last);
+}
+
+function isFigcaption(context: Rule.RuleContext, element: TSESTree.JSXElement): boolean {
+  return getElementType(context)(element.openingElement).toLowerCase() === 'figcaption';
+}
+
+// A label is associated when it references a control via for/htmlFor or wraps a labelable control.
+function isAssociatedLabel(
+  context: Rule.RuleContext,
+  opening: TSESTree.JSXOpeningElement,
+): boolean {
+  if (getProp(attributesOf(opening), 'for') || getProp(attributesOf(opening), 'htmlFor')) {
+    return true;
+  }
+  const element = opening.parent;
+  return element?.type === 'JSXElement' && containsLabelableControl(context, element);
+}
+
+function containsLabelableControl(
+  context: Rule.RuleContext,
+  element: TSESTree.JSXElement,
+): boolean {
+  return element.children.some(child => {
+    if (child.type !== 'JSXElement') {
+      return false;
+    }
+    const tag = getElementType(context)(child.openingElement).toLowerCase();
+    return LABELABLE_CONTROLS.has(tag) || containsLabelableControl(context, child);
+  });
+}

--- a/packages/analysis/src/jsts/rules/S6842/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6842/decorator.ts
@@ -248,7 +248,10 @@ function hasFigcaptionChild(
     return false;
   }
   const first = elementChildren[0];
-  const last = elementChildren[elementChildren.length - 1];
+  const last = elementChildren.at(-1);
+  if (last === undefined) {
+    return false;
+  }
   return isFigcaption(context, first) || isFigcaption(context, last);
 }
 

--- a/packages/analysis/src/jsts/rules/S6842/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6842/decorator.ts
@@ -206,7 +206,10 @@ function hasAccessibleNameAttribute(
   if (!attribute) {
     return false;
   }
-  if (isNonEmptyStringAttribute(attribute)) {
+  if (
+    isNonEmptyStringAttribute(attribute) ||
+    isPotentiallyNonEmptyTemplateLiteralAttribute(attribute)
+  ) {
     return true;
   }
 
@@ -230,6 +233,20 @@ function isNonEmptyStringAttribute(attribute: JSXAttribute): boolean {
   }
 
   return false;
+}
+
+function isPotentiallyNonEmptyTemplateLiteralAttribute(attribute: JSXAttribute): boolean {
+  if (
+    attribute.value?.type !== 'JSXExpressionContainer' ||
+    attribute.value.expression.type !== 'TemplateLiteral'
+  ) {
+    return false;
+  }
+
+  return (
+    attribute.value.expression.expressions.length > 0 ||
+    attribute.value.expression.quasis.some(quasi => quasi.value.cooked?.trim() !== '')
+  );
 }
 
 // A figure caption must be the first or last child of the figure per the HTML content model.

--- a/packages/analysis/src/jsts/rules/S6842/index.ts
+++ b/packages/analysis/src/jsts/rules/S6842/index.ts
@@ -15,4 +15,6 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rules } from '../external/a11y.js';
-export const rule = rules['no-noninteractive-element-to-interactive-role'];
+import { decorate } from './decorator.js';
+
+export const rule = decorate(rules['no-noninteractive-element-to-interactive-role']);

--- a/packages/analysis/src/jsts/rules/S6842/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6842/unit.test.ts
@@ -14,9 +14,8 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { deepStrictEqual, ok } from 'node:assert';
+import { deepStrictEqual } from 'node:assert';
 import { describe, it } from 'node:test';
-import { getUpstreamRecommendedConfiguration } from '../external/a11y.js';
 import { defaultOptions } from '../helpers/configs.js';
 import { fields } from './config.js';
 import { rule } from './index.js';
@@ -24,169 +23,117 @@ import { NoTypeCheckingRuleTester } from '../../../../tests/jsts/tools/testers/r
 
 type Allowlist = Record<string, string[]>;
 
-function isAllowlist(
-  configuration: Record<string, boolean | string[]>,
-): configuration is Allowlist {
-  return Object.values(configuration).every(Array.isArray);
-}
+const OPTIONS = defaultOptions(fields) as [Allowlist];
 
-const upstreamConfiguration = getUpstreamRecommendedConfiguration(
-  'no-noninteractive-element-to-interactive-role',
-);
-if (!isAllowlist(upstreamConfiguration)) {
-  throw new Error(
-    'eslint-plugin-jsx-a11y: expected S6842 upstream config to contain only string[] values',
-  );
-}
-const UPSTREAM_ALLOWLIST = upstreamConfiguration;
-const LIST_CONTAINER_COMPOSITE_ROLES = [
-  'listbox',
-  'menu',
-  'menubar',
-  'radiogroup',
-  'tablist',
-  'toolbar',
-  'tree',
-];
-const TABLE_COMPOSITE_ROLES = [...LIST_CONTAINER_COMPOSITE_ROLES, 'grid', 'treegrid'];
-const TABLE_ALLOWED_ROLES = ['grid', ...LIST_CONTAINER_COMPOSITE_ROLES, 'treegrid'];
+// The flat, spec-derived allowlist exposed as default options. Context-sensitive elements
+// (li, img, figure, label), "any role" elements and the `toolbar` structure role are enforced
+// by the decorator, not by these options.
 const EXPECTED_ALLOWLIST: Allowlist = {
-  ...UPSTREAM_ALLOWLIST,
-  ul: [...UPSTREAM_ALLOWLIST.ul, 'toolbar'],
-  ol: [...UPSTREAM_ALLOWLIST.ol, 'toolbar'],
-  table: TABLE_ALLOWED_ROLES,
-  menu: LIST_CONTAINER_COMPOSITE_ROLES,
-  tbody: TABLE_COMPOSITE_ROLES,
-  thead: TABLE_COMPOSITE_ROLES,
-  tfoot: TABLE_COMPOSITE_ROLES,
+  ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'],
+  ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'],
+  menu: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'],
+  nav: ['menu', 'menubar', 'tablist'],
+  h1: ['tab'],
+  h2: ['tab'],
+  h3: ['tab'],
+  h4: ['tab'],
+  h5: ['tab'],
+  h6: ['tab'],
+  fieldset: ['radiogroup', 'presentation'],
+  td: ['gridcell'],
+  progress: ['progressbar'],
+  li: [],
 };
 
-const OPTIONS = defaultOptions(fields) as [Allowlist];
-const [allowlist] = OPTIONS;
-const COMPOSITE_VALID_CASES = [
-  {
-    code: `<ul role="listbox"><li role="option">Item</li></ul>`,
-    options: OPTIONS,
-  },
-  {
-    code: `<ol role="listbox"><li role="option">Item</li></ol>`,
-    options: OPTIONS,
-  },
-  {
-    code: `<table><tr><td role="gridcell">Item</td></tr></table>`,
-    options: OPTIONS,
-  },
-  {
-    code: `<fieldset role="radiogroup"><legend>Label</legend></fieldset>`,
-    options: OPTIONS,
-  },
-  {
-    code: `<fieldset role="presentation"><legend>Label</legend></fieldset>`,
-    options: OPTIONS,
-  },
-];
+const LIST_CONTAINER_ROLES = ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'];
 
 const VALID_CASES = [
-  ...allowlist.ul.map(role => ({
-    code: `<ul role="${role}"><li>Item</li></ul>`,
+  // Composite list containers: every spec-allowed role, plus the `toolbar` structure role.
+  ...['ul', 'ol', 'menu'].flatMap(tag =>
+    [...LIST_CONTAINER_ROLES, 'toolbar'].map(role => ({
+      code: `<${tag} role="${role}"><li>Item</li></${tag}>`,
+      options: OPTIONS,
+    })),
+  ),
+  // A list child may take any role once its parent no longer exposes the list role.
+  { code: `<ul role="menu"><li role="menuitem">Item</li></ul>`, options: OPTIONS },
+  { code: `<ol role="listbox"><li role="option">Item</li></ol>`, options: OPTIONS },
+  { code: `<div><li role="button">Item</li></div>`, options: OPTIONS },
+  { code: `<div role="navigation"><li role="menuitem">Item</li></div>`, options: OPTIONS },
+  // nav / headings composite overrides.
+  ...['menu', 'menubar', 'tablist'].map(role => ({
+    code: `<nav role="${role}">Item</nav>`,
     options: OPTIONS,
   })),
-  ...allowlist.ol.map(role => ({
-    code: `<ol role="${role}"><li>Item</li></ol>`,
+  ...['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map(tag => ({
+    code: `<${tag} role="tab">Item</${tag}>`,
     options: OPTIONS,
   })),
-  ...allowlist.menu.map(role => ({
-    code: `<menu role="${role}"><li>Item</li></menu>`,
+  { code: `<fieldset role="radiogroup"><legend>Label</legend></fieldset>`, options: OPTIONS },
+  { code: `<fieldset role="presentation"><legend>Label</legend></fieldset>`, options: OPTIONS },
+  { code: `<table><tr><td role="gridcell">Item</td></tr></table>`, options: OPTIONS },
+  { code: `<progress role="progressbar" />`, options: OPTIONS },
+  // "Any role" elements: table family and text-level elements accept any role.
+  ...['button', 'grid', 'treegrid', 'menuitem'].flatMap(role =>
+    ['table', 'tbody', 'thead', 'tfoot'].map(tag => ({
+      code:
+        tag === 'table'
+          ? `<table role="${role}"><tr><td>Item</td></tr></table>`
+          : `<table><${tag} role="${role}"><tr><td>Item</td></tr></${tag}></table>`,
+      options: OPTIONS,
+    })),
+  ),
+  ...['p', 'blockquote', 'time', 'output', 'abbr'].map(tag => ({
+    code: `<${tag} role="button">Item</${tag}>`,
     options: OPTIONS,
   })),
-  ...allowlist.li.map(role => ({
-    code: `<li role="${role}">Item</li>`,
+  // img with an accessible name and a permitted role.
+  { code: `<img alt="Logo" role="button" />`, options: OPTIONS },
+  { code: `<img aria-label="Logo" role="tab" />`, options: OPTIONS },
+  // figure without a caption, and a non-associated label, accept any role.
+  { code: `<figure role="button"><img alt="x" /></figure>`, options: OPTIONS },
+  { code: `<label role="button">Text</label>`, options: OPTIONS },
+];
+
+const INVALID_CASES = [
+  // treegrid is not permitted on ul/ol.
+  { code: `<ul role="treegrid"><li>Item</li></ul>`, options: OPTIONS, errors: 1 },
+  { code: `<ol role="treegrid"><li>Item</li></ol>`, options: OPTIONS, errors: 1 },
+  // Non-composite interactive roles on list containers.
+  { code: `<ul role="button"><li>Item</li></ul>`, options: OPTIONS, errors: 1 },
+  { code: `<ol role="button"><li>Item</li></ol>`, options: OPTIONS, errors: 1 },
+  { code: `<menu role="button"><li>Item</li></menu>`, options: OPTIONS, errors: 1 },
+  // A list child inside a real list is restricted to listitem.
+  { code: `<ul><li role="menuitem">Item</li></ul>`, options: OPTIONS, errors: 1 },
+  { code: `<ul role="list"><li role="button">Item</li></ul>`, options: OPTIONS, errors: 1 },
+  // img without an accessible name, or with a role it does not permit.
+  { code: `<img role="button" />`, options: OPTIONS, errors: 1 },
+  { code: `<img alt="" role="button" />`, options: OPTIONS, errors: 1 },
+  { code: `<img alt="Logo" role="combobox" />`, options: OPTIONS, errors: 1 },
+  // figure with a caption, and an associated label, are restricted.
+  {
+    code: `<figure role="button"><figcaption>Cap</figcaption></figure>`,
     options: OPTIONS,
-  })),
-  ...allowlist.table.map(role => ({
-    code: `<table role="${role}"><tr><td>Item</td></tr></table>`,
-    options: OPTIONS,
-  })),
-  ...allowlist.tbody.map(role => ({
-    code: `<table><tbody role="${role}"><tr><td>Item</td></tr></tbody></table>`,
-    options: OPTIONS,
-  })),
-  ...allowlist.thead.map(role => ({
-    code: `<table><thead role="${role}"><tr><th>Item</th></tr></thead></table>`,
-    options: OPTIONS,
-  })),
-  ...allowlist.tfoot.map(role => ({
-    code: `<table><tfoot role="${role}"><tr><td>Item</td></tr></tfoot></table>`,
-    options: OPTIONS,
-  })),
-  ...COMPOSITE_VALID_CASES,
+    errors: 1,
+  },
+  { code: `<label htmlFor="x" role="button">Name</label>`, options: OPTIONS, errors: 1 },
+  { code: `<label role="button"><input type="text" /></label>`, options: OPTIONS, errors: 1 },
+  // nav / headings / progress non-permitted roles.
+  { code: `<nav role="listbox">Item</nav>`, options: OPTIONS, errors: 1 },
+  { code: `<h1 role="button">Item</h1>`, options: OPTIONS, errors: 1 },
+  { code: `<progress role="button" />`, options: OPTIONS, errors: 1 },
 ];
 
 describe('S6842', () => {
-  it('should expose the spec-compliant allowlist as default options', () => {
-    deepStrictEqual(allowlist, EXPECTED_ALLOWLIST);
+  it('should expose the spec-derived flat allowlist as default options', () => {
+    deepStrictEqual(OPTIONS[0], EXPECTED_ALLOWLIST);
   });
 
-  it('should not flag spec-compliant composite widget overrides', () => {
+  it('should report only the element/role combinations forbidden by ARIA in HTML', () => {
     const ruleTester = new NoTypeCheckingRuleTester();
-    ok(
-      VALID_CASES.some(
-        ({ code }) => code === `<ul role="listbox"><li role="option">Item</li></ul>`,
-      ),
-    );
-    ok(
-      VALID_CASES.some(
-        ({ code }) => code === `<ol role="listbox"><li role="option">Item</li></ol>`,
-      ),
-    );
-    ok(VALID_CASES.some(({ code }) => code === `<ul role="toolbar"><li>Item</li></ul>`));
-    ok(VALID_CASES.some(({ code }) => code === `<ol role="toolbar"><li>Item</li></ol>`));
-    ok(VALID_CASES.some(({ code }) => code === `<menu role="toolbar"><li>Item</li></menu>`));
-    ok(
-      VALID_CASES.some(
-        ({ code }) => code === `<table role="treegrid"><tr><td>Item</td></tr></table>`,
-      ),
-    );
-    ok(
-      VALID_CASES.some(
-        ({ code }) =>
-          code === `<table><tbody role="toolbar"><tr><td>Item</td></tr></tbody></table>`,
-      ),
-    );
     ruleTester.run('no-noninteractive-element-to-interactive-role', rule, {
       valid: VALID_CASES,
-      invalid: [
-        {
-          code: `<ul role="button"><li>Item</li></ul>`,
-          options: OPTIONS,
-          errors: 1,
-        },
-        {
-          code: `<ol role="button"><li>Item</li></ol>`,
-          options: OPTIONS,
-          errors: 1,
-        },
-        {
-          code: `<li role="button">Foo</li>`,
-          options: OPTIONS,
-          errors: 1,
-        },
-        {
-          code: `<menu role="button"><li>Item</li></menu>`,
-          options: OPTIONS,
-          errors: 1,
-        },
-        {
-          code: `<table role="button"><tr><td>Item</td></tr></table>`,
-          options: OPTIONS,
-          errors: 1,
-        },
-        {
-          code: `<table><tbody role="button"><tr><td>Item</td></tr></tbody></table>`,
-          options: OPTIONS,
-          errors: 1,
-        },
-      ],
+      invalid: INVALID_CASES,
     });
   });
 });

--- a/packages/analysis/src/jsts/rules/S6842/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6842/unit.test.ts
@@ -90,6 +90,9 @@ const VALID_CASES = [
   // img with an accessible name and a permitted role.
   { code: `<img alt="Logo" role="button" />`, options: OPTIONS },
   { code: `<img aria-label="Logo" role="tab" />`, options: OPTIONS },
+  { code: `<img alt={label} role="button" />`, options: OPTIONS },
+  { code: `<img aria-label={t('logo')} role="tab" />`, options: OPTIONS },
+  { code: `<img aria-labelledby={computedId} role="link" />`, options: OPTIONS },
   // figure without a caption, and a non-associated label, accept any role.
   { code: `<figure role="button"><img alt="x" /></figure>`, options: OPTIONS },
   { code: `<label role="button">Text</label>`, options: OPTIONS },
@@ -109,6 +112,9 @@ const INVALID_CASES = [
   // img without an accessible name, or with a role it does not permit.
   { code: `<img role="button" />`, options: OPTIONS, errors: 1 },
   { code: `<img alt="" role="button" />`, options: OPTIONS, errors: 1 },
+  { code: `<img alt={null} role="button" />`, options: OPTIONS, errors: 1 },
+  { code: `<img aria-label={null} role="button" />`, options: OPTIONS, errors: 1 },
+  { code: `<img aria-labelledby={null} role="button" />`, options: OPTIONS, errors: 1 },
   { code: `<img alt="Logo" role="combobox" />`, options: OPTIONS, errors: 1 },
   // figure with a caption, and an associated label, are restricted.
   {

--- a/packages/analysis/src/jsts/rules/S6842/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6842/unit.test.ts
@@ -93,6 +93,8 @@ const VALID_CASES = [
   { code: `<img alt={label} role="button" />`, options: OPTIONS },
   { code: `<img aria-label={t('logo')} role="tab" />`, options: OPTIONS },
   { code: `<img aria-labelledby={computedId} role="link" />`, options: OPTIONS },
+  { code: `<img alt={\`Logo\`} role="button" />`, options: OPTIONS },
+  { code: `<img aria-label={\`\${x} logo\`} role="tab" />`, options: OPTIONS },
   // figure without a caption, and a non-associated label, accept any role.
   { code: `<figure role="button"><img alt="x" /></figure>`, options: OPTIONS },
   { code: `<label role="button">Text</label>`, options: OPTIONS },
@@ -113,6 +115,7 @@ const INVALID_CASES = [
   // img without an accessible name, or with a role it does not permit.
   { code: `<img role="button" />`, options: OPTIONS, errors: 1 },
   { code: `<img alt="" role="button" />`, options: OPTIONS, errors: 1 },
+  { code: `<img alt={\`\`} role="button" />`, options: OPTIONS, errors: 1 },
   { code: `<img alt={null} role="button" />`, options: OPTIONS, errors: 1 },
   { code: `<img aria-label={null} role="button" />`, options: OPTIONS, errors: 1 },
   { code: `<img aria-labelledby={null} role="button" />`, options: OPTIONS, errors: 1 },

--- a/packages/analysis/src/jsts/rules/S6842/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6842/unit.test.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { deepStrictEqual } from 'node:assert';
+import { deepStrictEqual, doesNotThrow } from 'node:assert';
 import { describe, it } from 'node:test';
 import { defaultOptions } from '../helpers/configs.js';
 import { fields } from './config.js';
@@ -137,9 +137,11 @@ describe('S6842', () => {
 
   it('should report only the element/role combinations forbidden by ARIA in HTML', () => {
     const ruleTester = new NoTypeCheckingRuleTester();
-    ruleTester.run('no-noninteractive-element-to-interactive-role', rule, {
-      valid: VALID_CASES,
-      invalid: INVALID_CASES,
-    });
+    doesNotThrow(() =>
+      ruleTester.run('no-noninteractive-element-to-interactive-role', rule, {
+        valid: VALID_CASES,
+        invalid: INVALID_CASES,
+      }),
+    );
   });
 });

--- a/packages/analysis/src/jsts/rules/S6842/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6842/unit.test.ts
@@ -26,8 +26,8 @@ type Allowlist = Record<string, string[]>;
 const OPTIONS = defaultOptions(fields) as [Allowlist];
 
 // The flat, spec-derived allowlist exposed as default options. Context-sensitive elements
-// (li, img, figure, label), "any role" elements and the `toolbar` structure role are enforced
-// by the decorator, not by these options.
+// (li, img, figure, label), "any role" elements and the list-container `toolbar` structure role
+// are enforced by the decorator, not by these options.
 const EXPECTED_ALLOWLIST: Allowlist = {
   ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'],
   ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'],
@@ -109,6 +109,7 @@ const INVALID_CASES = [
   // A list child inside a real list is restricted to listitem.
   { code: `<ul><li role="menuitem">Item</li></ul>`, options: OPTIONS, errors: 1 },
   { code: `<ul role="list"><li role="button">Item</li></ul>`, options: OPTIONS, errors: 1 },
+  { code: `<ul role="list"><li role="toolbar">Item</li></ul>`, options: OPTIONS, errors: 1 },
   // img without an accessible name, or with a role it does not permit.
   { code: `<img role="button" />`, options: OPTIONS, errors: 1 },
   { code: `<img alt="" role="button" />`, options: OPTIONS, errors: 1 },

--- a/packages/analysis/src/jsts/rules/S6842/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6842/unit.test.ts
@@ -39,6 +39,27 @@ if (!isAllowlist(upstreamConfiguration)) {
   );
 }
 const UPSTREAM_ALLOWLIST = upstreamConfiguration;
+const LIST_CONTAINER_COMPOSITE_ROLES = [
+  'listbox',
+  'menu',
+  'menubar',
+  'radiogroup',
+  'tablist',
+  'toolbar',
+  'tree',
+];
+const TABLE_COMPOSITE_ROLES = [...LIST_CONTAINER_COMPOSITE_ROLES, 'grid', 'treegrid'];
+const TABLE_ALLOWED_ROLES = ['grid', ...LIST_CONTAINER_COMPOSITE_ROLES, 'treegrid'];
+const EXPECTED_ALLOWLIST: Allowlist = {
+  ...UPSTREAM_ALLOWLIST,
+  ul: [...UPSTREAM_ALLOWLIST.ul, 'toolbar'],
+  ol: [...UPSTREAM_ALLOWLIST.ol, 'toolbar'],
+  table: TABLE_ALLOWED_ROLES,
+  menu: LIST_CONTAINER_COMPOSITE_ROLES,
+  tbody: TABLE_COMPOSITE_ROLES,
+  thead: TABLE_COMPOSITE_ROLES,
+  tfoot: TABLE_COMPOSITE_ROLES,
+};
 
 const OPTIONS = defaultOptions(fields) as [Allowlist];
 const [allowlist] = OPTIONS;
@@ -49,10 +70,6 @@ const COMPOSITE_VALID_CASES = [
   },
   {
     code: `<ol role="listbox"><li role="option">Item</li></ol>`,
-    options: OPTIONS,
-  },
-  {
-    code: `<table role="grid"><tr><td>Item</td></tr></table>`,
     options: OPTIONS,
   },
   {
@@ -78,19 +95,39 @@ const VALID_CASES = [
     code: `<ol role="${role}"><li>Item</li></ol>`,
     options: OPTIONS,
   })),
+  ...allowlist.menu.map(role => ({
+    code: `<menu role="${role}"><li>Item</li></menu>`,
+    options: OPTIONS,
+  })),
   ...allowlist.li.map(role => ({
     code: `<li role="${role}">Item</li>`,
+    options: OPTIONS,
+  })),
+  ...allowlist.table.map(role => ({
+    code: `<table role="${role}"><tr><td>Item</td></tr></table>`,
+    options: OPTIONS,
+  })),
+  ...allowlist.tbody.map(role => ({
+    code: `<table><tbody role="${role}"><tr><td>Item</td></tr></tbody></table>`,
+    options: OPTIONS,
+  })),
+  ...allowlist.thead.map(role => ({
+    code: `<table><thead role="${role}"><tr><th>Item</th></tr></thead></table>`,
+    options: OPTIONS,
+  })),
+  ...allowlist.tfoot.map(role => ({
+    code: `<table><tfoot role="${role}"><tr><td>Item</td></tr></tfoot></table>`,
     options: OPTIONS,
   })),
   ...COMPOSITE_VALID_CASES,
 ];
 
 describe('S6842', () => {
-  it('should expose the upstream recommended allowlist as default options', () => {
-    deepStrictEqual(allowlist, UPSTREAM_ALLOWLIST);
+  it('should expose the spec-compliant allowlist as default options', () => {
+    deepStrictEqual(allowlist, EXPECTED_ALLOWLIST);
   });
 
-  it('should not flag upstream recommended element/role combinations', () => {
+  it('should not flag spec-compliant composite widget overrides', () => {
     const ruleTester = new NoTypeCheckingRuleTester();
     ok(
       VALID_CASES.some(
@@ -100,6 +137,20 @@ describe('S6842', () => {
     ok(
       VALID_CASES.some(
         ({ code }) => code === `<ol role="listbox"><li role="option">Item</li></ol>`,
+      ),
+    );
+    ok(VALID_CASES.some(({ code }) => code === `<ul role="toolbar"><li>Item</li></ul>`));
+    ok(VALID_CASES.some(({ code }) => code === `<ol role="toolbar"><li>Item</li></ol>`));
+    ok(VALID_CASES.some(({ code }) => code === `<menu role="toolbar"><li>Item</li></menu>`));
+    ok(
+      VALID_CASES.some(
+        ({ code }) => code === `<table role="treegrid"><tr><td>Item</td></tr></table>`,
+      ),
+    );
+    ok(
+      VALID_CASES.some(
+        ({ code }) =>
+          code === `<table><tbody role="toolbar"><tr><td>Item</td></tr></tbody></table>`,
       ),
     );
     ruleTester.run('no-noninteractive-element-to-interactive-role', rule, {
@@ -117,6 +168,21 @@ describe('S6842', () => {
         },
         {
           code: `<li role="button">Foo</li>`,
+          options: OPTIONS,
+          errors: 1,
+        },
+        {
+          code: `<menu role="button"><li>Item</li></menu>`,
+          options: OPTIONS,
+          errors: 1,
+        },
+        {
+          code: `<table role="button"><tr><td>Item</td></tr></table>`,
+          options: OPTIONS,
+          errors: 1,
+        },
+        {
+          code: `<table><tbody role="button"><tr><td>Item</td></tr></tbody></table>`,
           options: OPTIONS,
           errors: 1,
         },


### PR DESCRIPTION
## Summary
Align `S6842` with the full [ARIA in HTML conformance table](https://w3c.github.io/html-aria/#docconformance), not only the composite-widget overrides. jsx-a11y's element→roles allowlist cannot express context, so the rule is now decorated: `config.ts` keeps the flat, spec-derived allowlists and `decorator.ts` handles everything the allowlist cannot. This brings the JS/TS analyzer to parity with the sonar-html implementation (SONARHTML-403) — both now agree with the spec on every element/role pair.

## Changes
- `config.ts`: enumerated allowlists per the conformance table — `ul`/`ol`/`menu` (drop `treegrid`), `nav`, `h1`–`h6`, `fieldset`, `td`, `progress`; `li` is left to the decorator.
- `decorator.ts` (new): suppresses the combinations the table permits but the allowlist cannot describe:
  - elements that accept **any role** (`table`/`tbody`/`thead`/`tfoot`, text-level elements such as `p`, `blockquote`, `time`, `output`, …);
  - context-sensitive elements — `li` (only restricted when a parent exposes a `list` role), `img` (interactive roles allowed only with an accessible name), `figure` (restricted only with a `figcaption`), `label` (restricted only when associated with a control);
  - `toolbar` treated as a structure role (non-interactive), consistent with sonar-html and the WAI-ARIA role taxonomy.

## Fixes vs. the previous revision
- Removes false positives on `nav`, headings, named `img`, and any-role elements.
- Restores the missing `treegrid`-on-`ul`/`ol` report (spec forbids it).
- Drops the incorrect `table[role="button"]` / `tbody[role="button"]` true positives — the table family accepts any role.

## Tests
`unit.test.ts` rewritten as a spec matrix (valid + invalid) covering every case above.
