### PR TITLE
JS-2045 Use promoted sonar-lits 0.13.0.5954 in ITs

### DIFF
--- a/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
+++ b/its/plugin/fast-tests/src/test/java/com/sonar/javascript/it/plugin/SonarScannerIntegrationHelper.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.javascript.TypeScriptLanguage;
 
 public final class SonarScannerIntegrationHelper {
 
-  static final String LITS_VERSION = "0.12.0.5861";
+  static final String LITS_VERSION = "0.13.0.5954";
 
   /**
    * Get the engine version based on the sonar.runtimeVersion system property.

--- a/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/javascript/it/RulingTest.java
@@ -56,7 +56,7 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 class RulingTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RulingTest.class);
-  static final String LITS_VERSION = "0.12.0.5861";
+  static final String LITS_VERSION = "0.13.0.5954";
   static final String SCANNER_VERSION = "5.0.1.3006";
 
   static final String DEFAULT_EXCLUSIONS = "**/.*,**/*.d.ts";
@@ -279,11 +279,15 @@ class RulingTest {
       .setScannerVersion(SCANNER_VERSION)
       .setProperty(
         "sonar.lits.dump.old",
-        FileLocation.of("src/test/expected/" + projectKey).getFile().getAbsolutePath()
+        FileLocation.of("src/test/expected/" + projectKey)
+          .getFile()
+          .getAbsolutePath()
       )
       .setProperty(
         "sonar.lits.dump.new",
-        FileLocation.of("target/actual/" + projectKey).getFile().getAbsolutePath()
+        FileLocation.of("target/actual/" + projectKey)
+          .getFile()
+          .getAbsolutePath()
       )
       .setProperty("sonar.lits.differences", differencesPath.toString())
       .setProperty("sonar.exclusions", actualExclusions)


### PR DESCRIPTION
## Summary
- use the promoted `sonar-lits` artifact `0.13.0.5954` from SonarSource/sonar-lits#143 in `RulingTest`
- keep `SonarScannerIntegrationHelper` on the same LITS version so the Java integration tests stay aligned

## Verification
- `npm run bbf`
- `mvn -pl its/ruling -am -DskipTests install`
- CI will run the full `RulingTest` flow