### PR TITLE
JS-2072 Cap published eslint-plugin TypeScript range

### DIFF
--- a/.pmgrc.toml
+++ b/.pmgrc.toml
@@ -22,8 +22,9 @@ eslint = "^8.0.0 || ^9.0.0 || ^10.0.0"
 # Version overrides: pmg auto-detects which deps are used, but these two need
 # non-default versions. `builtin-modules` stays on major 3 (`^3.3.0`) because
 # the plugin is compiled to CommonJS; the root package.json has 5.0.0 (ESM-only)
-# for the bridge. `typescript` is loosened to >=5 so consumers aren't forced
-# onto the exact version used to build.
+# for the bridge. `typescript` stays broad enough for consumers, but remains
+# capped to the current typescript-eslint support window to avoid resolving an
+# unsupported major on fresh installs.
 [data.dependencies]
-typescript = ">=5"
+typescript = ">=5 <6.1.0"
 builtin-modules = "^3.3.0"


### PR DESCRIPTION
## Context
- triggered by the latest comments in the [community thread](https://community.sonarsource.com/t/eslint-plugin-sonar-size/141181/29)
- `eslint-plugin-sonarjs` currently publishes `typescript` as `>=5`, which allows fresh installs to resolve TypeScript 7
- that falls outside the current `typescript-eslint` support window and shows up as unmet peer warnings in `pnpm` installs

## Summary
- cap the published `eslint-plugin-sonarjs` `typescript` dependency to `>=5 <6.1.0`
- keep fresh installs aligned with the current `typescript-eslint` support window until TypeScript 7 is supported there

## Verification
- `npm run eslint-plugin:compile`
- package the plugin locally and verify `pnpm add -D <tarball>` resolves `typescript@6.0.3`
- package the plugin locally and verify `pnpm add -D <tarball> typescript-eslint@latest` resolves `typescript@6.0.3` without unmet peer warnings
