### PR TITLE
JS-2095 FP in S9019: Enable ref-to-ref reassignment

### DIFF
--- a/packages/analysis/src/jsts/rules/S9019/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S9019/decorator.ts
@@ -17,9 +17,38 @@
 // https://sonarsource.github.io/rspec/#/rspec/S9019/javascript
 
 import type { Rule } from 'eslint';
+import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { interceptReport } from '../helpers/decorators/interceptor.js';
 import * as meta from './generated-meta.js';
+
+// eslint-plugin-vue's ref-object-references.js tracks all ref-creating calls for a variable in a
+// shared map keyed by reference node, overwriting entries per call it processes. When a ref-typed
+// variable is reassigned to a *different* ref-creating call, whichever call is processed last
+// (an artifact of import order, not of the code) determines whether the reassignment is flagged.
+// Suppress that non-deterministic case: reassigning a ref to a new ref/computed/etc. is a
+// legitimate Composition API pattern anyway, unlike assigning a plain value (still flagged).
+const REF_CREATING_CALLEES = new Set([
+  'ref',
+  'computed',
+  'toRef',
+  'customRef',
+  'shallowRef',
+  'toRefs',
+  'defineModel',
+]);
+
+function isRefToRefReassignment(node: estree.Node & Rule.NodeParentExtension): boolean {
+  const { parent } = node;
+  return (
+    parent.type === 'AssignmentExpression' &&
+    parent.operator === '=' &&
+    parent.left === node &&
+    parent.right.type === 'CallExpression' &&
+    parent.right.callee.type === 'Identifier' &&
+    REF_CREATING_CALLEES.has(parent.right.callee.name)
+  );
+}
 
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
   return interceptReport(
@@ -29,6 +58,12 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
     },
     (context, reportDescriptor) => {
       if ('messageId' in reportDescriptor && reportDescriptor.messageId === 'requireDotValue') {
+        if (
+          'node' in reportDescriptor &&
+          isRefToRefReassignment(reportDescriptor.node as estree.Node & Rule.NodeParentExtension)
+        ) {
+          return;
+        }
         const { messageId: _messageId, data, ...rest } = reportDescriptor;
         context.report({
           ...rest,

--- a/packages/analysis/src/jsts/rules/S9019/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S9019/decorator.ts
@@ -20,7 +20,10 @@ import type { Rule } from 'eslint';
 import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { interceptReport } from '../helpers/decorators/interceptor.js';
+import { getFullyQualifiedName } from '../helpers/module.js';
 import * as meta from './generated-meta.js';
+
+const VUE_FQN_PREFIX = 'vue.';
 
 // eslint-plugin-vue's ref-object-references.js tracks all ref-creating calls for a variable in a
 // shared map keyed by reference node, overwriting entries per call it processes. When a ref-typed
@@ -38,7 +41,24 @@ const REF_CREATING_CALLEES = new Set([
   'defineModel',
 ]);
 
-function isRefToRefReassignment(node: estree.Node & Rule.NodeParentExtension): boolean {
+function isRefCreatingCallee(context: Rule.RuleContext, callee: estree.Identifier): boolean {
+  const fqn = getFullyQualifiedName(context, callee);
+  // Resolving the import binding recognizes aliased imports too, e.g.
+  // `import { computed as makeComputed } from 'vue'`. Names with no resolvable import
+  // binding (e.g. `defineModel`, a <script setup> compiler macro that needs no import)
+  // fall back to matching the local spelling directly.
+  if (fqn !== null) {
+    return (
+      fqn.startsWith(VUE_FQN_PREFIX) && REF_CREATING_CALLEES.has(fqn.slice(VUE_FQN_PREFIX.length))
+    );
+  }
+  return REF_CREATING_CALLEES.has(callee.name);
+}
+
+function isRefToRefReassignment(
+  context: Rule.RuleContext,
+  node: estree.Node & Rule.NodeParentExtension,
+): boolean {
   const { parent } = node;
   return (
     parent.type === 'AssignmentExpression' &&
@@ -46,7 +66,7 @@ function isRefToRefReassignment(node: estree.Node & Rule.NodeParentExtension): b
     parent.left === node &&
     parent.right.type === 'CallExpression' &&
     parent.right.callee.type === 'Identifier' &&
-    REF_CREATING_CALLEES.has(parent.right.callee.name)
+    isRefCreatingCallee(context, parent.right.callee)
   );
 }
 
@@ -60,7 +80,10 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
       if ('messageId' in reportDescriptor && reportDescriptor.messageId === 'requireDotValue') {
         if (
           'node' in reportDescriptor &&
-          isRefToRefReassignment(reportDescriptor.node as estree.Node & Rule.NodeParentExtension)
+          isRefToRefReassignment(
+            context,
+            reportDescriptor.node as estree.Node & Rule.NodeParentExtension,
+          )
         ) {
           return;
         }

--- a/packages/analysis/src/jsts/rules/S9019/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S9019/unit.test.ts
@@ -62,6 +62,31 @@ if (hasItems.value) {
 </script>
 `,
         },
+        {
+          // reassigning a ref-typed variable to a new ref-creating call is a legitimate pattern,
+          // regardless of the unrelated import order of ref vs computed (JS-2095)
+          code: `
+<script setup>
+import { computed, defineComponent, ref } from 'vue';
+let isValid = ref(true);
+function revalidate() {
+  isValid = computed(() => true);
+}
+</script>
+`,
+        },
+        {
+          // same pattern with ref imported before computed
+          code: `
+<script setup>
+import { defineComponent, ref, computed } from 'vue';
+let isValid = ref(true);
+function revalidate() {
+  isValid = computed(() => true);
+}
+</script>
+`,
+        },
       ],
       invalid: [
         {

--- a/packages/analysis/src/jsts/rules/S9019/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S9019/unit.test.ts
@@ -87,6 +87,19 @@ function revalidate() {
 </script>
 `,
         },
+        {
+          // same pattern with aliased imports: the reassignment's callee must be resolved
+          // through the import binding, not matched by its local spelling (JS-2095)
+          code: `
+<script setup>
+import { computed as makeComputed, defineComponent, ref as makeRef } from 'vue';
+let isValid = makeRef(true);
+function revalidate() {
+  isValid = makeComputed(() => true);
+}
+</script>
+`,
+        },
       ],
       invalid: [
         {


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fixes:**
    - Suppress false positives in `S9019` when reassigning a ref to another ref-creating function call.
    - Added `isRefToRefReassignment` to detect and ignore legitimate `ref` or `computed` reassignments.

<sub>This will update automatically on new commits.</sub>