### PR TITLE
JS-2025 Use official cache and artifact actions in CI

### DIFF
--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -15,7 +15,7 @@ runs:
     # Restore only on branches (no save) - allows branches to read from default branch's cache
     - name: Restore Maven cache (branches)
       if: github.ref_name != github.event.repository.default_branch
-      uses: actions/cache/restore@v6
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ runner.os }}-${{ inputs.cache-month }}-${{ inputs.maven-hash }}
@@ -24,7 +24,7 @@ runs:
     # Full cache on default branch (save enabled)
     - name: Cache Maven dependencies (default branch)
       if: github.ref_name == github.event.repository.default_branch
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ runner.os }}-${{ inputs.cache-month }}-${{ inputs.maven-hash }}

--- a/.github/actions/orchestrator-cache/action.yml
+++ b/.github/actions/orchestrator-cache/action.yml
@@ -25,7 +25,7 @@ runs:
     # Also used when save is disabled
     - name: Restore Orchestrator cache (restore only)
       if: github.ref_name != github.event.repository.default_branch || inputs.save != 'true'
-      uses: actions/cache/restore@v6
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.ORCHESTRATOR_HOME }}
         key: ${{ inputs.key-prefix }}-${{ env.ORCHESTRATOR_CACHE_MONTH }}-${{ github.run_id }}
@@ -34,7 +34,7 @@ runs:
     # Full cache on default branch (save enabled) - uses run_id for rolling cache
     - name: Cache Orchestrator (default branch)
       if: github.ref_name == github.event.repository.default_branch && inputs.save == 'true'
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.ORCHESTRATOR_HOME }}
         key: ${{ inputs.key-prefix }}-${{ env.ORCHESTRATOR_CACHE_MONTH }}-${{ github.run_id }}

--- a/.github/actions/rule-api-cache/action.yml
+++ b/.github/actions/rule-api-cache/action.yml
@@ -22,7 +22,7 @@ runs:
     # Also used when save is disabled.
     - name: Restore Rule API cache (restore only)
       if: github.ref_name != github.event.repository.default_branch || inputs.save != 'true'
-      uses: actions/cache/restore@v6
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.RULE_API_CACHE_DIR }}
         key: ${{ inputs.key-prefix }}-${{ github.run_id }}
@@ -32,7 +32,7 @@ runs:
     # clone contents evolve independently of the SonarJS source tree.
     - name: Cache Rule API data (default branch)
       if: github.ref_name == github.event.repository.default_branch && inputs.save == 'true'
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.RULE_API_CACHE_DIR }}
         key: ${{ inputs.key-prefix }}-${{ github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,12 +97,14 @@ jobs:
       # Reuse the build number minted once in get_build_number everywhere workflow metadata is configured or promoted.
       BUILD_NUMBER: ${{ needs.get_build_number.outputs.build-number }}
     steps: &populate_npm_cache_steps
-      - name: Cache NPM dependencies
+      # Producer jobs need a lookup-only probe that still saves a freshly populated cache at job end.
+      - name: Check NPM dependencies cache
         id: cache
-        uses: SonarSource/gh-action_cache@v1
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ needs.setup.outputs.npm-hash }}
+          lookup-only: true
       - name: Checkout source code
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -162,11 +164,12 @@ jobs:
             maven = "3.9"
             node = "24.11.0"
       - &npm_cache
-        name: Cache NPM dependencies
-        uses: SonarSource/gh-action_cache@v1
+        name: Restore NPM dependencies
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ needs.setup.outputs.npm-hash }}
+          fail-on-cache-miss: true
       - &download_rspec_rule_data
         name: Download prepared RSPEC rule data
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -300,12 +303,13 @@ jobs:
       - *download_rspec_rule_data
       - name: Build ESLint plugin
         run: npm run eslint-plugin:build
-      - &eslint_tarball_cache
-        name: Cache ESLint plugin tarball
-        uses: SonarSource/gh-action_cache@v1
+      - name: Upload ESLint plugin tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: lib/*.tgz
-          key: eslint-tarball-${{ github.sha }}
+          name: eslint-tarball-${{ github.sha }}
+          path: lib/eslint-plugin-sonarjs-0.0.0-SNAPSHOT.tgz
+          if-no-files-found: error
+          retention-days: 1
 
   generated_files_freshness:
     runs-on: github-ubuntu-latest-s
@@ -388,7 +392,27 @@ jobs:
           mise_toml: |
             [tools]
             node = "${{ matrix.node-version }}"
-      - *eslint_tarball_cache
+      - name: Download ESLint plugin tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: eslint-tarball-${{ github.sha }}
+          path: lib
+      - name: Validate ESLint plugin tarball
+        shell: bash
+        run: |
+          TARBALL=lib/eslint-plugin-sonarjs-0.0.0-SNAPSHOT.tgz
+
+          if [ -f "$TARBALL" ]; then
+            exit 0
+          fi
+
+          FOUND_TARBALL=$(find lib -name "$(basename "$TARBALL")" -print -quit)
+          if [ -z "$FOUND_TARBALL" ]; then
+            echo "::error::Missing ESLint plugin tarball"
+            exit 1
+          fi
+
+          mv "$FOUND_TARBALL" "$TARBALL"
       - name: Test ESLint Plugin
         run: |
           cd its/eslint${{ matrix.eslint-version }}-plugin-sonarjs
@@ -419,7 +443,7 @@ jobs:
     steps:
       - name: Restore JS coverage cache
         id: cache
-        uses: SonarSource/gh-action_cache@v1
+        uses: actions/cache@v5
         with:
           path: coverage/js
           key: js-coverage-${{ needs.setup.outputs.js-files-hash }}
@@ -436,12 +460,13 @@ jobs:
             java = "21.0"
             maven = "3.9"
             node = "24.11.0"
-      - name: Cache NPM dependencies
+      - name: Restore NPM dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: SonarSource/gh-action_cache@v1
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ needs.setup.outputs.npm-hash }}
+          fail-on-cache-miss: true
       - if: steps.cache.outputs.cache-hit != 'true'
         name: Download prepared RSPEC rule data
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -454,7 +479,8 @@ jobs:
           npm run generate-meta
           npm run bridge:compile
           npm run bridge:test:cov
-      - name: Validate JS coverage reports
+      - &validate_js_coverage_reports
+        name: Validate JS coverage reports
         run: |
           for report in coverage/js/lcov.info coverage/js/test-report.xml; do
             if [ ! -f "$report" ]; then
@@ -478,9 +504,9 @@ jobs:
     needs: [setup, populate_npm_cache_win, prepare_rspec_rule_data]
     permissions: *read_permissions
     steps:
-      - name: Cache JS test results marker (Windows)
+      - name: Check JS test results marker (Windows)
         id: cache
-        uses: SonarSource/gh-action_cache@v1
+        uses: actions/cache@v5
         with:
           path: .js-test-marker-win
           key: js-test-win-${{ needs.setup.outputs.js-files-hash }}
@@ -498,12 +524,13 @@ jobs:
             java = "21.0"
             maven = "3.9"
             node = "24.11.0"
-      - name: Cache NPM dependencies
+      - name: Restore NPM dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: SonarSource/gh-action_cache@v1
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ needs.setup.outputs.npm-hash }}
+          fail-on-cache-miss: true
       - if: steps.cache.outputs.cache-hit != 'true'
         name: Download prepared RSPEC rule data
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -542,6 +569,7 @@ jobs:
         with:
           name: js-coverage-reports-${{ github.sha }}
           path: coverage/js
+      - *validate_js_coverage_reports
       - &download_maven_targets
         name: Download Maven target artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -603,6 +631,7 @@ jobs:
       - *npm_cache
       - *maven_cache
       - *download_js_coverage_reports
+      - *validate_js_coverage_reports
       - *download_maven_targets
       - *download_jacoco_xml_reports
       - *config_maven

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,16 +118,14 @@ jobs:
             java = "21.0"
             maven = "3.9"
             node = "24.11.0"
-      - if: steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
-        uses: SonarSource/ci-github-actions/config-npm@v1
-      - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      - if: steps.cache.outputs.cache-hit != 'true'
         id: secrets
         name: Access vault secrets
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/artifactory/token/${{ github.repository_owner }}-${{ github.event.repository.name }}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-      - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      - if: steps.cache.outputs.cache-hit != 'true'
         name: Configure npm registry
         run: |
           npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,9 +139,10 @@ jobs:
   populate_npm_cache_win:
     runs-on: github-windows-latest-s
     name: Populate NPM cache for Windows
-    needs: setup
+    needs: [setup, get_build_number]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions: *read_permissions
+    env: *shared_build_number
     steps: *populate_npm_cache_steps
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,17 +401,10 @@ jobs:
         run: |
           TARBALL=lib/eslint-plugin-sonarjs-0.0.0-SNAPSHOT.tgz
 
-          if [ -f "$TARBALL" ]; then
-            exit 0
-          fi
-
-          FOUND_TARBALL=$(find lib -name "$(basename "$TARBALL")" -print -quit)
-          if [ -z "$FOUND_TARBALL" ]; then
-            echo "::error::Missing ESLint plugin tarball"
+          if [ ! -f "$TARBALL" ]; then
+            echo "::error file=$TARBALL::Missing ESLint plugin tarball"
             exit 1
           fi
-
-          mv "$FOUND_TARBALL" "$TARBALL"
       - name: Test ESLint Plugin
         run: |
           cd its/eslint${{ matrix.eslint-version }}-plugin-sonarjs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       # Producer jobs need a lookup-only probe that still saves a freshly populated cache at job end.
       - name: Check NPM dependencies cache
         id: cache
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ needs.setup.outputs.npm-hash }}
@@ -166,7 +166,7 @@ jobs:
             node = "24.11.0"
       - &npm_cache
         name: Restore NPM dependencies
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ needs.setup.outputs.npm-hash }}
@@ -444,7 +444,7 @@ jobs:
     steps:
       - name: Restore JS coverage cache
         id: cache
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: coverage/js
           key: js-coverage-${{ needs.setup.outputs.js-files-hash }}
@@ -463,7 +463,7 @@ jobs:
             node = "24.11.0"
       - name: Restore NPM dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ needs.setup.outputs.npm-hash }}
@@ -507,7 +507,7 @@ jobs:
     steps:
       - name: Check JS test results marker (Windows)
         id: cache
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .js-test-marker-win
           key: js-test-win-${{ needs.setup.outputs.js-files-hash }}
@@ -527,7 +527,7 @@ jobs:
             node = "24.11.0"
       - name: Restore NPM dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ needs.setup.outputs.npm-hash }}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,18 @@
+name: Cleanup PR Resources
+
+on:
+  pull_request:
+    types:
+      - closed
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  cleanup:
+    name: Cleanup PR caches and artifacts
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      actions: write
+    steps:
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v1

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,5 +1,7 @@
 # SonarJS Build
 
+For the GitHub Actions pipeline, cache design, artifacts, job graph, and external CI integrations, see [CI.md](CI.md).
+
 ## Default workflow
 
 Run `npm ci` first on a fresh checkout, and again after any `package.json` or lockfile change.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -141,112 +141,102 @@ flowchart TD
   T --> U["releasability"]
 ```
 
-## Full Job Graph
+## Detailed Dependency Views
 
-This is the exact dependency graph implied by the current workflow.
+The full 31-job dependency graph is too dense to read well as a single Mermaid diagram. The grouped views below are the readable version; the job table that follows is the exact exhaustive reference.
+
+### 1. Setup And Artifact Producers
 
 ```mermaid
-graph TD
-    setup["setup"]
-    setup["setup"] --> get_build_number["get_build_number"]
-    setup["setup"] --> populate_npm_cache["populate_npm_cache"]
-    get_build_number["get_build_number"] --> populate_npm_cache["populate_npm_cache"]
-    setup["setup"] --> populate_npm_cache_win["populate_npm_cache_win"]
-    get_build_number["get_build_number"] --> populate_npm_cache_win["populate_npm_cache_win"]
-    setup["setup"] --> build["build"]
-    get_build_number["get_build_number"] --> build["build"]
-    populate_npm_cache["populate_npm_cache"] --> build["build"]
-    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> build["build"]
-    setup["setup"] --> build_win["build_win"]
-    get_build_number["get_build_number"] --> build_win["build_win"]
-    populate_npm_cache_win["populate_npm_cache_win"] --> build_win["build_win"]
-    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> build_win["build_win"]
-    setup["setup"] --> prepare_rspec_rule_data["prepare_rspec_rule_data"]
-    populate_npm_cache["populate_npm_cache"] --> prepare_rspec_rule_data["prepare_rspec_rule_data"]
-    setup["setup"] --> build_eslint_plugin["build_eslint_plugin"]
-    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> build_eslint_plugin["build_eslint_plugin"]
-    setup["setup"] --> generated_files_freshness["generated_files_freshness"]
-    populate_npm_cache["populate_npm_cache"] --> generated_files_freshness["generated_files_freshness"]
-    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> generated_files_freshness["generated_files_freshness"]
-    setup["setup"] --> test_eslint_plugin["test_eslint_plugin"]
-    build_eslint_plugin["build_eslint_plugin"] --> test_eslint_plugin["test_eslint_plugin"]
-    setup["setup"] --> knip["knip"]
-    populate_npm_cache["populate_npm_cache"] --> knip["knip"]
-    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> knip["knip"]
-    setup["setup"] --> test_js["test_js"]
-    populate_npm_cache["populate_npm_cache"] --> test_js["test_js"]
-    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> test_js["test_js"]
-    setup["setup"] --> test_js_win["test_js_win"]
-    populate_npm_cache_win["populate_npm_cache_win"] --> test_js_win["test_js_win"]
-    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> test_js_win["test_js_win"]
-    setup["setup"] --> analyze_primary["analyze_primary"]
-    get_build_number["get_build_number"] --> analyze_primary["analyze_primary"]
-    test_js["test_js"] --> analyze_primary["analyze_primary"]
-    build["build"] --> analyze_primary["analyze_primary"]
-    setup["setup"] --> analyze_shadows["analyze_shadows"]
-    get_build_number["get_build_number"] --> analyze_shadows["analyze_shadows"]
-    test_js["test_js"] --> analyze_shadows["analyze_shadows"]
-    build["build"] --> analyze_shadows["analyze_shadows"]
-    setup["setup"] --> plugin_qa_with_node["plugin_qa_with_node"]
-    get_build_number["get_build_number"] --> plugin_qa_with_node["plugin_qa_with_node"]
-    build["build"] --> plugin_qa_with_node["plugin_qa_with_node"]
-    setup["setup"] --> plugin_qa_fast_with_node["plugin_qa_fast_with_node"]
-    get_build_number["get_build_number"] --> plugin_qa_fast_with_node["plugin_qa_fast_with_node"]
-    build["build"] --> plugin_qa_fast_with_node["plugin_qa_fast_with_node"]
-    setup["setup"] --> plugin_qa_without_node["plugin_qa_without_node"]
-    get_build_number["get_build_number"] --> plugin_qa_without_node["plugin_qa_without_node"]
-    build["build"] --> plugin_qa_without_node["plugin_qa_without_node"]
-    setup["setup"] --> plugin_qa_without_node_dev["plugin_qa_without_node_dev"]
-    get_build_number["get_build_number"] --> plugin_qa_without_node_dev["plugin_qa_without_node_dev"]
-    build["build"] --> plugin_qa_without_node_dev["plugin_qa_without_node_dev"]
-    setup["setup"] --> plugin_qa_without_node_alpine["plugin_qa_without_node_alpine"]
-    get_build_number["get_build_number"] --> plugin_qa_without_node_alpine["plugin_qa_without_node_alpine"]
-    build["build"] --> plugin_qa_without_node_alpine["plugin_qa_without_node_alpine"]
-    setup["setup"] --> plugin_qa_fast_without_node["plugin_qa_fast_without_node"]
-    get_build_number["get_build_number"] --> plugin_qa_fast_without_node["plugin_qa_fast_without_node"]
-    build["build"] --> plugin_qa_fast_without_node["plugin_qa_fast_without_node"]
-    setup["setup"] --> plugin_qa_fast_without_node_dev["plugin_qa_fast_without_node_dev"]
-    get_build_number["get_build_number"] --> plugin_qa_fast_without_node_dev["plugin_qa_fast_without_node_dev"]
-    build["build"] --> plugin_qa_fast_without_node_dev["plugin_qa_fast_without_node_dev"]
-    setup["setup"] --> plugin_qa_fast_without_node_alpine["plugin_qa_fast_without_node_alpine"]
-    get_build_number["get_build_number"] --> plugin_qa_fast_without_node_alpine["plugin_qa_fast_without_node_alpine"]
-    build["build"] --> plugin_qa_fast_without_node_alpine["plugin_qa_fast_without_node_alpine"]
-    setup["setup"] --> plugin_qa_win["plugin_qa_win"]
-    get_build_number["get_build_number"] --> plugin_qa_win["plugin_qa_win"]
-    build["build"] --> plugin_qa_win["plugin_qa_win"]
-    setup["setup"] --> plugin_qa_sonarlint_win["plugin_qa_sonarlint_win"]
-    get_build_number["get_build_number"] --> plugin_qa_sonarlint_win["plugin_qa_sonarlint_win"]
-    build["build"] --> plugin_qa_sonarlint_win["plugin_qa_sonarlint_win"]
-    setup["setup"] --> plugin_qa_win_fast_with_node["plugin_qa_win_fast_with_node"]
-    get_build_number["get_build_number"] --> plugin_qa_win_fast_with_node["plugin_qa_win_fast_with_node"]
-    build["build"] --> plugin_qa_win_fast_with_node["plugin_qa_win_fast_with_node"]
-    setup["setup"] --> js_ts_ruling["js_ts_ruling"]
-    populate_npm_cache["populate_npm_cache"] --> js_ts_ruling["js_ts_ruling"]
-    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> js_ts_ruling["js_ts_ruling"]
-    setup["setup"] --> ruling["ruling"]
-    get_build_number["get_build_number"] --> ruling["ruling"]
-    build["build"] --> ruling["ruling"]
-    analyze_primary["analyze_primary"] --> run_iris["run_iris"]
-    analyze_shadows["analyze_shadows"] --> run_iris["run_iris"]
-    get_build_number["get_build_number"] --> promote["promote"]
-    build["build"] --> promote["promote"]
-    build_win["build_win"] --> promote["promote"]
-    test_js["test_js"] --> promote["promote"]
-    test_js_win["test_js_win"] --> promote["promote"]
-    analyze_primary["analyze_primary"] --> promote["promote"]
-    test_eslint_plugin["test_eslint_plugin"] --> promote["promote"]
-    plugin_qa_with_node["plugin_qa_with_node"] --> promote["promote"]
-    plugin_qa_without_node["plugin_qa_without_node"] --> promote["promote"]
-    plugin_qa_fast_with_node["plugin_qa_fast_with_node"] --> promote["promote"]
-    plugin_qa_fast_without_node["plugin_qa_fast_without_node"] --> promote["promote"]
-    plugin_qa_without_node_alpine["plugin_qa_without_node_alpine"] --> promote["promote"]
-    plugin_qa_fast_without_node_alpine["plugin_qa_fast_without_node_alpine"] --> promote["promote"]
-    plugin_qa_win["plugin_qa_win"] --> promote["promote"]
-    plugin_qa_sonarlint_win["plugin_qa_sonarlint_win"] --> promote["promote"]
-    plugin_qa_win_fast_with_node["plugin_qa_win_fast_with_node"] --> promote["promote"]
-    ruling["ruling"] --> promote["promote"]
-    js_ts_ruling["js_ts_ruling"] --> promote["promote"]
-    promote["promote"] --> releasability["releasability"]
+flowchart TD
+  setup["setup"] --> get_build_number["get_build_number"]
+  setup --> populate_npm_cache["populate_npm_cache"]
+  get_build_number --> populate_npm_cache
+  setup --> populate_npm_cache_win["populate_npm_cache_win"]
+  get_build_number --> populate_npm_cache_win
+
+  setup --> prepare_rspec_rule_data["prepare_rspec_rule_data"]
+  populate_npm_cache --> prepare_rspec_rule_data
+
+  setup --> build["build"]
+  get_build_number --> build
+  populate_npm_cache --> build
+  prepare_rspec_rule_data --> build
+
+  setup --> build_win["build_win"]
+  get_build_number --> build_win
+  populate_npm_cache_win --> build_win
+  prepare_rspec_rule_data --> build_win
+
+  setup --> build_eslint_plugin["build_eslint_plugin"]
+  prepare_rspec_rule_data --> build_eslint_plugin
+  build_eslint_plugin --> test_eslint_plugin["test_eslint_plugin"]
+```
+
+### 2. Verification And Analysis
+
+```mermaid
+flowchart TD
+  setup["setup"] --> populate_npm_cache["populate_npm_cache"]
+  setup --> populate_npm_cache_win["populate_npm_cache_win"]
+  setup --> prepare_rspec_rule_data["prepare_rspec_rule_data"]
+  populate_npm_cache --> prepare_rspec_rule_data
+
+  setup --> knip["knip"]
+  populate_npm_cache --> knip
+  prepare_rspec_rule_data --> knip
+
+  setup --> test_js["test_js"]
+  populate_npm_cache --> test_js
+  prepare_rspec_rule_data --> test_js
+
+  setup --> test_js_win["test_js_win"]
+  populate_npm_cache_win --> test_js_win
+  prepare_rspec_rule_data --> test_js_win
+
+  setup --> generated_files_freshness["generated_files_freshness"]
+  populate_npm_cache --> generated_files_freshness
+  prepare_rspec_rule_data --> generated_files_freshness
+
+  setup --> analyze_primary["analyze_primary"]
+  get_build_number["get_build_number"] --> analyze_primary
+  build["build"] --> analyze_primary
+  test_js --> analyze_primary
+
+  setup --> analyze_shadows["analyze_shadows"]
+  get_build_number --> analyze_shadows
+  build --> analyze_shadows
+  test_js --> analyze_shadows
+
+  analyze_primary --> run_iris["run_iris"]
+  analyze_shadows --> run_iris
+```
+
+### 3. QA, Ruling, And Release Fan-In
+
+```mermaid
+flowchart TD
+  build["build"] --> plugin_qa["plugin QA matrix"]
+  get_build_number["get_build_number"] --> plugin_qa
+
+  build --> ruling["ruling"]
+  get_build_number --> ruling
+
+  populate_npm_cache["populate_npm_cache"] --> js_ts_ruling["js_ts_ruling"]
+  prepare_rspec_rule_data["prepare_rspec_rule_data"] --> js_ts_ruling
+
+  build --> promote["promote"]
+  build_win["build_win"] --> promote
+  test_js["test_js"] --> promote
+  test_js_win["test_js_win"] --> promote
+  analyze_primary["analyze_primary"] --> promote
+  test_eslint_plugin["test_eslint_plugin"] --> promote
+  plugin_qa --> promote
+  ruling --> promote
+  js_ts_ruling --> promote
+  get_build_number --> promote
+
+  promote --> releasability["releasability"]
 ```
 
 ## Job Index

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,942 @@
+# SonarJS CI Reference
+
+This document explains the main GitHub Actions pipeline in
+[`../.github/workflows/build.yml`](../.github/workflows/build.yml).
+
+It is intentionally written for the cache/artifact model introduced by the current cache migration:
+
+- direct workflow-level cache usage in `build.yml` uses official GitHub cache actions
+- same-run file handoff uses official GitHub artifact actions
+- local cache wrappers (`maven-cache`, `orchestrator-cache`, `rule-api-cache`) also use official GitHub cache actions
+- SonarSource's S3-backed cache action is no longer used directly in `build.yml`
+- SonarSource's S3-backed cache action still matters indirectly through `SonarSource/ci-github-actions/config-npm`, which caches `~/.npm` on Linux cache-population jobs
+
+This is the document to read first when you need to answer any of these questions quickly:
+
+- Which jobs exist and why?
+- Which jobs depend on which other jobs?
+- What data moves via outputs, caches, and artifacts?
+- What is shared across jobs in one run?
+- What is shared from the default branch to other branches?
+- Where does S3 still appear, and where does it not?
+- How do Repox, Vault, RSPEC, SonarQube, and promotion fit into the pipeline?
+
+## Scope
+
+This document focuses on the main `Build` workflow:
+
+- [`../.github/workflows/build.yml`](../.github/workflows/build.yml)
+- [`../.github/actions/maven-cache/action.yml`](../.github/actions/maven-cache/action.yml)
+- [`../.github/actions/orchestrator-cache/action.yml`](../.github/actions/orchestrator-cache/action.yml)
+- [`../.github/actions/rule-api-cache/action.yml`](../.github/actions/rule-api-cache/action.yml)
+
+Other workflows exist in `.github/workflows/`, but they are out of scope unless they directly affect the `build.yml` lifecycle.
+
+## What This Cache Migration Changes
+
+Historically, `build.yml` used `SonarSource/gh-action_cache` directly for several kinds of handoff. The current design changes that split.
+
+### Direct changes in `build.yml`
+
+- `node_modules` cache production now uses `actions/cache` in probe mode (`lookup-only: true`) instead of `SonarSource/gh-action_cache`
+- downstream `node_modules` consumers now use `actions/cache/restore` with `fail-on-cache-miss: true`
+- ESLint plugin tarball handoff is now modeled as `upload-artifact` + `download-artifact`, not as a cache
+- JS coverage reuse and Windows JS test marker reuse now use official GitHub cache actions directly
+- downloaded JS coverage is validated before Sonar analysis jobs consume it
+- Windows NPM cache population now mirrors the Linux job's build-number dependency wiring
+- local wrapper actions for Maven, orchestrator, and rule-api caches are pinned to the same `actions/cache` v6.1.0 commit as the direct workflow cache steps
+
+### What remains intentionally unchanged
+
+- `prepare_rspec_rule_data` still refreshes RSPEC once and shares the result through a per-run artifact
+- Maven/orchestrator/rule-api caches still use local wrapper actions so branch save policy stays centralized
+- `config-maven` still configures Maven and Repox access, but its built-in caching is disabled in `build.yml`
+- Linux NPM cache population still uses `config-npm` for auth/bootstrap, which means `~/.npm` still goes through SonarSource's S3-backed cache action indirectly
+
+## Trigger Model And Global Controls
+
+`build.yml` runs on:
+
+- `push` to `master`
+- `push` to `branch-*`
+- `push` to `dogfood-*`
+- `pull_request`
+- `merge_group`
+- `workflow_dispatch`
+- nightly `schedule`
+
+Global behavior:
+
+- `concurrency.group = ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
+- `cancel-in-progress: true`
+
+That means:
+
+- one PR gets at most one active `Build` run
+- one branch ref gets at most one active `Build` run
+- new pushes cancel older in-flight runs for the same PR/ref
+
+## Runner Strategy
+
+Runner labels express relative size and environment, not a stable hardware contract. The workflow uses them as follows:
+
+| Runner label | Typical jobs | Why it is used |
+| --- | --- | --- |
+| `sonar-xs` | `setup`, `get_build_number`, `populate_npm_cache`, `prepare_rspec_rule_data`, `knip`, `promote`, `releasability`, `run_iris` | Lightweight orchestration, metadata, cache preparation, and control-plane jobs |
+| `sonar-m` | `test_js`, `analyze_primary`, `analyze_shadows`, most Linux plugin QA jobs | Medium Linux compute for tests and analysis |
+| `sonar-l` | `build` | Main Linux Maven build and deploy |
+| `sonar-xl` | `js_ts_ruling`, `ruling` | Large ruling workloads |
+| `github-ubuntu-latest-s` | `build_eslint_plugin`, `test_eslint_plugin`, `generated_files_freshness` | Small GitHub-hosted Linux jobs |
+| `github-windows-latest-s` | `populate_npm_cache_win` | Small Windows cache producer |
+| `github-windows-latest-m` | `build_win`, `test_js_win`, Windows plugin QA jobs | Medium Windows build/test jobs |
+| `warp-custom-ubuntu-24-04` + Alpine container | Alpine QA jobs | Host runner plus containerized musl/Alpine validation |
+
+## High-Level Pipeline Map
+
+```mermaid
+flowchart TD
+  A["setup"] --> B["get_build_number"]
+  A --> C["populate_npm_cache"]
+  A --> D["populate_npm_cache_win"]
+  C --> E["prepare_rspec_rule_data"]
+
+  B --> F["build"]
+  C --> F
+  E --> F
+
+  B --> G["build_win"]
+  D --> G
+  E --> G
+
+  E --> H["build_eslint_plugin"]
+  H --> I["test_eslint_plugin"]
+
+  C --> J["test_js"]
+  E --> J
+
+  D --> K["test_js_win"]
+  E --> K
+
+  C --> L["knip"]
+  E --> L
+
+  C --> M["generated_files_freshness (nightly)"]
+  E --> M
+
+  F --> N["plugin QA fan-out"]
+  F --> O["ruling"]
+  C --> P["js/ts ruling"]
+  E --> P
+
+  F --> Q["analyze_primary"]
+  J --> Q
+  F --> R["analyze_shadows (nightly)"]
+  J --> R
+
+  Q --> S["run_iris (nightly)"]
+  R --> S
+
+  B --> T["promote"]
+  F --> T
+  G --> T
+  I --> T
+  J --> T
+  K --> T
+  N --> T
+  O --> T
+  P --> T
+  Q --> T
+
+  T --> U["releasability"]
+```
+
+## Full Job Graph
+
+This is the exact dependency graph implied by the current workflow.
+
+```mermaid
+graph TD
+    setup["setup"]
+    setup["setup"] --> get_build_number["get_build_number"]
+    setup["setup"] --> populate_npm_cache["populate_npm_cache"]
+    get_build_number["get_build_number"] --> populate_npm_cache["populate_npm_cache"]
+    setup["setup"] --> populate_npm_cache_win["populate_npm_cache_win"]
+    get_build_number["get_build_number"] --> populate_npm_cache_win["populate_npm_cache_win"]
+    setup["setup"] --> build["build"]
+    get_build_number["get_build_number"] --> build["build"]
+    populate_npm_cache["populate_npm_cache"] --> build["build"]
+    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> build["build"]
+    setup["setup"] --> build_win["build_win"]
+    get_build_number["get_build_number"] --> build_win["build_win"]
+    populate_npm_cache_win["populate_npm_cache_win"] --> build_win["build_win"]
+    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> build_win["build_win"]
+    setup["setup"] --> prepare_rspec_rule_data["prepare_rspec_rule_data"]
+    populate_npm_cache["populate_npm_cache"] --> prepare_rspec_rule_data["prepare_rspec_rule_data"]
+    setup["setup"] --> build_eslint_plugin["build_eslint_plugin"]
+    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> build_eslint_plugin["build_eslint_plugin"]
+    setup["setup"] --> generated_files_freshness["generated_files_freshness"]
+    populate_npm_cache["populate_npm_cache"] --> generated_files_freshness["generated_files_freshness"]
+    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> generated_files_freshness["generated_files_freshness"]
+    setup["setup"] --> test_eslint_plugin["test_eslint_plugin"]
+    build_eslint_plugin["build_eslint_plugin"] --> test_eslint_plugin["test_eslint_plugin"]
+    setup["setup"] --> knip["knip"]
+    populate_npm_cache["populate_npm_cache"] --> knip["knip"]
+    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> knip["knip"]
+    setup["setup"] --> test_js["test_js"]
+    populate_npm_cache["populate_npm_cache"] --> test_js["test_js"]
+    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> test_js["test_js"]
+    setup["setup"] --> test_js_win["test_js_win"]
+    populate_npm_cache_win["populate_npm_cache_win"] --> test_js_win["test_js_win"]
+    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> test_js_win["test_js_win"]
+    setup["setup"] --> analyze_primary["analyze_primary"]
+    get_build_number["get_build_number"] --> analyze_primary["analyze_primary"]
+    test_js["test_js"] --> analyze_primary["analyze_primary"]
+    build["build"] --> analyze_primary["analyze_primary"]
+    setup["setup"] --> analyze_shadows["analyze_shadows"]
+    get_build_number["get_build_number"] --> analyze_shadows["analyze_shadows"]
+    test_js["test_js"] --> analyze_shadows["analyze_shadows"]
+    build["build"] --> analyze_shadows["analyze_shadows"]
+    setup["setup"] --> plugin_qa_with_node["plugin_qa_with_node"]
+    get_build_number["get_build_number"] --> plugin_qa_with_node["plugin_qa_with_node"]
+    build["build"] --> plugin_qa_with_node["plugin_qa_with_node"]
+    setup["setup"] --> plugin_qa_fast_with_node["plugin_qa_fast_with_node"]
+    get_build_number["get_build_number"] --> plugin_qa_fast_with_node["plugin_qa_fast_with_node"]
+    build["build"] --> plugin_qa_fast_with_node["plugin_qa_fast_with_node"]
+    setup["setup"] --> plugin_qa_without_node["plugin_qa_without_node"]
+    get_build_number["get_build_number"] --> plugin_qa_without_node["plugin_qa_without_node"]
+    build["build"] --> plugin_qa_without_node["plugin_qa_without_node"]
+    setup["setup"] --> plugin_qa_without_node_dev["plugin_qa_without_node_dev"]
+    get_build_number["get_build_number"] --> plugin_qa_without_node_dev["plugin_qa_without_node_dev"]
+    build["build"] --> plugin_qa_without_node_dev["plugin_qa_without_node_dev"]
+    setup["setup"] --> plugin_qa_without_node_alpine["plugin_qa_without_node_alpine"]
+    get_build_number["get_build_number"] --> plugin_qa_without_node_alpine["plugin_qa_without_node_alpine"]
+    build["build"] --> plugin_qa_without_node_alpine["plugin_qa_without_node_alpine"]
+    setup["setup"] --> plugin_qa_fast_without_node["plugin_qa_fast_without_node"]
+    get_build_number["get_build_number"] --> plugin_qa_fast_without_node["plugin_qa_fast_without_node"]
+    build["build"] --> plugin_qa_fast_without_node["plugin_qa_fast_without_node"]
+    setup["setup"] --> plugin_qa_fast_without_node_dev["plugin_qa_fast_without_node_dev"]
+    get_build_number["get_build_number"] --> plugin_qa_fast_without_node_dev["plugin_qa_fast_without_node_dev"]
+    build["build"] --> plugin_qa_fast_without_node_dev["plugin_qa_fast_without_node_dev"]
+    setup["setup"] --> plugin_qa_fast_without_node_alpine["plugin_qa_fast_without_node_alpine"]
+    get_build_number["get_build_number"] --> plugin_qa_fast_without_node_alpine["plugin_qa_fast_without_node_alpine"]
+    build["build"] --> plugin_qa_fast_without_node_alpine["plugin_qa_fast_without_node_alpine"]
+    setup["setup"] --> plugin_qa_win["plugin_qa_win"]
+    get_build_number["get_build_number"] --> plugin_qa_win["plugin_qa_win"]
+    build["build"] --> plugin_qa_win["plugin_qa_win"]
+    setup["setup"] --> plugin_qa_sonarlint_win["plugin_qa_sonarlint_win"]
+    get_build_number["get_build_number"] --> plugin_qa_sonarlint_win["plugin_qa_sonarlint_win"]
+    build["build"] --> plugin_qa_sonarlint_win["plugin_qa_sonarlint_win"]
+    setup["setup"] --> plugin_qa_win_fast_with_node["plugin_qa_win_fast_with_node"]
+    get_build_number["get_build_number"] --> plugin_qa_win_fast_with_node["plugin_qa_win_fast_with_node"]
+    build["build"] --> plugin_qa_win_fast_with_node["plugin_qa_win_fast_with_node"]
+    setup["setup"] --> js_ts_ruling["js_ts_ruling"]
+    populate_npm_cache["populate_npm_cache"] --> js_ts_ruling["js_ts_ruling"]
+    prepare_rspec_rule_data["prepare_rspec_rule_data"] --> js_ts_ruling["js_ts_ruling"]
+    setup["setup"] --> ruling["ruling"]
+    get_build_number["get_build_number"] --> ruling["ruling"]
+    build["build"] --> ruling["ruling"]
+    analyze_primary["analyze_primary"] --> run_iris["run_iris"]
+    analyze_shadows["analyze_shadows"] --> run_iris["run_iris"]
+    get_build_number["get_build_number"] --> promote["promote"]
+    build["build"] --> promote["promote"]
+    build_win["build_win"] --> promote["promote"]
+    test_js["test_js"] --> promote["promote"]
+    test_js_win["test_js_win"] --> promote["promote"]
+    analyze_primary["analyze_primary"] --> promote["promote"]
+    test_eslint_plugin["test_eslint_plugin"] --> promote["promote"]
+    plugin_qa_with_node["plugin_qa_with_node"] --> promote["promote"]
+    plugin_qa_without_node["plugin_qa_without_node"] --> promote["promote"]
+    plugin_qa_fast_with_node["plugin_qa_fast_with_node"] --> promote["promote"]
+    plugin_qa_fast_without_node["plugin_qa_fast_without_node"] --> promote["promote"]
+    plugin_qa_without_node_alpine["plugin_qa_without_node_alpine"] --> promote["promote"]
+    plugin_qa_fast_without_node_alpine["plugin_qa_fast_without_node_alpine"] --> promote["promote"]
+    plugin_qa_win["plugin_qa_win"] --> promote["promote"]
+    plugin_qa_sonarlint_win["plugin_qa_sonarlint_win"] --> promote["promote"]
+    plugin_qa_win_fast_with_node["plugin_qa_win_fast_with_node"] --> promote["promote"]
+    ruling["ruling"] --> promote["promote"]
+    js_ts_ruling["js_ts_ruling"] --> promote["promote"]
+    promote["promote"] --> releasability["releasability"]
+```
+
+## Job Index
+
+| Job | Runner | Needs | Condition |
+| --- | --- | --- | --- |
+| `setup` | `sonar-xs` | `-` | default |
+| `get_build_number` | `sonar-xs` | `setup` | non-fork PRs and all non-PR runs |
+| `populate_npm_cache` | `sonar-xs` | `setup`, `get_build_number` | non-fork PRs and all non-PR runs |
+| `populate_npm_cache_win` | `github-windows-latest-s` | `setup`, `get_build_number` | non-fork PRs and all non-PR runs |
+| `prepare_rspec_rule_data` | `sonar-xs` | `setup`, `populate_npm_cache` | non-fork PRs and all non-PR runs |
+| `build` | `sonar-l` | `setup`, `get_build_number`, `populate_npm_cache`, `prepare_rspec_rule_data` | non-fork PRs and all non-PR runs |
+| `build_win` | `github-windows-latest-m` | `setup`, `get_build_number`, `populate_npm_cache_win`, `prepare_rspec_rule_data` | non-fork PRs and all non-PR runs |
+| `build_eslint_plugin` | `github-ubuntu-latest-s` | `setup`, `prepare_rspec_rule_data` | non-fork PRs and all non-PR runs |
+| `generated_files_freshness` | `github-ubuntu-latest-s` | `setup`, `populate_npm_cache`, `prepare_rspec_rule_data` | nightly only |
+| `test_eslint_plugin` | `github-ubuntu-latest-s` | `setup`, `build_eslint_plugin` | default |
+| `knip` | `sonar-xs` | `setup`, `populate_npm_cache`, `prepare_rspec_rule_data` | default |
+| `test_js` | `sonar-m` | `setup`, `populate_npm_cache`, `prepare_rspec_rule_data` | default |
+| `test_js_win` | `github-windows-latest-m` | `setup`, `populate_npm_cache_win`, `prepare_rspec_rule_data` | default |
+| `analyze_primary` | `sonar-m` | `setup`, `get_build_number`, `test_js`, `build` | non-fork PRs and all non-PR runs |
+| `analyze_shadows` | `sonar-m` | `setup`, `get_build_number`, `test_js`, `build` | nightly only |
+| `plugin_qa_with_node` | `sonar-m` | `setup`, `get_build_number`, `build` | non-fork PRs and all non-PR runs |
+| `plugin_qa_fast_with_node` | `sonar-m` | `setup`, `get_build_number`, `build` | non-fork PRs and all non-PR runs |
+| `plugin_qa_without_node` | `sonar-m` | `setup`, `get_build_number`, `build` | non-fork PRs and all non-PR runs |
+| `plugin_qa_without_node_dev` | `sonar-m` | `setup`, `get_build_number`, `build` | nightly only |
+| `plugin_qa_without_node_alpine` | `warp-custom-ubuntu-24-04` | `setup`, `get_build_number`, `build` | nightly only |
+| `plugin_qa_fast_without_node` | `sonar-m` | `setup`, `get_build_number`, `build` | non-fork PRs and all non-PR runs |
+| `plugin_qa_fast_without_node_dev` | `sonar-m` | `setup`, `get_build_number`, `build` | nightly only |
+| `plugin_qa_fast_without_node_alpine` | `warp-custom-ubuntu-24-04` | `setup`, `get_build_number`, `build` | nightly only |
+| `plugin_qa_win` | `github-windows-latest-m` | `setup`, `get_build_number`, `build` | non-fork PRs and all non-PR runs |
+| `plugin_qa_sonarlint_win` | `github-windows-latest-m` | `setup`, `get_build_number`, `build` | non-fork PRs and all non-PR runs |
+| `plugin_qa_win_fast_with_node` | `github-windows-latest-m` | `setup`, `get_build_number`, `build` | non-fork PRs and all non-PR runs |
+| `js_ts_ruling` | `sonar-xl` | `setup`, `populate_npm_cache`, `prepare_rspec_rule_data` | non-fork PRs and all non-PR runs |
+| `ruling` | `sonar-xl` | `setup`, `get_build_number`, `build` | non-fork PRs and all non-PR runs |
+| `run_iris` | `sonar-xs` | `analyze_primary`, `analyze_shadows` | nightly only |
+| `promote` | `sonar-xs` | many fan-in jobs | only when upstream jobs succeeded and the run is allowed to promote |
+| `releasability` | `sonar-xs` | `promote` | only after successful promote on `master`, `branch-*`, or `dogfood-*` |
+
+## Control-Plane Handoff
+
+These are the small data items passed as job outputs or step outputs, not bulky file payloads.
+
+| Producer | Data | Consumers | Meaning |
+| --- | --- | --- | --- |
+| `setup` | `node-matrix` | Node-matrix plugin QA jobs | Derived from `package.json` engine range |
+| `setup` | `js-files-hash` | `test_js`, `test_js_win` | Cache key seed for JS coverage and Windows JS marker |
+| `setup` | `maven-hash` | all `maven-cache` users | Cache key seed for Maven dependencies |
+| `setup` | `npm-hash` | all `node_modules` producers/consumers | Exact cache key seed for installed Node dependencies |
+| `setup` | `cache-month` | `maven-cache` | Monthly key rotation value |
+| `setup` | `is-default-branch` | most `mise-action` calls | Controls when tool caches may be saved |
+| `get_build_number` | `build-number` | build, QA, analysis, promotion, and shared env anchor users | One build number is minted once and reused consistently |
+| `config-maven` | `project-version` | `analyze_primary`, `analyze_shadows` | Sonar analysis version value |
+
+### Important internal detail: build number cache
+
+`SonarSource/ci-github-actions/get-build-number` itself uses GitHub cache internally:
+
+- restore: `build-number-${github.run_id}`
+- save: same key
+- purpose: rerun stability within one workflow run
+
+That cache is tiny, but it is still part of the repository's GitHub cache footprint.
+
+## File-Plane Handoff Inside One Workflow Run
+
+Artifacts are the only cross-job file handoff mechanism that is guaranteed to stay inside one workflow run. They do not flow from `master` to branches or from one run to the next.
+
+### Artifacts
+
+| Producer | Artifact name | Consumers | Purpose | Retention |
+| --- | --- | --- | --- | --- |
+| `prepare_rspec_rule_data` | `rspec-rule-data-${github.sha}` | `build`, `build_win`, `build_eslint_plugin`, `generated_files_freshness`, `knip`, `test_js`, `test_js_win`, `js_ts_ruling` | One RSPEC refresh per run; downstream jobs do not refresh again | 1 day |
+| `build` | `sonarjs-m2` | all plugin QA jobs, `ruling` | Share locally built SonarJS Maven artifacts instead of rebuilding them everywhere | 1 day |
+| `build` | `maven-targets-${github.sha}` | `analyze_primary`, `analyze_shadows` | Reuse compiled Maven outputs for Sonar analysis | 1 day |
+| `build` | `jacoco-xml-reports-${github.sha}` | `analyze_primary`, `analyze_shadows` | Reuse JaCoCo XML coverage reports | 1 day |
+| `build_eslint_plugin` | `eslint-tarball-${github.sha}` | `test_eslint_plugin` | Same-run ESLint plugin tarball handoff | 1 day |
+| `test_js` | `js-coverage-reports-${github.sha}` | `analyze_primary`, `analyze_shadows` | Reuse JS coverage reports for Sonar analysis | 1 day |
+| `ruling` | `ruling-differences` | humans only on failure | Failure triage artifact | default retention for upload step |
+
+### Why ESLint Tarball Is An Artifact, Not A Cache
+
+The ESLint plugin tarball is purely same-run handoff:
+
+- producer: `build_eslint_plugin`
+- consumer: `test_eslint_plugin`
+- no reuse across workflow runs is needed
+- stale cross-run reuse would be actively misleading
+
+That is exactly artifact semantics, not cache semantics.
+
+## Cross-Run State: Caches
+
+### Explicit workflow-owned caches
+
+| Cache | Path | Producer(s) | Consumer(s) | Key shape | Save policy |
+| --- | --- | --- | --- | --- | --- |
+| installed NPM dependencies | `node_modules` | `populate_npm_cache`, `populate_npm_cache_win` | `build`, `build_win`, `prepare_rspec_rule_data`, `generated_files_freshness`, `knip`, `test_js`, `test_js_win`, `analyze_primary`, `analyze_shadows`, `js_ts_ruling` | `npm-${runner.os}-${npm-hash}` | producer jobs use `actions/cache` with `lookup-only: true`; save happens only after a miss and a successful install |
+| JS coverage cache | `coverage/js` | `test_js` | `test_js` itself | `js-coverage-${js-files-hash}` | combined restore/save cache; allows skip when exact coverage already exists |
+| Windows JS marker | `.js-test-marker-win` | `test_js_win` | `test_js_win` itself | `js-test-win-${js-files-hash}` | lookup-only probe; on miss the job runs tests and saves marker at job end |
+| Maven repository | `~/.m2/repository` | default-branch runs through `maven-cache` | all `maven-cache` users | `maven-${runner.os}-${cache-month}-${maven-hash}` plus monthly restore prefix | only default branch saves; non-default branches restore only |
+| Orchestrator home | `${github.workspace}/orchestrator` | default-branch QA jobs through `orchestrator-cache` | orchestrator-based QA/ruling jobs | `${key-prefix}-${month}-${github.run_id}` with monthly restore prefix | only default branch saves unless `save: false` |
+| Rule API clone/cache | `$HOME/.sonar/rule-api` | default-branch `prepare_rspec_rule_data` through `rule-api-cache` | `prepare_rspec_rule_data` | `${key-prefix}-${github.run_id}` with prefix restore | only default branch saves unless `save: false` |
+
+### Helper-owned or transitive caches
+
+| Owner | Path or payload | Backend after this change | Why it exists |
+| --- | --- | --- | --- |
+| `get-build-number` action | `.build_number.txt` | GitHub cache | Reuse one build number across reruns of the same workflow run |
+| `config-npm` action on Linux | `~/.npm` | SonarSource S3 cache action, transitively | Speeds package download reuse when `npm ci` actually runs |
+| `jdx/mise-action` | tool/runtime downloads | action-managed cache behavior | Reuses provisioned Java/Maven/Node toolchains; not a SonarJS-specific cache contract |
+
+### Local wrapper semantics
+
+#### Maven cache wrapper
+
+`maven-cache` is the repo's opinionated wrapper around official GitHub cache primitives:
+
+- branches: `actions/cache/restore` only
+- default branch: full `actions/cache`
+- keys rotate monthly and also hash all `pom.xml` files
+- restore key allows reuse of other Maven entries from the same month when the exact key misses
+- after restore, the wrapper deletes `~/.m2/repository/org/sonarsource/javascript`
+
+That last cleanup is important:
+
+- branch jobs may restore Maven dependencies from cache
+- but they must not accidentally consume a stale locally built SonarJS artifact from cache
+- SonarJS artifacts are instead handed over explicitly via the `sonarjs-m2` artifact
+
+#### Orchestrator cache wrapper
+
+`orchestrator-cache` is intentionally more rolling and less content-addressed:
+
+- key includes `github.run_id`
+- restore uses a prefix within the current month
+- only default branch saves
+- `key-prefix` separates normal and `fast` orchestrator environments
+- `save: 'false'` forces restore-only even on default branch
+
+This matches orchestrator state better than a content hash would:
+
+- the workload depends on runtime images and evolving infrastructure state
+- exact content identity is less important than getting a recent warm baseline
+
+#### Rule API cache wrapper
+
+`rule-api-cache` behaves like a rolling GitHub cache:
+
+- key includes `github.run_id`
+- restore uses a stable prefix
+- only default branch saves unless disabled
+
+This is deliberate because the underlying RSPEC clone/cache evolves independently of the SonarJS tree. A pure repository hash would be a poor invalidation signal here.
+
+## Branch, PR, And Default-Branch Data Flow
+
+### 1. Same workflow run
+
+Use artifacts.
+
+- `prepare_rspec_rule_data` produces RSPEC files once
+- `build` produces Maven outputs and coverage reports once
+- `build_eslint_plugin` produces one tarball
+- downstream jobs download exactly those outputs from the same run
+
+Artifacts never become the default-branch warm source for future runs.
+
+### 2. Default branch to non-default branches
+
+Use caches.
+
+#### `node_modules`
+
+The `node_modules` design is strict:
+
+- exact key only
+- no restore keys
+- Linux and Windows keys are separated by `runner.os`
+
+Implications:
+
+- if the default branch has already populated `npm-${runner.os}-${npm-hash}`, a branch/PR run can restore that exact cache
+- if the default branch does not have that exact cache yet, producer jobs do a real install and then save at job end
+- consumer jobs fail on a cache miss; they assume the producer job already handled population
+
+The producer pattern matters:
+
+- `actions/cache` with `lookup-only: true` checks existence without downloading content
+- on hit: skip checkout/tool setup/install
+- on miss: do the install
+- because the step is `actions/cache`, not `actions/cache/restore`, the post step still saves the populated cache after success
+
+#### Maven / orchestrator / rule-api
+
+The repo explicitly centralizes branch behavior:
+
+- non-default branches restore only
+- default branch is the intended producer of warm caches
+- restore keys allow branches to reuse recent default-branch entries
+- branches do not write their own long-lived copies of those caches
+
+This makes `master` the canonical source of warm cross-branch state for those caches.
+
+### 3. Branch or PR back to default branch
+
+There is effectively no promotion of branch-produced file payloads back to the default branch:
+
+- artifacts are run-local only
+- branch caches do not become the default-branch cache
+- restore-only wrappers make that explicit for Maven/orchestrator/rule-api
+- default branch stays the authoritative producer for shared long-lived cache state
+
+### 4. PR-specific state
+
+PR runs still create PR-scoped GitHub state:
+
+- build-number caches
+- `node_modules` caches when the exact key is missing
+- JS coverage cache
+- Windows JS marker cache
+- action-owned caches such as `mise`
+- workflow artifacts for that PR's runs
+
+That is why a PR-close cleanup workflow is now more relevant than before.
+
+## Where S3 Still Matters
+
+### Historical direct usage
+
+`SonarSource/gh-action_cache` is not a generic wrapper around GitHub cache. It is a SonarSource cache action whose primary backend is S3 and whose semantics include:
+
+- branch-scoped paths
+- default-branch fallback behavior
+- optional migration from GitHub cache to S3
+- S3 credential setup and credential guard logic
+
+### Current direct usage in `build.yml`
+
+After this migration:
+
+- direct `build.yml` cache usage is GitHub-native
+- direct same-run file handoff is artifact-native
+- local repo wrappers are also GitHub-native
+
+So if you inspect only `build.yml` plus the local wrapper actions, the answer is:
+
+- GitHub cache for cross-run reusable state
+- GitHub artifacts for same-run file payloads
+- no direct S3 cache action calls
+
+### Current indirect usage
+
+S3 still appears indirectly through `SonarSource/ci-github-actions/config-npm` on Linux:
+
+- when `populate_npm_cache` misses the `node_modules` cache
+- `config-npm` configures npm auth and also caches `~/.npm`
+- that helper action still uses `SonarSource/gh-action_cache`
+
+This means:
+
+- `build.yml` is not yet 100 percent free of SonarSource cache action behavior
+- only the Linux package-download cache path still depends on it
+- Windows NPM registry setup is manual in `build.yml`, so there is no equivalent transitive `config-npm` cache there
+
+### If we want to remove S3 entirely from this pipeline later
+
+We would need one of these follow-ups:
+
+- keep `config-npm`, but disable its internal caching and rely only on `node_modules`
+- stop using `config-npm` in `build.yml` and configure Linux npm auth manually, like the Windows job does
+
+That is a separate decision from this migration.
+
+## Why GitHub Cache / Artifact Makes Sense Here
+
+### Good fits for official GitHub primitives
+
+| Payload | Best primitive | Why |
+| --- | --- | --- |
+| `node_modules` | GitHub cache | exact-key reusable install output; natural cross-run cache |
+| JS coverage skip output | GitHub cache | cache key is tied to source hash; restore/save in same job |
+| Windows JS test marker | GitHub cache | tiny skip marker, not a reusable artifact |
+| RSPEC prepared files | artifact | per-run output shared by many downstream jobs |
+| ESLint tarball | artifact | one producer, one consumer, same run only |
+| Maven build outputs for analysis | artifact | exact same run-local compiled outputs are required |
+| locally built SonarJS Maven artifacts | artifact | explicit handoff is safer than accidentally restoring stale cached builds |
+
+### Why not use one cache mechanism for everything?
+
+Because the semantics differ:
+
+- caches are for future reuse across runs
+- artifacts are for deterministic handoff inside the current run
+- pretending a run-local artifact is a cache invites stale reuse
+- pretending a reusable dependency directory is an artifact creates needless uploads and downloads on every run
+
+## Job-By-Job Walkthrough
+
+### Foundation and dependency preparation
+
+#### `setup`
+
+Responsibilities:
+
+- derive Node matrix from `package.json`
+- hash JavaScript sources for JS test reuse
+- hash Maven files for Maven cache
+- hash lockfile plus patches for `node_modules` cache
+- compute cache month
+- expose whether this is the default branch
+
+This job is the control-plane root of the workflow.
+
+#### `get_build_number`
+
+Responsibilities:
+
+- mint or recover a single build number
+- make that value available to later jobs
+
+This prevents downstream jobs from inventing inconsistent build numbers.
+
+#### `populate_npm_cache` / `populate_npm_cache_win`
+
+Responsibilities:
+
+- probe the exact `node_modules` cache
+- if present, stop early
+- if missing, install dependencies and let the post step save the cache
+
+Linux specifics:
+
+- uses `config-npm`
+- therefore also touches the transitive `~/.npm` S3 cache path
+
+Windows specifics:
+
+- configures Repox manually through Vault-fetched Artifactory token
+- does not use `config-npm`
+
+#### `prepare_rspec_rule_data`
+
+Responsibilities:
+
+- restore `node_modules`
+- restore Maven cache
+- restore rule-api cache
+- authenticate to RSPEC through Vault-fetched GitHub token
+- run `npm run rspec:refresh`
+- upload refreshed rule JSON and `rspec.sha` files as an artifact
+
+This is the only job in the pipeline that refreshes RSPEC.
+
+### Core build and correctness jobs
+
+#### `build`
+
+Responsibilities:
+
+- restore `node_modules`
+- restore Maven cache
+- download refreshed RSPEC files
+- configure Maven/Repox
+- fetch deploy/signing credentials
+- run Maven deploy with coverage/sign/release profiles
+- upload:
+  - `sonarjs-m2`
+  - `maven-targets-${github.sha}`
+  - `jacoco-xml-reports-${github.sha}`
+- remove local SonarJS Maven artifacts before default-branch cache save
+
+This is the central build producer job.
+
+#### `build_win`
+
+Responsibilities:
+
+- Windows verification build
+- restores `node_modules`, Maven cache, and RSPEC artifact
+- runs `mvn verify -T1C`
+
+It validates Windows buildability but does not deploy artifacts.
+
+#### `build_eslint_plugin`
+
+Responsibilities:
+
+- configure npm registry
+- download refreshed RSPEC data
+- build ESLint plugin package
+- upload tarball artifact
+
+#### `generated_files_freshness`
+
+Nightly-only maintenance job:
+
+- restores `node_modules`
+- downloads refreshed RSPEC data
+- regenerates tracked generated files
+- opens or updates a bot PR if generated content drifted
+
+#### `knip`
+
+Responsibilities:
+
+- restore `node_modules`
+- download refreshed RSPEC data
+- run `npm run bbf`
+- run `npx knip`
+
+#### `test_js`
+
+Responsibilities:
+
+- use `coverage/js` cache as a skip mechanism
+- on miss, restore `node_modules`, download refreshed RSPEC data, generate metadata, compile bridge, run JS tests with coverage
+- validate coverage files exist
+- upload coverage reports artifact for analysis jobs
+
+This job is both a cache consumer and a cache producer.
+
+#### `test_js_win`
+
+Responsibilities:
+
+- use a Windows marker cache as a skip mechanism
+- on miss, restore `node_modules`, download refreshed RSPEC data, generate metadata, compile bridge, run JS tests
+- create marker directory so the post step can save it
+
+### Analysis, QA, and ruling fan-out
+
+#### `analyze_primary`
+
+Responsibilities:
+
+- wait for `build` and `test_js`
+- restore `node_modules` and Maven cache
+- download JS coverage reports, Maven targets, and JaCoCo XML
+- configure Maven
+- fetch SonarQube Next credentials from Vault
+- run Maven Sonar analysis
+
+#### `analyze_shadows`
+
+Nightly-only twin of `analyze_primary`:
+
+- runs against shadow platforms
+- matrix includes SonarCloud EU and SonarQube US
+
+#### Plugin QA family
+
+These jobs all consume:
+
+- `sonarjs-m2` artifact from `build`
+- Maven cache
+- often orchestrator cache
+- various licenses and runtime credentials
+
+Variants differ by:
+
+- Node present vs disabled
+- normal vs `fast`
+- Linux vs Windows vs Alpine
+- `LATEST_RELEASE` vs nightly `DEV`
+
+Important details:
+
+- Alpine jobs pre-seed `BUILD_NUMBER` from `get_build_number` because the `get-build-number` action's GitHub cache approach is unreliable in Alpine-container context
+- `fast` jobs use `key-prefix: orchestrator-fast`
+- `DEV` jobs intentionally skip orchestrator cache because the target version changes too frequently
+
+#### `js_ts_ruling`
+
+Responsibilities:
+
+- checkout with submodules
+- restore `node_modules`
+- download refreshed RSPEC data
+- run JS/TS ruling
+- on PRs or default branch, generate a ruling report
+- if expected results are stale, create/update a fix branch and PR
+- update PR comments or job summary
+- fail the workflow when ruling needs an update
+
+This job is more than test execution; it is also automated ruling maintenance.
+
+#### `ruling`
+
+Responsibilities:
+
+- checkout with submodules
+- restore Maven cache
+- download `sonarjs-m2`
+- configure Maven
+- optionally restore orchestrator cache with `save: 'false'`
+- run Maven ruling tests with explicit parallelism cap
+- upload `ruling-differences` on failure
+
+Note the explicit `save: 'false'`:
+
+- this job may benefit from a recent orchestrator baseline
+- but it should not publish new orchestrator cache state
+
+### Finalization
+
+#### `run_iris`
+
+Nightly-only post-analysis comparison:
+
+- runs only after primary and shadow analyses
+- compares Next against shadow platforms through the dedicated IRIS action
+
+#### `promote`
+
+This is the main fan-in gate.
+
+It waits for:
+
+- build
+- Windows build
+- JS tests
+- Windows JS tests
+- primary analysis
+- ESLint plugin tests
+- Linux/Windows/Alpine plugin QA jobs
+- ruling jobs
+- build-number generation
+
+Then it runs `SonarSource/ci-github-actions/promote@v1`, which promotes build info/artifacts in Repox.
+
+#### `releasability`
+
+Final branch-level status job:
+
+- runs only after successful promote
+- only on `master`, `branch-*`, and `dogfood-*`
+- computes releasability state and updates GitHub commit status
+
+## Repox, Vault, RSPEC, Sonar Platforms, And Other External Systems
+
+### Repox / Artifactory
+
+Repox is the repository manager behind both npm and Maven flows here.
+
+#### npm
+
+Linux:
+
+- `config-npm` defaults `repox-url` to `https://repox.jfrog.io`
+- it configures npm auth against Repox Artifactory
+- it also caches `~/.npm`
+
+Windows:
+
+- the workflow fetches a private-reader token from Vault directly
+- it runs:
+  - `npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=...`
+  - `npm config set registry https://repox.jfrog.io/artifactory/api/npm/npm/`
+
+#### Maven
+
+`config-maven`:
+
+- defaults `repox-url` to `https://repox.jfrog.io`
+- writes Maven `settings.xml`
+- sets `SONARSOURCE_REPOSITORY_URL=$ARTIFACTORY_URL/sonarsource-qa`
+- exports authentication environment variables for Maven
+
+`build` additionally fetches deployer credentials and pushes to `sonarsource-public-qa`.
+
+`promote` later promotes the produced build info/artifacts in Artifactory.
+
+### Vault
+
+Vault is the central credentials source. Typical secrets include:
+
+- Artifactory reader token for npm/Maven reads
+- Artifactory deployer token for `build`
+- Artifactory promoter token for `promote`
+- signing key and passphrase
+- RSPEC GitHub token
+- SonarQube platform URLs and tokens
+- GitHub token for licenses access
+
+### RSPEC
+
+The private RSPEC repository is consumed only through `prepare_rspec_rule_data` in this workflow. The result is then frozen into the run-local `rspec-rule-data-${github.sha}` artifact and reused downstream.
+
+### Sonar platforms
+
+The workflow targets:
+
+- SonarQube Next in `analyze_primary`
+- SonarCloud EU in `analyze_shadows`
+- SonarQube US in `analyze_shadows`
+- IRIS comparison across those platforms during nightly runs
+
+## External Actions Used By `build.yml`
+
+These are the most important reusable components in the current pipeline.
+
+| Action | Approx. uses in `build.yml` | Purpose | Cache / artifact relevance |
+| --- | --- | --- | --- |
+| `actions/checkout` | 28 | source checkout | none |
+| `jdx/mise-action` | 27 | provision Java, Maven, Node | action-managed runtime cache behavior |
+| `actions/download-artifact` | 27 | same-run file handoff | run-local artifact consumption |
+| `SonarSource/vault-action-wrapper` | 19 | credentials from Vault | none directly, but enables Repox/RSPEC/Sonar access |
+| `./.github/actions/maven-cache` | 17 | repo-owned Maven cache policy | official GitHub cache, restore-only on branches |
+| `SonarSource/ci-github-actions/config-maven` | 17 | Maven + Repox setup | built-in caching disabled in this workflow |
+| `actions/cache/restore` | 10 | restore-only cache consumers | direct GitHub cache use |
+| `./.github/actions/orchestrator-cache` | 9 | repo-owned orchestrator cache policy | official GitHub cache, rolling monthly prefix |
+| `actions/upload-artifact` | 7 | same-run file handoff | artifact production |
+| `actions/cache` | 4 | cache producer/probe jobs | direct GitHub cache use |
+| `SonarSource/ci-github-actions/config-npm` | 1 direct Linux code path | npm auth/bootstrap | transitively still uses SonarSource S3 cache for `~/.npm` |
+| `SonarSource/ci-github-actions/get-build-number` | 1 | stable build number | internally uses GitHub cache |
+| `./.github/actions/rule-api-cache` | 1 | repo-owned rule-api cache policy | official GitHub cache, rolling prefix |
+| `peter-evans/create-pull-request` | 1 | nightly generated-files PR | none |
+| `SonarSource/unified-dogfooding-actions/run-iris` | 1 | nightly cross-platform comparison | none |
+| `SonarSource/ci-github-actions/promote` | 1 | Artifactory/Repox promotion | downstream of all build/test gates |
+| `SonarSource/gh-action_releasability/releasability-status` | 1 | releasability commit status | none |
+
+## Optional Follow-Up: `pr-cleanup.yml`
+
+A separate PR-close cleanup workflow now makes more sense than before. The common pattern is:
+
+```yaml
+name: Cleanup PR Resources
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      actions: write
+    steps:
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v1
+```
+
+What it would help with in SonarJS:
+
+- delete PR-scoped GitHub caches after the PR closes
+- delete branch-run artifacts for the PR's head branch
+- reduce stale GitHub cache/artifact footprint created by:
+  - build-number caches
+  - `node_modules` caches
+  - JS coverage and Windows JS marker caches
+  - action-owned GitHub caches such as `mise`
+  - large short-lived artifacts like `sonarjs-m2` and `maven-targets`
+
+What it would **not** help with:
+
+- default-branch caches used as warm shared sources
+- restore-only branch consumers of Maven/orchestrator/rule-api caches
+- the remaining S3-backed `~/.npm` cache inside `config-npm`
+
+So the value of `pr-cleanup.yml` is:
+
+- yes for housekeeping and storage churn reduction
+- no as a correctness or performance fix for active PRs
+
+## Mental Model Summary
+
+If you remember only one model, remember this one:
+
+1. `setup` computes all cache keys and matrix inputs.
+2. `get_build_number` mints one build number.
+3. `populate_npm_cache*` are producer/probe jobs for `node_modules`.
+4. `prepare_rspec_rule_data` is the one RSPEC refresh job.
+5. `build` is the main artifact producer.
+6. downstream jobs either:
+   - restore caches for reusable dependency state, or
+   - download artifacts for exact same-run payloads
+7. `promote` is the fan-in gate for artifact promotion.
+8. `releasability` is the final status gate.
+
+And for caches specifically:
+
+- GitHub cache is now the direct mechanism in this workflow
+- artifacts carry run-local build products
+- default branch is the intended long-lived producer for shared warm caches
+- S3 is now only an indirect side path through Linux `config-npm`

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -42,7 +42,7 @@ The workflow uses a deliberate split between GitHub cache and GitHub artifacts:
 - Maven, orchestrator, and rule-api cache policy is centralized in local wrapper actions
 - `config-maven` configures Maven and Repox access, but its built-in caching is disabled in `build.yml`
 - Linux NPM cache population uses `config-npm` for auth/bootstrap, so `~/.npm` still goes through SonarSource's S3-backed cache action indirectly
-- all direct workflow cache steps and the local cache wrappers are pinned to the same `actions/cache` v6.1.0 commit
+- all direct workflow cache steps and the local cache wrappers use the same official GitHub cache actions
 
 ## Trigger Model And Global Controls
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -8,8 +8,8 @@ It documents the cache/artifact model used by the workflow:
 - direct workflow-level cache usage in `build.yml` uses official GitHub cache actions
 - same-run file handoff uses official GitHub artifact actions
 - local cache wrappers (`maven-cache`, `orchestrator-cache`, `rule-api-cache`) also use official GitHub cache actions
-- `build.yml` does not call SonarSource's S3-backed cache action directly
-- SonarSource's S3-backed cache action still matters indirectly through `SonarSource/ci-github-actions/config-npm`, which caches `~/.npm` on Linux cache-population jobs
+- `build.yml` uses explicit npm registry configuration on both Linux and Windows cache-population jobs
+- `build.yml` does not use SonarSource's S3-backed cache action
 
 This is the document to read first when you need to answer any of these questions quickly:
 
@@ -41,7 +41,7 @@ The workflow uses a deliberate split between GitHub cache and GitHub artifacts:
 - `prepare_rspec_rule_data` refreshes RSPEC once and shares the result through a per-run artifact
 - Maven, orchestrator, and rule-api cache policy is centralized in local wrapper actions
 - `config-maven` configures Maven and Repox access, but its built-in caching is disabled in `build.yml`
-- Linux NPM cache population uses `config-npm` for auth/bootstrap, so `~/.npm` still goes through SonarSource's S3-backed cache action indirectly
+- NPM registry authentication is configured explicitly in `build.yml` through Vault-fetched Artifactory tokens
 - all direct workflow cache steps and the local cache wrappers use the same official GitHub cache actions
 
 ## Trigger Model And Global Controls
@@ -355,7 +355,6 @@ That is exactly artifact semantics, not cache semantics.
 | Owner | Path or payload | Backend | Why it exists |
 | --- | --- | --- | --- |
 | `get-build-number` action | `.build_number.txt` | GitHub cache | Reuse one build number across reruns of the same workflow run |
-| `config-npm` action on Linux | `~/.npm` | SonarSource S3 cache action, transitively | Speeds package download reuse when `npm ci` actually runs |
 | `jdx/mise-action` | tool/runtime downloads | action-managed cache behavior | Reuses provisioned Java/Maven/Node toolchains; not a SonarJS-specific cache contract |
 
 ### Local wrapper semantics
@@ -472,48 +471,16 @@ PR runs still create PR-scoped GitHub state:
 
 That is why the repository also defines a PR-close cleanup workflow.
 
-## Where S3 Still Matters
+## S3 In This Workflow
 
-`SonarSource/gh-action_cache` is not a generic wrapper around GitHub cache. It is a SonarSource cache action whose primary backend is S3 and whose semantics include:
+`build.yml` does not use SonarSource's S3-backed cache action.
 
-- branch-scoped paths
-- default-branch fallback behavior
-- S3 credential setup and credential guard logic
-
-### Direct usage in `build.yml`
-
-- direct `build.yml` cache usage is GitHub-native
-- direct same-run file handoff is artifact-native
-- local repo wrappers are also GitHub-native
-
-So if you inspect only `build.yml` plus the local wrapper actions, the answer is:
+For this workflow, the relevant storage primitives are:
 
 - GitHub cache for cross-run reusable state
 - GitHub artifacts for same-run file payloads
-- no direct S3 cache action calls
 
-### Indirect usage via `config-npm`
-
-S3 still appears indirectly through `SonarSource/ci-github-actions/config-npm` on Linux:
-
-- when `populate_npm_cache` misses the `node_modules` cache
-- `config-npm` configures npm auth and also caches `~/.npm`
-- that helper action still uses `SonarSource/gh-action_cache`
-
-This means:
-
-- `build.yml` is not 100 percent free of SonarSource cache action behavior
-- only the Linux package-download cache path still depends on it
-- Windows NPM registry setup is manual in `build.yml`, so there is no equivalent transitive `config-npm` cache there
-
-### Removing S3 entirely from this pipeline
-
-This would require one of these approaches:
-
-- keep `config-npm`, but disable its internal caching and rely only on `node_modules`
-- stop using `config-npm` in `build.yml` and configure Linux npm auth manually, like the Windows job does
-
-That is a separate decision from the current workflow design.
+S3 may still exist elsewhere in SonarSource reusable actions or in other workflows, but it is not part of the `build.yml` data path described in this document.
 
 ## Why GitHub Cache / Artifact Makes Sense Here
 
@@ -572,15 +539,11 @@ Responsibilities:
 - if present, stop early
 - if missing, install dependencies and let the post step save the cache
 
-Linux specifics:
+Platform specifics:
 
-- uses `config-npm`
-- therefore also touches the transitive `~/.npm` S3 cache path
-
-Windows specifics:
-
-- configures Repox manually through Vault-fetched Artifactory token
-- does not use `config-npm`
+- both jobs fetch an Artifactory access token from Vault
+- both jobs configure the npm registry explicitly with `npm config set`
+- Linux and Windows still produce separate `node_modules` caches because the cache key includes `runner.os`
 
 #### `prepare_rspec_rule_data`
 
@@ -788,16 +751,10 @@ Repox is the repository manager behind both npm and Maven flows here.
 
 #### npm
 
-Linux:
+Both Linux and Windows cache-population jobs:
 
-- `config-npm` defaults `repox-url` to `https://repox.jfrog.io`
-- it configures npm auth against Repox Artifactory
-- it also caches `~/.npm`
-
-Windows:
-
-- the workflow fetches a private-reader token from Vault directly
-- it runs:
+- fetch a private-reader token from Vault
+- run:
   - `npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=...`
   - `npm config set registry https://repox.jfrog.io/artifactory/api/npm/npm/`
 
@@ -855,7 +812,6 @@ These are the most important reusable components in the current pipeline.
 | `./.github/actions/orchestrator-cache` | 9 | repo-owned orchestrator cache policy | official GitHub cache, rolling monthly prefix |
 | `actions/upload-artifact` | 7 | same-run file handoff | artifact production |
 | `actions/cache` | 4 | cache producer/probe jobs | direct GitHub cache use |
-| `SonarSource/ci-github-actions/config-npm` | 1 direct Linux code path | npm auth/bootstrap | transitively still uses SonarSource S3 cache for `~/.npm` |
 | `SonarSource/ci-github-actions/get-build-number` | 1 | stable build number | internally uses GitHub cache |
 | `./.github/actions/rule-api-cache` | 1 | repo-owned rule-api cache policy | official GitHub cache, rolling prefix |
 | `peter-evans/create-pull-request` | 1 | nightly generated-files PR | none |
@@ -909,7 +865,6 @@ What it would **not** help with:
 
 - default-branch caches used as warm shared sources
 - restore-only branch consumers of Maven/orchestrator/rule-api caches
-- the remaining S3-backed `~/.npm` cache inside `config-npm`
 
 So the value of `pr-cleanup.yml` is:
 
@@ -936,4 +891,3 @@ And for caches specifically:
 - GitHub cache is the direct mechanism in this workflow
 - artifacts carry run-local build products
 - default branch is the intended long-lived producer for shared warm caches
-- S3 is only an indirect side path through Linux `config-npm`

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -3,12 +3,12 @@
 This document explains the main GitHub Actions pipeline in
 [`../.github/workflows/build.yml`](../.github/workflows/build.yml).
 
-It is intentionally written for the cache/artifact model introduced by the current cache migration:
+It documents the cache/artifact model used by the workflow:
 
 - direct workflow-level cache usage in `build.yml` uses official GitHub cache actions
 - same-run file handoff uses official GitHub artifact actions
 - local cache wrappers (`maven-cache`, `orchestrator-cache`, `rule-api-cache`) also use official GitHub cache actions
-- SonarSource's S3-backed cache action is no longer used directly in `build.yml`
+- `build.yml` does not call SonarSource's S3-backed cache action directly
 - SonarSource's S3-backed cache action still matters indirectly through `SonarSource/ci-github-actions/config-npm`, which caches `~/.npm` on Linux cache-population jobs
 
 This is the document to read first when you need to answer any of these questions quickly:
@@ -32,26 +32,17 @@ This document focuses on the main `Build` workflow:
 
 Other workflows exist in `.github/workflows/`, but they are out of scope unless they directly affect the `build.yml` lifecycle.
 
-## What This Cache Migration Changes
+## Cache And Artifact Model
 
-Historically, `build.yml` used `SonarSource/gh-action_cache` directly for several kinds of handoff. The current design changes that split.
+The workflow uses a deliberate split between GitHub cache and GitHub artifacts:
 
-### Direct changes in `build.yml`
-
-- `node_modules` cache production now uses `actions/cache` in probe mode (`lookup-only: true`) instead of `SonarSource/gh-action_cache`
-- downstream `node_modules` consumers now use `actions/cache/restore` with `fail-on-cache-miss: true`
-- ESLint plugin tarball handoff is now modeled as `upload-artifact` + `download-artifact`, not as a cache
-- JS coverage reuse and Windows JS test marker reuse now use official GitHub cache actions directly
-- downloaded JS coverage is validated before Sonar analysis jobs consume it
-- Windows NPM cache population now mirrors the Linux job's build-number dependency wiring
-- local wrapper actions for Maven, orchestrator, and rule-api caches are pinned to the same `actions/cache` v6.1.0 commit as the direct workflow cache steps
-
-### What remains intentionally unchanged
-
-- `prepare_rspec_rule_data` still refreshes RSPEC once and shares the result through a per-run artifact
-- Maven/orchestrator/rule-api caches still use local wrapper actions so branch save policy stays centralized
-- `config-maven` still configures Maven and Repox access, but its built-in caching is disabled in `build.yml`
-- Linux NPM cache population still uses `config-npm` for auth/bootstrap, which means `~/.npm` still goes through SonarSource's S3-backed cache action indirectly
+- `node_modules`, Maven, orchestrator, rule-api, JS coverage, and the Windows JS marker use cache semantics
+- RSPEC data, built Maven outputs, JaCoCo reports, JS coverage reports, and the ESLint plugin tarball use artifact semantics
+- `prepare_rspec_rule_data` refreshes RSPEC once and shares the result through a per-run artifact
+- Maven, orchestrator, and rule-api cache policy is centralized in local wrapper actions
+- `config-maven` configures Maven and Repox access, but its built-in caching is disabled in `build.yml`
+- Linux NPM cache population uses `config-npm` for auth/bootstrap, so `~/.npm` still goes through SonarSource's S3-backed cache action indirectly
+- all direct workflow cache steps and the local cache wrappers are pinned to the same `actions/cache` v6.1.0 commit
 
 ## Trigger Model And Global Controls
 
@@ -361,7 +352,7 @@ That is exactly artifact semantics, not cache semantics.
 
 ### Helper-owned or transitive caches
 
-| Owner | Path or payload | Backend after this change | Why it exists |
+| Owner | Path or payload | Backend | Why it exists |
 | --- | --- | --- | --- |
 | `get-build-number` action | `.build_number.txt` | GitHub cache | Reuse one build number across reruns of the same workflow run |
 | `config-npm` action on Linux | `~/.npm` | SonarSource S3 cache action, transitively | Speeds package download reuse when `npm ci` actually runs |
@@ -479,22 +470,17 @@ PR runs still create PR-scoped GitHub state:
 - action-owned caches such as `mise`
 - workflow artifacts for that PR's runs
 
-That is why a PR-close cleanup workflow is now more relevant than before.
+That is why the repository also defines a PR-close cleanup workflow.
 
 ## Where S3 Still Matters
-
-### Historical direct usage
 
 `SonarSource/gh-action_cache` is not a generic wrapper around GitHub cache. It is a SonarSource cache action whose primary backend is S3 and whose semantics include:
 
 - branch-scoped paths
 - default-branch fallback behavior
-- optional migration from GitHub cache to S3
 - S3 credential setup and credential guard logic
 
-### Current direct usage in `build.yml`
-
-After this migration:
+### Direct usage in `build.yml`
 
 - direct `build.yml` cache usage is GitHub-native
 - direct same-run file handoff is artifact-native
@@ -506,7 +492,7 @@ So if you inspect only `build.yml` plus the local wrapper actions, the answer is
 - GitHub artifacts for same-run file payloads
 - no direct S3 cache action calls
 
-### Current indirect usage
+### Indirect usage via `config-npm`
 
 S3 still appears indirectly through `SonarSource/ci-github-actions/config-npm` on Linux:
 
@@ -516,18 +502,18 @@ S3 still appears indirectly through `SonarSource/ci-github-actions/config-npm` o
 
 This means:
 
-- `build.yml` is not yet 100 percent free of SonarSource cache action behavior
+- `build.yml` is not 100 percent free of SonarSource cache action behavior
 - only the Linux package-download cache path still depends on it
 - Windows NPM registry setup is manual in `build.yml`, so there is no equivalent transitive `config-npm` cache there
 
-### If we want to remove S3 entirely from this pipeline later
+### Removing S3 entirely from this pipeline
 
-We would need one of these follow-ups:
+This would require one of these approaches:
 
 - keep `config-npm`, but disable its internal caching and rely only on `node_modules`
 - stop using `config-npm` in `build.yml` and configure Linux npm auth manually, like the Windows job does
 
-That is a separate decision from this migration.
+That is a separate decision from the current workflow design.
 
 ## Why GitHub Cache / Artifact Makes Sense Here
 
@@ -879,7 +865,7 @@ These are the most important reusable components in the current pipeline.
 
 ## PR Cleanup Workflow
 
-This branch also adds a companion workflow:
+The repository also defines a companion workflow:
 
 - [`../.github/workflows/pr-cleanup.yml`](../.github/workflows/pr-cleanup.yml)
 
@@ -947,7 +933,7 @@ If you remember only one model, remember this one:
 
 And for caches specifically:
 
-- GitHub cache is now the direct mechanism in this workflow
+- GitHub cache is the direct mechanism in this workflow
 - artifacts carry run-local build products
 - default branch is the intended long-lived producer for shared warm caches
-- S3 is now only an indirect side path through Linux `config-npm`
+- S3 is only an indirect side path through Linux `config-npm`

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -877,9 +877,20 @@ These are the most important reusable components in the current pipeline.
 | `SonarSource/ci-github-actions/promote` | 1 | Artifactory/Repox promotion | downstream of all build/test gates |
 | `SonarSource/gh-action_releasability/releasability-status` | 1 | releasability commit status | none |
 
-## Optional Follow-Up: `pr-cleanup.yml`
+## PR Cleanup Workflow
 
-A separate PR-close cleanup workflow now makes more sense than before. The common pattern is:
+This branch also adds a companion workflow:
+
+- [`../.github/workflows/pr-cleanup.yml`](../.github/workflows/pr-cleanup.yml)
+
+It runs on `pull_request.closed` and uses `SonarSource/ci-github-actions/pr_cleanup@v1`.
+
+The workflow is intentionally separate from [`../.github/workflows/PullRequestClosed.yml`](../.github/workflows/PullRequestClosed.yml):
+
+- `PullRequestClosed.yml` handles Jira/backlog behavior
+- `pr-cleanup.yml` handles GitHub Actions resource cleanup
+
+The workflow shape is:
 
 ```yaml
 name: Cleanup PR Resources
@@ -897,7 +908,7 @@ jobs:
       - uses: SonarSource/ci-github-actions/pr_cleanup@v1
 ```
 
-What it would help with in SonarJS:
+What it helps with in SonarJS:
 
 - delete PR-scoped GitHub caches after the PR closes
 - delete branch-run artifacts for the PR's head branch


### PR DESCRIPTION
## Summary

- replace `SonarSource/gh-action_cache` usage in `build.yml` with official GitHub cache actions where the workflow depends on standard `lookup-only` semantics
- use workflow artifacts for explicit job-to-job handoff of JS coverage reports and the ESLint plugin tarball
- keep the existing local GitHub cache wrappers for Maven, orchestrator, and rule-api data

## Why

This follows up on #7481 and #7494.

The recent `gh-action_cache` behavior change exposed that parts of our workflow were relying on cache side effects rather than explicit handoff. For the SonarJS build workflow, we do not need the SonarSource S3 cache wrapper for these paths, and using the official GitHub cache/artifact actions makes the behavior align with what the workflow is actually trying to do.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "build.yml parsed"'`
- CI not run locally

----
## Summary by Gitar

- **CI documentation:**
  - Added `docs/CI.md` as a canonical reference for the CI pipeline architecture and data flow.
  - Updated `docs/BUILD.md` to link to the new documentation.
- **Cleanup workflow:**
  - Added `pr-cleanup.yml` to automatically prune PR-scoped GitHub caches and artifacts upon closure.
- **Dependency management:**
  - Aligned `populate_npm_cache_win` with `get_build_number` dependency and added shared environment variables.
  - Integrated `validate_js_coverage_reports` as a shared step in `test_js` and `analyze_primary` to ensure data integrity during artifact handoff.
- **Action pinning:**
  - Pinned all `actions/cache` and `actions/download-artifact` references to specific SHAs and versions for stability.

<sub>This will update automatically on new commits.</sub>