### PR TITLE
JS-2021 Node Assert Strict : JS-specific FP fix

### DIFF
--- a/its/sources/custom/jsts/tests/S2699.js
+++ b/its/sources/custom/jsts/tests/S2699.js
@@ -19,15 +19,14 @@ describe('supertest', function () { // Compliant
   });
 });
 
-import { describe as d, it as t } from 'node:test';
 import assert from 'node:assert/strict';
 
-d('node:assert/strict', () => {
-  t('should recognize assert/strict assertions', () => { // Compliant
-    assert.strictEqual(1, 1);
+describe('node:assert/strict', () => {
+  it('should recognize assert/strict assertions', () => { // Compliant
+    assert.strictEqual(actual, expected);
   });
 
-  t('should raise without assertions', () => { // Noncompliant
+  it('should raise without assertions', () => { // Noncompliant
     const x = 1 + 2;
   });
 });

--- a/its/sources/custom/jsts/tests/S2699.js
+++ b/its/sources/custom/jsts/tests/S2699.js
@@ -18,3 +18,16 @@ describe('supertest', function () { // Compliant
     return supertest(app).get(`/foo/bar`);
   });
 });
+
+import { describe as d, it as t } from 'node:test';
+import assert from 'node:assert/strict';
+
+d('node:assert/strict', () => {
+  t('should recognize assert/strict assertions', () => { // Compliant
+    assert.strictEqual(1, 1);
+  });
+
+  t('should raise without assertions', () => { // Noncompliant
+    const x = 1 + 2;
+  });
+});

--- a/its/sources/custom/jsts/tests/S2699.ts
+++ b/its/sources/custom/jsts/tests/S2699.ts
@@ -1,0 +1,12 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('node:assert/strict', () => {
+  it('should recognize assert/strict assertions', () => { // Compliant
+    assert.strictEqual(1, 1);
+  });
+
+  it('should raise without assertions', () => { // Noncompliant
+    const x = 1 + 2;
+  });
+});

--- a/its/sources/custom/jsts/tests/S2699.ts
+++ b/its/sources/custom/jsts/tests/S2699.ts
@@ -1,9 +1,9 @@
-import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 
 describe('node:assert/strict', () => {
   it('should recognize assert/strict assertions', () => { // Compliant
-    assert.strictEqual(1, 1);
+    assert.strictEqual(actual, expected);
   });
 
   it('should raise without assertions', () => { // Noncompliant

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -288,7 +288,8 @@ function isFunctionCallFromNodeAssert(context: Rule.RuleContext, node: estree.No
     return false;
   }
   const fullyQualifiedName = getFullyQualifiedName(context, node);
-  return fullyQualifiedName?.split('.')[0] === 'assert';
+  const root = fullyQualifiedName?.split('.')[0];
+  return root === 'assert' || root === 'assert/strict';
 }
 
 function isShouldMember(node: estree.Node): node is estree.MemberExpression {


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Rule logic update:**
  - Updated `isFunctionCallFromNodeAssert` in `assertion-detection.ts` to support `assert/strict` as a valid assertion module.
- **Test coverage:**
  - Added integration tests in `S2699.js` and `S2699.ts` to verify recognition of `node:assert/strict` assertions.

<sub>This will update automatically on new commits.</sub>