### PR TITLE
JS-2040 docs: run uc check before committing in the new-rule skill

### DIFF
--- a/.claude/skills/new-rule/SKILL.md
+++ b/.claude/skills/new-rule/SKILL.md
@@ -129,6 +129,15 @@ npx tsx --test packages/analysis/src/jsts/rules/S1234/**/*.test.ts
 
 See `/ruling` skill. Required before merging new or modified rules.
 
+## Step 8: Run Checks Before Committing
+
+```bash
+uc check
+```
+
+Covers merge conflicts against the base branch, `knip`, a `tsgo` type check, and the unit and
+ruling tests scoped to this rule's changes. Fix anything it flags before committing.
+
 ## Rule Implementation Patterns
 
 ### Wrapping an ESLint Rule (`decorated`)


### PR DESCRIPTION
## Summary

- The `/new-rule` skill's workflow ended at ruling with no pre-commit validation step.
- Add a step to run `uc check` (merge conflicts, knip, tsgo type check, and unit/ruling tests scoped to the changed rule) before committing.

## Test plan

- [x] Docs-only change, no code affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a Claude skill file; no runtime or rule behavior is affected.
> 
> **Overview**
> The `/new-rule` skill workflow now includes **Step 8: Run Checks Before Committing**, after ruling and before commit.
> 
> Contributors are instructed to run **`uc check`**, which validates merge conflicts against the base branch, **`knip`**, a **`tsgo`** type check, and unit/ruling tests scoped to the rule’s changes. The step tells them to fix any failures before committing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9fb3db7dae02f2f77463d7db7668ec56bcc660. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->