### PR TITLE
JS-2020 Fix S3735 false positives on voided member calls

### DIFF
--- a/its/ruling/src/test/expected/eigen/typescript-S3735.json
+++ b/its/ruling/src/test/expected/eigen/typescript-S3735.json
@@ -1,6 +1,0 @@
-{
-"eigen:src/palette/organisms/screenStructure/Screen.tsx": [
-74,
-234
-]
-}

--- a/packages/analysis/src/jsts/rules/S3735/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3735/rule.ts
@@ -18,6 +18,7 @@
 
 import type { Rule } from 'eslint';
 import type estree from 'estree';
+import { unwrapChainExpression } from '../helpers/expect-call-chain.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import {
   isRequiredParserServices,
@@ -101,10 +102,7 @@ function isShortCircuitExpression(node: estree.Node) {
  * @return Whether the expression has a callable shape.
  */
 function isCallLikeExpression(node: estree.Node) {
-  return (
-    node.type === 'CallExpression' ||
-    (node.type === 'ChainExpression' && node.expression.type === 'CallExpression')
-  );
+  return unwrapChainExpression(node).type === 'CallExpression';
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S3735/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3735/rule.ts
@@ -96,7 +96,7 @@ function isCallLikeExpression(node: estree.Node) {
  * Returns true when TypeScript cannot determine whether `node` resolves to a promise.
  * @param node The expression used with `void`.
  * @param services The TypeScript parser services.
- * @return Whether the resolved type is `any`, `unknown`, or an unresolved error type.
+ * @return Whether the resolved type is `any` or `unknown`.
  */
 function hasIndeterminateType(node: estree.Node, services: RequiredParserServices) {
   const type = getTypeFromTreeNode(node, services);

--- a/packages/analysis/src/jsts/rules/S3735/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3735/rule.ts
@@ -18,7 +18,6 @@
 
 import type { Rule } from 'eslint';
 import type estree from 'estree';
-import ts from 'typescript';
 import { generateMeta } from '../helpers/generate-meta.js';
 import {
   isRequiredParserServices,
@@ -26,6 +25,7 @@ import {
 } from '../helpers/parser-services.js';
 import {
   getTypeFromTreeNode,
+  isAnyOrUnknownType,
   isThenableOrGuardUnion,
   isThenableOrVoidUnion,
 } from '../helpers/type.js';
@@ -114,6 +114,5 @@ function isCallLikeExpression(node: estree.Node) {
  * @return Whether the resolved type is `any` or `unknown`.
  */
 function hasIndeterminateType(node: estree.Node, services: RequiredParserServices) {
-  const type = getTypeFromTreeNode(node, services);
-  return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+  return isAnyOrUnknownType(getTypeFromTreeNode(node, services));
 }

--- a/packages/analysis/src/jsts/rules/S3735/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3735/rule.ts
@@ -24,7 +24,11 @@ import {
   isRequiredParserServices,
   type RequiredParserServices,
 } from '../helpers/parser-services.js';
-import { getTypeFromTreeNode, isThenableOrVoidUnion } from '../helpers/type.js';
+import {
+  getTypeFromTreeNode,
+  isThenableOrGuardUnion,
+  isThenableOrVoidUnion,
+} from '../helpers/type.js';
 import * as meta from './generated-meta.js';
 
 export const rule: Rule.RuleModule = {
@@ -70,6 +74,8 @@ function isPromiseLike(context: Rule.RuleContext, expr: estree.UnaryExpression) 
   if (isRequiredParserServices(services)) {
     return (
       isThenableOrVoidUnion(expr.argument, services) ||
+      (isShortCircuitExpression(expr.argument) &&
+        isThenableOrGuardUnion(expr.argument, services)) ||
       (isCallLikeExpression(expr.argument) && hasIndeterminateType(expr.argument, services))
     );
   } else {
@@ -78,6 +84,15 @@ function isPromiseLike(context: Rule.RuleContext, expr: estree.UnaryExpression) 
     // For this rule, it will result in not raising an issue.
     return isCallLikeExpression(expr.argument);
   }
+}
+
+/**
+ * Returns true when `node` is a short-circuit expression whose result depends on a guard.
+ * @param node The expression used with `void`.
+ * @return Whether the expression is a logical (`||`, `&&`, `??`) or conditional (`?:`) expression.
+ */
+function isShortCircuitExpression(node: estree.Node) {
+  return node.type === 'LogicalExpression' || node.type === 'ConditionalExpression';
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S3735/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3735/rule.ts
@@ -18,10 +18,13 @@
 
 import type { Rule } from 'eslint';
 import type estree from 'estree';
+import ts from 'typescript';
 import { generateMeta } from '../helpers/generate-meta.js';
-import { isFunctionCall } from '../helpers/ast.js';
-import { isRequiredParserServices } from '../helpers/parser-services.js';
-import { isThenableOrVoidUnion } from '../helpers/type.js';
+import {
+  isRequiredParserServices,
+  type RequiredParserServices,
+} from '../helpers/parser-services.js';
+import { getTypeFromTreeNode, isThenableOrVoidUnion } from '../helpers/type.js';
 import * as meta from './generated-meta.js';
 
 export const rule: Rule.RuleModule = {
@@ -65,11 +68,37 @@ function isIIFE(expr: estree.UnaryExpression) {
 function isPromiseLike(context: Rule.RuleContext, expr: estree.UnaryExpression) {
   const services = context.sourceCode.parserServices;
   if (isRequiredParserServices(services)) {
-    return isThenableOrVoidUnion(expr.argument, services);
+    return (
+      isThenableOrVoidUnion(expr.argument, services) ||
+      (isCallLikeExpression(expr.argument) && hasIndeterminateType(expr.argument, services))
+    );
   } else {
     // If we don't have typescript types, we can't reason if it's a promise.
     // Therefore, if this is a function call, assume it is a promise.
     // For this rule, it will result in not raising an issue.
-    return isFunctionCall(expr.argument);
+    return isCallLikeExpression(expr.argument);
   }
+}
+
+/**
+ * Returns true when `node` is a direct call or an optionally chained call.
+ * @param node The expression used with `void`.
+ * @return Whether the expression has a callable shape.
+ */
+function isCallLikeExpression(node: estree.Node) {
+  return (
+    node.type === 'CallExpression' ||
+    (node.type === 'ChainExpression' && node.expression.type === 'CallExpression')
+  );
+}
+
+/**
+ * Returns true when TypeScript cannot determine whether `node` resolves to a promise.
+ * @param node The expression used with `void`.
+ * @param services The TypeScript parser services.
+ * @return Whether the resolved type is `any`, `unknown`, or an unresolved error type.
+ */
+function hasIndeterminateType(node: estree.Node, services: RequiredParserServices) {
+  const type = getTypeFromTreeNode(node, services);
+  return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
 }

--- a/packages/analysis/src/jsts/rules/S3735/rule.ts
+++ b/packages/analysis/src/jsts/rules/S3735/rule.ts
@@ -80,9 +80,7 @@ function isPromiseLike(context: Rule.RuleContext, expr: estree.UnaryExpression) 
       (isCallLikeExpression(expr.argument) && hasIndeterminateType(expr.argument, services))
     );
   } else {
-    // If we don't have typescript types, we can't reason if it's a promise.
-    // Therefore, if this is a function call, assume it is a promise.
-    // For this rule, it will result in not raising an issue.
+    // No type info: treat any call-like expression as a possible promise and don't raise.
     return isCallLikeExpression(expr.argument);
   }
 }

--- a/packages/analysis/src/jsts/rules/S3735/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S3735/unit.test.ts
@@ -60,6 +60,25 @@ describe('S3735', () => {
             const f = () => {};
             void f(); // FN: should raise since 'f()' is not a promise but we are missing type information`,
         },
+        {
+          code: `
+            class Component {
+              load() {}
+
+              onClick() {
+                void this.load();
+              }
+            }
+            `,
+        },
+        {
+          code: `
+            const service = {
+              load() {},
+            };
+            void service?.load();
+            `,
+        },
       ],
       invalid: [
         {
@@ -73,6 +92,15 @@ describe('S3735', () => {
               endColumn: 5,
             },
           ],
+        },
+        {
+          code: `
+            const service = {
+              load() {},
+            };
+            void service.load;
+            `,
+          errors: 1,
         },
       ],
     });
@@ -154,6 +182,26 @@ describe('S3735', () => {
             void z;
             `,
         },
+        {
+          code: `
+            const service = {
+              doAsync: async () => {},
+            };
+            void service.doAsync();
+            `,
+        },
+        {
+          code: `
+            declare const anyService: { doAsync: any };
+            void anyService.doAsync();
+            `,
+        },
+        {
+          code: `
+            declare const unknownCallable: unknown;
+            void unknownCallable();
+            `,
+        },
       ],
       invalid: [
         {
@@ -174,6 +222,15 @@ describe('S3735', () => {
             declare const skipCheck: boolean;
             declare const checkPromise: Promise<void>;
             void (skipCheck || checkPromise);
+            `,
+          errors: 1,
+        },
+        {
+          code: `
+            const service = {
+              doSync: () => 42,
+            };
+            void service.doSync();
             `,
           errors: 1,
         },

--- a/packages/analysis/src/jsts/rules/S3735/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S3735/unit.test.ts
@@ -202,6 +202,30 @@ describe('S3735', () => {
             void unknownCallable();
             `,
         },
+        {
+          code: `
+            // Guarded promise: boolean || Promise
+            declare const skipCheck: boolean;
+            declare const checkPromise: Promise<void>;
+            void (skipCheck || checkPromise);
+            `,
+        },
+        {
+          code: `
+            // Guarded promise: boolean && Promise
+            declare const runCheck: boolean;
+            declare const checkPromise: Promise<void>;
+            void (runCheck && checkPromise);
+            `,
+        },
+        {
+          code: `
+            // Guarded promise: conditional with boolean fallback
+            declare const cond: boolean;
+            declare const checkPromise: Promise<void>;
+            void (cond ? checkPromise : false);
+            `,
+        },
       ],
       invalid: [
         {
@@ -218,10 +242,10 @@ describe('S3735', () => {
         },
         {
           code: `
-            // Union with boolean (logical expressions)
-            declare const skipCheck: boolean;
+            // Short-circuit where the guard is a real value (string), not a boolean
+            declare const label: string;
             declare const checkPromise: Promise<void>;
-            void (skipCheck || checkPromise);
+            void (label || checkPromise);
             `,
           errors: 1,
         },

--- a/packages/analysis/src/jsts/rules/helpers/type.ts
+++ b/packages/analysis/src/jsts/rules/helpers/type.ts
@@ -176,6 +176,8 @@ export function isThenable(node: estree.Node, services: RequiredParserServices) 
   return hasThenMethod(checker.getTypeAtLocation(mapped), checker);
 }
 
+const NOTHING_TYPE_FLAGS = ts.TypeFlags.Void | ts.TypeFlags.Undefined | ts.TypeFlags.Null;
+
 /**
  * Checks if a node's type is either:
  * - Thenable (Promise-like), OR
@@ -186,21 +188,40 @@ export function isThenable(node: estree.Node, services: RequiredParserServices) 
  * optional async callbacks (() => void | Promise<void>).
  */
 export function isThenableOrVoidUnion(node: estree.Node, services: RequiredParserServices) {
+  return isThenableUnionWithGuards(node, services, NOTHING_TYPE_FLAGS);
+}
+
+/**
+ * Like {@link isThenableOrVoidUnion}, but also accepts boolean members as guards.
+ *
+ * Short-circuit expressions such as `skipCheck || checkPromise` resolve to
+ * `boolean | Promise<void>`, where the boolean is only a guard deciding whether
+ * the promise runs. Voiding such an expression is the `no-floating-promises`
+ * idiom and must not be flagged.
+ */
+export function isThenableOrGuardUnion(node: estree.Node, services: RequiredParserServices) {
+  return isThenableUnionWithGuards(node, services, NOTHING_TYPE_FLAGS | ts.TypeFlags.BooleanLike);
+}
+
+function isThenableUnionWithGuards(
+  node: estree.Node,
+  services: RequiredParserServices,
+  guardFlags: ts.TypeFlags,
+) {
   const checker = services.program.getTypeChecker();
   const type = getTypeFromTreeNode(node, services);
   const unionTypes = type.isUnion() ? type.types : [type];
   let hasThenable = false;
-  let allThenableOrVoid = true;
+  let allThenableOrGuard = true;
 
   for (const unionType of unionTypes) {
     const isThenable = hasThenMethod(unionType, checker);
-    const isNothingType =
-      (unionType.flags & (ts.TypeFlags.Void | ts.TypeFlags.Undefined | ts.TypeFlags.Null)) !== 0;
+    const isGuard = (unionType.flags & guardFlags) !== 0;
     hasThenable ||= isThenable;
-    allThenableOrVoid &&= isThenable || isNothingType;
+    allThenableOrGuard &&= isThenable || isGuard;
   }
 
-  return hasThenable && allThenableOrVoid;
+  return hasThenable && allThenableOrGuard;
 }
 
 function hasThenMethod(type: ts.Type, checker: ts.TypeChecker): boolean {

--- a/packages/analysis/src/jsts/rules/helpers/type.ts
+++ b/packages/analysis/src/jsts/rules/helpers/type.ts
@@ -330,7 +330,7 @@ function areSameTypeArguments(
   return checker.typeToString(left) === checker.typeToString(right);
 }
 
-function isAnyOrUnknownType(type: ts.Type): boolean {
+export function isAnyOrUnknownType(type: ts.Type): boolean {
   return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
 }
 


### PR DESCRIPTION
## Summary
This fixes `S3735` false positives on untyped member calls such as `void this.load()`, which currently conflict with `@typescript-eslint/no-floating-promises` when type information is unavailable.

## Changes
- broadened the no-type-info fallback so member calls and optionally chained calls are treated like other voided call expressions
- kept typed member calls precise while failing open only when the resolved call type is indeterminate
- added rule tests for untyped member calls, optional chaining, indeterminate typed calls, and preserved non-promise reports

