### PR TITLE
JS-2151 Improve S1135: ignore TODO comments anchored by Jira issue keys

### DIFF
--- a/its/ruling/src/test/expected/eigen/typescript-S1135.json
+++ b/its/ruling/src/test/expected/eigen/typescript-S1135.json
@@ -89,57 +89,13 @@
 15
 ],
 "eigen:src/app/Scenes/City/City.tsx": [
-171,
-255
-],
-"eigen:src/app/Scenes/City/CityBMWList.tsx": [
-49
-],
-"eigen:src/app/Scenes/City/CityFairList.tsx": [
-60
-],
-"eigen:src/app/Scenes/City/CityPicker.tsx": [
-45
-],
-"eigen:src/app/Scenes/City/CitySavedList.tsx": [
-52
-],
-"eigen:src/app/Scenes/City/CitySectionList.tsx": [
-75
-],
-"eigen:src/app/Scenes/City/Components/AllEvents.tsx": [
-227
-],
-"eigen:src/app/Scenes/City/Components/EventList.tsx": [
-37
-],
-"eigen:src/app/Scenes/City/Components/FairEventSection/Components/FairEventSectionCard.tsx": [
-19
-],
-"eigen:src/app/Scenes/City/Components/SavedEventSection/index.tsx": [
-27
+171
 ],
 "eigen:src/app/Scenes/City/Components/TabFairItemRow/index.tests.tsx": [
-9,
-10
+9
 ],
 "eigen:src/app/Scenes/Fair/Components/SimpleTabs.tsx": [
 41
-],
-"eigen:src/app/Scenes/Fair/FairBMWArtActivation.tsx": [
-51
-],
-"eigen:src/app/Scenes/Favorites/FavoriteArtists.tsx": [
-62
-],
-"eigen:src/app/Scenes/Favorites/FavoriteArtworks.tsx": [
-77
-],
-"eigen:src/app/Scenes/Favorites/FavoriteCategories.tsx": [
-62
-],
-"eigen:src/app/Scenes/Favorites/FavoriteShows.tsx": [
-61
 ],
 "eigen:src/app/Scenes/Inbox/Components/Conversations/Messages.tsx": [
 116
@@ -150,7 +106,6 @@
 ],
 "eigen:src/app/Scenes/Map/GlobalMap.tsx": [
 214,
-547,
 688
 ],
 "eigen:src/app/Scenes/MyBids/MyBids.tsx": [

--- a/packages/analysis/src/jsts/rules/CHANGELOG.md
+++ b/packages/analysis/src/jsts/rules/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2026-07-14, Version 4.2.0
 
+- [[JS-2151](https://sonarsource.atlassian.net/browse/JS-2151)] - Improve S1135 (`todo-tag`): ignore TODO comments anchored by Jira issue keys
 - [[JS-2043](https://sonarsource.atlassian.net/browse/JS-2043)] - S8988: Create decorated rule for `vue/no-side-effects-in-computed-properties`
 - [[JS-2018](https://sonarsource.atlassian.net/browse/JS-2018)] - Fix S2699 Node assert strict detection
 - [[JS-2016](https://sonarsource.atlassian.net/browse/JS-2016)] - S8984: Import `vue/valid-v-for` as an external rule

--- a/packages/analysis/src/jsts/rules/CHANGELOG.md
+++ b/packages/analysis/src/jsts/rules/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 2026-07-14, Version 4.2.0
 
-- [[JS-2151](https://sonarsource.atlassian.net/browse/JS-2151)] - Improve S1135 (`todo-tag`): ignore TODO comments anchored by Jira issue keys
 - [[JS-2043](https://sonarsource.atlassian.net/browse/JS-2043)] - S8988: Create decorated rule for `vue/no-side-effects-in-computed-properties`
 - [[JS-2018](https://sonarsource.atlassian.net/browse/JS-2018)] - Fix S2699 Node assert strict detection
 - [[JS-2016](https://sonarsource.atlassian.net/browse/JS-2016)] - S8984: Import `vue/valid-v-for` as an external rule

--- a/packages/analysis/src/jsts/rules/S1134/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1134/unit.test.ts
@@ -86,6 +86,18 @@ describe('S1134', () => {
           errors: 1,
         },
         {
+          code: `// FIXME(JS-1234): remove this later`,
+          errors: [
+            {
+              message: 'Take the required action to fix the issue indicated by this comment.',
+              line: 1,
+              endLine: 1,
+              column: 4,
+              endColumn: 9,
+            },
+          ],
+        },
+        {
           code: `
       // FIXME just fix me 
 

--- a/packages/analysis/src/jsts/rules/S1135/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1135/rule.ts
@@ -23,6 +23,9 @@ import * as meta from './generated-meta.js';
 
 const todoPattern = 'todo';
 const letterPattern = /[\p{Letter}]/u;
+const jiraIssueKeyPattern = /\b[A-Z][A-Z0-9]+-\d+\b/u;
+
+type IgnorePatternMatch = (line: string, start: number, pattern: string) => boolean;
 
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta, {
@@ -33,7 +36,7 @@ export const rule: Rule.RuleModule = {
   create(context: Rule.RuleContext) {
     return {
       'Program:exit': () => {
-        reportPatternInComment(context, todoPattern, 'completeTODO');
+        reportPatternInComment(context, todoPattern, 'completeTODO', isJiraAnchoredTodo);
       },
     };
   },
@@ -43,28 +46,42 @@ export function reportPatternInComment(
   context: Rule.RuleContext,
   pattern: string,
   messageId: string,
+  shouldIgnoreMatch: IgnorePatternMatch = () => false,
 ) {
   const sourceCode = context.sourceCode;
   for (const comment of sourceCode.getAllComments() as TSESTree.Comment[]) {
     if (comment.value.trim().startsWith('eslint-disable')) {
       continue;
     }
-    const rawText = comment.value.toLowerCase();
+    const lines = comment.value.split(/\r\n?|\n/);
 
-    if (rawText.includes(pattern)) {
-      const lines = rawText.split(/\r\n?|\n/);
+    for (const [i, originalLine] of lines.entries()) {
+      const line = originalLine.toLowerCase();
+      const index = line.indexOf(pattern);
 
-      for (const [i, line] of lines.entries()) {
-        const index = line.indexOf(pattern);
-        if (index >= 0 && !isLetterAround(line, index, pattern)) {
-          context.report({
-            messageId,
-            loc: getPatternPosition(i, index, comment, pattern),
-          });
-        }
+      if (
+        index >= 0 &&
+        !isLetterAround(line, index, pattern) &&
+        !shouldIgnoreMatch(originalLine, index, pattern)
+      ) {
+        context.report({
+          messageId,
+          loc: getPatternPosition(i, index, comment, pattern),
+        });
       }
     }
   }
+}
+
+/**
+ * Checks whether a TODO is followed by a Jira issue key on the same line.
+ * @param line The original comment line.
+ * @param start The start index of the matched TODO marker.
+ * @param pattern The tracked marker.
+ * @return `true` when the TODO should be ignored.
+ */
+function isJiraAnchoredTodo(line: string, start: number, pattern: string) {
+  return jiraIssueKeyPattern.test(line.slice(start + pattern.length));
 }
 
 function isLetterAround(line: string, start: number, pattern: string) {

--- a/packages/analysis/src/jsts/rules/S1135/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1135/unit.test.ts
@@ -49,6 +49,15 @@ describe('S1135', () => {
         // TODO whatever
         `,
         },
+        {
+          code: `// TODO JS-1234 remove this later`,
+        },
+        {
+          code: `// ToDo(JS-1234): remove this later`,
+        },
+        {
+          code: `/* TODO APPSEC-42 remove this later */`,
+        },
       ],
       invalid: [
         {
@@ -97,6 +106,18 @@ describe('S1135', () => {
         {
           code: `// TODO  TODO`,
           errors: 1,
+        },
+        {
+          code: `// TODO task-123 remove this later`,
+          errors: [
+            {
+              message: 'Complete the task associated to this "TODO" comment.',
+              line: 1,
+              endLine: 1,
+              column: 4,
+              endColumn: 8,
+            },
+          ],
         },
         {
           code: `

--- a/packages/analysis/src/jsts/rules/S1135/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1135/unit.test.ts
@@ -58,6 +58,12 @@ describe('S1135', () => {
         {
           code: `/* TODO APPSEC-42 remove this later */`,
         },
+        {
+          code: `// Temporary fix. (TODO PROJ-123 improve method)`,
+        },
+        {
+          code: `// TODO fix this. See PROJ-123.`,
+        },
       ],
       invalid: [
         {


### PR DESCRIPTION
## Summary
S1135 was still raising on TODO comments that were already anchored to Jira follow-up work. This change ignores Jira-backed TODOs while keeping plain TODOs and non-Jira lookalikes reportable.

## Changes
- Add an S1135-specific Jira-key exemption without widening the shared S1134 comment scanning behavior.
- Cover Jira-anchored single-line, block-comment, and mixed-case TODO forms, plus a non-Jira hyphenated token that must still raise.
- Record the rule behavior change in the rules changelog.

