### PR TITLE
JS-2140: Extend S8959 to Testing Library debug utils

### DIFF
--- a/its/ruling/src/test/expected/vitest/typescript-S8959.json
+++ b/its/ruling/src/test/expected/vitest/typescript-S8959.json
@@ -1,0 +1,5 @@
+{
+"vitest:test/ui/fixtures/console.test.ts": [
+32
+]
+}

--- a/packages/analysis/src/jsts/rules/S8959/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8959/rule.ts
@@ -21,9 +21,19 @@ import type estree from 'estree';
 import { hasParent, isIdentifier, isMethodCall } from '../helpers/ast.js';
 import { chainStartsWithCy } from '../helpers/cypress.js';
 import { generateMeta } from '../helpers/generate-meta.js';
+import { getFullyQualifiedName } from '../helpers/module.js';
 import { removeNodeWithLeadingWhitespaces } from '../helpers/quickfix.js';
 import { isTestRelatedFile } from '../helpers/test-file-pattern.js';
 import * as meta from './generated-meta.js';
+
+const TESTING_LIBRARY_MODULES = [
+  '@testing-library/dom',
+  '@testing-library/react',
+  '@testing-library/vue',
+  '@testing-library/angular',
+  '@testing-library/svelte',
+  '@testing-library/preact',
+];
 
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta, {
@@ -41,10 +51,10 @@ export const rule: Rule.RuleModule = {
       CallExpression(node: estree.Node) {
         const call = node as estree.CallExpression;
         if (isMethodCall(call)) {
-          if (isUiTestDebugCommand(call.callee)) {
+          if (isUiTestDebugCommand(context, call)) {
             reportDebugCommand(context, call, call.callee.property);
           }
-        } else if (isIdentifier(call.callee, 'prettyDOM', 'logRoles')) {
+        } else if (isTestingLibraryDebugCommand(context, call)) {
           reportDebugCommand(context, call, call.callee);
         }
       },
@@ -52,20 +62,43 @@ export const rule: Rule.RuleModule = {
   },
 };
 
-function isUiTestDebugCommand(callee: estree.MemberExpression & { property: estree.Identifier }) {
+function isUiTestDebugCommand(
+  context: Rule.RuleContext,
+  call: estree.CallExpression & {
+    callee: estree.MemberExpression & { property: estree.Identifier };
+  },
+) {
+  const { callee } = call;
   const { object, property } = callee;
   switch (property.name) {
     case 'pause':
       return chainStartsWithCy(object) || isIdentifier(object, 'page');
     case 'debug':
-      return chainStartsWithCy(object) || isIdentifier(object, 'screen');
+      return isTestingLibraryDebugCommand(context, call) || chainStartsWithCy(object);
     case 'logTestingPlaygroundURL':
-    case 'prettyDOM':
-    case 'logRoles':
-      return isIdentifier(object, 'screen');
+      return isTestingLibraryDebugCommand(context, call);
     default:
       return false;
   }
+}
+
+function isTestingLibraryDebugCommand(
+  context: Rule.RuleContext,
+  call: estree.CallExpression,
+): boolean {
+  const fqn = getFullyQualifiedName(context, call.callee);
+  if (!fqn) {
+    return false;
+  }
+  return TESTING_LIBRARY_MODULES.some(module => {
+    const prefix = module.replace('/', '.');
+    return [
+      `${prefix}.screen.debug`,
+      `${prefix}.screen.logTestingPlaygroundURL`,
+      `${prefix}.prettyDOM`,
+      `${prefix}.logRoles`,
+    ].includes(fqn);
+  });
 }
 
 function reportDebugCommand(

--- a/packages/analysis/src/jsts/rules/S8959/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8959/rule.ts
@@ -40,12 +40,12 @@ export const rule: Rule.RuleModule = {
     return {
       CallExpression(node: estree.Node) {
         const call = node as estree.CallExpression;
-        if (!isMethodCall(call)) {
-          return;
-        }
-
-        if (isUiTestDebugCommand(call.callee)) {
-          reportDebugCommand(context, call);
+        if (isMethodCall(call)) {
+          if (isUiTestDebugCommand(call.callee)) {
+            reportDebugCommand(context, call, call.callee.property);
+          }
+        } else if (isIdentifier(call.callee, 'prettyDOM', 'logRoles')) {
+          reportDebugCommand(context, call, call.callee);
         }
       },
     };
@@ -58,7 +58,11 @@ function isUiTestDebugCommand(callee: estree.MemberExpression & { property: estr
     case 'pause':
       return chainStartsWithCy(object) || isIdentifier(object, 'page');
     case 'debug':
-      return chainStartsWithCy(object);
+      return chainStartsWithCy(object) || isIdentifier(object, 'screen');
+    case 'logTestingPlaygroundURL':
+    case 'prettyDOM':
+    case 'logRoles':
+      return isIdentifier(object, 'screen');
     default:
       return false;
   }
@@ -66,10 +70,11 @@ function isUiTestDebugCommand(callee: estree.MemberExpression & { property: estr
 
 function reportDebugCommand(
   context: Rule.RuleContext,
-  call: estree.CallExpression & { callee: estree.MemberExpression },
+  call: estree.CallExpression,
+  reportNode: estree.Node,
 ) {
   context.report({
-    node: call.callee.property,
+    node: reportNode,
     messageId: 'removeDebugCommand',
     fix: fixer => removeDebugCommand(context, call, fixer),
   });
@@ -77,28 +82,36 @@ function reportDebugCommand(
 
 /**
  * Removes the whole statement only for root debug calls used as standalone statements, e.g.
- * `cy.pause();` or `await page.pause();`. For Cypress chains, only the `.pause()`/`.debug()`
+ * `cy.pause();`, `await page.pause();`, `screen.debug();`, or `prettyDOM(el);`. For Cypress chains, only the `.pause()`/`.debug()`
  * link is spliced out, e.g. `cy.get('x').debug().click();` -> `cy.get('x').click();` and
  * `cy.get('x').pause();` -> `cy.get('x');`.
  */
 function removeDebugCommand(
   context: Rule.RuleContext,
-  call: estree.CallExpression & { callee: estree.MemberExpression },
+  call: estree.CallExpression,
   fixer: Rule.RuleFixer,
 ): Rule.Fix | null {
   const statement = unwrapToStatementExpression(call);
-  if (isRootDebugReceiver(call.callee.object) && hasParent(statement)) {
+  if (call.callee.type === 'MemberExpression') {
+    if (isRootDebugReceiver(call.callee.object) && hasParent(statement)) {
+      const { parent } = statement;
+      if (parent.type === 'ExpressionStatement' && parent.expression === statement) {
+        return removeNodeWithLeadingWhitespaces(context, parent, fixer);
+      }
+    }
+    const objectRange = call.callee.object.range;
+    const callRange = call.range;
+    if (!objectRange || !callRange) {
+      return null;
+    }
+    return fixer.removeRange([objectRange[1], callRange[1]]);
+  } else if (hasParent(statement)) {
     const { parent } = statement;
     if (parent.type === 'ExpressionStatement' && parent.expression === statement) {
       return removeNodeWithLeadingWhitespaces(context, parent, fixer);
     }
   }
-  const objectRange = call.callee.object.range;
-  const callRange = call.range;
-  if (!objectRange || !callRange) {
-    return null;
-  }
-  return fixer.removeRange([objectRange[1], callRange[1]]);
+  return null;
 }
 
 function unwrapToStatementExpression(node: estree.Node): estree.Node {
@@ -118,7 +131,7 @@ function unwrapToStatementExpression(node: estree.Node): estree.Node {
 }
 
 function isRootDebugReceiver(node: estree.Node): boolean {
-  return isIdentifier(unwrapChainExpression(node), 'cy', 'page');
+  return isIdentifier(unwrapChainExpression(node), 'cy', 'page', 'screen');
 }
 
 function unwrapChainExpression(node: estree.Node): estree.Node {

--- a/packages/analysis/src/jsts/rules/S8959/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8959/rule.ts
@@ -35,6 +35,14 @@ const TESTING_LIBRARY_MODULES = [
   '@testing-library/preact',
 ];
 
+const TESTING_LIBRARY_DEBUG_COMMANDS = [
+  'screen.debug',
+  'screen.logTestingPlaygroundURL',
+  'render.debug',
+  'prettyDOM',
+  'logRoles',
+];
+
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta, {
     messages: {
@@ -86,18 +94,18 @@ function isTestingLibraryDebugCommand(
   context: Rule.RuleContext,
   call: estree.CallExpression,
 ): boolean {
+  // getFullyQualifiedName intentionally resolves imports in the current file only.
+  // Custom test-utils wrappers that re-export Testing Library symbols are not resolved here.
   const fqn = getFullyQualifiedName(context, call.callee);
   if (!fqn) {
     return false;
   }
   return TESTING_LIBRARY_MODULES.some(module => {
-    const prefix = module.replace('/', '.');
-    return [
-      `${prefix}.screen.debug`,
-      `${prefix}.screen.logTestingPlaygroundURL`,
-      `${prefix}.prettyDOM`,
-      `${prefix}.logRoles`,
-    ].includes(fqn);
+    const prefix = `${module.replace('/', '.')}.`;
+    return (
+      fqn.startsWith(prefix) &&
+      TESTING_LIBRARY_DEBUG_COMMANDS.some(command => fqn.endsWith(`.${command}`))
+    );
   });
 }
 

--- a/packages/analysis/src/jsts/rules/S8959/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8959/unit.test.ts
@@ -92,6 +92,31 @@ describe('S8959', () => {
           `,
           filename: 'tests/tl.test.tsx',
         },
+        {
+          code: `
+            import { prettyDOM, logRoles } from './test-utils';
+
+            test('ignores unrelated debug helpers', () => {
+              prettyDOM(container);
+              logRoles(container);
+            });
+          `,
+          filename: 'tests/tl-lookalikes.test.tsx',
+        },
+        {
+          code: `
+            const screen = {
+              debug() {},
+              logTestingPlaygroundURL() {},
+            };
+
+            test('ignores unrelated screen objects', () => {
+              screen.debug();
+              screen.logTestingPlaygroundURL();
+            });
+          `,
+          filename: 'tests/screen-lookalike.test.tsx',
+        },
       ],
       invalid: [
         {
@@ -228,6 +253,8 @@ describe('S8959', () => {
         },
         {
           code: `
+            import { screen } from '@testing-library/react';
+
             test('uses Testing Library screen.debug', () => {
               screen.debug();
             });
@@ -235,12 +262,16 @@ describe('S8959', () => {
           filename: 'tests/tl-debug.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }],
           output: `
+            import { screen } from '@testing-library/react';
+
             test('uses Testing Library screen.debug', () => {
             });
           `,
         },
         {
           code: `
+            import { screen } from '@testing-library/react';
+
             test('uses Testing Library logTestingPlaygroundURL', () => {
               screen.logTestingPlaygroundURL();
             });
@@ -248,12 +279,16 @@ describe('S8959', () => {
           filename: 'tests/tl-playground.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }],
           output: `
+            import { screen } from '@testing-library/react';
+
             test('uses Testing Library logTestingPlaygroundURL', () => {
             });
           `,
         },
         {
           code: `
+            import { prettyDOM, logRoles } from '@testing-library/dom';
+
             test('uses Testing Library standalone prettyDOM and logRoles', () => {
               prettyDOM(container);
               logRoles(container);
@@ -262,6 +297,8 @@ describe('S8959', () => {
           filename: 'tests/tl-helpers.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }, { messageId: 'removeDebugCommand' }],
           output: `
+            import { prettyDOM, logRoles } from '@testing-library/dom';
+
             test('uses Testing Library standalone prettyDOM and logRoles', () => {
               logRoles(container);
             });

--- a/packages/analysis/src/jsts/rules/S8959/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8959/unit.test.ts
@@ -71,6 +71,7 @@ describe('S8959', () => {
             cy.pause();
             cy.debug();
             page.pause();
+            screen.debug();
           `,
           filename: 'src/app/page.ts',
         },
@@ -82,6 +83,14 @@ describe('S8959', () => {
             });
           `,
           filename: 'tests/debugger.spec.ts',
+        },
+        {
+          code: `
+            test('Testing Library queries are valid', () => {
+              screen.getByRole('button');
+            });
+          `,
+          filename: 'tests/tl.test.tsx',
         },
       ],
       invalid: [
@@ -214,6 +223,47 @@ describe('S8959', () => {
           output: `
             it('keeps optional Cypress chain tail when debug ends the statement', () => {
               cy?.contains('Saved');
+            });
+          `,
+        },
+        {
+          code: `
+            test('uses Testing Library screen.debug', () => {
+              screen.debug();
+            });
+          `,
+          filename: 'tests/tl-debug.test.tsx',
+          errors: [{ messageId: 'removeDebugCommand' }],
+          output: `
+            test('uses Testing Library screen.debug', () => {
+            });
+          `,
+        },
+        {
+          code: `
+            test('uses Testing Library logTestingPlaygroundURL', () => {
+              screen.logTestingPlaygroundURL();
+            });
+          `,
+          filename: 'tests/tl-playground.test.tsx',
+          errors: [{ messageId: 'removeDebugCommand' }],
+          output: `
+            test('uses Testing Library logTestingPlaygroundURL', () => {
+            });
+          `,
+        },
+        {
+          code: `
+            test('uses Testing Library standalone prettyDOM and logRoles', () => {
+              prettyDOM(container);
+              logRoles(container);
+            });
+          `,
+          filename: 'tests/tl-helpers.test.tsx',
+          errors: [{ messageId: 'removeDebugCommand' }, { messageId: 'removeDebugCommand' }],
+          output: `
+            test('uses Testing Library standalone prettyDOM and logRoles', () => {
+              logRoles(container);
             });
           `,
         },

--- a/packages/analysis/src/jsts/rules/S8959/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8959/unit.test.ts
@@ -105,6 +105,16 @@ describe('S8959', () => {
         },
         {
           code: `
+            import { screen } from './test-utils';
+
+            test('does not resolve custom test-utils re-exports', () => {
+              screen.debug();
+            });
+          `,
+          filename: 'tests/tl-wrapper.test.tsx',
+        },
+        {
+          code: `
             const screen = {
               debug() {},
               logTestingPlaygroundURL() {},
@@ -265,6 +275,60 @@ describe('S8959', () => {
             import { screen } from '@testing-library/react';
 
             test('uses Testing Library screen.debug', () => {
+            });
+          `,
+        },
+        {
+          code: `
+            import { screen } from '@testing-library/react/pure';
+
+            test('uses Testing Library screen.debug from a subpath entrypoint', () => {
+              screen.debug();
+            });
+          `,
+          filename: 'tests/tl-pure-debug.test.tsx',
+          errors: [{ messageId: 'removeDebugCommand' }],
+          output: `
+            import { screen } from '@testing-library/react/pure';
+
+            test('uses Testing Library screen.debug from a subpath entrypoint', () => {
+            });
+          `,
+        },
+        {
+          code: `
+            import { render } from '@testing-library/react';
+
+            test('uses the debug method returned by render', () => {
+              const { debug } = render(<Component />);
+              debug();
+            });
+          `,
+          filename: 'tests/tl-render-debug.test.tsx',
+          errors: [{ messageId: 'removeDebugCommand' }],
+          output: `
+            import { render } from '@testing-library/react';
+
+            test('uses the debug method returned by render', () => {
+              const { debug } = render(<Component />);
+            });
+          `,
+        },
+        {
+          code: `
+            import { render } from '@testing-library/react';
+
+            test('uses the debug method returned by render inline', () => {
+              render(<Component />).debug();
+            });
+          `,
+          filename: 'tests/tl-render-inline-debug.test.tsx',
+          errors: [{ messageId: 'removeDebugCommand' }],
+          output: `
+            import { render } from '@testing-library/react';
+
+            test('uses the debug method returned by render inline', () => {
+              render(<Component />);
             });
           `,
         },


### PR DESCRIPTION
## Summary
Extends rule `S8959` (`UI test debug commands should not be committed to version control`) to detect Testing Library debug utilities:
- `screen.debug()`
- `screen.logTestingPlaygroundURL()`
- `prettyDOM()` / `logRoles()`

## Related Links
- Jira Ticket: https://sonarsource.atlassian.net/browse/JS-2140
- RSPEC PR: https://github.com/SonarSource/rspec/pull/7602

----
## Summary by Gitar

- **New rules:**
    - Added rule `S9078` to disallow duplicate test cases in parameterized tests with auto-fixing support

<sub>This will update automatically on new commits.</sub>