### PR TITLE
CLP-152 Clean up Renovate config in SonarJS

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,12 +43,5 @@
         "schedule:weekly"
       ]
     }
-  ],
-  "hostRules": [
-    {
-      "hostType": "npm",
-      "matchHost": "https://repox.jfrog.io/artifactory/api/npm/npm/",
-      "token": "{{ secrets.REPOX_TOKEN }}"
-    }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,14 +3,6 @@
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
-  "enabledManagers": [
-    "github-actions",
-    "maven",
-    "npm"
-  ],
-  "dockerfile": {
-    "enabled": true
-  },
   "ignorePaths": [
     "its/sources/**",
     "its/plugin/projects/**",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,22 +35,6 @@
       "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "pinDigests": false
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "pin",
-        "rollback"
-      ],
-      "enabled": false
-    },
-    {
       "description": "@typescript/native-preview - dev builds update daily, limit to weekly",
       "matchPackageNames": [
         "@typescript/native-preview"


### PR DESCRIPTION
Part of CLP-11.

This PR cleans up the local Renovate config after the latest updates in the squad parent preset.

Expected current effective delta:
- track `Dockerfile` updates
- pin third-party GitHub Actions to commit SHAs
- allow rollback PRs for third-party GitHub Actions
