### PR TITLE
JS-2094: Remove sonar-plugin-api-impl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,12 +260,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.sonarsource.sonarqube</groupId>
-        <artifactId>sonar-plugin-api-impl</artifactId>
-        <version>${sonar.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.sonarsource.scanner.engine</groupId>
         <artifactId>plugin-api-scanner-impl</artifactId>
         <version>${scanner-engine.version}</version>

--- a/sonar-plugin/bridge/pom.xml
+++ b/sonar-plugin/bridge/pom.xml
@@ -92,10 +92,6 @@
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.scanner.engine</groupId>
       <artifactId>plugin-api-scanner-impl</artifactId>
       <scope>test</scope>

--- a/sonar-plugin/css/pom.xml
+++ b/sonar-plugin/css/pom.xml
@@ -42,10 +42,6 @@
       <artifactId>sonar-analyzer-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.scanner.engine</groupId>
       <artifactId>plugin-api-scanner-impl</artifactId>
       <scope>test</scope>

--- a/sonar-plugin/css/src/test/java/org/sonar/css/CssProfileDefinitionTest.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/CssProfileDefinitionTest.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.BuiltInQualityProfile;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.Context;
 import org.sonar.api.server.rule.RulesDefinition;
@@ -30,7 +30,7 @@ import org.sonar.api.utils.Version;
 
 class CssProfileDefinitionTest {
 
-  private static final SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarLint(
+  private static final SonarRuntime sonarRuntime = TestSonarRuntime.forSonarLint(
     Version.create(9, 3)
   );
 

--- a/sonar-plugin/css/src/test/java/org/sonar/css/CssRulesDefinitionTest.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/CssRulesDefinitionTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.debt.DebtRemediationFunction.Type;
 import org.sonar.api.server.rule.RuleParamType;
@@ -32,7 +32,7 @@ import org.sonar.api.utils.Version;
 
 class CssRulesDefinitionTest {
 
-  private static final SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarLint(
+  private static final SonarRuntime sonarRuntime = TestSonarRuntime.forSonarLint(
     Version.create(9, 3)
   );
 

--- a/sonar-plugin/css/src/test/java/org/sonar/css/StylelintReportSensorTest.java
+++ b/sonar-plugin/css/src/test/java/org/sonar/css/StylelintReportSensorTest.java
@@ -41,7 +41,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.ExternalIssue;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
@@ -211,7 +211,7 @@ class StylelintReportSensorTest {
   }
 
   private SonarRuntime getRuntime(int major, int minor) {
-    return SonarRuntimeImpl.forSonarQube(
+    return TestSonarRuntime.forSonarQube(
       Version.create(major, minor),
       SonarQubeSide.SERVER,
       SonarEdition.COMMUNITY

--- a/sonar-plugin/sonar-javascript-plugin/pom.xml
+++ b/sonar-plugin/sonar-javascript-plugin/pom.xml
@@ -69,10 +69,6 @@
       <artifactId>sonar-plugin-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.scanner.engine</groupId>
       <artifactId>plugin-api-scanner-impl</artifactId>
       <scope>test</scope>

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptPluginTest.java
@@ -30,7 +30,7 @@ import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
 
@@ -44,7 +44,7 @@ class JavaScriptPluginTest {
   @Test
   void count_extensions_lts() {
     Plugin.Context context = setupContext(
-      SonarRuntimeImpl.forSonarQube(LTS_VERSION, SonarQubeSide.SERVER, SonarEdition.COMMUNITY)
+      TestSonarRuntime.forSonarQube(LTS_VERSION, SonarQubeSide.SERVER, SonarEdition.COMMUNITY)
     );
     assertThat(context.getExtensions()).isNotEmpty();
   }
@@ -56,7 +56,7 @@ class JavaScriptPluginTest {
 
   @Test
   void count_extensions_for_sonarlint() {
-    Plugin.Context context = setupContext(SonarRuntimeImpl.forSonarLint(LTS_VERSION));
+    Plugin.Context context = setupContext(TestSonarRuntime.forSonarLint(LTS_VERSION));
     assertThat(context.getExtensions()).isNotEmpty();
   }
 
@@ -157,7 +157,7 @@ class JavaScriptPluginTest {
 
   private List<PropertyDefinition> properties() {
     var extensions = setupContext(
-      SonarRuntimeImpl.forSonarQube(LTS_VERSION, SonarQubeSide.SERVER, SonarEdition.COMMUNITY)
+      TestSonarRuntime.forSonarQube(LTS_VERSION, SonarQubeSide.SERVER, SonarEdition.COMMUNITY)
     ).getExtensions();
 
     return extensions

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinitionTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/JavaScriptProfilesDefinitionTest.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rule.RuleStatus;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
@@ -52,7 +52,7 @@ import org.sonarsource.analyzer.commons.BuiltInQualityProfileJsonLoader;
 
 class JavaScriptProfilesDefinitionTest {
 
-  private static final SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarLint(
+  private static final SonarRuntime sonarRuntime = TestSonarRuntime.forSonarLint(
     Version.create(9, 3)
   );
   private final BuiltInQualityProfilesDefinition.Context context =

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisProcessorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/AnalysisProcessorTest.java
@@ -33,7 +33,7 @@ import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.IssueResolution;
 import org.sonar.scanner.plugin.api.impl.config.MapSettings;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -289,7 +289,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(13, 5),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -321,7 +321,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(13, 5),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -353,7 +353,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(13, 4),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -377,7 +377,7 @@ class AnalysisProcessorTest {
   void should_ignore_sonar_resolve_in_sonarlint() {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
-    sensorContext.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(13, 6)));
+    sensorContext.setRuntime(TestSonarRuntime.forSonarLint(Version.create(13, 6)));
     var context = new JsTsContext<>(sensorContext);
     var file = createInputFile(sensorContext, "js", "file.js", "const x = 1;\n");
     var response = responseWithSonarResolveComments(
@@ -402,7 +402,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(13, 5),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -434,7 +434,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(13, 5),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -491,7 +491,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(13, 5),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -530,7 +530,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(13, 5),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -563,7 +563,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(13, 5),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -644,7 +644,7 @@ class AnalysisProcessorTest {
     var processor = createProcessor();
     var sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setRuntime(
-      SonarRuntimeImpl.forSonarQube(apiVersion, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY)
+      TestSonarRuntime.forSonarQube(apiVersion, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY)
     );
     sensorContext.setSettings(settings);
     var context = new JsTsContext<>(sensorContext);

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
@@ -78,7 +78,7 @@ import org.sonar.api.batch.sensor.issue.IssueLocation;
 import org.sonar.scanner.plugin.api.impl.sensor.issue.DefaultNoSonarFilter;
 import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 import org.sonar.scanner.plugin.api.impl.utils.DefaultTempFolder;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -174,7 +174,7 @@ class WebSensorTest {
 
     context = createSensorContext(baseDir);
     context.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(9, 3),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -1245,7 +1245,7 @@ class WebSensorTest {
       }
     );
     context.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(9, 1),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -1403,7 +1403,7 @@ class WebSensorTest {
       }
     );
 
-    context.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(4, 4)));
+    context.setRuntime(TestSonarRuntime.forSonarLint(Version.create(4, 4)));
     executeSensorMockingResponse(createSonarLintSensor(), expectedResponse);
 
     assertThat(inputFile.hasNoSonarAt(7)).isTrue();
@@ -1586,7 +1586,7 @@ class WebSensorTest {
       )
     );
     context.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(10, 9),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY
@@ -2291,12 +2291,12 @@ class WebSensorTest {
   }
 
   private void setSonarLintRuntime(SensorContextTester context) {
-    context.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(8, 9)));
+    context.setRuntime(TestSonarRuntime.forSonarLint(Version.create(8, 9)));
   }
 
   private void setSonarQubeRuntime(SensorContextTester context) {
     context.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(9, 3),
         SonarQubeSide.SCANNER,
         SonarEdition.COMMUNITY

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/cache/CacheStrategyTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/cache/CacheStrategyTest.java
@@ -52,7 +52,7 @@ import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.cache.ReadCache;
 import org.sonar.api.batch.sensor.cache.WriteCache;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.javascript.analysis.JsTsContext;
@@ -125,7 +125,7 @@ class CacheStrategyTest {
     astCacheKey = CacheKey.forFile(inputFile, PLUGIN_VERSION).forAst().toString();
 
     when(sensorContext.runtime()).thenReturn(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(9, 6),
         SonarQubeSide.SCANNER,
         SonarEdition.ENTERPRISE
@@ -153,7 +153,7 @@ class CacheStrategyTest {
   void should_not_fail_on_older_versions() throws Exception {
     when(sensorContext.getSonarQubeVersion()).thenReturn(Version.create(9, 3));
     when(sensorContext.runtime()).thenReturn(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(9, 3),
         SonarQubeSide.SCANNER,
         SonarEdition.ENTERPRISE
@@ -169,7 +169,7 @@ class CacheStrategyTest {
 
   @Test
   void should_not_fail_in_sonarlint() throws Exception {
-    when(sensorContext.runtime()).thenReturn(SonarRuntimeImpl.forSonarLint(Version.create(9, 6)));
+    when(sensorContext.runtime()).thenReturn(TestSonarRuntime.forSonarLint(Version.create(9, 6)));
 
     var strategy = CacheStrategies.getStrategyFor(context, inputFile, PLUGIN_VERSION);
     assertThat(strategy.getName()).isEqualTo(CacheStrategy.NO_CACHE);

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/cache/CacheTestUtils.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/cache/CacheTestUtils.java
@@ -34,7 +34,7 @@ import org.sonar.api.SonarQubeSide;
 import org.sonar.api.batch.sensor.cache.ReadCache;
 import org.sonar.api.batch.sensor.cache.WriteCache;
 import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.javascript.analyzeproject.grpc.CpdToken;
 import org.sonar.plugins.javascript.analyzeproject.grpc.Location;
@@ -78,7 +78,7 @@ public class CacheTestUtils {
     var context = SensorContextTester.create(baseDir.toRealPath());
     context.fileSystem().setWorkDir(workDir);
     context.setRuntime(
-      SonarRuntimeImpl.forSonarQube(
+      TestSonarRuntime.forSonarQube(
         Version.create(9, 6),
         SonarQubeSide.SCANNER,
         SonarEdition.ENTERPRISE

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/TslintReportSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/external/TslintReportSensorTest.java
@@ -40,7 +40,7 @@ import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.ExternalIssue;
 import org.sonar.scanner.plugin.api.impl.config.MapSettings;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
@@ -66,7 +66,7 @@ class TslintReportSensorTest {
   private TslintReportSensor tslintReportSensor = new TslintReportSensor();
   private DefaultInputFile inputFile = createInputFile(context, CONTENT, "myFile.ts");
 
-  private static final SonarRuntime RUNTIME = SonarRuntimeImpl.forSonarQube(
+  private static final SonarRuntime RUNTIME = TestSonarRuntime.forSonarQube(
     Version.create(7, 9),
     SonarQubeSide.SERVER,
     SonarEdition.COMMUNITY

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/JavaScriptRulesDefinitionTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/JavaScriptRulesDefinitionTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.debt.DebtRemediationFunction.Type;
 import org.sonar.api.server.rule.RuleParamType;
@@ -33,7 +33,7 @@ import org.sonar.plugins.javascript.TestUtils;
 
 class JavaScriptRulesDefinitionTest {
 
-  private static final SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarLint(
+  private static final SonarRuntime sonarRuntime = TestSonarRuntime.forSonarLint(
     Version.create(9, 3)
   );
 

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinitionTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/rules/TypeScriptRulesDefinitionTest.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.debt.DebtRemediationFunction.Type;
 import org.sonar.api.server.rule.RulesDefinition.Param;
@@ -41,7 +41,7 @@ import org.sonar.plugins.javascript.api.EslintHook;
 class TypeScriptRulesDefinitionTest {
 
   private static final Gson gson = new Gson();
-  private static final SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarLint(
+  private static final SonarRuntime sonarRuntime = TestSonarRuntime.forSonarLint(
     Version.create(9, 3)
   );
 


### PR DESCRIPTION
## Context

The scanner-engine refactoring that de-duplicated the SonarQube Server and SonarQube Cloud scanner implementations moved scanner-side test utilities and implementation classes out of the SonarQube implementation artifact.

PR #7514 performed the required compatibility migration for SonarJS: it added scanner-engine 13.4.0.3968, moved `SensorContextTester` and `TestInputFileBuilder` to `sensor-test-fixtures`, and moved usages of concrete scanner-side implementations to their new `org.sonar.scanner.plugin.api.impl` packages.

That migration left one question from JS-2094 and the scanner-engine migration notice unresolved: do the SonarJS tests still need `org.sonarsource.sonarqube:sonar-plugin-api-impl`?

The answer is no. This PR removes that dependency completely.

## The important artifact distinction

There are two similarly named implementation artifacts involved, but they have different responsibilities:

| Artifact | Purpose in this repository | Decision |
| --- | --- | --- |
| `org.sonarsource.sonarqube:sonar-plugin-api-impl` | Implementation JAR published from the SonarQube repository. After #7514, SonarJS used it only for the old test helper `org.sonar.api.internal.SonarRuntimeImpl`. | Remove it. Scanner extension tests should not depend on the SonarQube implementation solely to construct a test runtime. |
| `org.sonarsource.scanner.engine:plugin-api-scanner-impl` | The new scanner-engine home of concrete scanner-side Plugin API implementations. | Keep it. SonarJS tests directly use scanner implementations from this artifact. |
| `org.sonarsource.scanner.engine:sensor-test-fixtures` | Public test fixtures intended for analyzer sensor tests, including `SensorContextTester`, `TestInputFileBuilder`, and `TestSonarRuntime`. | Keep it and use `TestSonarRuntime` instead of the SonarQube implementation. |
| `org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures` | Separate Plugin API test helpers such as `LogTesterJUnit5`. It is not the SonarQube implementation artifact mentioned in the migration notice. | Keep it because those test helpers are still used. |

This PR is therefore not intended to remove every package containing `.impl`. It specifically removes the obsolete dependency on the SonarQube implementation artifact. The scanner implementation artifact remains necessary with the current test design.

## Why `plugin-api-scanner-impl` is still required

The tests directly import concrete scanner-side types such as:

- `DefaultInputFile`
- `DefaultFileSystem`
- `DefaultTextPointer` and `DefaultTextRange`
- `MapSettings`
- `ActiveRulesBuilder`, `DefaultActiveRules`, and `NewActiveRule`
- `DefaultSensorDescriptor`
- `DefaultNoSonarFilter`
- `DefaultTempFolder`

These types were moved by the scanner-engine refactoring and now correctly live under `org.sonar.scanner.plugin.api.impl`. Because SonarJS directly imports them, retaining a direct test-scoped dependency on `plugin-api-scanner-impl` is intentional. Although `sensor-test-fixtures` also brings it transitively, declaring it directly avoids relying on another artifact's implementation dependency for classes that SonarJS itself imports.

Removing `plugin-api-scanner-impl` would require a broader redesign of these tests around fixture interfaces and public helpers. That is neither required by the migration notice nor part of JS-2094.

## Why `sonar-plugin-api-impl` was removable

After #7514, the only remaining usages supplied by `sonar-plugin-api-impl` were calls to `org.sonar.api.internal.SonarRuntimeImpl` in CSS and JavaScript tests. Those calls created SonarQube or SonarLint runtimes through `forSonarQube(...)` and `forSonarLint(...)`.

The new `sensor-test-fixtures` artifact provides `TestSonarRuntime`, a public test fixture implementing `SonarRuntime` with equivalent factories for the scenarios exercised by these tests. Using it has several advantages:

- tests use an API designed specifically for test setup;
- scanner extension tests no longer reach into `org.sonar.api.internal`;
- SonarJS is decoupled from the SonarQube implementation JAR and its release cadence;
- future SonarQube implementation refactorings cannot break these tests through that obsolete dependency;
- the dependency graph now reflects the actual boundary: Plugin API plus scanner-engine implementations and fixtures.

The bridge module no longer referenced any class from `sonar-plugin-api-impl` after #7514, so its declaration was simply unused. CSS and JavaScript needed only the `TestSonarRuntime` replacement before their declarations could also be removed.

## Changes

- replace every test usage of `SonarRuntimeImpl` with `TestSonarRuntime`;
- remove `sonar-plugin-api-impl` from root dependency management;
- remove the dependency from the bridge, CSS, and JavaScript module POMs;
- retain `plugin-api-scanner-impl`, `sensor-test-fixtures`, and `sonar-plugin-api-test-fixtures` for the distinct test APIs described above.

No production code or runtime dependency is changed.

## Validation

- `npm ci`
- `npm run bbf`
- all test sources in the bridge, CSS, and JavaScript modules compile without `sonar-plugin-api-impl`;
- 125 focused tests pass: 14 CSS tests and 111 JavaScript tests covering the runtime replacement;
- a Maven dependency-tree query filtered to `org.sonarsource.sonarqube:sonar-plugin-api-impl` is empty for the affected reactor, confirming that the artifact is absent both directly and transitively.

The repository-wide local test run also reached the unrelated rule-metadata tests, which require the generated `S2925.html` RSPEC resource. The GitHub workflow's `Prepare RSPEC rule data` job supplies that generated input before the normal build, so CI provides the clean-checkout full verification.

## Links

- Jira: https://sonarsource.atlassian.net/browse/JS-2094
- Initial scanner fixture migration: https://github.com/SonarSource/SonarJS/pull/7514
