### PR TITLE
JS-2148 Collect package import telemetry

### DIFF
--- a/packages/analysis/src/jsts/linter/linter.ts
+++ b/packages/analysis/src/jsts/linter/linter.ts
@@ -60,9 +60,10 @@ import {
 } from './filters/index.js';
 import { getClosestDependencyManifestDir } from '../rules/helpers/dependency-manifests/closest.js';
 import { getOptionalProjectAnalysisTelemetryCollector } from '../../telemetry.js';
+import { collectPackageImports } from '../../package-imports.js';
 import type { FileType } from '../../contracts/file.js';
 import { clearFileCaches, getCurrentFileImports } from '../rules/helpers/module.js';
-import { parseInlineNPMImport } from '../rules/helpers/dependency-manifests/resolvers/deno.js';
+import { parseInlineNPMImport } from '../rules/helpers/dependency-manifests/resolvers/npm-import.js';
 
 interface InitializeParams {
   rules?: RuleConfig[];
@@ -332,7 +333,11 @@ export class Linter {
     // Make inline npm: imports visible to both rule activation and to dependency helpers
     // (getReactVersion, getDependenciesSanitizePaths) called from rules during linting.
     // Cleared by clearFileCaches() once linting completes.
-    setCurrentFileInlineDependencies(sourceCode ? extractInlineNpmDependencies(sourceCode) : null);
+    setCurrentFileInlineDependencies(
+      sourceCode
+        ? extractInlineNpmDependencies(sourceCode, manifestDependencies, normalizedFilePath)
+        : null,
+    );
     const baseContext = {
       extensionName: extname(normalizePath(filePath)),
       fileType,
@@ -458,9 +463,14 @@ function getURLScheme(moduleName: string): string | undefined {
  * and records telemetry for any URL-scheme imports (npm:, jsr:, https:, ...).
  * Returns null if the file has no inline npm imports.
  */
-function extractInlineNpmDependencies(sourceCode: SourceCode): DependenciesList | null {
+function extractInlineNpmDependencies(
+  sourceCode: SourceCode,
+  manifestDependencies: DependenciesList,
+  filePath: NormalizedAbsolutePath,
+): DependenciesList | null {
   let inlineDependencies: DependenciesList | null = null;
-  for (const moduleName of getCurrentFileImports(sourceCode)) {
+  const moduleNames = getCurrentFileImports(sourceCode);
+  for (const moduleName of moduleNames) {
     const protocol = getURLScheme(moduleName);
     if (protocol !== undefined) {
       getOptionalProjectAnalysisTelemetryCollector()?.recordDenoImport(protocol);
@@ -471,6 +481,10 @@ function extractInlineNpmDependencies(sourceCode: SourceCode): DependenciesList 
       inlineDependencies.set(parsedSpecifier.packageName, parsedSpecifier.version);
     }
   }
+  getOptionalProjectAnalysisTelemetryCollector()?.recordPackageImports(
+    filePath,
+    collectPackageImports(moduleNames, manifestDependencies),
+  );
   return inlineDependencies;
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/deno.ts
@@ -25,11 +25,8 @@ import { DENO_JSON, DENO_JSONC } from '../index.js';
 import { getManifestFileInDir } from './helpers.js';
 import { addDependenciesArray, addDependency } from '../parse.js';
 import { parseDenoManifest } from '../parsed-dependency-files.js';
-
-type ImportMapSpecifier = {
-  packageName: string;
-  version?: string;
-};
+import { parseInlineNPMImport } from './npm-import.js';
+export { parseInlineNPMImport } from './npm-import.js';
 
 export const denoManifestResolver: ManifestResolver = {
   resolve(dir, topDir, fileSystem): DependencyManifest[] {
@@ -82,32 +79,4 @@ function buildDependencies(manifest: DenoJson): DependenciesList {
   }
 
   return dependencies;
-}
-
-// Captures `npm:` payload as: package name (scoped or unscoped), optional version, optional ignored subpath.
-// Examples:
-// npm:cowsay@^1.6.0
-// npm:@scopename/mypackage@~11.1.0
-const DENO_NPM_IMPORT_PATTERN = /^(@[^/]*\/[^/@]*|[^/@]+)(?:@([^/]*))?(?:\/.*)?$/;
-
-/**
- * Parses an import map URL Specifier matching Deno npm format:
- * npm:<package>[@<version>][/<path>]
- */
-export function parseInlineNPMImport(value: string): ImportMapSpecifier | undefined {
-  // currently only handle npm: specifiers since rules are focused on NPM dependencies
-  if (!value.startsWith('npm:')) {
-    return undefined;
-  }
-
-  const match = DENO_NPM_IMPORT_PATTERN.exec(value.slice('npm:'.length));
-  if (!match) {
-    return undefined;
-  }
-
-  const [, packageName, version] = match;
-  return {
-    packageName,
-    version: version || undefined,
-  };
 }

--- a/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm-import.ts
+++ b/packages/analysis/src/jsts/rules/helpers/dependency-manifests/resolvers/npm-import.ts
@@ -1,0 +1,45 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+type ImportMapSpecifier = {
+  packageName: string;
+  version?: string;
+};
+
+// Captures `npm:` payload as: package name (scoped or unscoped), optional version, optional ignored subpath.
+const DENO_NPM_IMPORT_PATTERN = /^(@[^/]*\/[^/@]*|[^/@]+)(?:@([^/]*))?(?:\/.*)?$/;
+
+/**
+ * Parses an import map URL specifier matching the Deno npm format:
+ * npm:<package>[@<version>][/<path>]
+ */
+export function parseInlineNPMImport(value: string): ImportMapSpecifier | undefined {
+  if (!value.startsWith('npm:')) {
+    return undefined;
+  }
+
+  const match = DENO_NPM_IMPORT_PATTERN.exec(value.slice('npm:'.length));
+  if (!match) {
+    return undefined;
+  }
+
+  const [, packageName, version] = match;
+  return {
+    packageName,
+    version: version || undefined,
+  };
+}

--- a/packages/analysis/src/jsts/rules/helpers/module.ts
+++ b/packages/analysis/src/jsts/rules/helpers/module.ts
@@ -44,8 +44,7 @@ const CURRENT_FILE_IMPORTS: {
 };
 
 /**
- * Compute the set of all module names imported or required
- * in the file currently being analyzed (via import declarations, require(), or dynamic import()).
+ * Compute the set of all literal module names referenced in the file currently being analyzed.
  *
  * Supported patterns:
  * import foo from 'lodash';
@@ -54,7 +53,9 @@ const CURRENT_FILE_IMPORTS: {
  * const lodash = import('lodash');
  * const lodash = await import('lodash');
  *
- * Unsupported patterns (not stored in a variable):
+ * export { partition } from 'lodash';
+ * export * from 'lodash';
+ * import lodash = require('lodash');
  * require('lodash');
  * import('lodash').then(lodash => ...);
  */
@@ -66,25 +67,51 @@ function computeCurrentFileImports(sourceCode: SourceCode): void {
   CURRENT_FILE_IMPORTS.sourceCode = sourceCode;
   CURRENT_FILE_IMPORTS.imports.clear();
 
-  for (const node of sourceCode.ast.body) {
-    if (node.type === 'ImportDeclaration' && typeof node.source.value === 'string') {
-      CURRENT_FILE_IMPORTS.imports.add(node.source.value);
+  const pending: estree.Node[] = [sourceCode.ast];
+  while (pending.length > 0) {
+    const node = pending.pop()!;
+    const moduleName = getReferencedModuleName(node);
+    if (moduleName !== undefined) {
+      CURRENT_FILE_IMPORTS.imports.add(moduleName);
     }
-  }
-
-  for (const scope of sourceCode.scopeManager.scopes) {
-    for (const variable of scope.variables) {
-      for (const def of variable.defs) {
-        if (def.type === 'Variable' && def.node.init) {
-          const name =
-            getRequireModuleName(def.node.init) ?? getDynamicImportModuleName(def.node.init);
-          if (name !== undefined) {
-            CURRENT_FILE_IMPORTS.imports.add(name);
-          }
-        }
+    for (const visitorKey of sourceCode.visitorKeys[node.type] ?? []) {
+      const child = (node as unknown as Record<string, unknown>)[visitorKey];
+      if (Array.isArray(child)) {
+        pending.push(...child.filter(isNode));
+      } else if (isNode(child)) {
+        pending.push(child);
       }
     }
   }
+}
+
+function getReferencedModuleName(node: estree.Node): string | undefined {
+  if (
+    (node.type === 'ImportDeclaration' ||
+      node.type === 'ExportNamedDeclaration' ||
+      node.type === 'ExportAllDeclaration') &&
+    node.source &&
+    typeof node.source.value === 'string'
+  ) {
+    return node.source.value;
+  }
+  if ((node as TSESTree.Node).type === 'TSImportEqualsDeclaration') {
+    const moduleReference = (node as unknown as TSESTree.TSImportEqualsDeclaration).moduleReference;
+    if (
+      moduleReference.type === 'TSExternalModuleReference' &&
+      moduleReference.expression.type === 'Literal' &&
+      typeof moduleReference.expression.value === 'string'
+    ) {
+      return moduleReference.expression.value;
+    }
+  }
+  return getRequireModuleName(node) ?? getDynamicImportModuleName(node);
+}
+
+function isNode(value: unknown): value is estree.Node {
+  return (
+    typeof value === 'object' && value !== null && typeof (value as estree.Node).type === 'string'
+  );
 }
 
 /**

--- a/packages/analysis/src/package-imports.ts
+++ b/packages/analysis/src/package-imports.ts
@@ -1,0 +1,203 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { builtinModules } from 'node:module';
+import { parseInlineNPMImport } from './jsts/rules/helpers/dependency-manifests/resolvers/npm-import.js';
+import type { DependenciesList } from './jsts/rules/helpers/dependency-manifests/resolvers/types.js';
+
+// Curated from the package-import telemetry canvas: its popularity, current, proposed, and
+// runtime cohorts are kept as one deduplicated set, including deprecated-but-valid entries.
+const ALLOWLIST = new Set(
+  `
+typescript, react, mocha, jest, react-dom, chai, lodash, chalk
+axios, vue, express, commander, fs-extra, sinon, prop-types, request
+moment, glob, inquirer, debug, @testing-library/react, semver, yargs, dotenv
+rxjs, uuid, @storybook/react, postcss, tape, @testing-library/jest-dom, async, antd
+classnames, node-fetch, mkdirp, ava, ora, minimist, react-test-renderer, shelljs
+vue-router, @testing-library/user-event, jsdom, bluebird, enzyme, should, colors, styled-components
+jquery, jasmine-core, body-parser, @angular/core, underscore, @angular/common, react-native, sinon-chai
+react-router-dom, @angular/platform-browser, jsonwebtoken, redux, @angular/platform-browser-dynamic, @ant-design/web3-common, @ant-design/web3-icons, js-yaml
+cheerio, enzyme-adapter-react-16, ws, supertest, @angular/forms, react-redux, web-vitals, bootstrap
+through2, chokidar, execa, vuex, @angular/router, chai-as-promised, puppeteer, winston
+graphql, aws-sdk, qs, handlebars, @angular/animations, ejs, dayjs, @storybook/testing-library
+ajv, @vue/test-utils, cross-spawn, jasmine, element-ui, @emotion/styled, mongoose, deepmerge
+date-fns, cors, nock, ethers, globby, yeoman-generator, @emotion/react, identity-obj-proxy
+marked, q, crypto-js, tailwindcss, mongodb, ramda, highlight.js, vitest
+tap, lodash-es, resolve, react-addons-test-utils, co, socket.io, react-router, @alifd/next
+koa, figlet, tsconfig-paths, react-is, superagent, @angular/http, form-data, expect.js
+download-git-repo, got, minimatch, @material-ui/core, tap-spec, express-validator, cookie-session, immutable
+jest-environment-jsdom, xml2js, pg, acorn, socket.io-client, cookie-parser, svelte, redis
+proxyquire, camelcase, morgan, request-promise, markdown-it, next, mime, fast-glob
+node-notifier, expect, portfinder, http-proxy-middleware, @mui/material, mysql, joi, prompts
+query-string, @nestjs/common, nanoid, @testing-library/react-hooks, react-transition-group, tmp, js-cookie, clsx
+prompt, promise, compression, redux-thunk, strip-ansi, @stencil/core, bignumber.js, meow
+prismjs, react-icons, echarts, yosay, lodash.merge, path-to-regexp, md5, mime-types
+cypress, @ethersproject/providers, node-nats-streaming, web3, @fortawesome/fontawesome-svg-core, enzyme-to-json, history, @storybook/blocks
+yaml, @material-ui/icons, lru-cache, normalize.css, tiny-invariant, @fortawesome/free-solid-svg-icons, font-awesome, inherits
+moment-timezone, d3, @nestjs/core, zod, extend, benchmark, big.js, faker
+nodemailer, connect-history-api-fallback, dotenv-expand, pug, cross-fetch, eventemitter3, optimist, connect
+serve-static, iconv-lite, type-fest, log-symbols, discord.js, react-select, @ant-design/icons, validator
+@ethersproject/address, ms, readable-stream, boxen, lodash.debounce, react-bootstrap, immer, json5
+archiver, bn.js, lodash.get, invariant, mustache, node-uuid, escape-string-regexp, lit
+ember-resolver, express-session, @popperjs/core, graceful-fs, file-saver, graphql-tag, find-up, vuepress
+which, i18next, watch, tar, @angular/cdk, replace-in-file, yup, three
+tiny-warning, jade, path-exists, sequelize, polished, yeoman-assert, mobx, firebase
+async-validator, @mui/icons-material, xlsx, @storybook/node-logger, jsdom-global, concat-stream, pluralize, vue-class-component
+micromatch, koa-router, progress, @fortawesome/react-fontawesome, vue-i18n, angular, yeoman-test, lodash.clonedeep
+codemirror, @ethersproject/contracts, @testing-library/dom, @jest/globals, lodash.camelcase, @ethersproject/solidity, merge2, @emotion/core
+ioredis, simple-git, svgo, ansi-styles, jszip, esprima, passport, browserslist
+merge-stream, vue-property-decorator, ant-design-vue, fast-deep-equal, @nestjs/testing, clone, decimal.js-light, npmlog
+vinyl, pify, jest-styled-components, argparse, log4js, jsonfile, lodash.isequal, mockjs
+multer, function-bind, xtend, request-promise-native, ip, diff, toformat, js-beautify
+react-helmet, cookie, slash, through, color, event-stream, config, safe-buffer
+ansi-regex, supports-color, change-case, @storybook/theming, vuedraggable, mysql2, yargs-parser, ember-source
+jsbi, styled-system, react-hook-form, power-assert, clear, markdown-it-container, deep-equal, rewire
+popper.js, luxon, pino, @angular/material, lit-element, postcss-safe-parser, ember-data, class-validator
+@ethersproject/networks, ini, dumi, ethereumjs-util, react-i18next, shortid, jest-extended, enquirer
+readline-sync, preact, chalk-animation, element-plus, js-base64, class-transformer, arg, requirejs
+pump, cli-table, @vitejs/plugin-vue-jsx, once, @vueuse/core, typeorm, adm-zip, react-intl
+@sveltejs/kit, ember-ajax, https-proxy-agent, jasmine-node, hoist-non-react-statics, react-dnd, bunyan, picocolors
+http-errors, @angular/platform-server, ethereum-waffle, @reduxjs/toolkit, http-proxy, markdown-it-anchor, jwt-decode, url-join
+chart.js, @fortawesome/fontawesome-free, csstype, nprogress, protobufjs, knex, @nestjs/platform-express, cosmiconfig
+bs58, formik, require-dir, underscore.string, react-dnd-html5-backend, throttle-debounce, clipboard, pkg-dir
+lodash.throttle, get-port, fastify, node-emoji, koa-static, @storybook/react-vite, uppercamelcase, estraverse
+stream-browserify, dateformat, @openzeppelin/contracts, systemjs, lolex, p-limit, amqplib, validate-npm-package-name
+redux-saga, color-convert, @stdlib/bench, koa-bodyparser, strip-json-comments, framer-motion, monaco-editor, nightwatch
+escodegen, reselect, mock-fs, helmet, anymatch, is-ci, @open-wc/testing, ansi-colors
+nuxt, react-color, @mdx-js/react, elliptic, swiper, nunjucks, mqtt, @playwright/test
+@octokit/rest, kleur, redux-logger, consola, chai-spies, lit-html, sprintf-js, read-pkg-up
+unified, command-line-args, jest-fetch-mock, bcryptjs, mobx-react, sortablejs, localforage, @apollo/client
+app-root-path, base64-js, xmldom, dedent, react-markdown, react-popper, @capacitor/core, tinycolor2
+tough-cookie, pako, tweetnacl, vows, leaflet, acorn-jsx, braces, serve-favicon
+object-hash, pretty-bytes, @solana/web3.js, serialize-javascript, is-plain-object, html2canvas, @ckeditor/ckeditor5-autoformat, @web/test-runner
+numeral, url-parse, merge, parse5, mitt, @uniswap/v2-core, hapi, recompose
+recursive-readdir, hammerjs, react-use, solid-js, styled-jsx, @vercel/og, satori, twin.macro
+@ag-grid-community/core, karma-jasmine, qunit, @testing-library/vue, @testing-library/angular, @testing-library/svelte, @testing-library/preact, storybook
+cookies, csurf, errorhandler, helmet-csp, hsts, hide-powered-by, formidable, telnet-client
+ftp, jose, node-jose, ldapjs, sqlite3, better-sqlite3, mssql, oracledb
+pg-promise, aws-cdk-lib, @aws-sdk/client-ses, cdk8s, cdk8s-plus-25, @pulumi/aws, @pulumi/pulumi, @cdktf/provider-aws
+libxmljs, libxmljs2, extract-zip, yauzl, dompurify, isomorphic-dompurify, swig, kramed
+strapi-utils, @strapi/utils, viem, tronweb, obsidian, jest-mock, @vitest/browser, @vitest/ui
+@vitest/coverage-v8, @vitest/coverage-istanbul, chai-http, playwright, @playwright/experimental-ct-react, @playwright/experimental-ct-vue, @playwright/experimental-ct-svelte, @playwright/experimental-ct-solid
+@cypress/react, @cypress/vue, @cypress/angular, @cypress/svelte, jasmine-browser-runner, @jasminejs/reporters, @nestjs/platform-fastify, @nestjs/config
+@nestjs/swagger, @nestjs/graphql, @nestjs/microservices, @nestjs/websockets, @sveltejs/vite-plugin-svelte, @angular/compiler, @angular/elements, pinia
+@vue/compiler-sfc, @vue/server-renderer, @vue/compat, vue-template-compiler, vue-server-renderer, @solidjs/router, @solidjs/start, vite-plugin-solid
+babel-preset-solid, @tailwindcss/postcss, @tailwindcss/vite, @tailwindcss/cli, @tailwindcss/forms, @tailwindcss/typography, postcss-scss, postcss-js
+node:assert, node:assert/strict, node:async_hooks, node:buffer, node:child_process, node:cluster, node:console, node:constants
+node:crypto, node:dgram, node:diagnostics_channel, node:dns, node:dns/promises, node:domain, node:events, node:fs
+node:fs/promises, node:http, node:http2, node:https, node:inspector, node:inspector/promises, node:module, node:net
+node:os, node:path, node:path/posix, node:path/win32, node:perf_hooks, node:process, node:punycode, node:querystring
+node:readline, node:readline/promises, node:repl, node:sea, node:sqlite, node:stream, node:stream/consumers, node:stream/promises
+node:stream/web, node:string_decoder, node:sys, node:test, node:test/reporters, node:timers, node:timers/promises, node:tls
+node:trace_events, node:tty, node:url, node:util, node:util/types, node:v8, node:vm, node:wasi
+node:worker_threads, node:zlib, bun, bun:ffi, bun:jsc, bun:sqlite, bun:test
+`
+    .trim()
+    .split(/[,\s]+/),
+);
+
+const RUNTIME_ALLOWLIST = new Set(
+  [...ALLOWLIST].filter(
+    name => name === 'bun' || name.startsWith('bun:') || name.startsWith('node:'),
+  ),
+);
+const PACKAGE_ALLOWLIST = new Set([...ALLOWLIST].filter(name => !RUNTIME_ALLOWLIST.has(name)));
+const BARE_NODE_BUILTINS = new Map<string, string>();
+
+for (const builtin of builtinModules) {
+  const bare = builtin.startsWith('node:') ? builtin.slice('node:'.length) : builtin;
+  const canonical = `node:${bare}`;
+  if (RUNTIME_ALLOWLIST.has(canonical)) {
+    BARE_NODE_BUILTINS.set(bare, canonical);
+  }
+}
+
+const PACKAGE_NAME_PART = /^[a-z0-9][a-z0-9._~-]*$/;
+
+/**
+ * Returns only canonical, allowlisted package and runtime names used by the supplied imports.
+ *
+ * Ordinary packages must also be exact direct manifest keys. This limits telemetry to known
+ * ecosystem names and avoids collecting private package names, local paths, or aliases.
+ */
+export function collectPackageImports(
+  moduleSpecifiers: ReadonlySet<string>,
+  dependencies: DependenciesList,
+): Set<string> {
+  const result = new Set<string>();
+
+  for (const specifier of moduleSpecifiers) {
+    if (RUNTIME_ALLOWLIST.has(specifier)) {
+      result.add(specifier);
+      continue;
+    }
+
+    const builtin = BARE_NODE_BUILTINS.get(specifier);
+    if (builtin !== undefined) {
+      result.add(builtin);
+      continue;
+    }
+
+    const inlineNpmImport = parseInlineNPMImport(specifier);
+    if (inlineNpmImport !== undefined) {
+      if (PACKAGE_ALLOWLIST.has(inlineNpmImport.packageName)) {
+        result.add(inlineNpmImport.packageName);
+      }
+      continue;
+    }
+
+    const packageName = packageRoot(specifier);
+    if (
+      packageName !== undefined &&
+      PACKAGE_ALLOWLIST.has(packageName) &&
+      dependencies.has(packageName)
+    ) {
+      result.add(packageName);
+    }
+  }
+
+  return result;
+}
+
+function packageRoot(specifier: string): string | undefined {
+  if (
+    specifier.length === 0 ||
+    specifier.startsWith('.') ||
+    specifier.startsWith('/') ||
+    specifier.startsWith('#') ||
+    specifier.includes('\\') ||
+    specifier.includes(':')
+  ) {
+    return undefined;
+  }
+
+  const segments = specifier.split('/');
+  const rootLength = specifier.startsWith('@') ? 2 : 1;
+  const rootSegments = segments.slice(0, rootLength);
+  const subpathSegments = segments.slice(rootLength);
+
+  if (
+    rootSegments.length !== rootLength ||
+    !rootSegments.every((part, index) =>
+      PACKAGE_NAME_PART.test(index === 0 && part.startsWith('@') ? part.slice(1) : part),
+    ) ||
+    subpathSegments.some(part => part === '' || part === '.' || part === '..')
+  ) {
+    return undefined;
+  }
+
+  return rootSegments.join('/');
+}

--- a/packages/analysis/src/telemetry.ts
+++ b/packages/analysis/src/telemetry.ts
@@ -99,6 +99,7 @@ export type ProjectAnalysisTelemetry = {
   esmFileCount: number;
   cjsFileCount: number;
   denoImportCounts: Record<string, number>;
+  packageImportFileCounts: Record<string, number>;
   generatedSources: GeneratedSourcesTelemetry;
 };
 
@@ -134,6 +135,7 @@ export class ProjectAnalysisTelemetryCollector {
   private esmFileCount = 0;
   private cjsFileCount = 0;
   private readonly denoImportCountsByProtocol = new Map<string, number>();
+  private readonly packageImportFiles = new Map<string, Set<string>>();
   private generatedSources = createEmptyGeneratedSourcesTelemetry();
 
   constructor() {
@@ -177,6 +179,17 @@ export class ProjectAnalysisTelemetryCollector {
     this.denoImportCountsByProtocol.set(protocol, currentCount + 1);
   }
 
+  recordPackageImports(filePath: string, packageNames: Iterable<string>): void {
+    for (const packageName of packageNames) {
+      let files = this.packageImportFiles.get(packageName);
+      if (files === undefined) {
+        files = new Set();
+        this.packageImportFiles.set(packageName, files);
+      }
+      files.add(filePath);
+    }
+  }
+
   recordModuleType(moduleType: ModuleType | undefined) {
     if (moduleType === 'module') {
       this.esmFileCount += 1;
@@ -210,6 +223,11 @@ export class ProjectAnalysisTelemetryCollector {
       esmFileCount: this.esmFileCount,
       cjsFileCount: this.cjsFileCount,
       denoImportCounts: Object.fromEntries(this.denoImportCountsByProtocol),
+      packageImportFileCounts: Object.fromEntries(
+        [...this.packageImportFiles]
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([packageName, files]) => [packageName, files.size]),
+      ),
       generatedSources: cloneGeneratedSourcesTelemetry(this.generatedSources),
     };
   }

--- a/packages/analysis/tests/analyzeProject-sonarqube.test.ts
+++ b/packages/analysis/tests/analyzeProject-sonarqube.test.ts
@@ -297,6 +297,7 @@ describe('SonarQube project analysis', () => {
           esmFileCount: 0,
           cjsFileCount: 0,
           denoImportCounts: {},
+          packageImportFileCounts: {},
           generatedSources: {
             familyCount: 0,
             resolvedFileCount: 0,

--- a/packages/analysis/tests/jsts/rules/helpers/module.test.ts
+++ b/packages/analysis/tests/jsts/rules/helpers/module.test.ts
@@ -1,0 +1,73 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { expect } from 'expect';
+import { Linter, type Rule } from 'eslint';
+import { getCurrentFileImports } from '../../../../src/jsts/rules/helpers/module.js';
+
+describe('getCurrentFileImports', () => {
+  it('collects literal module references throughout a file', () => {
+    let imports = new Set<string>();
+    const captureImports: Rule.RuleModule = {
+      create(context) {
+        return {
+          Program() {
+            imports = new Set(getCurrentFileImports(context.sourceCode));
+          },
+        };
+      },
+    };
+
+    new Linter().verify(
+      `
+        import value from 'static-import';
+        export { value } from 'named-export';
+        export * from 'all-export';
+        require('standalone-require');
+        function load() {
+          return import('nested-dynamic').then(module => module.default);
+        }
+      `,
+      {
+        languageOptions: {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+        },
+        plugins: {
+          test: {
+            rules: {
+              captureImports,
+            },
+          },
+        },
+        rules: {
+          'test/captureImports': 'error',
+        },
+      },
+    );
+
+    expect(imports).toEqual(
+      new Set([
+        'static-import',
+        'named-export',
+        'all-export',
+        'standalone-require',
+        'nested-dynamic',
+      ]),
+    );
+  });
+});

--- a/packages/analysis/tests/package-imports.test.ts
+++ b/packages/analysis/tests/package-imports.test.ts
@@ -1,0 +1,61 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { expect } from 'expect';
+import { collectPackageImports } from '../src/package-imports.js';
+
+describe('package import telemetry', () => {
+  it('normalizes direct npm dependency subpaths', () => {
+    const imports = new Set(['react/jsx-runtime', '@angular/core/testing']);
+    const dependencies = new Map([
+      ['react', '^19.0.0'],
+      ['@angular/core', '^20.0.0'],
+    ]);
+
+    expect(collectPackageImports(imports, dependencies)).toEqual(
+      new Set(['react', '@angular/core']),
+    );
+  });
+
+  it('accepts inline npm and runtime imports without manifests', () => {
+    const imports = new Set([
+      'npm:react@19.0.0/jsx-runtime',
+      'fs/promises',
+      'node:test',
+      'bun:test',
+    ]);
+
+    expect(collectPackageImports(imports, new Map())).toEqual(
+      new Set(['react', 'node:fs/promises', 'node:test', 'bun:test']),
+    );
+  });
+
+  it('rejects undeclared packages and private module names', () => {
+    const imports = new Set([
+      'react',
+      '@company/private',
+      'components/Button',
+      './local.js',
+      '#internal',
+      'https://example.com/module.js',
+      'jsr:@std/assert',
+      'bun:wrap',
+    ]);
+
+    expect(collectPackageImports(imports, new Map())).toEqual(new Set());
+  });
+});

--- a/packages/analysis/tests/telemetry.test.ts
+++ b/packages/analysis/tests/telemetry.test.ts
@@ -180,4 +180,16 @@ describe('project analysis telemetry', () => {
       ],
     });
   });
+
+  it('should count unique files importing each package', () => {
+    const collector = new ProjectAnalysisTelemetryCollector();
+    collector.recordPackageImports('/project/a.ts', ['react', '@angular/core']);
+    collector.recordPackageImports('/project/a.ts', ['react']);
+    collector.recordPackageImports('/project/b.ts', ['react']);
+
+    expect(collector.getTelemetry().packageImportFileCounts).toEqual({
+      '@angular/core': 1,
+      react: 2,
+    });
+  });
 });

--- a/packages/grpc/src/analyze-project-convert.ts
+++ b/packages/grpc/src/analyze-project-convert.ts
@@ -165,6 +165,7 @@ function toTelemetry(
     cjsFileCount: telemetry.cjsFileCount,
     denoImportCounts: telemetry.denoImportCounts,
     generatedSources: toGeneratedSourcesTelemetry(telemetry.generatedSources),
+    packageImportFileCounts: telemetry.packageImportFileCounts,
   };
 }
 

--- a/packages/grpc/src/proto/analyze-project.proto
+++ b/packages/grpc/src/proto/analyze-project.proto
@@ -280,6 +280,7 @@ message ProjectAnalysisTelemetry {
   int32 cjs_file_count = 7;
   map<string, int32> deno_import_counts = 8;
   GeneratedSourcesTelemetry generated_sources = 9;
+  map<string, int32> package_import_file_counts = 10;
 }
 
 message ProgramCreationTelemetry {

--- a/packages/grpc/tests/analyze-project-convert.test.ts
+++ b/packages/grpc/tests/analyze-project-convert.test.ts
@@ -38,6 +38,9 @@ function createProjectAnalysisTelemetry() {
     esmFileCount: 0,
     cjsFileCount: 0,
     denoImportCounts: {},
+    packageImportFileCounts: {
+      react: 2,
+    },
     generatedSources: {
       familyCount: 1,
       resolvedFileCount: 4,
@@ -84,6 +87,9 @@ describe('analyze-project convert', () => {
     expect(toPlainTelemetryValue(decodedUnary.meta?.telemetry?.generatedSources)).toEqual(
       telemetry.generatedSources,
     );
+    expect(decodedUnary.meta?.telemetry?.packageImportFileCounts).toEqual(
+      telemetry.packageImportFileCounts,
+    );
 
     const streamResponse = toAnalyzeProjectStreamResponse(
       {
@@ -101,6 +107,9 @@ describe('analyze-project convert', () => {
 
     expect(toPlainTelemetryValue(decodedStream.meta?.telemetry?.generatedSources)).toEqual(
       telemetry.generatedSources,
+    );
+    expect(decodedStream.meta?.telemetry?.packageImportFileCounts).toEqual(
+      telemetry.packageImportFileCounts,
     );
   });
 });

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/PluginTelemetry.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/PluginTelemetry.java
@@ -36,6 +36,7 @@ public class PluginTelemetry {
   private static final String TELEMETRY_PREFIX = KEY_PREFIX + "telemetry.";
   private static final String GENERATED_SOURCES_PREFIX = TELEMETRY_PREFIX + "generated-sources.";
   private static final String MODULE_TYPE_PREFIX = TELEMETRY_PREFIX + "module-type.";
+  private static final String IMPORT_PREFIX = TELEMETRY_PREFIX + "import.";
 
   private final BridgeServer server;
   private final JsTsContext<?> ctx;
@@ -148,6 +149,14 @@ public class PluginTelemetry {
       Integer.toString(projectAnalysisTelemetry.getCjsFileCount())
     );
 
+    keyMapToSave.put(IMPORT_PREFIX + "schema-version", "1");
+    projectAnalysisTelemetry.getPackageImportFileCountsMap().forEach((packageName, fileCount) -> {
+      var telemetryKey = packageImportTelemetryKey(packageName);
+      if (telemetryKey != null && fileCount > 0) {
+        keyMapToSave.put(telemetryKey, Integer.toString(fileCount));
+      }
+    });
+
     if (projectAnalysisTelemetry.hasGeneratedSources()) {
       var generatedSources = projectAnalysisTelemetry.getGeneratedSources();
       keyMapToSave.put(
@@ -189,6 +198,26 @@ public class PluginTelemetry {
       return;
     }
     addValueList(keyMapToSave, TELEMETRY_PREFIX + "typescript.compiler-options." + option, values);
+  }
+
+  @Nullable
+  private static String packageImportTelemetryKey(String packageName) {
+    if (packageName.startsWith("node:")) {
+      return IMPORT_PREFIX + "builtin.node." + packageName.substring(5).replace('/', '.');
+    }
+    if (packageName.equals("bun")) {
+      return IMPORT_PREFIX + "builtin.bun";
+    }
+    if (packageName.startsWith("bun:")) {
+      return IMPORT_PREFIX + "builtin.bun." + packageName.substring(4).replace('/', '.');
+    }
+    if (packageName.matches("[a-z0-9][a-z0-9._~-]*")) {
+      return IMPORT_PREFIX + packageName;
+    }
+    if (packageName.matches("@[a-z0-9][a-z0-9._~-]*/[a-z0-9][a-z0-9._~-]*")) {
+      return IMPORT_PREFIX + "scoped." + packageName.substring(1).replace('/', '.');
+    }
+    return null;
   }
 
   private static void addValueList(

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/PluginTelemetryTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/PluginTelemetryTest.java
@@ -111,6 +111,22 @@ class PluginTelemetryTest {
       )
       .setEsmFileCount(4)
       .setCjsFileCount(1)
+      .putAllPackageImportFileCounts(
+        Map.of(
+          "react",
+          3,
+          "@angular/core",
+          2,
+          "node:test",
+          1,
+          "bun:test",
+          4,
+          "../private",
+          5,
+          "vue",
+          0
+        )
+      )
       .build();
 
     new PluginTelemetry(jsTsContext, server, projectTelemetry).reportTelemetry();
@@ -156,6 +172,13 @@ class PluginTelemetryTest {
     );
     verify(ctx).addTelemetryProperty("javascript.telemetry.module-type.esm-file-count", "4");
     verify(ctx).addTelemetryProperty("javascript.telemetry.module-type.cjs-file-count", "1");
-    verify(ctx, times(17)).addTelemetryProperty(anyString(), anyString());
+    verify(ctx).addTelemetryProperty("javascript.telemetry.import.schema-version", "1");
+    verify(ctx).addTelemetryProperty("javascript.telemetry.import.react", "3");
+    verify(ctx).addTelemetryProperty("javascript.telemetry.import.scoped.angular.core", "2");
+    verify(ctx).addTelemetryProperty("javascript.telemetry.import.builtin.node.test", "1");
+    verify(ctx).addTelemetryProperty("javascript.telemetry.import.builtin.bun.test", "4");
+    verify(ctx, never()).addTelemetryProperty("javascript.telemetry.import...private", "5");
+    verify(ctx, never()).addTelemetryProperty("javascript.telemetry.import.vue", "0");
+    verify(ctx, times(22)).addTelemetryProperty(anyString(), anyString());
   }
 }


### PR DESCRIPTION
## Summary

- collect literal JS/TS package imports from static imports, exports, `require`, dynamic imports, and TypeScript import-equals declarations
- limit telemetry to a checked-in 655-name public allowlist, direct manifest dependencies, npm specifiers, and public Node/Bun built-ins
- aggregate unique importing-file counts and emit bounded `javascript.telemetry.import.*` properties through the typed gRPC telemetry pipeline

## Privacy

Unknown, private, local, relative, absolute, URL-based, and undeclared path-aliased module names are discarded locally and never enter telemetry.

## Test plan

- `npm run bbf`
- focused package import, telemetry collector, module extraction, and gRPC conversion tests
- `mvn -pl sonar-plugin/sonar-javascript-plugin -am -Dtest=PluginTelemetryTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `uc check` (all pre-PR checks passed; the Sonar issues step required an open PR)

## Links

- Jira: https://sonarsource.atlassian.net/browse/JS-2148