### PR TITLE
JS-2050: S8980: explain why act() is unnecessary in the issue message

### DIFF
--- a/packages/analysis/src/jsts/rules/S8980/cb.fixture.tsx
+++ b/packages/analysis/src/jsts/rules/S8980/cb.fixture.tsx
@@ -6,23 +6,23 @@ function Form() {
 }
 
 function submitsForm() {
-    act(() => { // Noncompliant {{Avoid wrapping Testing Library util calls in `act`}}
+    act(() => { // Noncompliant {{Remove this redundant `act()` call; the wrapped call already flushes its own updates.}}
         render(<Form />);
     });
 
-    act(() => { // Noncompliant {{Avoid wrapping Testing Library util calls in `act`}}
+    act(() => { // Noncompliant {{Remove this redundant `act()` call; the wrapped call already flushes its own updates.}}
         fireEvent.click(screen.getByRole('button'));
     });
 
-    act(() => screen.getByRole('button')); // Noncompliant {{Avoid wrapping Testing Library util calls in `act`}}
+    act(() => screen.getByRole('button')); // Noncompliant {{Remove this redundant `act()` call; the wrapped call already flushes its own updates.}}
 }
 
 async function usesUserEventAndWaitFor() {
-    await act(async () => { // Noncompliant {{Avoid wrapping Testing Library util calls in `act`}}
+    await act(async () => { // Noncompliant {{Remove this redundant `act()` call; the wrapped call already flushes its own updates.}}
         await userEvent.click(screen.getByRole('button'));
     });
 
-    await act(async () => { // Noncompliant {{Avoid wrapping Testing Library util calls in `act`}}
+    await act(async () => { // Noncompliant {{Remove this redundant `act()` call; the wrapped call already flushes its own updates.}}
         await waitFor(() => screen.getByText('done'));
     });
 }

--- a/packages/analysis/src/jsts/rules/S8980/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S8980/decorator.ts
@@ -138,10 +138,25 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
       }
       if (
         'messageId' in reportDescriptor &&
-        reportDescriptor.messageId === TESTING_LIBRARY_UTIL_MESSAGE_ID &&
-        'node' in reportDescriptor &&
-        actCallbackHasNoRecognizedTestingLibraryCall(context, reportDescriptor.node as estree.Node)
+        reportDescriptor.messageId === TESTING_LIBRARY_UTIL_MESSAGE_ID
       ) {
+        if (
+          'node' in reportDescriptor &&
+          actCallbackHasNoRecognizedTestingLibraryCall(
+            context,
+            reportDescriptor.node as estree.Node,
+          )
+        ) {
+          return;
+        }
+        // Upstream's own message only states what is wrong, not why it matters
+        // or what to do; state the fix and the risk of leaving it in place.
+        const { messageId, data, ...rest } = reportDescriptor;
+        context.report({
+          ...rest,
+          message:
+            'Remove this redundant `act()` call; the wrapped call already flushes its own updates.',
+        });
         return;
       }
       context.report(reportDescriptor);

--- a/packages/analysis/src/jsts/rules/S8980/import-resolution.fixture.tsx
+++ b/packages/analysis/src/jsts/rules/S8980/import-resolution.fixture.tsx
@@ -11,7 +11,7 @@ function Form() {
 // the local binding name, confirming detection is based on where `act`
 // actually comes from rather than a hardcoded identifier name `act`.
 function aliasedTestingLibraryAct() {
-    tlAct(() => { // Noncompliant {{Avoid wrapping Testing Library util calls in `act`}}
+    tlAct(() => { // Noncompliant {{Remove this redundant `act()` call; the wrapped call already flushes its own updates.}}
         testingLibraryRender(<Form />);
     });
 }

--- a/packages/analysis/src/jsts/rules/S8980/legacy-act-import.fixture.tsx
+++ b/packages/analysis/src/jsts/rules/S8980/legacy-act-import.fixture.tsx
@@ -6,7 +6,7 @@ function Form() {
 }
 
 function usesLegacyActImport() {
-    legacyAct(() => { // Noncompliant {{Avoid wrapping Testing Library util calls in `act`}}
+    legacyAct(() => { // Noncompliant {{Remove this redundant `act()` call; the wrapped call already flushes its own updates.}}
         render(<Form />);
     });
 }


### PR DESCRIPTION
## Summary

The S8980 issue message inherited from upstream (`eslint-plugin-testing-library`'s `no-unnecessary-act`) only states what's wrong ("Avoid wrapping Testing Library util calls in `act`"), not why it matters or what to do about it.

- Overrides the message at report time (same pattern already used by S8950 for its own decorated rule) to: **"Remove this redundant `act()` call; the wrapped call already flushes its own updates."**
- Updated the three comment-based fixtures to assert the new message text.
- No detection-logic change — verified first via a fresh `uc peach diff` review that the current detection is sound (4/4 new real-world issues since merge confirmed true positives by inspecting the checked-out source imports directly, 0 false positives, 0 unclear) before touching only the wording.

## Links

- Jira: https://sonarsource.atlassian.net/browse/JS-2050
- Original rule PR: https://github.com/SonarSource/SonarJS/pull/7480
