### PR TITLE
JS-2126 Update S6582 ruling expectations

### DIFF
--- a/its/ruling/src/test/expected/Joust/typescript-S6582.json
+++ b/its/ruling/src/test/expected/Joust/typescript-S6582.json
@@ -1,0 +1,81 @@
+{
+"Joust:ts/Launcher.tsx": [
+50,
+194,
+424
+],
+"Joust:ts/components/DebugApplication.tsx": [
+126
+],
+"Joust:ts/components/EventLog.tsx": [
+171,
+175,
+226,
+330,
+424
+],
+"Joust:ts/components/EventLogLine.tsx": [
+75,
+80,
+146,
+162,
+174,
+212,
+213
+],
+"Joust:ts/components/GameWidget.tsx": [
+333
+],
+"Joust:ts/components/GameWrapper.tsx": [
+148
+],
+"Joust:ts/components/LoadingScreen.tsx": [
+108
+],
+"Joust:ts/components/Scrubber.tsx": [
+122,
+160,
+163
+],
+"Joust:ts/components/game/Card.tsx": [
+48,
+103,
+232
+],
+"Joust:ts/components/game/Choices.tsx": [
+54
+],
+"Joust:ts/components/game/EntityInPlay.tsx": [
+112
+],
+"Joust:ts/components/game/Hand.tsx": [
+39
+],
+"Joust:ts/components/game/Hero.tsx": [
+42,
+52
+],
+"Joust:ts/components/game/HeroPower.tsx": [
+32
+],
+"Joust:ts/components/game/Minion.tsx": [
+25
+],
+"Joust:ts/components/game/Player.tsx": [
+109,
+113,
+263
+],
+"Joust:ts/components/game/Weapon.tsx": [
+20
+],
+"Joust:ts/protocol/HSReplayDecoder.ts": [
+422
+],
+"Joust:ts/state/GameStateScrubber.ts": [
+234
+],
+"Joust:ts/state/plugins/Timer.ts": [
+66
+]
+}

--- a/its/ruling/src/test/expected/TypeScript/typescript-S6582.json
+++ b/its/ruling/src/test/expected/TypeScript/typescript-S6582.json
@@ -291,8 +291,242 @@
 4582,
 4587
 ],
+"TypeScript:src/harness/compilerRunner.ts": [
+114
+],
+"TypeScript:src/harness/fourslash.ts": [
+280,
+973,
+1011,
+1031,
+1085,
+1184,
+1306,
+1898,
+1915,
+1933,
+1934,
+1941,
+1956,
+1972,
+1984,
+2340,
+2349,
+2534,
+2610,
+2848
+],
+"TypeScript:src/harness/harness.ts": [
+742,
+905,
+1307,
+1591,
+1909,
+1909,
+1964,
+1964
+],
+"TypeScript:src/harness/harnessLanguageService.ts": [
+151,
+189,
+259,
+323,
+620
+],
+"TypeScript:src/harness/projectsRunner.ts": [
+106,
+522
+],
+"TypeScript:src/harness/virtualFileSystem.ts": [
+136,
+169,
+214
+],
+"TypeScript:src/server/builder.ts": [
+338
+],
+"TypeScript:src/server/client.ts": [
+509
+],
+"TypeScript:src/server/editorServices.ts": [
+448,
+943,
+1392,
+1432,
+1507
+],
+"TypeScript:src/server/lsHost.ts": [
+75,
+81,
+192,
+197
+],
+"TypeScript:src/server/project.ts": [
+319,
+407,
+418,
+697,
+887
+],
+"TypeScript:src/server/scriptVersionCache.ts": [
+555
+],
 "TypeScript:src/server/server.ts": [
 40,
 63
+],
+"TypeScript:src/server/session.ts": [
+609,
+610,
+805,
+1149
+],
+"TypeScript:src/server/typingsCache.ts": [
+83
+],
+"TypeScript:src/server/typingsInstaller/nodeTypingsInstaller.ts": [
+162,
+162
+],
+"TypeScript:src/server/typingsInstaller/typingsInstaller.ts": [
+25
+],
+"TypeScript:src/services/classifier.ts": [
+701,
+845
+],
+"TypeScript:src/services/codefixes/disableJsDiagnostics.ts": [
+11,
+27
+],
+"TypeScript:src/services/codefixes/fixClassSuperMustPrecedeThisAccess.ts": [
+21
+],
+"TypeScript:src/services/codefixes/fixExtendsInterfaceBecomesImplements.ts": [
+20
+],
+"TypeScript:src/services/codefixes/helpers.ts": [
+60
+],
+"TypeScript:src/services/codefixes/importFixes.ts": [
+159,
+251,
+252,
+278,
+301
+],
+"TypeScript:src/services/codefixes/unusedIdentifierFixes.ts": [
+52,
+56,
+103,
+120
+],
+"TypeScript:src/services/completions.ts": [
+42,
+149,
+480,
+730,
+1060,
+1104,
+1106,
+1115,
+1182,
+1198
+],
+"TypeScript:src/services/documentHighlights.ts": [
+49,
+54,
+136
+],
+"TypeScript:src/services/documentRegistry.ts": [
+124
+],
+"TypeScript:src/services/findAllReferences.ts": [
+47,
+554,
+649,
+695,
+949,
+1057,
+1155,
+1193,
+1323,
+1376,
+1622
+],
+"TypeScript:src/services/formatting/formatting.ts": [
+143,
+159,
+178,
+473
+],
+"TypeScript:src/services/formatting/formattingScanner.ts": [
+145
+],
+"TypeScript:src/services/goToDefinition.ts": [
+18
+],
+"TypeScript:src/services/importTracker.ts": [
+105,
+106,
+222,
+328,
+344,
+539
+],
+"TypeScript:src/services/jsTyping.ts": [
+67
+],
+"TypeScript:src/services/navigationBar.ts": [
+448,
+449,
+585,
+613
+],
+"TypeScript:src/services/pathCompletions.ts": [
+57,
+93,
+171,
+292,
+533
+],
+"TypeScript:src/services/services.ts": [
+873,
+878,
+1003,
+1044,
+1052,
+1053,
+1116,
+1147,
+1214,
+1509,
+2117
+],
+"TypeScript:src/services/shims.ts": [
+628,
+1174
+],
+"TypeScript:src/services/signatureHelp.ts": [
+72,
+88,
+124,
+144
+],
+"TypeScript:src/services/symbolDisplay.ts": [
+85,
+113,
+116,
+279,
+435
+],
+"TypeScript:src/services/utilities.ts": [
+130,
+144,
+181,
+219,
+817,
+868,
+1355
 ]
 }

--- a/its/ruling/src/test/expected/ant-design/typescript-S6582.json
+++ b/its/ruling/src/test/expected/ant-design/typescript-S6582.json
@@ -1,0 +1,124 @@
+{
+"ant-design:components/_util/wave.tsx": [
+16,
+22,
+60,
+131,
+138,
+154
+],
+"ant-design:components/affix/utils.ts": [
+89,
+95
+],
+"ant-design:components/alert/ErrorBoundary.tsx": [
+33
+],
+"ant-design:components/auto-complete/index.tsx": [
+47
+],
+"ant-design:components/back-top/index.tsx": [
+35
+],
+"ant-design:components/badge/ScrollNumber.tsx": [
+67
+],
+"ant-design:components/breadcrumb/Breadcrumb.tsx": [
+99
+],
+"ant-design:components/button/button.tsx": [
+178
+],
+"ant-design:components/calendar/Header.tsx": [
+38
+],
+"ant-design:components/calendar/generateCalendar.tsx": [
+199,
+225
+],
+"ant-design:components/card/Card.tsx": [
+66,
+115,
+145,
+157
+],
+"ant-design:components/comment/index.tsx": [
+52
+],
+"ant-design:components/config-provider/context.tsx": [
+105
+],
+"ant-design:components/config-provider/index.tsx": [
+146,
+234
+],
+"ant-design:components/form/Form.tsx": [
+69
+],
+"ant-design:components/form/FormItem.tsx": [
+370,
+377
+],
+"ant-design:components/form/FormItemInput.tsx": [
+83
+],
+"ant-design:components/input/Search.tsx": [
+52
+],
+"ant-design:components/list/index.tsx": [
+147,
+158
+],
+"ant-design:components/locale-provider/LocaleReceiver.tsx": [
+39
+],
+"ant-design:components/locale-provider/index.tsx": [
+63,
+73,
+79
+],
+"ant-design:components/modal/confirm.tsx": [
+35
+],
+"ant-design:components/modal/useModal/HookModal.tsx": [
+37
+],
+"ant-design:components/space/index.tsx": [
+91
+],
+"ant-design:components/spin/index.tsx": [
+136
+],
+"ant-design:components/table/Table.tsx": [
+194,
+378,
+379,
+380,
+521
+],
+"ant-design:components/table/hooks/useFilter/FilterDropdown.tsx": [
+206,
+207
+],
+"ant-design:components/table/hooks/useFilter/index.tsx": [
+170
+],
+"ant-design:components/table/hooks/useLazyKVMap.ts": [
+20
+],
+"ant-design:components/table/hooks/useSorter.tsx": [
+182,
+407,
+408
+],
+"ant-design:components/typography/Editable.tsx": [
+53
+],
+"ant-design:components/upload/UploadList/index.tsx": [
+112
+],
+"ant-design:site/theme/template/IconDisplay/IconPicSearcher.tsx": [
+73,
+75
+]
+}

--- a/its/ruling/src/test/expected/console/typescript-S6582.json
+++ b/its/ruling/src/test/expected/console/typescript-S6582.json
@@ -1,0 +1,92 @@
+{
+"console:src/routes.tsx": [
+117
+],
+"console:src/utils/relay.ts": [
+39
+],
+"console:src/utils/valueparser.ts": [
+93
+],
+"console:src/views/ActionsView/ActionBoxes.tsx": [
+73
+],
+"console:src/views/FunctionsView/FunctionPopup/FunctionPopup.tsx": [
+587
+],
+"console:src/views/FunctionsView/FunctionRow.tsx": [
+186
+],
+"console:src/views/Integrations/Algolia/AlgoliaView.tsx": [
+63,
+134
+],
+"console:src/views/Integrations/AlgoliaPopup/AlgoliaPopupIndexes.tsx": [
+30
+],
+"console:src/views/PermissionsView/PermissionPopup/AffectedFields.tsx": [
+113
+],
+"console:src/views/PermissionsView/PermissionPopup/PermissionPopup.tsx": [
+512,
+512,
+513
+],
+"console:src/views/PermissionsView/RelationPermissionPopup/RelationPermissionPopup.tsx": [
+428,
+428,
+429
+],
+"console:src/views/ProjectRootView/SideNav.tsx": [
+413,
+544
+],
+"console:src/views/RelationsPopup/ModelSelectionBox.tsx": [
+37
+],
+"console:src/views/RelationsPopup/RelationFooter.tsx": [
+87,
+89
+],
+"console:src/views/RelationsPopup/RelationPopup.tsx": [
+142,
+143,
+284,
+285,
+286
+],
+"console:src/views/SchemaView/SchemaOverview/AddType.tsx": [
+66,
+67
+],
+"console:src/views/Settings/Billing/Billing.tsx": [
+111
+],
+"console:src/views/Settings/General/ProjectInfo.tsx": [
+169,
+193,
+195
+],
+"console:src/views/account/AccountView/SettingsTab.tsx": [
+41
+],
+"console:src/views/models/AuthProviderPopup/AuthProviderPopup.tsx": [
+173
+],
+"console:src/views/models/DatabrowserView/Cell/SelectNodesCell/SelectNodesCell.tsx": [
+308,
+394
+],
+"console:src/views/models/DatabrowserView/Cell/SelectNodesCell/Table/Table.tsx": [
+176,
+214,
+219
+],
+"console:src/views/models/DatabrowserView/RelationsPopup.tsx": [
+240
+],
+"console:src/views/models/FieldPopup/FieldHorizontalSelect.tsx": [
+123,
+141
+]
+}

--- a/its/ruling/src/test/expected/eigen/typescript-S6582.json
+++ b/its/ruling/src/test/expected/eigen/typescript-S6582.json
@@ -1,0 +1,285 @@
+{
+"eigen:src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx": [
+276
+],
+"eigen:src/app/Components/Artist/ArtistShows/ArtistShow.tsx": [
+28,
+39
+],
+"eigen:src/app/Components/Artist/ArtistShows/Metadata.tsx": [
+16,
+49
+],
+"eigen:src/app/Components/ArtistListItem.tsx": [
+115
+],
+"eigen:src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx": [
+171
+],
+"eigen:src/app/Components/Bidding/Screens/ConfirmBid/index.tsx": [
+163
+],
+"eigen:src/app/Components/Bidding/Screens/Registration.tsx": [
+203
+],
+"eigen:src/app/Components/Bidding/Screens/SelectMaxBid.tsx": [
+71
+],
+"eigen:src/app/Components/EntityList/index.tsx": [
+50
+],
+"eigen:src/app/Components/Lists/ShowItemRow.tsx": [
+121,
+140
+],
+"eigen:src/app/Components/RelatedArtists/RelatedArtist.tsx": [
+24
+],
+"eigen:src/app/Scenes/Artwork/Artwork.tsx": [
+124,
+124,
+126,
+348,
+362
+],
+"eigen:src/app/Scenes/Artwork/Components/AboutArtist.tsx": [
+17
+],
+"eigen:src/app/Scenes/Artwork/Components/ArtworkActions.tsx": [
+41,
+126
+],
+"eigen:src/app/Scenes/Artwork/Components/ArtworkDetails.tsx": [
+38,
+41,
+44,
+46
+],
+"eigen:src/app/Scenes/Artwork/Components/ArtworkExtraLinks/AuctionFaqSection.tsx": [
+34
+],
+"eigen:src/app/Scenes/Artwork/Components/ArtworkExtraLinks/FaqAndSpecialistSection.tsx": [
+23
+],
+"eigen:src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx": [
+134
+],
+"eigen:src/app/Scenes/Artwork/Components/AuctionPrice.tsx": [
+18,
+56,
+61,
+62
+],
+"eigen:src/app/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx": [
+28,
+30,
+239,
+240
+],
+"eigen:src/app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx": [
+69
+],
+"eigen:src/app/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton.tsx": [
+76
+],
+"eigen:src/app/Scenes/Artwork/Components/CommercialButtons/helpers.ts": [
+26
+],
+"eigen:src/app/Scenes/Artwork/Components/CommercialEditionSetInformation.tsx": [
+24,
+31,
+56
+],
+"eigen:src/app/Scenes/Artwork/Components/CommercialPartnerInformation.tsx": [
+15
+],
+"eigen:src/app/Scenes/Artwork/Components/ContextCard.tsx": [
+123,
+132,
+137,
+142
+],
+"eigen:src/app/Scenes/Artwork/Components/ImageCarousel/FullScreen/DeepZoom/DeepZoomLevel.tsx": [
+180
+],
+"eigen:src/app/Scenes/Artwork/Components/ImageCarousel/FullScreen/DeepZoom/DeepZoomPyramid.ts": [
+68
+],
+"eigen:src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx": [
+173
+],
+"eigen:src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarouselContext.tsx": [
+104
+],
+"eigen:src/app/Scenes/Artwork/Components/PartnerCard.tsx": [
+96
+],
+"eigen:src/app/Scenes/City/CityBMWList.tsx": [
+132
+],
+"eigen:src/app/Scenes/City/CityFairList.tsx": [
+147
+],
+"eigen:src/app/Scenes/City/CitySavedList.tsx": [
+134
+],
+"eigen:src/app/Scenes/City/CitySectionList.tsx": [
+176
+],
+"eigen:src/app/Scenes/City/Components/AllEvents.tsx": [
+60,
+97,
+104,
+111,
+118,
+124,
+131
+],
+"eigen:src/app/Scenes/Fair/FairArtworks.tests.tsx": [
+35
+],
+"eigen:src/app/Scenes/Fair/FairCollections.tests.tsx": [
+35
+],
+"eigen:src/app/Scenes/Fair/FairEditorial.tests.tsx": [
+35
+],
+"eigen:src/app/Scenes/Fair/FairExhibitorRail.tests.tsx": [
+37
+],
+"eigen:src/app/Scenes/Fair/FairExhibitors.tests.tsx": [
+33
+],
+"eigen:src/app/Scenes/Fair/FairFollowedArtistsRail.tests.tsx": [
+41
+],
+"eigen:src/app/Scenes/Fair/FairMoreInfo.tests.tsx": [
+38
+],
+"eigen:src/app/Scenes/Fair/FairMoreInfo.tsx": [
+32
+],
+"eigen:src/app/Scenes/Favorites/FavoriteArtworks.tsx": [
+173
+],
+"eigen:src/app/Scenes/Favorites/FavoriteCategories.tsx": [
+148
+],
+"eigen:src/app/Scenes/Favorites/FavoriteShows.tsx": [
+139
+],
+"eigen:src/app/Scenes/Home/Components/HomeHero.tsx": [
+12
+],
+"eigen:src/app/Scenes/Inbox/Components/ActiveBids/ActiveBid.tsx": [
+83,
+130,
+142
+],
+"eigen:src/app/Scenes/Inbox/Components/Conversations/Composer.tsx": [
+74
+],
+"eigen:src/app/Scenes/Inbox/Components/Conversations/ConversationSnippet.tsx": [
+89
+],
+"eigen:src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx": [
+201
+],
+"eigen:src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx": [
+62
+],
+"eigen:src/app/Scenes/Inbox/Components/Conversations/Messages.tsx": [
+73
+],
+"eigen:src/app/Scenes/Inbox/Components/Conversations/Shipping.tsx": [
+42
+],
+"eigen:src/app/Scenes/LotsByArtistsYouFollow/LotsByArtistsYouFollow.tsx": [
+73
+],
+"eigen:src/app/Scenes/Map/EventEmitter.ts": [
+32
+],
+"eigen:src/app/Scenes/Map/GlobalMap.tsx": [
+314,
+322,
+384,
+481,
+590
+],
+"eigen:src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx": [
+48
+],
+"eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx": [
+98
+],
+"eigen:src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tsx": [
+26
+],
+"eigen:src/app/Scenes/MyCollection/utils/localArtworkSortAndFilter.ts": [
+160
+],
+"eigen:src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalizationArtistListItem.tsx": [
+129
+],
+"eigen:src/app/Scenes/Onboarding/OnboardingSocialPick.tsx": [
+79
+],
+"eigen:src/app/Scenes/OrderHistory/OrderDetails/Components/SoldBySection.tsx": [
+13
+],
+"eigen:src/app/Scenes/Partner/Components/PartnerArtwork.tsx": [
+118
+],
+"eigen:src/app/Scenes/Partner/Components/PartnerOverview.tsx": [
+132
+],
+"eigen:src/app/Scenes/Partner/Components/PartnerShows.tsx": [
+38,
+215
+],
+"eigen:src/app/Scenes/Partner/Components/PartnerShowsRail.tsx": [
+102
+],
+"eigen:src/app/Scenes/Partner/Screens/PartnerLocations.tsx": [
+81
+],
+"eigen:src/app/Scenes/Sales/Components/SaleListItem.tsx": [
+56
+],
+"eigen:src/app/Scenes/Search/SearchArtworksGrid.tsx": [
+175
+],
+"eigen:src/app/Scenes/Show/ShowArtworks.tests.tsx": [
+33
+],
+"eigen:src/app/store/AuthModel.ts": [
+76
+],
+"eigen:src/app/tests/MockRelayRendererFixtures.tsx": [
+29
+],
+"eigen:src/app/utils/convertCityToGeoJSON.ts": [
+52
+],
+"eigen:src/app/utils/googleMaps.ts": [
+71,
+72,
+73,
+74,
+75,
+76
+],
+"eigen:src/app/utils/renderWithPlaceholder.tsx": [
+51
+],
+"eigen:src/app/utils/useWebViewEvent.ts": [
+59
+],
+"eigen:src/app/utils/verifyEmail.ts": [
+7
+],
+"eigen:src/app/utils/verifyID.ts": [
+7
+]
+}

--- a/its/ruling/src/test/expected/fireface/typescript-S6582.json
+++ b/its/ruling/src/test/expected/fireface/typescript-S6582.json
@@ -1,0 +1,5 @@
+{
+"fireface:src/create/create.component.ts": [
+190
+]
+}

--- a/its/ruling/src/test/expected/postgraphql/typescript-S6582.json
+++ b/its/ruling/src/test/expected/postgraphql/typescript-S6582.json
@@ -1,0 +1,34 @@
+{
+"postgraphql:src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts": [
+23
+],
+"postgraphql:src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts": [
+31
+],
+"postgraphql:src/graphql/schema/connection/createConnectionGqlField.ts": [
+106,
+107
+],
+"postgraphql:src/graphql/schema/node/createNodeFieldEntry.ts": [
+46
+],
+"postgraphql:src/graphql/schema/type/getGqlInputType.ts": [
+208
+],
+"postgraphql:src/graphql/schema/type/getGqlOutputType.ts": [
+232
+],
+"postgraphql:src/postgraphql/postgraphql.ts": [
+142
+],
+"postgraphql:src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts": [
+80
+],
+"postgraphql:src/postgraphql/withPostGraphQLContext.ts": [
+209
+],
+"postgraphql:src/postgres/inventory/type/PgRangeType.ts": [
+137,
+138
+]
+}

--- a/its/ruling/src/test/expected/prettier-vscode/typescript-S6582.json
+++ b/its/ruling/src/test/expected/prettier-vscode/typescript-S6582.json
@@ -1,0 +1,6 @@
+{
+"prettier-vscode:src/requirePkg.ts": [
+16,
+17
+]
+}

--- a/its/ruling/src/test/expected/rxjs/typescript-S6582.json
+++ b/its/ruling/src/test/expected/rxjs/typescript-S6582.json
@@ -1,0 +1,33 @@
+{
+"rxjs:src/Notification.ts": [
+33,
+35,
+37,
+53,
+55,
+57
+],
+"rxjs:src/Observable.ts": [
+130
+],
+"rxjs:src/Subject.ts": [
+143,
+150,
+157
+],
+"rxjs:src/observable/dom/WebSocketSubject.ts": [
+176,
+196,
+260,
+271
+],
+"rxjs:src/operator/toPromise.ts": [
+60
+],
+"rxjs:src/operator/windowTime.ts": [
+257
+],
+"rxjs:src/operator/zip.ts": [
+252
+]
+}


### PR DESCRIPTION
The master JS/TS and Java ruling jobs fail because S6582 now reports TypeScript issues after the ES2020 gating change, but nine expected-result snapshots are missing or stale.

This restores the nine snapshots generated by the master ruling run (894 insertions total), byte-for-byte verified against the CI-generated results.

Generated from master commit c4e9462884c8f75654c86a228408ad125ecf1354.