### PR TITLE
JS-2104 Bump version to 13.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   </issueManagement>
 
   <properties>
-    <revision>13.3.0-SNAPSHOT</revision>
+    <revision>13.4.0-SNAPSHOT</revision>
     <gitRepositoryName>SonarJS</gitRepositoryName>
     <license.title>SonarQube JavaScript Plugin</license.title>
     <!-- Version corresponds to SQ 9.9 LTS -->


### PR DESCRIPTION
----
## Summary by Gitar

- **Version bump:**
    - Updated `revision` in `pom.xml` from `13.3.0-SNAPSHOT` to `13.4.0-SNAPSHOT`.

<sub>This will update automatically on new commits.</sub>