### PR TITLE
JS-2063 Update rule S1534: Cover vue duplication

### DIFF
--- a/packages/analysis/src/jsts/rules/S1534/meta.ts
+++ b/packages/analysis/src/jsts/rules/S1534/meta.ts
@@ -20,4 +20,5 @@ export const externalRules = [
   { externalPlugin: 'eslint', externalRule: 'no-dupe-keys' },
   { externalPlugin: 'typescript-eslint', externalRule: 'no-dupe-class-members' },
   { externalPlugin: 'react', externalRule: 'jsx-no-duplicate-props' },
+  { externalPlugin: 'vue', externalRule: 'no-duplicate-attributes' },
 ];

--- a/packages/analysis/src/jsts/rules/S1534/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1534/rule.ts
@@ -44,7 +44,8 @@ export const rule: Rule.RuleModule = {
       {
         type: 'object',
         properties: {
-          ...(jsxNoDuplicatePropsRule.meta!.schema as { properties: object }[])[0].properties,
+          ...(jsxNoDuplicatePropsRule.meta?.schema as { properties: object }[] | undefined)?.[0]
+            ?.properties,
           ...(
             vueNoDuplicateAttributesRule.meta?.schema as { properties: object }[] | undefined
           )?.[0]?.properties,

--- a/packages/analysis/src/jsts/rules/S1534/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1534/rule.ts
@@ -20,6 +20,7 @@ import type { Rule } from 'eslint';
 import { getESLintCoreRule } from '../external/core.js';
 import { rules as tsEslintRules } from '../external/typescript-eslint/index.js';
 import { rules as reactRules } from '../external/react.js';
+import { rules as vueRules } from '../external/vue.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { mergeRules } from '../helpers/decorators/merger.js';
 import { decorate } from './decorator.js';
@@ -28,6 +29,7 @@ import * as meta from './generated-meta.js';
 const noDupeKeysRule = decorate(getESLintCoreRule('no-dupe-keys'));
 const noDupeClassMembersRule = tsEslintRules['no-dupe-class-members'];
 const jsxNoDuplicatePropsRule = reactRules['jsx-no-duplicate-props'];
+const vueNoDuplicateAttributesRule = vueRules['no-duplicate-attributes'];
 
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta, {
@@ -36,14 +38,33 @@ export const rule: Rule.RuleModule = {
       ...noDupeKeysRule.meta!.messages,
       ...noDupeClassMembersRule.meta!.messages,
       ...jsxNoDuplicatePropsRule.meta!.messages,
+      ...vueNoDuplicateAttributesRule.meta?.messages,
     },
-    schema: jsxNoDuplicatePropsRule.meta!.schema, // the other 2 rules have no options
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ...(jsxNoDuplicatePropsRule.meta!.schema as { properties: object }[])[0].properties,
+          ...(
+            vueNoDuplicateAttributesRule.meta?.schema as { properties: object }[] | undefined
+          )?.[0]?.properties,
+        },
+        additionalProperties: false,
+      },
+    ], // the other 2 rules have no options
   }),
   create(context: Rule.RuleContext) {
     const noDupeKeysListener: Rule.RuleListener = noDupeKeysRule.create(context);
     const noDupeClassMembersListener: Rule.RuleListener = noDupeClassMembersRule.create(context);
     const jsxNoDuplicatePropsListener: Rule.RuleListener = jsxNoDuplicatePropsRule.create(context);
+    const vueNoDuplicateAttributesListener: Rule.RuleListener =
+      vueNoDuplicateAttributesRule.create(context);
 
-    return mergeRules(noDupeKeysListener, noDupeClassMembersListener, jsxNoDuplicatePropsListener);
+    return mergeRules(
+      noDupeKeysListener,
+      noDupeClassMembersListener,
+      jsxNoDuplicatePropsListener,
+      vueNoDuplicateAttributesListener,
+    );
   },
 };

--- a/packages/analysis/src/jsts/rules/S1534/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1534/unit.test.ts
@@ -14,9 +14,13 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import { DefaultParserRuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
+import {
+  DefaultParserRuleTester,
+  NoTypeCheckingRuleTester,
+} from '../../../../tests/jsts/tools/testers/rule-tester.js';
 import { rule } from './rule.js';
 import { describe, it } from 'node:test';
+import parser from 'vue-eslint-parser';
 
 describe('S1534', () => {
   it('S1534', () => {
@@ -104,6 +108,41 @@ let x = {
               ],
             },
           ],
+        },
+      ],
+    });
+  });
+
+  it('S1534 (decorated: vue/no-duplicate-attributes)', () => {
+    const ruleTesterVue = new NoTypeCheckingRuleTester({ parser });
+    ruleTesterVue.run(`Vue template duplicate attributes`, rule, {
+      valid: [
+        {
+          // class/style coexistence is explicitly allowed by default
+          code: `
+<template>
+  <div class="a" :class="b" style="color: red" :style="c" />
+</template>
+`,
+        },
+      ],
+      invalid: [
+        {
+          code: `
+<template>
+  <div id="a" id="b" />
+</template>
+`,
+          errors: [{ message: "Duplicate attribute 'id'." }],
+        },
+        {
+          // plain attribute and its bound (v-bind) form resolve to the same name
+          code: `
+<template>
+  <div id="a" :id="b" />
+</template>
+`,
+          errors: [{ message: "Duplicate attribute 'id'." }],
         },
       ],
     });

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1110.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1110.json
@@ -1,19 +1,19 @@
 {
-  "title": "Unnecessary parentheses should be removed",
+  "title": "Redundant pairs of parentheses should be removed",
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "CLEAR"
   },
   "status": "deprecated",
   "remediation": {
     "func": "Constant/Issue",
-    "constantCost": "2 min"
+    "constantCost": "1min"
   },
   "tags": [],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-1110",
   "sqKey": "S1110",
   "scope": "Main",
@@ -22,5 +22,12 @@
     "js",
     "ts"
   ],
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "extra": {
+    "replacementRules": [],
+    "legacyKeys": [
+      "UselessParenthesesCheck",
+      "Parentheses"
+    ]
+  }
 }

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1534.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S1534.json
@@ -13,7 +13,9 @@
     "constantCost": "5min"
   },
   "tags": [
-    "pitfall"
+    "pitfall",
+    "react",
+    "vue"
   ],
   "extra": {
     "replacementRules": [],


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule S1534 updates:**
  - Integrated `vue/no-duplicate-attributes` to extend duplication checking into Vue templates.
  - Updated `rule.ts` to include Vue rule logic, merged schemas, and added necessary metadata.
  - Added unit tests in `unit.test.ts` using `vue-eslint-parser` to verify correct detection of duplicate Vue attributes.
  - Updated `S1534.json` metadata to include the `vue` tag.
- **Rule S1110 updates:**
  - Modified `S1110.json` to update title, increase maintainability impact to `MEDIUM`, adjust remediation cost, and set default severity to `Major`.

<sub>This will update automatically on new commits.</sub>