### PR TITLE
JS-393 Add regression for destructured hook props

### DIFF
--- a/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
+++ b/packages/analysis/src/jsts/rules/S6767/unit.typescript.test.ts
@@ -717,6 +717,76 @@ function SectionListComponent() {
     });
   });
 
+  it('should not report props forwarded to a helper with a destructured parameter', () => {
+    const ruleTester = new RuleTester({
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: path.join(import.meta.dirname, 'fixtures'),
+      },
+    });
+
+    const fixtureFile = path.join(import.meta.dirname, 'fixtures', 'placeholder.tsx');
+
+    ruleTester.run('no-unused-prop-types', rule, {
+      valid: [
+        {
+          code: `
+declare const React: any;
+enum ImageOrientation {
+  left = 'left',
+  right = 'right',
+}
+type ImageReference = {
+  valid: boolean;
+  uid: string;
+  href: string;
+};
+type ParallaxEffect = {
+  orientation: ImageOrientation;
+  size: string;
+  href: string;
+};
+type ParallaxImagesProps = {
+  images: ImageReference[];
+};
+const useParallaxImages = ({ images }: ParallaxImagesProps) => {
+  return {
+    images: images.map(img => ({
+      ...img,
+      size: '1',
+      orientation: ImageOrientation.left,
+    })),
+  };
+};
+const ParallaxImage = ({ orientation, size, href }: ParallaxEffect) => {
+  return <div>{orientation}, {size}, {href}</div>;
+};
+export const ParallaxImages = (props: ParallaxImagesProps) => {
+  const { images } = useParallaxImages(props);
+  return (
+    <>
+      {images.map(
+        i =>
+          i.valid && (
+            <ParallaxImage
+              key={i.uid}
+              orientation={i.orientation}
+              href={i.href}
+              size={i.size}
+            />
+          ),
+      )}
+    </>
+  );
+};
+`,
+          filename: fixtureFile,
+        },
+      ],
+      invalid: [],
+    });
+  });
+
   it('should report props when destructured via patterns not tracked by hasDestructuredParamPropUsage', () => {
     const ruleTester = new RuleTester({
       parserOptions: {


### PR DESCRIPTION
## Summary
Adds regression coverage for the original JS-393 S6767 false-positive scenario where a component forwards its props to a helper that destructures the parameter. The current rule behavior is already correct on `master`, and this PR locks that behavior in.

## Changes
- add the Jira reproducer as a TypeScript S6767 regression test
- cover the combination of whole-props forwarding and helper-parameter destructuring
- keep the change test-only, with no analyzer behavior change

:warning::warning: This is not ready for review :warning::warning:
