### PR TITLE
JS-2143 Fix ruling bot checkout with generated changes

### DIFF
--- a/.github/actions/ruling_bot/run.sh
+++ b/.github/actions/ruling_bot/run.sh
@@ -153,7 +153,9 @@ if [ "$RULING_FAILED" = "true" ] && [ "$HAS_DIFFERENCES" = "true" ]; then
   git fetch origin "$TARGET_REF"
   git config user.name "github-actions[bot]"
   git config user.email "github-actions[bot]@users.noreply.github.com"
-  git checkout -B "$FIX_BRANCH" "origin/$TARGET_REF"
+  # Ruling preparation can modify generated files outside the expected-results directory.
+  # Those changes must not prevent switching from the tested merge ref to the PR branch.
+  git checkout -f -B "$FIX_BRANCH" "origin/$TARGET_REF"
   restore_ruling_changes
 
   git add -- "$OLD_RESULTS_PATH"


### PR DESCRIPTION
Part of

## Summary

- force the ruling bot branch checkout after synchronized ruling results are stashed
- discard unrelated generated-file changes left by ruling preparation so they cannot block creation of the ruling update PR

## Validation

- reproduced the failed checkout with a dirty generated file and stashed ruling result
- verified the forced checkout switches to the target branch and restores only the ruling result
- `bash -n .github/actions/ruling_bot/run.sh`
- `npm ci`
- `npm run bbf`
