### PR TITLE
JS-2119 USER-2209 Do not warn for supported Node.js versions

### DIFF
--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarning.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarning.java
@@ -89,7 +89,7 @@ public class NodeDeprecationWarning {
         "Using Node.js version %s to execute analysis is not recommended. " +
           "Please use a supported LTS version of Node.js: %s.",
         actualNodeVersion,
-        SUPPORTED_NODE_VERSIONS
+        String.join(", ", SUPPORTED_NODE_VERSIONS.stream().map(Version::toString).toList())
       );
       LOG.warn(msg);
       analysisWarnings.addUnique(msg);

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarning.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarning.java
@@ -36,8 +36,7 @@ public class NodeDeprecationWarning {
   private static final String NODE_PROPERTIES_FILE = "node-info.properties";
   private static final String NODE_SUPPORTED_VERSIONS_PROPERTY = "node.supported.versions";
   static final Version MIN_SUPPORTED_NODE_VERSION;
-  private static final List<String> RECOMMENDED_NODE_VERSIONS;
-  public static final Version RECOMMENDED_NODE_VERSION;
+  private static final List<Version> SUPPORTED_NODE_VERSIONS;
   private final AnalysisWarningsWrapper analysisWarnings;
 
   static {
@@ -51,11 +50,10 @@ public class NodeDeprecationWarning {
           NODE_SUPPORTED_VERSIONS_PROPERTY
       );
     }
-    RECOMMENDED_NODE_VERSIONS = Arrays.asList(supportedVersions.split(","));
-    MIN_SUPPORTED_NODE_VERSION = Version.parse(RECOMMENDED_NODE_VERSIONS.get(0));
-    RECOMMENDED_NODE_VERSION = Version.parse(
-      RECOMMENDED_NODE_VERSIONS.get(RECOMMENDED_NODE_VERSIONS.size() - 1)
-    );
+    SUPPORTED_NODE_VERSIONS = Arrays.stream(supportedVersions.split(","))
+      .map(Version::parse)
+      .toList();
+    MIN_SUPPORTED_NODE_VERSION = SUPPORTED_NODE_VERSIONS.get(0);
   }
 
   public NodeDeprecationWarning(AnalysisWarningsWrapper analysisWarnings) {
@@ -81,15 +79,24 @@ public class NodeDeprecationWarning {
   }
 
   void logNodeDeprecation(Version actualNodeVersion) {
-    if (!actualNodeVersion.isGreaterThanOrEqual(RECOMMENDED_NODE_VERSION)) {
+    boolean isSupported = SUPPORTED_NODE_VERSIONS.stream().anyMatch(
+      supportedVersion ->
+        actualNodeVersion.major() == supportedVersion.major() &&
+        actualNodeVersion.isGreaterThanOrEqual(supportedVersion)
+    );
+    if (!isSupported) {
       String msg = String.format(
         "Using Node.js version %s to execute analysis is not recommended. " +
-          "Please upgrade to a newer LTS version of Node.js: %s.",
+          "Please use a supported LTS version of Node.js: %s.",
         actualNodeVersion,
-        RECOMMENDED_NODE_VERSION
+        SUPPORTED_NODE_VERSIONS
       );
       LOG.warn(msg);
       analysisWarnings.addUnique(msg);
     }
+  }
+
+  static List<Version> supportedNodeVersions() {
+    return SUPPORTED_NODE_VERSIONS;
   }
 }

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarningTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarningTest.java
@@ -22,10 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
@@ -53,34 +55,48 @@ class NodeDeprecationWarningTest {
    * versions of NodeJS. Here we should only care about the deprecation warnings.
    */
   @ParameterizedTest
-  @ValueSource(strings = { "16.10.0", "18.16.0", "20.11.9", "22.10.0" })
-  void test_unsupported(String version) {
-    deprecationWarning.logNodeDeprecation(Version.parse(version));
+  @MethodSource("unsupportedNodeVersions")
+  void test_unsupported(Version version) {
+    deprecationWarning.logNodeDeprecation(version);
     assertWarnings(
       String.format(
         "Using Node.js version %s to execute analysis is not recommended. " +
-          "Please upgrade to a newer LTS version of Node.js: %s.",
-        Version.parse(version),
-        NodeDeprecationWarning.RECOMMENDED_NODE_VERSION
+          "Please use a supported LTS version of Node.js: %s.",
+        version,
+        NodeDeprecationWarning.supportedNodeVersions()
       )
     );
   }
 
   @ParameterizedTest
-  @ValueSource(strings = { "18.20.0", "20.13.0", "22.11.0" })
-  void test_supported(String version) {
-    var parsedVersion = Version.parse(version);
-    deprecationWarning.logNodeDeprecation(parsedVersion);
-    if (parsedVersion.major() < NodeDeprecationWarning.RECOMMENDED_NODE_VERSION.major()) {
-      assertWarnings(
-        String.format(
-          "Using Node.js version %s to execute analysis is not recommended. " +
-            "Please upgrade to a newer LTS version of Node.js: %s.",
-          parsedVersion,
-          NodeDeprecationWarning.RECOMMENDED_NODE_VERSION
-        )
+  @MethodSource("supportedNodeVersions")
+  void test_supported(Version version) {
+    deprecationWarning.logNodeDeprecation(version);
+    assertWarnings();
+  }
+
+  static Stream<Version> supportedNodeVersions() {
+    return NodeDeprecationWarning.supportedNodeVersions()
+      .stream()
+      .flatMap(version ->
+        Stream.of(version, Version.create(version.major(), version.minor() + 1, 0))
       );
-    }
+  }
+
+  static Stream<Version> unsupportedNodeVersions() {
+    var supportedVersions = NodeDeprecationWarning.supportedNodeVersions();
+    int minMajor = supportedVersions.get(0).major();
+    int maxMajor = supportedVersions.get(supportedVersions.size() - 1).major();
+
+    var versionsBelowSupportedMinimums = supportedVersions
+      .stream()
+      .filter(version -> version.minor() > 0)
+      .map(version -> Version.create(version.major(), version.minor() - 1, 0));
+    var unsupportedMajors = IntStream.rangeClosed(minMajor - 1, maxMajor + 1)
+      .filter(major -> supportedVersions.stream().noneMatch(version -> version.major() == major))
+      .mapToObj(major -> Version.create(major, 0, 0));
+
+    return Stream.concat(versionsBelowSupportedMinimums, unsupportedMajors).distinct();
   }
 
   private void assertWarnings(String... messages) {

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarningTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/NodeDeprecationWarningTest.java
@@ -63,7 +63,10 @@ class NodeDeprecationWarningTest {
         "Using Node.js version %s to execute analysis is not recommended. " +
           "Please use a supported LTS version of Node.js: %s.",
         version,
-        NodeDeprecationWarning.supportedNodeVersions()
+        String.join(
+          ", ",
+          NodeDeprecationWarning.supportedNodeVersions().stream().map(Version::toString).toList()
+        )
       )
     );
   }


### PR DESCRIPTION
Part of [USER-2209](https://sonarsource.atlassian.net/browse/USER-2209)

## Summary

- do not report an analysis warning for Node.js versions declared supported in `package.json`
- keep warning for unsupported majors and versions below a supported line's minimum
- derive supported and unsupported JUnit parameters from the generated `node-info.properties` data

This keeps the warning behavior and its tests synchronized automatically when `engines.node` changes.

## Validation

- `npm run bbf`
- focused `NodeDeprecationWarningTest` through the Maven reactor: 13 tests passed
- Prettier check on the changed Java files


[USER-2209]: https://sonarsource.atlassian.net/browse/USER-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ