### PR TITLE
JS-2105 Reuse QA deployer for SQAA release registry

### DIFF
--- a/.github/workflows/sqaa-release.yml
+++ b/.github/workflows/sqaa-release.yml
@@ -191,22 +191,13 @@ jobs:
           username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
 
-      - name: Access vault release registry secrets
-        if: ${{ inputs.publish-to-release-repo }}
-        id: release-secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release access_token | ARTIFACTORY_RELEASE_PASSWORD;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-docker-release username | ARTIFACTORY_RELEASE_USERNAME;
-
       - name: Docker login to Repox release registry
         if: ${{ inputs.publish-to-release-repo }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           registry: ${{ env.DOCKER_REPOX_RELEASES_REGISTRY }}
-          username: ${{ fromJSON(steps.release-secrets.outputs.vault).ARTIFACTORY_RELEASE_USERNAME }}
-          password: ${{ fromJSON(steps.release-secrets.outputs.vault).ARTIFACTORY_RELEASE_PASSWORD }}
+          username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
 
       - name: Setup Docker image
         shell: bash

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -155,10 +155,16 @@ This workflow does the following:
 9. Run `npm run grpc:build`.
 10. Log in to `repox-sonarsource-docker-builds.jfrog.io`.
 11. If `publish-to-release-repo` is enabled, also log in to `repox-sonarsource-docker-releases.jfrog.io`.
-12. Build and push the Docker image with:
+12. Build and push the Docker image once, with one or two registry tags depending on
+    `publish-to-release-repo`.
+
+For an official release, the resulting command is equivalent to:
 
 ```bash
-docker buildx build --platform linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
+docker buildx build --platform linux/arm64 \
+  --tag "repox-sonarsource-docker-builds.jfrog.io/a3s/analysis/javascript:<build_number>" \
+  --tag "repox-sonarsource-docker-releases.jfrog.io/a3s/analysis/javascript:<build_number>" \
+  --push .
 ```
 
 The image is pushed to:
@@ -172,6 +178,44 @@ When `publish-to-release-repo=true`, the same tag is also pushed to:
 ```text
 repox-sonarsource-docker-releases.jfrog.io/a3s/analysis/javascript:<build_number>
 ```
+
+#### Why official releases currently use both registries
+
+The two registry entries are two tags for one Docker Buildx result, not two independently built
+analyzers. The workflow always adds the builds-registry tag. When
+`publish-to-release-repo=true`, it adds the releases-registry tag to the same `docker buildx build`
+invocation before pushing. Both tags therefore come from the same source ref, build number, and
+Docker build.
+
+The registries serve different lifecycle purposes:
+
+| Registry                                     | Purpose                                                                                                                                                                    |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repox-sonarsource-docker-builds.jfrog.io`   | Historical SQAA destination for branch, ad hoc, and staging images. Its artifacts expire after 90 days, so it must not be the source of an official long-lived deployment. |
+| `repox-sonarsource-docker-releases.jfrog.io` | Durable source for images produced from an official SonarJS release tag. `sonar-analysis-as-a-service` must pull released JSTS versions from here.                         |
+
+Before durable publication was added, SonarJS published only to the builds registry and
+`sonar-analysis-as-a-service` pulled JSTS from that location. The release workflow initially kept
+the builds tag while adding the releases tag so the producer and consumer could be migrated across
+repositories without breaking the existing handoff. This makes the dual publication a
+compatibility bridge, not a requirement to maintain two independent release artifacts.
+
+The standard automated release sets `publish-to-release-repo=true`, so it currently publishes both
+tags. The manual workflow defaults the input to `false`, which publishes only to the builds
+registry for ordinary branch or ad hoc builds. A manual rerun of an official release must reuse the
+original build number and set the input to `true` so the durable image is restored.
+
+The same `qa-deployer` credentials intentionally authenticate to both endpoints. Their existing
+`repox-qa-deployers` permissions authorize both pushes; the registry names describe artifact
+retention and intended use, not separate Vault identities. Do not introduce a second
+`docker-release` Vault role for this workflow.
+
+Downstream consumers must not rely on the expiring builds copy of an official release. The
+SonarJS-to-SQAA handoff passes the numeric tag through `analysis/js_ts_image_tag`, while
+`sonar-analysis-as-a-service` owns the registry selection and must choose the releases registry.
+Once no compatibility consumer needs official tags in the builds registry, the official release
+path can be simplified to publish only to the releases registry; branch and ad hoc builds should
+continue to use the builds registry.
 
 The `a3s` repository segment is still intentional legacy naming. Do not change it during a routine SQAA release.
 


### PR DESCRIPTION
Part of

## Summary

- reuse the existing `qa-deployer` Vault credentials for both Repox Docker registries
- remove the lookup of the unprovisioned `docker-release` Vault role
- document why official SQAA releases currently publish the same Docker build to both registries

## Why

The automated SQAA release failed before publishing the Docker image because the protected SonarJS workflow role cannot access `development/artifactory/token/SonarSource-SonarJS-docker-release`.

The proposed Terraform role was previously closed after confirming that `qa-deployer` already supplies the same `repox-qa-deployers` permissions. Reusing the credentials already loaded by the workflow avoids duplicating the Vault role and restores publication to the durable release registry.

The release documentation now also explains the surrounding publication model: `docker-builds` is the historical, 90-day-retention destination for branch and ad hoc images; `docker-releases` is the durable source for official releases; and the current dual tag is a compatibility bridge while downstream consumers use the durable registry. Both tags are pushed from one Docker Buildx build, and `sonar-analysis-as-a-service` must select the releases registry for official JSTS versions.

Failed job: https://github.com/SonarSource/SonarJS/actions/runs/29578344985/job/87883161538

Related Terraform review: https://github.com/SonarSource/re-terraform-aws-vault/pull/8477#discussion_r2742622528

## Validation

- `git diff --check`
- parsed `.github/workflows/sqaa-release.yml` with Python/PyYAML
- parsed `.github/workflows/sqaa-release.yml` with Ruby/Psych
- checked `docs/RELEASE.md` with the repository's Prettier options
