### PR TITLE
JS-2089 Support Playwright test.expect assertions

### DIFF
--- a/packages/analysis/src/jsts/rules/S2699/playwright/fixtures/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S2699/playwright/fixtures/cb.fixture.js
@@ -1,3 +1,5 @@
+import { test } from '@playwright/test';
+
 describe('playwright assertions', () => {
   it('recognizes expect on locators', () => { // Compliant
     expect(page.locator('h1')).toHaveText('Hello');
@@ -9,6 +11,10 @@ describe('playwright assertions', () => {
 
   test('recognizes test()', () => { // Compliant
     expect(page.locator('h1')).toHaveText('Hello');
+  });
+
+  test('recognizes test.expect()', async ({ page }) => { // Compliant
+    await test.expect(page.locator('h1')).toHaveText('Hello');
   });
 
   it('should recognize issue', () => { // Noncompliant {{Add at least one assertion to this test case.}}

--- a/packages/analysis/src/jsts/rules/S2699/playwright/fixtures/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S2699/playwright/fixtures/cb.fixture.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 describe('playwright assertions', () => {
   it('recognizes expect on locators', () => { // Compliant
@@ -15,6 +15,22 @@ describe('playwright assertions', () => {
 
   test('recognizes test.expect()', async ({ page }) => { // Compliant
     await test.expect(page.locator('h1')).toHaveText('Hello');
+  });
+
+  test('recognizes test.expect.soft()', async ({ page }) => { // Compliant
+    await test.expect.soft(page.locator('h1')).toHaveText('Hello');
+  });
+
+  test('recognizes test.expect.poll()', async () => { // Compliant
+    await test.expect.poll(() => 1).toBe(1);
+  });
+
+  test('recognizes expect.soft() from imported expect', async ({ page }) => { // Compliant
+    await expect.soft(page.locator('h1')).toHaveText('Hello');
+  });
+
+  test('recognizes expect.poll() from imported expect', async () => { // Compliant
+    await expect.poll(() => 1).toBe(1);
   });
 
   it('should recognize issue', () => { // Noncompliant {{Add at least one assertion to this test case.}}

--- a/packages/analysis/src/jsts/rules/S2699/playwright/fixtures/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S2699/playwright/fixtures/cb.fixture.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { expect as playwrightExpect } from '@playwright/test';
 
 describe('playwright assertions', () => {
   it('recognizes expect on locators', () => { // Compliant
@@ -25,12 +26,32 @@ describe('playwright assertions', () => {
     await test.expect.poll(() => 1).toBe(1);
   });
 
+  test('recognizes test.expect.configure()', async ({ page }) => { // Compliant
+    await test.expect.configure({ timeout: 1000 })(page.locator('h1')).toHaveText('Hello');
+  });
+
   test('recognizes expect.soft() from imported expect', async ({ page }) => { // Compliant
     await expect.soft(page.locator('h1')).toHaveText('Hello');
   });
 
   test('recognizes expect.poll() from imported expect', async () => { // Compliant
     await expect.poll(() => 1).toBe(1);
+  });
+
+  test('recognizes expect.configure() from imported expect', async ({ page }) => { // Compliant
+    await expect.configure({ timeout: 1000 })(page.locator('h1')).toHaveText('Hello');
+  });
+
+  test('recognizes expect.soft() from aliased imported expect', async ({ page }) => { // Compliant
+    await playwrightExpect.soft(page.locator('h1')).toHaveText('Hello');
+  });
+
+  test('recognizes expect.poll() from aliased imported expect', async () => { // Compliant
+    await playwrightExpect.poll(() => 1).toBe(1);
+  });
+
+  test('recognizes expect.configure() from aliased imported expect', async ({ page }) => { // Compliant
+    await playwrightExpect.configure({ timeout: 1000 })(page.locator('h1')).toHaveText('Hello');
   });
 
   it('should recognize issue', () => { // Noncompliant {{Add at least one assertion to this test case.}}

--- a/packages/analysis/src/jsts/rules/S2699/typescript-detection/fixtures/b.fixture.ts
+++ b/packages/analysis/src/jsts/rules/S2699/typescript-detection/fixtures/b.fixture.ts
@@ -1,4 +1,5 @@
 import vitest from "vitest";
+import { test } from "@playwright/test";
 import {functionWithAssertion, functionWithoutAssertion, functionWithInnerAssertion} from "./a.js"
 
 describe("tests", () => {
@@ -23,5 +24,9 @@ describe("tests", () => {
   // reported as assertion-less.
   it("treats expect.extend as a compile-time check under the type-checker", () => { // Compliant
     vitest.expect.extend({ toBeFoo: () => ({ pass: true, message: () => "" }) });
+  });
+
+  test("recognizes test.expect via the type-checker path", async ({ page }) => { // Compliant
+    await test.expect(page.locator("div").first()).toBeVisible();
   });
 });

--- a/packages/analysis/src/jsts/rules/S2699/typescript-detection/fixtures/b.fixture.ts
+++ b/packages/analysis/src/jsts/rules/S2699/typescript-detection/fixtures/b.fixture.ts
@@ -1,5 +1,5 @@
 import vitest from "vitest";
-import { test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import {functionWithAssertion, functionWithoutAssertion, functionWithInnerAssertion} from "./a.js"
 
 describe("tests", () => {
@@ -28,5 +28,21 @@ describe("tests", () => {
 
   test("recognizes test.expect via the type-checker path", async ({ page }) => { // Compliant
     await test.expect(page.locator("div").first()).toBeVisible();
+  });
+
+  test("recognizes test.expect.soft via the type-checker path", async ({ page }) => { // Compliant
+    await test.expect.soft(page.locator("div").first()).toBeVisible();
+  });
+
+  test("recognizes test.expect.poll via the type-checker path", async () => { // Compliant
+    await test.expect.poll(() => 1).toBe(1);
+  });
+
+  test("recognizes expect.soft via the type-checker path", async ({ page }) => { // Compliant
+    await expect.soft(page.locator("div").first()).toBeVisible();
+  });
+
+  test("recognizes expect.poll via the type-checker path", async () => { // Compliant
+    await expect.poll(() => 1).toBe(1);
   });
 });

--- a/packages/analysis/src/jsts/rules/S2699/typescript-detection/fixtures/b.fixture.ts
+++ b/packages/analysis/src/jsts/rules/S2699/typescript-detection/fixtures/b.fixture.ts
@@ -1,5 +1,6 @@
 import vitest from "vitest";
 import { test, expect } from "@playwright/test";
+import { expect as playwrightExpect } from "@playwright/test";
 import {functionWithAssertion, functionWithoutAssertion, functionWithInnerAssertion} from "./a.js"
 
 describe("tests", () => {
@@ -38,11 +39,31 @@ describe("tests", () => {
     await test.expect.poll(() => 1).toBe(1);
   });
 
+  test("recognizes test.expect.configure via the type-checker path", async ({ page }) => { // Compliant
+    await test.expect.configure({ timeout: 1000 })(page.locator("div").first()).toBeVisible();
+  });
+
   test("recognizes expect.soft via the type-checker path", async ({ page }) => { // Compliant
     await expect.soft(page.locator("div").first()).toBeVisible();
   });
 
   test("recognizes expect.poll via the type-checker path", async () => { // Compliant
     await expect.poll(() => 1).toBe(1);
+  });
+
+  test("recognizes expect.configure via the type-checker path", async ({ page }) => { // Compliant
+    await expect.configure({ timeout: 1000 })(page.locator("div").first()).toBeVisible();
+  });
+
+  test("recognizes aliased expect.soft via the type-checker path", async ({ page }) => { // Compliant
+    await playwrightExpect.soft(page.locator("div").first()).toBeVisible();
+  });
+
+  test("recognizes aliased expect.poll via the type-checker path", async () => { // Compliant
+    await playwrightExpect.poll(() => 1).toBe(1);
+  });
+
+  test("recognizes aliased expect.configure via the type-checker path", async ({ page }) => { // Compliant
+    await playwrightExpect.configure({ timeout: 1000 })(page.locator("div").first()).toBeVisible();
   });
 });

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -283,6 +283,14 @@ describe('Observable error handling with object syntax', () => {
 });
 `,
         },
+        {
+          code: `
+import { expect as playwrightExpect, test } from '@playwright/test';
+test('aliased expect import', async ({ page }) => {
+  await playwrightExpect(page.locator('div')).toBeVisible();
+});
+`,
+        },
       ],
       invalid: [
         {
@@ -783,6 +791,14 @@ describe('Observable error handling with object syntax', () => {
       complete: () => { done(); }
     });
   });
+});
+`,
+        },
+        {
+          code: `
+import { expect as playwrightExpect, test } from '@playwright/test';
+test('aliased expect import', async ({ page }) => {
+  await playwrightExpect(page.locator('div')).toBeVisible();
 });
 `,
         },

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -291,6 +291,20 @@ test('aliased expect import', async ({ page }) => {
 });
 `,
         },
+        {
+          code: `
+import { expect, test } from '@playwright/test';
+import { expect as playwrightExpect } from '@playwright/test';
+
+test('member-based playwright expect entrypoints', async ({ page }) => {
+  await test.expect.configure({ timeout: 1000 })(page.locator('div')).toBeVisible();
+  await expect.configure({ timeout: 1000 })(page.locator('div')).toBeVisible();
+  await playwrightExpect.soft(page.locator('div')).toBeVisible();
+  await playwrightExpect.poll(() => 1).toBe(1);
+  await playwrightExpect.configure({ timeout: 1000 })(page.locator('div')).toBeVisible();
+});
+`,
+        },
       ],
       invalid: [
         {
@@ -799,6 +813,20 @@ describe('Observable error handling with object syntax', () => {
 import { expect as playwrightExpect, test } from '@playwright/test';
 test('aliased expect import', async ({ page }) => {
   await playwrightExpect(page.locator('div')).toBeVisible();
+});
+`,
+        },
+        {
+          code: `
+import { expect, test } from '@playwright/test';
+import { expect as playwrightExpect } from '@playwright/test';
+
+test('member-based playwright expect entrypoints', async ({ page }) => {
+  await test.expect.configure({ timeout: 1000 })(page.locator('div')).toBeVisible();
+  await expect.configure({ timeout: 1000 })(page.locator('div')).toBeVisible();
+  await playwrightExpect.soft(page.locator('div')).toBeVisible();
+  await playwrightExpect.poll(() => 1).toBe(1);
+  await playwrightExpect.configure({ timeout: 1000 })(page.locator('div')).toBeVisible();
 });
 `,
         },

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -98,6 +98,10 @@ const GLOBAL_EXPECT_NAMES = new Set([
 
 const PLAYWRIGHT_TEST_EXPECT_FQN = '@playwright.test.test.expect';
 
+function isPlaywrightTestExpectFqn(fqn: string | null | undefined): boolean {
+  return fqn?.replaceAll('/', '.') === PLAYWRIGHT_TEST_EXPECT_FQN;
+}
+
 const CHAI_NON_TERMINAL_PROPERTY_NAMES = new Set([
   'all',
   'also',
@@ -308,8 +312,7 @@ function isGlobalExpectExpressionJS(
   const innerCall = current;
   return (
     (innerCall.callee.type === 'Identifier' && GLOBAL_EXPECT_NAMES.has(innerCall.callee.name)) ||
-    getFullyQualifiedName(context, innerCall.callee)?.replaceAll('/', '.') ===
-      PLAYWRIGHT_TEST_EXPECT_FQN
+    isPlaywrightTestExpectFqn(getFullyQualifiedName(context, innerCall.callee))
   );
 }
 
@@ -461,8 +464,7 @@ function isGlobalExpectExpression(
   return (
     (innerCallExpression.expression.kind === ts.SyntaxKind.Identifier &&
       GLOBAL_EXPECT_NAMES.has((innerCallExpression.expression as ts.Identifier).text)) ||
-    getFullyQualifiedNameTS(services, innerCallExpression.expression)?.replaceAll('/', '.') ===
-      PLAYWRIGHT_TEST_EXPECT_FQN
+    isPlaywrightTestExpectFqn(getFullyQualifiedNameTS(services, innerCallExpression.expression))
   );
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -96,6 +96,8 @@ const GLOBAL_EXPECT_NAMES = new Set([
   'expectTypeOf',
 ]);
 
+const PLAYWRIGHT_TEST_EXPECT_FQN = '@playwright.test.test.expect';
+
 const CHAI_NON_TERMINAL_PROPERTY_NAMES = new Set([
   'all',
   'also',
@@ -187,7 +189,7 @@ const SCRIPT_CAPABLE_DETECTORS: AssertionDetector[] = [
 const RUNNER_BOUND_DETECTORS: AssertionDetector[] = [
   Vitest.isAssertion,
   (_context, node) => Cypress.isAssertion(node),
-  (_context, node) => node.type === 'CallExpression' && isGlobalExpectExpressionJS(node),
+  (context, node) => node.type === 'CallExpression' && isGlobalExpectExpressionJS(context, node),
 ];
 
 const ASSERTION_DETECTORS: AssertionDetector[] = [
@@ -278,11 +280,15 @@ function isTSShouldAccess(node: ts.Node): node is ts.PropertyAccessExpression {
 /**
  * Checks if the node matches the pattern expectX(...).method() where:
  * - expectX is one of the known global expect entry points ({@link GLOBAL_EXPECT_NAMES})
+ *   or Playwright's `test.expect(...)` alias
  * - method is a chained property access with a method call (e.g., .toBe(), .toEqual(), .not.toBe())
  *
  * This mirrors the TypeScript isGlobalExpectExpression function logic.
  */
-function isGlobalExpectExpressionJS(node: estree.CallExpression): boolean {
+function isGlobalExpectExpressionJS(
+  context: Rule.RuleContext,
+  node: estree.CallExpression,
+): boolean {
   if (node.callee.type !== 'MemberExpression') {
     return false;
   }
@@ -300,7 +306,11 @@ function isGlobalExpectExpressionJS(node: estree.CallExpression): boolean {
   }
 
   const innerCall = current;
-  return innerCall.callee.type === 'Identifier' && GLOBAL_EXPECT_NAMES.has(innerCall.callee.name);
+  return (
+    (innerCall.callee.type === 'Identifier' && GLOBAL_EXPECT_NAMES.has(innerCall.callee.name)) ||
+    getFullyQualifiedName(context, innerCall.callee)?.replaceAll('/', '.') ===
+      PLAYWRIGHT_TEST_EXPECT_FQN
+  );
 }
 
 function isFunctionCallFromNodeAssert(context: Rule.RuleContext, node: estree.Node): boolean {
@@ -421,13 +431,16 @@ function isGlobalTSAssertion(services: ParserServicesWithTypeInformation, node: 
   }
   const callExpressionNode = node as ts.CallExpression;
   // check for global expect
-  if (isGlobalExpectExpression(callExpressionNode)) {
+  if (isGlobalExpectExpression(services, callExpressionNode)) {
     return true;
   }
   return isFunctionCallFromNodeAssertTS(services, node);
 }
 
-function isGlobalExpectExpression(node: ts.CallExpression) {
+function isGlobalExpectExpression(
+  services: ParserServicesWithTypeInformation,
+  node: ts.CallExpression,
+) {
   if (node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression) {
     return false;
   }
@@ -446,8 +459,10 @@ function isGlobalExpectExpression(node: ts.CallExpression) {
 
   const innerCallExpression = current as ts.CallExpression;
   return (
-    innerCallExpression.expression.kind === ts.SyntaxKind.Identifier &&
-    GLOBAL_EXPECT_NAMES.has((innerCallExpression.expression as ts.Identifier).text)
+    (innerCallExpression.expression.kind === ts.SyntaxKind.Identifier &&
+      GLOBAL_EXPECT_NAMES.has((innerCallExpression.expression as ts.Identifier).text)) ||
+    getFullyQualifiedNameTS(services, innerCallExpression.expression)?.replaceAll('/', '.') ===
+      PLAYWRIGHT_TEST_EXPECT_FQN
   );
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -32,6 +32,7 @@ import type estree from 'estree';
 import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
 import ts from 'typescript';
 import * as Chai from './chai.js';
+import * as Playwright from './playwright.js';
 import * as Sinon from './sinon.js';
 import * as Vitest from './vitest.js';
 import * as Supertest from './supertest.js';
@@ -95,25 +96,6 @@ const GLOBAL_EXPECT_NAMES = new Set([
   'expectSubscriptions',
   'expectTypeOf',
 ]);
-
-// Two roots: the `test.expect` alias and the direct `import { expect }` from '@playwright/test'.
-// Prefix match covers static helpers like `.soft`, `.poll`, `.configure`.
-// `.replaceAll('/', '.')` normalises the scoped-package slash that
-// getFullyQualifiedNameTS preserves (e.g. '@playwright/test') while getFullyQualifiedName uses dots.
-const PLAYWRIGHT_EXPECT_FQN_ROOTS = [
-  '@playwright.test.test.expect', // test.expect alias
-  '@playwright.test.expect', // import { expect } from '@playwright/test'
-];
-
-function isPlaywrightExpectFqn(fqn: string | null | undefined): boolean {
-  if (!fqn) {
-    return false;
-  }
-  const normalized = fqn.replaceAll('/', '.');
-  return PLAYWRIGHT_EXPECT_FQN_ROOTS.some(
-    root => normalized === root || normalized.startsWith(root + '.'),
-  );
-}
 
 const CHAI_NON_TERMINAL_PROPERTY_NAMES = new Set([
   'all',
@@ -297,7 +279,7 @@ function isTSShouldAccess(node: ts.Node): node is ts.PropertyAccessExpression {
 /**
  * Checks if the node matches the pattern expectX(...).method() where:
  * - expectX is one of the known global expect entry points ({@link GLOBAL_EXPECT_NAMES})
- *   or Playwright's `test.expect(...)` alias
+ *   or a Playwright `expect(...)` entry point
  * - method is a chained property access with a method call (e.g., .toBe(), .toEqual(), .not.toBe())
  *
  * This mirrors the TypeScript isGlobalExpectExpression function logic.
@@ -325,7 +307,7 @@ function isGlobalExpectExpressionJS(
   const innerCall = current;
   return (
     (innerCall.callee.type === 'Identifier' && GLOBAL_EXPECT_NAMES.has(innerCall.callee.name)) ||
-    isPlaywrightExpectFqn(getFullyQualifiedName(context, innerCall.callee))
+    Playwright.isExpectFqn(getFullyQualifiedName(context, innerCall.callee))
   );
 }
 
@@ -477,7 +459,7 @@ function isGlobalExpectExpression(
   return (
     (innerCallExpression.expression.kind === ts.SyntaxKind.Identifier &&
       GLOBAL_EXPECT_NAMES.has((innerCallExpression.expression as ts.Identifier).text)) ||
-    isPlaywrightExpectFqn(getFullyQualifiedNameTS(services, innerCallExpression.expression))
+    Playwright.isExpectFqn(getFullyQualifiedNameTS(services, innerCallExpression.expression))
   );
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -96,10 +96,21 @@ const GLOBAL_EXPECT_NAMES = new Set([
   'expectTypeOf',
 ]);
 
-const PLAYWRIGHT_TEST_EXPECT_FQN = '@playwright.test.test.expect';
+// Two roots: the `test.expect` alias and the direct `import { expect }` from '@playwright/test'.
+// Prefix match covers static helpers like `.soft`, `.poll`, `.configure`.
+// `.replaceAll('/', '.')` normalises the scoped-package slash that
+// getFullyQualifiedNameTS preserves (e.g. '@playwright/test') while getFullyQualifiedName uses dots.
+const PLAYWRIGHT_EXPECT_FQN_ROOTS = [
+  '@playwright.test.test.expect', // test.expect alias
+  '@playwright.test.expect', // import { expect } from '@playwright/test'
+];
 
-function isPlaywrightTestExpectFqn(fqn: string | null | undefined): boolean {
-  return fqn?.replaceAll('/', '.') === PLAYWRIGHT_TEST_EXPECT_FQN;
+function isPlaywrightExpectFqn(fqn: string | null | undefined): boolean {
+  if (!fqn) return false;
+  const normalized = fqn.replaceAll('/', '.');
+  return PLAYWRIGHT_EXPECT_FQN_ROOTS.some(
+    root => normalized === root || normalized.startsWith(root + '.'),
+  );
 }
 
 const CHAI_NON_TERMINAL_PROPERTY_NAMES = new Set([
@@ -312,7 +323,7 @@ function isGlobalExpectExpressionJS(
   const innerCall = current;
   return (
     (innerCall.callee.type === 'Identifier' && GLOBAL_EXPECT_NAMES.has(innerCall.callee.name)) ||
-    isPlaywrightTestExpectFqn(getFullyQualifiedName(context, innerCall.callee))
+    isPlaywrightExpectFqn(getFullyQualifiedName(context, innerCall.callee))
   );
 }
 
@@ -464,7 +475,7 @@ function isGlobalExpectExpression(
   return (
     (innerCallExpression.expression.kind === ts.SyntaxKind.Identifier &&
       GLOBAL_EXPECT_NAMES.has((innerCallExpression.expression as ts.Identifier).text)) ||
-    isPlaywrightTestExpectFqn(getFullyQualifiedNameTS(services, innerCallExpression.expression))
+    isPlaywrightExpectFqn(getFullyQualifiedNameTS(services, innerCallExpression.expression))
   );
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -106,7 +106,9 @@ const PLAYWRIGHT_EXPECT_FQN_ROOTS = [
 ];
 
 function isPlaywrightExpectFqn(fqn: string | null | undefined): boolean {
-  if (!fqn) return false;
+  if (!fqn) {
+    return false;
+  }
   const normalized = fqn.replaceAll('/', '.');
   return PLAYWRIGHT_EXPECT_FQN_ROOTS.some(
     root => normalized === root || normalized.startsWith(root + '.'),

--- a/packages/analysis/src/jsts/rules/helpers/playwright.ts
+++ b/packages/analysis/src/jsts/rules/helpers/playwright.ts
@@ -18,6 +18,10 @@ import type estree from 'estree';
 import { isIdentifier } from './ast.js';
 
 const describeModifiers = ['parallel', 'serial'];
+const EXPECT_FQN_ROOTS = [
+  '@playwright.test.test.expect', // test.expect alias
+  '@playwright.test.expect', // import { expect } from '@playwright/test'
+];
 
 export function isDescribe(node: estree.Node | undefined): boolean {
   if (node?.type !== 'MemberExpression' || node.computed) {
@@ -29,4 +33,15 @@ export function isDescribe(node: estree.Node | undefined): boolean {
     (isIdentifier(object, 'test') && isIdentifier(property, 'describe')) ||
     (isIdentifier(property, ...describeModifiers) && isDescribe(object))
   );
+}
+
+// Prefix match covers static helpers like `.soft`, `.poll`, and `.configure`.
+// `.replaceAll('/', '.')` normalizes the scoped-package slash that
+// getFullyQualifiedNameTS preserves (e.g. '@playwright/test') while ESTree FQNs use dots.
+export function isExpectFqn(fqn: string | null | undefined): boolean {
+  if (!fqn) {
+    return false;
+  }
+  const normalized = fqn.replaceAll('/', '.');
+  return EXPECT_FQN_ROOTS.some(root => normalized === root || normalized.startsWith(`${root}.`));
 }


### PR DESCRIPTION
## Summary
Fix S2699 false positives on Playwright tests that use `test.expect(...)`.
The rule now treats the Playwright `test.expect` alias as an assertion in both the AST-only and type-aware detection paths.

## Changes
- extend shared assertion detection to recognize Playwright `test.expect(...)`
- add Playwright fixture coverage for the comment-based rule tests
- add a type-aware regression fixture for the alias

## Functional Validation
Artifact: [JS-2089-fv.zip](https://github.com/user-attachments/files/30052877/JS-2089-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "sample/input.ts"...
Results:
    - Rule "S2699" -> L.3

****** Branch "fix/js-2089-support-playwright-test-expect" ******
Analyzing "sample/input.ts"...
Results:
    (none)
```
