### PR TITLE
JS-2047 Fix ruling bot report baseline on PR merge refs

### DIFF
--- a/.github/actions/ruling_bot/run.sh
+++ b/.github/actions/ruling_bot/run.sh
@@ -12,6 +12,7 @@ FIX_PR_URL=""
 FIX_BRANCH_EXISTS="false"
 HAS_DIFFERENCES="false"
 STASHED_CHANGES="false"
+INPUT_BASE_SHA="${BASE_SHA}"
 
 if [ "${IS_PULL_REQUEST}" = "true" ]; then
   FIX_PR_TITLE="Update ruling results for PR #${PR_NUMBER}"
@@ -56,6 +57,9 @@ write_pr_comment() {
         echo "**Ruling needs updating.** A fix PR has been created: ${FIX_PR_URL}"
         echo ""
         echo "Please review and merge it into your branch."
+      elif [ "$RULING_FAILED" = "false" ]; then
+        echo "---"
+        echo "**Ruling passed with these expected-result updates already present in the branch. No fix PR was needed.**"
       fi
     } > comment.md
   else
@@ -103,12 +107,25 @@ write_summary() {
 }
 
 git fetch origin "$BASE_REF"
-if [ -n "${BASE_SHA}" ]; then
-  git fetch origin "$BASE_SHA" || true
-  if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
-    echo "::error::Failed to fetch PR base SHA: $BASE_SHA"
+
+REPORT_BASE_SHA=""
+if [ "$IS_PULL_REQUEST" = "true" ]; then
+  # Pull request runs execute on GitHub's synthetic merge ref.
+  # Align the ruling report baseline with the merge tree that was actually tested.
+  REPORT_BASE_SHA="$(git merge-base HEAD "origin/$BASE_REF" 2>/dev/null || true)"
+fi
+
+if [ -z "$REPORT_BASE_SHA" ] && [ -n "${INPUT_BASE_SHA}" ]; then
+  git fetch origin "$INPUT_BASE_SHA" || true
+  if ! git cat-file -e "$INPUT_BASE_SHA^{commit}" 2>/dev/null; then
+    echo "::error::Failed to fetch PR base SHA: $INPUT_BASE_SHA"
     exit 1
   fi
+  REPORT_BASE_SHA="$INPUT_BASE_SHA"
+fi
+
+if [ -n "$REPORT_BASE_SHA" ]; then
+  echo "Using ruling report base SHA: $REPORT_BASE_SHA"
 fi
 
 if [ "$RULING_FAILED" = "true" ]; then
@@ -121,7 +138,7 @@ if [ "$RULING_FAILED" = "true" ]; then
   node "$ACTION_PATH/sync-results.mjs" "$NEW_RESULTS_PATH" "$OLD_RESULTS_PATH"
 fi
 
-BASE_REF="$BASE_REF" BASE_SHA="$BASE_SHA" node "$ACTION_PATH/generate-report.mjs" "$OLD_RESULTS_PATH" > ruling-report.md
+BASE_REF="$BASE_REF" BASE_SHA="$REPORT_BASE_SHA" node "$ACTION_PATH/generate-report.mjs" "$OLD_RESULTS_PATH" > ruling-report.md
 if [ -s ruling-report.md ]; then
   HAS_DIFFERENCES="true"
 fi


### PR DESCRIPTION
## Summary
- derive the ruling report baseline from the tested pull request merge ref instead of relying only on `github.event.pull_request.base.sha`
- keep the event `base.sha` as a fallback when merge-base resolution is unavailable
- clarify the PR comment when ruling differences exist but no fix PR is expected because the ruling run already passed

## Why
[PR #7514](https://github.com/SonarSource/SonarJS/pull/7514) showed ruling differences in the bot comment without opening a fix PR.

The core issue is that the ruling bot comment is **not** meant to answer only "are the expected results stale right now?". Its real job is to answer "what ruling behavior changes does this PR introduce relative to its base?".

That distinction is why the bot needs a **base commit**.

## What The Ruling Comment Is For
There are two separate comparisons in the ruling flow:

1. `expected` vs `actual`
   This answers: "is the branch stale right now?"
   If they differ, the ruling run failed and the fix-PR path may update the checked-in expected results.

2. `branch expected` vs `base expected`
   This answers: "what ruling behavior changes does this PR introduce relative to the target branch?"
   This is what the PR comment is for.

Only using `expected` vs `actual` is not enough:
- if a PR changes analyzer behavior **and already committed the correct expected-result updates**, then `expected == actual`, so a pure freshness diff would show nothing
- reviewers would lose the summary of the new and removed issues introduced by the PR
- after syncing results on a failing PR, `expected == actual` again, so the comment would also lose the full "what changed because of this PR" context

That is the reason [PR #6157](https://github.com/SonarSource/SonarJS/pull/6157) changed the original logic to compare against the base branch rather than only against the current branch state.

## Why Comparing Against Moving `master` Was Wrong
This was the first failure mode the history was trying to fix.

Step by step:
1. `master` is at commit [`M0`](https://github.com/SonarSource/SonarJS/commit/29e5c7b6369e5d79b56cb1fa159356439cfce55d) when a PR is created.
2. The PR changes a rule and updates expected ruling results accordingly.
3. Later, `master` moves to a newer commit `M1` and brings unrelated ruling-result changes.
4. If the ruling comment compares the PR branch against the **current tip of `master`**, then the diff becomes:
   `PR branch` vs `M1`
5. That diff now includes:
   - the ruling changes introduced by the PR
   - plus unrelated ruling changes that happened on `master` after the PR was created
6. The PR comment becomes noisy or misleading, because it attributes some `master` changes to the PR.

This is why the comparison target evolved through:
- [PR #6157](https://github.com/SonarSource/SonarJS/pull/6157): compare against `origin/master` instead of `HEAD`
- [PR #6580](https://github.com/SonarSource/SonarJS/pull/6580): compare against the real base branch, not hardcoded `master`
- [PR #6619](https://github.com/SonarSource/SonarJS/pull/6619): compare against the exact PR base SHA instead of the moving branch tip

The intent behind [PR #6619](https://github.com/SonarSource/SonarJS/pull/6619) was correct: freeze the baseline at the PR's original base snapshot so the report does not drift while the base branch moves.

## Why [PR #7514](https://github.com/SonarSource/SonarJS/pull/7514) Still Looked Wrong
This is the second failure mode, and it only appears because `pull_request` workflows now run on GitHub's synthetic merge ref.

Step by step:
1. A PR is created from base snapshot `M0`.
2. Later, the base branch advances to `M1`.
3. On a `pull_request` run, GitHub Actions does **not** necessarily check out the raw PR head. It checks out:
   `merge(PR head, current base branch)`
4. In the observed [run 29048160128](https://github.com/SonarSource/SonarJS/actions/runs/29048160128) for [PR #7514](https://github.com/SonarSource/SonarJS/pull/7514), Actions checked out `refs/remotes/pull/7514/merge`.
5. That checked-out merge commit was built on top of [`e76d467bcafd68b13dceecd6e0bdb9a8ee9eca2c`](https://github.com/SonarSource/SonarJS/commit/e76d467bcafd68b13dceecd6e0bdb9a8ee9eca2c), which was the current base branch state at the time of the run.
6. The ruling job therefore analyzed the merge tree:
   `merge(PR, M1)`
7. But the ruling report still used the stale event payload `base.sha=[29e5c7b6369e5d79b56cb1fa159356439cfce55d](https://github.com/SonarSource/SonarJS/commit/29e5c7b6369e5d79b56cb1fa159356439cfce55d)`, which corresponded to the original PR base snapshot `M0`.
8. So the report diff effectively became:
   `merge(PR, M1)` vs `M0`
9. That reintroduced the same problem in another form: the diff included `M0 -> M1` changes from the base branch, even though those changes were not introduced by the PR itself.

That is why [PR #7514](https://github.com/SonarSource/SonarJS/pull/7514) could show:
- a ruling comment with differences
- but no fix PR

The comment showed differences because the report baseline was wrong.  
No fix PR was created because the ruling run itself passed on the merge tree that was actually tested.

## What This Fix Changes
This PR does **not** remove the base comparison logic.

Instead, it makes the compared base match the tree that the workflow actually tested:

1. On PR runs, derive the report baseline from the checked-out merge ref with:
   `git merge-base HEAD origin/$BASE_REF`
2. If `HEAD` is GitHub's synthetic merge commit `merge(PR, M1)`, that merge-base resolves to `M1`.
3. The report then compares:
   `merge(PR, M1)` vs `M1`
4. That leaves only the ruling-result changes introduced by the PR in the tested tree.
5. If merge-base resolution is unavailable, the action still falls back to the event `base.sha`.

So the old broken comparison was:
- tested merge tree vs stale PR-base snapshot

And the new comparison is:
- tested merge tree vs its actual base-branch ancestor

## Historical Context
1. [PR #6123](https://github.com/SonarSource/SonarJS/pull/6123) / [`f719f43610`](https://github.com/SonarSource/SonarJS/commit/f719f43610) / merged 2026-01-05 / `zglicz`
   Introduced automatic ruling updates for failing PRs. The report logic originally compared against `HEAD`.
2. [PR #6157](https://github.com/SonarSource/SonarJS/pull/6157) / [`6e395e2b3`](https://github.com/SonarSource/SonarJS/commit/6e395e2b3) / merged 2026-01-08 / `zglicz`
   Switched the report baseline from `HEAD` to `origin/master`. The explicit reason in the PR body was to show all ruling changes introduced by the PR, not only the latest bot delta.
3. [PR #6253](https://github.com/SonarSource/SonarJS/pull/6253) / [`51a31e61b9`](https://github.com/SonarSource/SonarJS/commit/51a31e61b9) / merged 2026-01-27 / `francois-mora-sonarsource`
   Changed the workflow to always post or update the PR ruling comment. From that point on, the comment and the automatic fix path were intentionally decoupled: comments happen whenever differences exist, but fix PRs only happen when the ruling run failed.
4. [PR #6466](https://github.com/SonarSource/SonarJS/pull/6466) / [`7f12e5e758`](https://github.com/SonarSource/SonarJS/commit/7f12e5e758) / merged 2026-02-27 / `zglicz`
   Replaced direct pushes with separate fix PRs targeting the contributor branch. The failure gate for automatic fixes stayed in place.
5. [PR #6504](https://github.com/SonarSource/SonarJS/pull/6504) / [`e99efdf562`](https://github.com/SonarSource/SonarJS/commit/e99efdf562) / merged 2026-03-03 / `zglicz`
   Fixed stale fix-PR cleanup so already merged fix PRs are not closed again.
6. [PR #6580](https://github.com/SonarSource/SonarJS/pull/6580) / [`b204b96ea5`](https://github.com/SonarSource/SonarJS/commit/b204b96ea5) / merged 2026-03-13 / `zglicz`
   Changed the comparison target from hardcoded `origin/master` to `origin/$BASE_REF`. The reason was to avoid unrelated diffs when the PR targets another branch or when `master` has moved.
7. [PR #6619](https://github.com/SonarSource/SonarJS/pull/6619) / [`838907e325`](https://github.com/SonarSource/SonarJS/commit/838907e325) / merged 2026-03-17 / `zglicz`
   Changed the comparison target again from the moving branch tip to `github.event.pull_request.base.sha`. The explicit goal was to keep the report stable and avoid drift while the base branch advances during the workflow run.
8. [PR #6883](https://github.com/SonarSource/SonarJS/pull/6883) / [`1db0e513fd`](https://github.com/SonarSource/SonarJS/commit/1db0e513fd) / merged 2026-04-21 / `zglicz`
   Generalized the logic for both PR and default-branch runs. The comparison semantics stayed the same.
9. [PR #7508](https://github.com/SonarSource/SonarJS/pull/7508) / [`4112b79c47`](https://github.com/SonarSource/SonarJS/commit/4112b79c47) / merged 2026-07-09 / `vdiez`
   Moved the SonarJS-specific ruling comment and fix-PR logic into the reusable [`./.github/actions/ruling_bot`](https://github.com/SonarSource/SonarJS/tree/master/.github/actions/ruling_bot) action. The refactor deliberately preserved the existing behavior, including the `base-sha` comparison.

## Validation
- `bash -n .github/actions/ruling_bot/run.sh`
- `node --check .github/actions/ruling_bot/generate-report.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/ruling_bot/action.yml"); puts "yaml ok"'`
- `git diff --check`
