### PR TITLE
JS-2101: Extend JavaScript test rules to bun:test and node:test

### DIFF
--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -28,6 +28,15 @@ describe('S2699', () => {
       valid: [
         {
           code: `
+import { test, expect } from 'bun:test';
+
+test('includes a Bun expectation', () => {
+  expect(1).toBe(1);
+});
+          `,
+        },
+        {
+          code: `
 const chai = require('chai');
 const { expect } = chai;
 describe('chai test cases', () => {
@@ -307,6 +316,14 @@ test('member-based playwright expect entrypoints', async ({ page }) => {
         },
       ],
       invalid: [
+        {
+          code: `
+import { test } from 'bun:test';
+
+test('has no Bun assertion', () => {});
+          `,
+          errors: 1,
+        },
         {
           code: `
 const chai = require('chai');

--- a/packages/analysis/src/jsts/rules/S5976/rule.ts
+++ b/packages/analysis/src/jsts/rules/S5976/rule.ts
@@ -38,7 +38,8 @@ const messages = {
 const JEST_MODULES = ['jest', '@jest/globals'];
 const PLAYWRIGHT_MODULES = ['@playwright/test'];
 const VITEST_MODULES = ['vitest'];
-const SUPPORTED_MODULE_FQNS = ['jest', '@jest.globals', 'vitest', '@playwright.test'];
+const BUN_MODULES = ['bun:test'];
+const SUPPORTED_MODULE_FQNS = ['bun:test', 'jest', '@jest.globals', 'vitest', '@playwright.test'];
 const UNSUPPORTED_TEST_MODULES = [
   'cypress',
   'jasmine',
@@ -65,6 +66,7 @@ interface ActiveFrameworks {
   jest: boolean;
   playwright: boolean;
   vitest: boolean;
+  bun: boolean;
 }
 
 interface ScopeFrame {
@@ -91,6 +93,7 @@ export const rule: Rule.RuleModule = {
       jest: importsOrDependsOnModule(context, JEST_MODULES, JEST_MODULES),
       playwright: importsOrDependsOnModule(context, PLAYWRIGHT_MODULES, PLAYWRIGHT_MODULES),
       vitest: importsOrDependsOnModule(context, VITEST_MODULES, VITEST_MODULES),
+      bun: importsOrDependsOnModule(context, BUN_MODULES, BUN_MODULES),
     };
 
     if (!Object.values(activeFrameworks).some(Boolean)) {

--- a/packages/analysis/src/jsts/rules/S5976/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5976/unit.test.ts
@@ -435,6 +435,31 @@ describe('outer', () => {
       invalid: [
         {
           code: `
+import { test, expect } from 'bun:test';
+
+test('normalizes 200', () => {
+  const status = normalize(200);
+  expect(status).toBe(200);
+  expect(status).toBeGreaterThan(199);
+});
+
+test('normalizes 201', () => {
+  const status = normalize(201);
+  expect(status).toBe(201);
+  expect(status).toBeGreaterThan(199);
+});
+
+test('normalizes 202', () => {
+  const status = normalize(202);
+  expect(status).toBe(202);
+  expect(status).toBeGreaterThan(199);
+});
+          `,
+          filename: noFrameworkTestFile,
+          errors: 1,
+        },
+        {
+          code: `
 test('normalizes a 200 status', () => {
   const status = normalize(200);
   expect(status).toBeGreaterThan(199);

--- a/packages/analysis/src/jsts/rules/S8754/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8754/rule.ts
@@ -31,7 +31,7 @@ import {
   SUPPORTED_TEST_FRAMEWORKS,
   TEST_FUNCTION_NAMES,
   getMochaCalleeParts,
-  getMochaConstructName,
+  getMochaConstructAndModifiers,
   getPlaywrightDescribeQualifiers,
   getPlaywrightTestQualifiers,
   getStaticTitle,
@@ -265,12 +265,12 @@ function isNonConcreteMochaSuite(context: Rule.RuleContext, node: estree.Node): 
     return false;
   }
 
-  const constructName = getMochaConstructName(context, calleeParts.base);
+  const { constructName, modifiers } = getMochaConstructAndModifiers(context, calleeParts);
   if (constructName === undefined || !SUITE_FUNCTION_NAMES.includes(constructName)) {
     return false;
   }
 
-  return !calleeParts.modifiers.every(modifier => isConcreteMochaTestModifier(context, modifier));
+  return !modifiers.every(modifier => isConcreteMochaTestModifier(context, modifier));
 }
 
 function getCallback(node: estree.CallExpression): CallbackFunctionNode | undefined {

--- a/packages/analysis/src/jsts/rules/S8754/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8754/unit.test.ts
@@ -212,6 +212,24 @@ test.describe.serial('guest checkout', () => {
       invalid: [
         {
           code: `
+import test from 'node:test';
+test('adds an item', () => {});
+test('adds an item', () => {});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
+const test = require('node:test');
+test('adds an item', () => {});
+test('adds an item', () => {});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
 import { describe, test } from 'bun:test';
 describe('cart', () => {
   test('adds an item', () => {});

--- a/packages/analysis/src/jsts/rules/S8754/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8754/unit.test.ts
@@ -212,6 +212,28 @@ test.describe.serial('guest checkout', () => {
       invalid: [
         {
           code: `
+import { describe, test } from 'bun:test';
+describe('cart', () => {
+  test('adds an item', () => {});
+  test('adds an item', () => {});
+});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
+import { describe, test } from 'node:test';
+describe('cart', () => {
+  test('adds an item', () => {});
+  test('adds an item', () => {});
+});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
 const jest = require('jest');
 describe('focused tests', () => {
   it.only('loads profile', () => {});

--- a/packages/analysis/src/jsts/rules/S8754/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8754/unit.test.ts
@@ -221,6 +221,24 @@ test('adds an item', () => {});
         },
         {
           code: `
+import test from 'node:test';
+test.it('adds an item', () => {});
+test.it('adds an item', () => {});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
+const test = require('node:test');
+test.it('adds an item', () => {});
+test.it('adds an item', () => {});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
 const test = require('node:test');
 test('adds an item', () => {});
 test('adds an item', () => {});

--- a/packages/analysis/src/jsts/rules/S8780/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8780/rule.ts
@@ -38,6 +38,8 @@ const VITEST_MODULES = ['vitest'];
 const JASMINE_MODULES = ['jasmine'];
 const JASMINE_DEPENDENCIES = ['jasmine', 'jasmine-core', 'jasmine-node', 'karma-jasmine'];
 const PLAYWRIGHT_MODULES = ['@playwright/test'];
+const BUN_MODULES = ['bun:test'];
+const NODE_TEST_MODULES = ['node:test'];
 
 const TEST_FUNCTION_NAMES = new Set([
   'it',
@@ -97,6 +99,8 @@ type Frameworks = {
   vitest: boolean;
   jasmine: boolean;
   playwright: boolean;
+  bun: boolean;
+  nodeTest: boolean;
 };
 
 type FunctionArgument = estree.FunctionExpression | estree.ArrowFunctionExpression;
@@ -110,6 +114,8 @@ export const rule: Rule.RuleModule = {
       vitest: importsOrDependsOnModule(context, VITEST_MODULES, VITEST_MODULES),
       jasmine: importsOrDependsOnModule(context, JASMINE_MODULES, JASMINE_DEPENDENCIES),
       playwright: importsOrDependsOnModule(context, PLAYWRIGHT_MODULES, PLAYWRIGHT_MODULES),
+      bun: importsOrDependsOnModule(context, BUN_MODULES, BUN_MODULES),
+      nodeTest: importsOrDependsOnModule(context, NODE_TEST_MODULES, NODE_TEST_MODULES),
     };
 
     if (!Object.values(frameworks).some(Boolean)) {
@@ -243,6 +249,7 @@ function getAsyncAssertionNode(
   return (
     getJestOrVitestAsyncNode(context, unwrapped, frameworks) ??
     getJasmineAsyncNode(context, unwrapped, frameworks) ??
+    getNodeAssertAsyncNode(context, unwrapped, frameworks) ??
     getPlaywrightAsyncNode(context, unwrapped, frameworks)
   );
 }
@@ -252,7 +259,7 @@ function getJestOrVitestAsyncNode(
   call: estree.CallExpression,
   frameworks: Frameworks,
 ): estree.Node | null {
-  if (!frameworks.jest && !frameworks.vitest) {
+  if (!frameworks.jest && !frameworks.vitest && !frameworks.bun) {
     return null;
   }
 
@@ -270,6 +277,24 @@ function getJestOrVitestAsyncNode(
   }
 
   return asyncSegment.node;
+}
+
+function getNodeAssertAsyncNode(
+  context: Rule.RuleContext,
+  call: estree.CallExpression,
+  frameworks: Frameworks,
+): estree.Node | null {
+  if (!frameworks.nodeTest) {
+    return null;
+  }
+
+  const fqn = getFullyQualifiedName(context, call.callee);
+  return fqn === 'assert.rejects' ||
+    fqn === 'assert.doesNotReject' ||
+    fqn === 'assert.strict.rejects' ||
+    fqn === 'assert.strict.doesNotReject'
+    ? call.callee
+    : null;
 }
 
 function getJasmineAsyncNode(
@@ -324,8 +349,10 @@ function isExpectCall(
       : fqn === 'expect' ||
           fqn === '@jest.globals.expect' ||
           fqn === 'vitest.expect' ||
+          fqn === 'bun:test.expect' ||
           (frameworks.jest && isIdentifier(call.callee, 'expect')) ||
-          (frameworks.vitest && isIdentifier(call.callee, 'expect'));
+          (frameworks.vitest && isIdentifier(call.callee, 'expect')) ||
+          (frameworks.bun && isIdentifier(call.callee, 'expect'));
   }
 
   return !playwrightOnly && isIdentifier(call.callee, 'expect');

--- a/packages/analysis/src/jsts/rules/S8780/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8780/rule.ts
@@ -60,6 +60,12 @@ const TEST_FUNCTION_NAMES = new Set([
   '@playwright.test.test',
   '@playwright.test.test.only',
   '@playwright.test.test.skip',
+  'bun:test.test',
+  'bun:test.test.only',
+  'bun:test.test.skip',
+  'test.test',
+  'test.test.only',
+  'test.test.skip',
 ]);
 
 const PLAYWRIGHT_ASYNC_MATCHERS = new Set([

--- a/packages/analysis/src/jsts/rules/S8780/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8780/rule.ts
@@ -60,9 +60,15 @@ const TEST_FUNCTION_NAMES = new Set([
   '@playwright.test.test',
   '@playwright.test.test.only',
   '@playwright.test.test.skip',
+  'bun:test.it',
+  'bun:test.it.only',
+  'bun:test.it.skip',
   'bun:test.test',
   'bun:test.test.only',
   'bun:test.test.skip',
+  'test.it',
+  'test.it.only',
+  'test.it.skip',
   'test.test',
   'test.test.only',
   'test.test.skip',
@@ -212,6 +218,9 @@ function isNodeTestCall(context: Rule.RuleContext, call: estree.CallExpression):
     fqn === 'test' ||
     fqn === 'test.only' ||
     fqn === 'test.skip' ||
+    fqn === 'test.it' ||
+    fqn === 'test.it.only' ||
+    fqn === 'test.it.skip' ||
     fqn === 'test.test' ||
     fqn === 'test.test.only' ||
     fqn === 'test.test.skip'

--- a/packages/analysis/src/jsts/rules/S8780/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8780/rule.ts
@@ -195,7 +195,8 @@ function isFunctionArgument(node: estree.Node | estree.SpreadElement): node is F
  * parameter (arity-based, regardless of its name). Mixing that with an awaited/returned assertion
  * makes the runtime throw ("cannot both take a 'done' callback and return something"), so the fix
  * this rule suggests doesn't apply to such tests. Node's first callback parameter is a
- * `TestContext`, not a `done` callback, so node:test calls are excluded from this heuristic.
+ * `TestContext`, while a second parameter is the `done` callback, so node:test calls are excluded
+ * from this heuristic only when they have a single callback parameter.
  * Playwright's fixtures parameter is always a destructuring pattern, never a plain identifier, so
  * it isn't mistaken for a done callback.
  */
@@ -206,7 +207,7 @@ function usesDoneCallback(
   frameworks: Frameworks,
 ): boolean {
   if (frameworks.nodeTest && isNodeTestCall(context, call)) {
-    return false;
+    return callback.params.length >= 2;
   }
   const [firstParam] = callback.params;
   return firstParam?.type === 'Identifier';

--- a/packages/analysis/src/jsts/rules/S8780/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8780/rule.ts
@@ -140,7 +140,7 @@ export const rule: Rule.RuleModule = {
           return;
         }
 
-        if (usesDoneCallback(callback)) {
+        if (usesDoneCallback(context, call, callback, frameworks)) {
           return;
         }
 
@@ -185,15 +185,37 @@ function isFunctionArgument(node: estree.Node | estree.SpreadElement): node is F
 }
 
 /**
- * Jest/Jasmine/Vitest pass a `done` callback whenever the test function declares a parameter
- * (arity-based, regardless of its name). Mixing that with an awaited/returned assertion makes
- * the runtime throw ("cannot both take a 'done' callback and return something"), so the fix this
- * rule suggests doesn't apply to such tests. Playwright's fixtures parameter is always a
- * destructuring pattern, never a plain identifier, so it isn't mistaken for a done callback.
+ * Jest/Jasmine/Vitest and Bun pass a `done` callback whenever the test function declares a
+ * parameter (arity-based, regardless of its name). Mixing that with an awaited/returned assertion
+ * makes the runtime throw ("cannot both take a 'done' callback and return something"), so the fix
+ * this rule suggests doesn't apply to such tests. Node's first callback parameter is a
+ * `TestContext`, not a `done` callback, so node:test calls are excluded from this heuristic.
+ * Playwright's fixtures parameter is always a destructuring pattern, never a plain identifier, so
+ * it isn't mistaken for a done callback.
  */
-function usesDoneCallback(callback: estree.Function): boolean {
+function usesDoneCallback(
+  context: Rule.RuleContext,
+  call: estree.CallExpression,
+  callback: estree.Function,
+  frameworks: Frameworks,
+): boolean {
+  if (frameworks.nodeTest && isNodeTestCall(context, call)) {
+    return false;
+  }
   const [firstParam] = callback.params;
   return firstParam?.type === 'Identifier';
+}
+
+function isNodeTestCall(context: Rule.RuleContext, call: estree.CallExpression): boolean {
+  const fqn = getFullyQualifiedName(context, call.callee);
+  return (
+    fqn === 'test' ||
+    fqn === 'test.only' ||
+    fqn === 'test.skip' ||
+    fqn === 'test.test' ||
+    fqn === 'test.test.only' ||
+    fqn === 'test.test.skip'
+  );
 }
 
 function forEachExpressionStatement(

--- a/packages/analysis/src/jsts/rules/S8780/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8780/unit.test.ts
@@ -25,6 +25,32 @@ describe('S8780', () => {
       valid: [
         {
           code: `
+            import { test, expect } from 'bun:test';
+
+            test('awaits Bun assertions', async () => {
+              await expect(fetchUser()).resolves.toBeDefined();
+              await expect(failingJob()).rejects.toThrow();
+            });
+
+            test('keeps Bun done callbacks out of scope', done => {
+              expect(fetchUser()).resolves.toBeDefined();
+              done();
+            });
+          `,
+        },
+        {
+          code: `
+            import test from 'node:test';
+            import assert from 'node:assert/strict';
+
+            test('awaits Node assertions', async () => {
+              await assert.rejects(failingJob());
+              return assert.doesNotReject(fetchUser());
+            });
+          `,
+        },
+        {
+          code: `
             import { expect, it } from '@jest/globals';
 
             async function fetchUser(id) {
@@ -150,6 +176,29 @@ describe('S8780', () => {
         },
       ],
       invalid: [
+        {
+          code: `
+            import { test, expect } from 'bun:test';
+
+            test('forgets to await Bun assertions', () => {
+              expect(fetchUser()).resolves.toBeDefined();
+              expect(failingJob()).rejects.toThrow();
+            });
+          `,
+          errors: 2,
+        },
+        {
+          code: `
+            import test from 'node:test';
+            import assert from 'node:assert/strict';
+
+            test('forgets to await Node assertions', () => {
+              assert.rejects(failingJob());
+              assert.doesNotReject(fetchUser());
+            });
+          `,
+          errors: 2,
+        },
         {
           code: `
             import { expect, it } from '@jest/globals';

--- a/packages/analysis/src/jsts/rules/S8780/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8780/unit.test.ts
@@ -210,6 +210,27 @@ describe('S8780', () => {
         },
         {
           code: `
+            import { it as bunIt, expect } from 'bun:test';
+
+            bunIt('forgets to await an aliased Bun assertion', () => {
+              expect(fetchUser()).resolves.toBeDefined();
+            });
+          `,
+          errors: 1,
+        },
+        {
+          code: `
+            import { it as nodeIt } from 'node:test';
+            import assert from 'node:assert/strict';
+
+            nodeIt('does not confuse TestContext with done', t => {
+              assert.rejects(failingJob());
+            });
+          `,
+          errors: 1,
+        },
+        {
+          code: `
             import { test, expect } from 'bun:test';
 
             test('forgets to await Bun assertions', () => {

--- a/packages/analysis/src/jsts/rules/S8780/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8780/unit.test.ts
@@ -178,6 +178,27 @@ describe('S8780', () => {
       invalid: [
         {
           code: `
+            import { test as bunTest, expect } from 'bun:test';
+
+            bunTest('forgets to await an aliased Bun assertion', () => {
+              expect(fetchUser()).resolves.toBeDefined();
+            });
+          `,
+          errors: 1,
+        },
+        {
+          code: `
+            import { test as nodeTest } from 'node:test';
+            import assert from 'node:assert/strict';
+
+            nodeTest('forgets to await an aliased Node assertion', () => {
+              assert.rejects(failingJob());
+            });
+          `,
+          errors: 1,
+        },
+        {
+          code: `
             import { test, expect } from 'bun:test';
 
             test('forgets to await Bun assertions', () => {

--- a/packages/analysis/src/jsts/rules/S8780/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8780/unit.test.ts
@@ -51,6 +51,17 @@ describe('S8780', () => {
         },
         {
           code: `
+            import test from 'node:test';
+            import assert from 'node:assert/strict';
+
+            test('uses an explicit done callback alongside TestContext', (t, done) => {
+              assert.rejects(failingJob());
+              done();
+            });
+          `,
+        },
+        {
+          code: `
             import { expect, it } from '@jest/globals';
 
             async function fetchUser(id) {

--- a/packages/analysis/src/jsts/rules/S8780/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8780/unit.test.ts
@@ -178,6 +178,17 @@ describe('S8780', () => {
       invalid: [
         {
           code: `
+            import test from 'node:test';
+            import assert from 'node:assert/strict';
+
+            test('does not confuse TestContext with done', t => {
+              assert.rejects(failingJob());
+            });
+          `,
+          errors: 1,
+        },
+        {
+          code: `
             import { test as bunTest, expect } from 'bun:test';
 
             bunTest('forgets to await an aliased Bun assertion', () => {

--- a/packages/analysis/src/jsts/rules/S8781/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8781/unit.test.ts
@@ -106,6 +106,22 @@ test('', () => {});
         },
         {
           code: `
+import test from 'node:test';
+test.it('', () => {});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
+const test = require('node:test');
+test.it('', () => {});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
 const test = require('node:test');
 test('', () => {});
           `,

--- a/packages/analysis/src/jsts/rules/S8781/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8781/unit.test.ts
@@ -98,6 +98,26 @@ test.describe.serial.only('registered checkout', () => {});
       invalid: [
         {
           code: `
+import { describe, test } from 'bun:test';
+describe(' ', () => {
+  test('', () => {});
+});
+          `,
+          filename: noFrameworkFixture,
+          errors: 2,
+        },
+        {
+          code: `
+import { describe, test } from 'node:test';
+describe(' ', () => {
+  test('', () => {});
+});
+          `,
+          filename: noFrameworkFixture,
+          errors: 2,
+        },
+        {
+          code: `
 const jest = require('jest');
 it('', async () => {});
           `,

--- a/packages/analysis/src/jsts/rules/S8781/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8781/unit.test.ts
@@ -98,6 +98,22 @@ test.describe.serial.only('registered checkout', () => {});
       invalid: [
         {
           code: `
+import test from 'node:test';
+test('', () => {});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
+const test = require('node:test');
+test('', () => {});
+          `,
+          filename: noFrameworkFixture,
+          errors: 1,
+        },
+        {
+          code: `
 import { describe, test } from 'bun:test';
 describe(' ', () => {
   test('', () => {});

--- a/packages/analysis/src/jsts/rules/S8784/fixtures/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S8784/fixtures/cb.fixture.js
@@ -1,5 +1,13 @@
 const { expect } = require('chai');
 const assert = require('node:assert');
+import { describe as bunDescribe, expect as bunExpect, test as bunTest } from 'bun:test';
+
+bunDescribe('Bun suite', () => {
+  bunExpect(config.enabled).toBe(true); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
+  bunTest('has a test assertion', () => {
+    bunExpect(config.enabled).toBe(true); // Compliant
+  });
+});
 
 // --- NONCOMPLIANT: module top level (runs at file load) ---
 expect(config.enabled).to.equal(true); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}

--- a/packages/analysis/src/jsts/rules/S8784/fixtures/node-test-default.fixture.js
+++ b/packages/analysis/src/jsts/rules/S8784/fixtures/node-test-default.fixture.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('contains an assertion', () => {
+  assert.strictEqual(1, 1); // Compliant
+});
+
+assert.strictEqual(1, 1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}

--- a/packages/analysis/src/jsts/rules/S8784/fixtures/node-test-namespace.fixture.js
+++ b/packages/analysis/src/jsts/rules/S8784/fixtures/node-test-namespace.fixture.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test.it('runs an assertion', () => {
+  assert.strictEqual(1, 1); // Compliant
+});
+
+assert.strictEqual(1, 1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}
+
+const nodeTest = require('node:test');
+
+nodeTest.it('runs an assertion', () => {
+  assert.strictEqual(1, 1); // Compliant
+});
+
+assert.strictEqual(1, 1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}

--- a/packages/analysis/src/jsts/rules/S8784/fixtures/node-test-require.fixture.js
+++ b/packages/analysis/src/jsts/rules/S8784/fixtures/node-test-require.fixture.js
@@ -1,0 +1,8 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('contains an assertion', () => {
+  assert.strictEqual(1, 1); // Compliant
+});
+
+assert.strictEqual(1, 1); // Noncompliant {{Move this assertion into a test case or a lifecycle hook.}}

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -49,6 +49,7 @@ const ASSERTION_LIBRARIES = [
   '@playwright/test',
   'assert',
   'assert/strict',
+  'bun:test',
   'node:assert',
   'node:assert/strict',
 ];
@@ -63,6 +64,7 @@ const SUPPORTED_TEST_FRAMEWORK_IMPORTS = [
   'jasmine',
   'jest',
   'mocha',
+  'bun:test',
   'node:test',
   'sinon',
   'supertest',

--- a/packages/analysis/src/jsts/rules/helpers/mocha-style-test-frameworks.ts
+++ b/packages/analysis/src/jsts/rules/helpers/mocha-style-test-frameworks.ts
@@ -127,7 +127,7 @@ function isQualifyingMember(
   return node.type === 'MemberExpression' && !node.computed && isIdentifier(node.property);
 }
 
-export function getMochaConstructName(
+function getMochaBaseConstructName(
   context: Rule.RuleContext,
   identifier: estree.Identifier,
 ): string | undefined {
@@ -146,11 +146,11 @@ export function getMochaConstructName(
   return variable == null || variable.defs.length === 0 ? identifier.name : undefined;
 }
 
-function getMochaConstructAndModifiers(
+export function getMochaConstructAndModifiers(
   context: Rule.RuleContext,
   calleeParts: { base: estree.Identifier; modifiers: string[] },
 ): { constructName: string | undefined; modifiers: string[] } {
-  const constructName = getMochaConstructName(context, calleeParts.base);
+  const constructName = getMochaBaseConstructName(context, calleeParts.base);
   if (
     constructName === 'test' &&
     isNodeTestDefaultBinding(context, calleeParts.base) &&

--- a/packages/analysis/src/jsts/rules/helpers/mocha-style-test-frameworks.ts
+++ b/packages/analysis/src/jsts/rules/helpers/mocha-style-test-frameworks.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import type { Rule } from 'eslint';
+import type { Rule, Scope } from 'eslint';
 import type estree from 'estree';
 import {
   FUNCTION_NODES,
@@ -132,13 +132,40 @@ export function getMochaConstructName(
   identifier: estree.Identifier,
 ): string | undefined {
   const variable = getVariableFromScope(context.sourceCode.getScope(identifier), identifier.name);
-  if (
-    variable?.defs.some(def => def.type === 'ImportBinding' || isSupportedRequireBinding(def.node))
-  ) {
-    return getMochaConstructNameFromFqn(getFullyQualifiedName(context, identifier));
+  const definition = variable?.defs.find(
+    def => def.type === 'ImportBinding' || isSupportedRequireBinding(def.node),
+  );
+  if (definition !== undefined) {
+    const fqn = getFullyQualifiedName(context, identifier);
+    return (
+      getMochaConstructNameFromFqn(fqn) ??
+      (fqn === 'test' && isNodeTestDefaultBinding(definition) ? 'test' : undefined)
+    );
   }
 
   return variable == null || variable.defs.length === 0 ? identifier.name : undefined;
+}
+
+function isNodeTestDefaultBinding(definition: Scope.Definition): boolean {
+  if (definition.type === 'ImportBinding') {
+    return (
+      definition.node.type === 'ImportDefaultSpecifier' &&
+      definition.parent.type === 'ImportDeclaration' &&
+      definition.parent.source.value === 'node:test'
+    );
+  }
+
+  if (definition.type !== 'Variable' || definition.node.type !== 'VariableDeclarator') {
+    return false;
+  }
+
+  const requireCall = definition.node.init && getRequireCall(definition.node.init);
+  const moduleName = requireCall?.arguments[0];
+  return (
+    definition.node.id.type === 'Identifier' &&
+    moduleName?.type === 'Literal' &&
+    moduleName.value === 'node:test'
+  );
 }
 
 function getMochaConstructNameFromFqn(fqn: string | null): string | undefined {

--- a/packages/analysis/src/jsts/rules/helpers/mocha-style-test-frameworks.ts
+++ b/packages/analysis/src/jsts/rules/helpers/mocha-style-test-frameworks.ts
@@ -58,12 +58,12 @@ export function isMochaTestConstruct(
     return false;
   }
 
-  const constructName = getMochaConstructName(context, calleeParts.base);
+  const { constructName, modifiers } = getMochaConstructAndModifiers(context, calleeParts);
   if (constructName === undefined || !constructs.includes(constructName)) {
     return false;
   }
 
-  return calleeParts.modifiers.every(
+  return modifiers.every(
     modifier =>
       (allowParameterized && modifier === 'each') || isConcreteMochaTestModifier(context, modifier),
   );
@@ -139,14 +139,46 @@ export function getMochaConstructName(
     const fqn = getFullyQualifiedName(context, identifier);
     return (
       getMochaConstructNameFromFqn(fqn) ??
-      (fqn === 'test' && isNodeTestDefaultBinding(definition) ? 'test' : undefined)
+      (fqn === 'test' && isNodeTestDefaultBindingDefinition(definition) ? 'test' : undefined)
     );
   }
 
   return variable == null || variable.defs.length === 0 ? identifier.name : undefined;
 }
 
-function isNodeTestDefaultBinding(definition: Scope.Definition): boolean {
+function getMochaConstructAndModifiers(
+  context: Rule.RuleContext,
+  calleeParts: { base: estree.Identifier; modifiers: string[] },
+): { constructName: string | undefined; modifiers: string[] } {
+  const constructName = getMochaConstructName(context, calleeParts.base);
+  if (
+    constructName === 'test' &&
+    isNodeTestDefaultBinding(context, calleeParts.base) &&
+    calleeParts.modifiers.length > 0
+  ) {
+    const [nodeTestConstructName, ...modifiers] = calleeParts.modifiers;
+    if (
+      TEST_FUNCTION_NAMES.includes(nodeTestConstructName) ||
+      SUITE_FUNCTION_NAMES.includes(nodeTestConstructName)
+    ) {
+      return { constructName: nodeTestConstructName, modifiers };
+    }
+  }
+  return { constructName, modifiers: calleeParts.modifiers };
+}
+
+function isNodeTestDefaultBinding(
+  context: Rule.RuleContext,
+  identifier: estree.Identifier,
+): boolean {
+  const variable = getVariableFromScope(context.sourceCode.getScope(identifier), identifier.name);
+  const definition = variable?.defs.find(
+    def => def.type === 'ImportBinding' || isSupportedRequireBinding(def.node),
+  );
+  return definition !== undefined && isNodeTestDefaultBindingDefinition(definition);
+}
+
+function isNodeTestDefaultBindingDefinition(definition: Scope.Definition): boolean {
   if (definition.type === 'ImportBinding') {
     return (
       definition.node.type === 'ImportDefaultSpecifier' &&

--- a/packages/analysis/src/jsts/rules/helpers/mocha-style-test-frameworks.ts
+++ b/packages/analysis/src/jsts/rules/helpers/mocha-style-test-frameworks.ts
@@ -25,8 +25,15 @@ import {
 } from './ast.js';
 import { getFullyQualifiedName, importsOrDependsOnModule } from './module.js';
 
-export const SUPPORTED_TEST_FRAMEWORKS = ['jest', 'mocha', 'vitest', '@playwright/test'];
-const MOCHA_STYLE_TEST_FRAMEWORKS = new Set(['jest', 'mocha', 'vitest']);
+export const SUPPORTED_TEST_FRAMEWORKS = [
+  'bun:test',
+  'jest',
+  'mocha',
+  'node:test',
+  'vitest',
+  '@playwright/test',
+];
+const MOCHA_STYLE_TEST_FRAMEWORKS = new Set(['bun:test', 'jest', 'mocha', 'test', 'vitest']);
 export const TEST_FUNCTION_NAMES = ['it', 'specify', 'test'];
 export const SUITE_FUNCTION_NAMES = ['describe', 'context', 'suite'];
 const COMMON_MOCHA_TEST_MODIFIERS = new Set(['only', 'concurrent']);

--- a/packages/analysis/src/jsts/rules/helpers/vitest.ts
+++ b/packages/analysis/src/jsts/rules/helpers/vitest.ts
@@ -41,7 +41,7 @@ export const TYPE_LEVEL_ROOTS = ['vitest.expectTypeOf', 'vitest.assertType'];
 // The set of valid matchers is open (custom matchers, matchers called on a stored
 // result), so we cannot enumerate them. Instead, we match anything under these
 // roots and then exclude the few non-assertion members below.
-const ASSERTION_ROOTS = ['vitest.expect', ...TYPE_LEVEL_ROOTS];
+const ASSERTION_ROOTS = ['bun:test.expect', 'vitest.expect', ...TYPE_LEVEL_ROOTS];
 
 // Static helpers on `expect` that share the `vitest.expect` root but configure or
 // declare rather than assert. This set IS closed, so we carve it out by name.


### PR DESCRIPTION
## Summary

- Recognize `bun:test` and `node:test` bindings in shared test-rule detection.
- Add Bun support to S8754, S8781, S8784, S8780, S5976, and S2699.
- Add Node `assert.rejects()` and `assert.doesNotReject()` support to S8780.

## Validation

- `npm run bridge:compile`
- Focused S2699, S5976, S8754, S8780, S8781, and S8784 suites

## Links

- Jira: https://sonarsource.atlassian.net/browse/JS-2101
- RSPEC PR: https://github.com/SonarSource/rspec/pull/7463