### PR TITLE
JS-2168 NO-JIRA Align S8959 with partial quickfix metadata

### DIFF
--- a/packages/analysis/src/jsts/rules/S8959/meta.ts
+++ b/packages/analysis/src/jsts/rules/S8959/meta.ts
@@ -16,4 +16,3 @@
  */
 export const implementation = 'original';
 export const eslintId = 'no-debug-commands-in-ui-tests';
-export const quickFixMessage = 'Remove this debug command';

--- a/packages/analysis/src/jsts/rules/S8959/rule.ts
+++ b/packages/analysis/src/jsts/rules/S8959/rule.ts
@@ -18,11 +18,10 @@
 
 import type { Rule } from 'eslint';
 import type estree from 'estree';
-import { hasParent, isIdentifier, isMethodCall } from '../helpers/ast.js';
+import { isIdentifier, isMethodCall } from '../helpers/ast.js';
 import { chainStartsWithCy } from '../helpers/cypress.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
-import { removeNodeWithLeadingWhitespaces } from '../helpers/quickfix.js';
 import { isTestRelatedFile } from '../helpers/test-file-pattern.js';
 import * as meta from './generated-meta.js';
 
@@ -48,7 +47,6 @@ export const rule: Rule.RuleModule = {
     messages: {
       removeDebugCommand: 'Remove this debug command from the test.',
     },
-    fixable: 'code',
   }),
   create(context: Rule.RuleContext) {
     if (!isTestRelatedFile(context.filename, context.settings?.testFileExtensions as string[])) {
@@ -60,10 +58,10 @@ export const rule: Rule.RuleModule = {
         const call = node as estree.CallExpression;
         if (isMethodCall(call)) {
           if (isUiTestDebugCommand(context, call)) {
-            reportDebugCommand(context, call, call.callee.property);
+            reportDebugCommand(context, call.callee.property);
           }
         } else if (isTestingLibraryDebugCommand(context, call)) {
-          reportDebugCommand(context, call, call.callee);
+          reportDebugCommand(context, call.callee);
         }
       },
     };
@@ -109,76 +107,9 @@ function isTestingLibraryDebugCommand(
   });
 }
 
-function reportDebugCommand(
-  context: Rule.RuleContext,
-  call: estree.CallExpression,
-  reportNode: estree.Node,
-) {
+function reportDebugCommand(context: Rule.RuleContext, reportNode: estree.Node) {
   context.report({
     node: reportNode,
     messageId: 'removeDebugCommand',
-    fix: fixer => removeDebugCommand(context, call, fixer),
   });
-}
-
-/**
- * Removes the whole statement only for root debug calls used as standalone statements, e.g.
- * `cy.pause();`, `await page.pause();`, `screen.debug();`, or `prettyDOM(el);`. For Cypress chains, only the `.pause()`/`.debug()`
- * link is spliced out, e.g. `cy.get('x').debug().click();` -> `cy.get('x').click();` and
- * `cy.get('x').pause();` -> `cy.get('x');`.
- */
-function removeDebugCommand(
-  context: Rule.RuleContext,
-  call: estree.CallExpression,
-  fixer: Rule.RuleFixer,
-): Rule.Fix | null {
-  const statement = unwrapToStatementExpression(call);
-  if (call.callee.type === 'MemberExpression') {
-    if (isRootDebugReceiver(call.callee.object) && hasParent(statement)) {
-      const { parent } = statement;
-      if (parent.type === 'ExpressionStatement' && parent.expression === statement) {
-        return removeNodeWithLeadingWhitespaces(context, parent, fixer);
-      }
-    }
-    const objectRange = call.callee.object.range;
-    const callRange = call.range;
-    if (!objectRange || !callRange) {
-      return null;
-    }
-    return fixer.removeRange([objectRange[1], callRange[1]]);
-  } else if (hasParent(statement)) {
-    const { parent } = statement;
-    if (parent.type === 'ExpressionStatement' && parent.expression === statement) {
-      return removeNodeWithLeadingWhitespaces(context, parent, fixer);
-    }
-  }
-  return null;
-}
-
-function unwrapToStatementExpression(node: estree.Node): estree.Node {
-  let current = node;
-  while (hasParent(current)) {
-    const { parent } = current;
-    if (
-      (parent.type === 'ChainExpression' && parent.expression === current) ||
-      (parent.type === 'AwaitExpression' && parent.argument === current)
-    ) {
-      current = parent;
-    } else {
-      break;
-    }
-  }
-  return current;
-}
-
-function isRootDebugReceiver(node: estree.Node): boolean {
-  return isIdentifier(unwrapChainExpression(node), 'cy', 'page', 'screen');
-}
-
-function unwrapChainExpression(node: estree.Node): estree.Node {
-  let current = node;
-  while (current.type === 'ChainExpression') {
-    current = current.expression;
-  }
-  return current;
 }

--- a/packages/analysis/src/jsts/rules/S8959/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8959/unit.test.ts
@@ -138,12 +138,6 @@ describe('S8959', () => {
           `,
           filename: 'cypress/e2e/save-user.cy.js',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            it('saves a user', () => {
-              cy.get('button.save').click();
-              cy.contains('Saved').should('be.visible');
-            });
-          `,
         },
         {
           code: `
@@ -154,12 +148,6 @@ describe('S8959', () => {
           `,
           filename: 'cypress/e2e/save-user.cy.js',
           errors: [{ messageId: 'removeDebugCommand' }, { messageId: 'removeDebugCommand' }],
-          // only the first fix applies in a single pass, since the two statements are adjacent
-          output: `
-            it('uses Cypress debug helpers', () => {
-              cy.debug();
-            });
-          `,
         },
         {
           code: `
@@ -170,12 +158,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/save-user.spec.js',
           errors: [{ messageId: 'removeDebugCommand' }, { messageId: 'removeDebugCommand' }],
-          output: `
-            it('uses Cypress chain debug helpers', () => {
-              cy.get('button.save');
-              cy.contains('Saved');
-            });
-          `,
         },
         {
           code: `
@@ -185,11 +167,6 @@ describe('S8959', () => {
           `,
           filename: 'cypress/e2e/visit.cy.js',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            it('uses chained Cypress pause helpers', () => {
-              cy.visit('/');
-            });
-          `,
         },
         {
           code: `
@@ -199,11 +176,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/debug-tail.spec.js',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            it('keeps preceding Cypress chain when debug ends the statement', () => {
-              cy.contains('Saved');
-            });
-          `,
         },
         {
           code: `
@@ -213,10 +185,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/save-user.spec.ts',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            test('uses Playwright pause', async ({ page }) => {
-            });
-          `,
         },
         {
           code: `
@@ -226,10 +194,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/non-awaited.spec.ts',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            test('reports non-awaited Playwright pause', () => {
-            });
-          `,
         },
         {
           code: `
@@ -240,12 +204,6 @@ describe('S8959', () => {
           `,
           filename: 'cypress/e2e/save-user.cy.js',
           errors: [{ messageId: 'removeDebugCommand' }, { messageId: 'removeDebugCommand' }],
-          // only the first fix applies in a single pass, since the two statements are adjacent
-          output: `
-            it('uses Cypress debug helpers via optional chaining', () => {
-              cy?.get('button.save');
-            });
-          `,
         },
         {
           code: `
@@ -255,11 +213,6 @@ describe('S8959', () => {
           `,
           filename: 'cypress/e2e/optional-tail.cy.js',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            it('keeps optional Cypress chain tail when debug ends the statement', () => {
-              cy?.contains('Saved');
-            });
-          `,
         },
         {
           code: `
@@ -271,12 +224,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/tl-debug.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            import { screen } from '@testing-library/react';
-
-            test('uses Testing Library screen.debug', () => {
-            });
-          `,
         },
         {
           code: `
@@ -288,12 +235,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/tl-pure-debug.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            import { screen } from '@testing-library/react/pure';
-
-            test('uses Testing Library screen.debug from a subpath entrypoint', () => {
-            });
-          `,
         },
         {
           code: `
@@ -306,13 +247,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/tl-render-debug.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            import { render } from '@testing-library/react';
-
-            test('uses the debug method returned by render', () => {
-              const { debug } = render(<Component />);
-            });
-          `,
         },
         {
           code: `
@@ -324,13 +258,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/tl-render-inline-debug.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            import { render } from '@testing-library/react';
-
-            test('uses the debug method returned by render inline', () => {
-              render(<Component />);
-            });
-          `,
         },
         {
           code: `
@@ -342,12 +269,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/tl-playground.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }],
-          output: `
-            import { screen } from '@testing-library/react';
-
-            test('uses Testing Library logTestingPlaygroundURL', () => {
-            });
-          `,
         },
         {
           code: `
@@ -360,13 +281,6 @@ describe('S8959', () => {
           `,
           filename: 'tests/tl-helpers.test.tsx',
           errors: [{ messageId: 'removeDebugCommand' }, { messageId: 'removeDebugCommand' }],
-          output: `
-            import { prettyDOM, logRoles } from '@testing-library/dom';
-
-            test('uses Testing Library standalone prettyDOM and logRoles', () => {
-              logRoles(container);
-            });
-          `,
         },
       ],
     });

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S8959.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S8959.json
@@ -16,7 +16,7 @@
   "ruleSpecification": "RSPEC-8959",
   "sqKey": "S8959",
   "scope": "Tests",
-  "quickfix": "covered",
+  "quickfix": "partial",
   "compatibleLanguages": [
     "js",
     "ts"


### PR DESCRIPTION
## Summary
- align S8959 with refreshed RSPEC metadata that marks the rule as partial quickfix
- remove the ESLint autofix contract and quick-fix-only assertions from S8959
- update the rule metadata and tests so generate-meta and quickfix validation stay consistent

## Verification
- npm run generate-meta
- npm run eslint-plugin:check
- npm run validate-quickfix
- npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/src/jsts/rules/S8959/unit.test.ts