### PR TITLE
JS-2191 USER-2352 Support AWS CDK assertions in S2699

### DIFF
--- a/packages/analysis/src/jsts/rules/S2699/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2699/rule.ts
@@ -229,7 +229,7 @@ class TestCaseAssertionVisitor {
       return visitedTSNodes.get(node)!;
     }
     visitedTSNodes.set(node, false);
-    if (isTSAssertion(services, node)) {
+    if (isTSAssertion(services, node, this.context)) {
       visitedTSNodes.set(node, true);
       return true;
     }

--- a/packages/analysis/src/jsts/rules/S2699/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2699/rule.ts
@@ -38,7 +38,7 @@ import {
   hasSupportedTestFramework,
   isAssertion,
   isIncompleteShouldAccess,
-  isTSAssertion,
+  isTSAssertionWithAssignmentFallback,
 } from '../helpers/assertion-detection.js';
 import * as meta from './generated-meta.js';
 import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
@@ -229,7 +229,7 @@ class TestCaseAssertionVisitor {
       return visitedTSNodes.get(node)!;
     }
     visitedTSNodes.set(node, false);
-    if (isTSAssertion(services, node, this.context)) {
+    if (isTSAssertionWithAssignmentFallback(services, node, this.context)) {
       visitedTSNodes.set(node, true);
       return true;
     }

--- a/packages/analysis/src/jsts/rules/S2699/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2699/rule.ts
@@ -34,11 +34,11 @@ import {
   followTypeScriptCallToImplementation,
 } from '../helpers/call-to-declaration.js';
 import {
-  hasSupportedAssertionLibrary,
+  hasAssertionLibraryIncludingUnclassified,
   hasSupportedTestFramework,
-  isAssertion,
+  isAssertionIncludingUnclassified,
   isIncompleteShouldAccess,
-  isTSAssertionWithAssignmentFallback,
+  isTSAssertionIncludingUnclassified,
 } from '../helpers/assertion-detection.js';
 import * as meta from './generated-meta.js';
 import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
@@ -52,7 +52,7 @@ import ts from 'typescript';
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta),
   create(context: Rule.RuleContext) {
-    if (!hasSupportedTestFramework(context) || !hasSupportedAssertionLibrary(context)) {
+    if (!hasSupportedTestFramework(context) || !hasAssertionLibraryIncludingUnclassified(context)) {
       return {};
     }
     const visitedNodes: Map<estree.Node, boolean> = new Map();
@@ -229,7 +229,7 @@ class TestCaseAssertionVisitor {
       return visitedTSNodes.get(node)!;
     }
     visitedTSNodes.set(node, false);
-    if (isTSAssertionWithAssignmentFallback(services, node, this.context)) {
+    if (isTSAssertionIncludingUnclassified(this.context, services, node)) {
       visitedTSNodes.set(node, true);
       return true;
     }
@@ -273,7 +273,10 @@ class TestCaseAssertionVisitor {
       return visitedNodes.get(node)!;
     }
     visitedNodes.set(node, false);
-    if (isAssertion(context, node) && !isIncompleteShouldAccess(context, node)) {
+    if (
+      isAssertionIncludingUnclassified(context, node) &&
+      !isIncompleteShouldAccess(context, node)
+    ) {
       visitedNodes.set(node, true);
       return true;
     }

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -33,6 +33,18 @@ describe('S2699', () => {
       valid: [
         {
           code: `
+import test from 'node:test';
+import { Template } from 'aws-cdk-lib/assertions';
+
+test('recognizes AWS CDK template assertions', () => {
+  const template = Template.fromStack({});
+  template.hasResourceProperties('AWS::S3::Bucket', {});
+  template.resourceCountIs('AWS::S3::Bucket', 1);
+});
+`,
+        },
+        {
+          code: `
 import { test, expect } from 'bun:test';
 
 test('includes a Bun expectation', () => {
@@ -652,6 +664,18 @@ describe('async tests with RxJS finalize', () => {
     typedRuleTester.run('Test cases must have assertions', rule, {
       valid: [
         {
+          code: `
+import test from 'node:test';
+import { Template } from 'aws-cdk-lib/assertions';
+
+test('recognizes typed AWS CDK template assertions', () => {
+  const template = Template.fromStack({});
+  template.hasResourceProperties('AWS::S3::Bucket', {});
+  template.resourceCountIs('AWS::S3::Bucket', 1);
+});
+`,
+        },
+        {
           code: `import { Mock } from "vitest";
           const input = Math.sqrt(4)
 describe('no import from test library', () => {
@@ -1064,6 +1088,17 @@ test('member-based playwright expect entrypoints', async ({ page }) => {
         },
       ],
       invalid: [
+        {
+          code: `
+import test from 'node:test';
+import { Template } from 'aws-cdk-lib/assertions';
+
+test('does not treat Template setup as an assertion', () => {
+  Template.fromStack({});
+});
+`,
+          errors: 1,
+        },
         {
           code: `
 import test from 'node:test';

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -1182,6 +1182,24 @@ test('does not treat AWS CDK template query APIs as assertions', () => {
         {
           code: `
 import test from 'node:test';
+import { Match } from 'aws-cdk-lib/assertions';
+
+class Template {
+  static fromStack(stack: unknown) {
+    return new Template();
+  }
+  hasResourceProperties(type: string, props: unknown) {}
+}
+
+test('does not treat a local Template look-alike as an assertion', () => {
+  Template.fromStack({}).hasResourceProperties('AWS::S3::Bucket', {});
+});
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import test from 'node:test';
 import assert from 'node:assert/strict';
 
 test('has no assertions', () => {

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -703,6 +703,21 @@ test('recognizes typed AWS CDK template assertions', () => {
         },
         {
           code: `
+import test, { beforeEach } from 'node:test';
+import { Template } from 'aws-cdk-lib/assertions';
+
+let template: Template;
+beforeEach(() => {
+  template = Template.fromStack({});
+});
+
+test('recognizes setup-initialized AWS CDK assertions', () => {
+  template.hasResourceProperties('AWS::S3::Bucket', {});
+});
+`,
+        },
+        {
+          code: `
 import test from 'node:test';
 import { Annotations, Tags, Template } from 'aws-cdk-lib/assertions';
 

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -45,6 +45,32 @@ test('recognizes AWS CDK template assertions', () => {
         },
         {
           code: `
+import test from 'node:test';
+import { Annotations, Tags, Template } from 'aws-cdk-lib/assertions';
+
+test('recognizes documented AWS CDK assertion APIs', () => {
+  Template.fromStack({}).resourcePropertiesCountIs('AWS::S3::Bucket', {}, 1);
+  Template.fromJSON({}).hasResource('AWS::S3::Bucket', {});
+  Template.fromJSON({}).allResources('AWS::S3::Bucket', {});
+  Template.fromJSON({}).allResourcesProperties('AWS::S3::Bucket', {});
+  Template.fromJSON({}).hasParameter('parameter', {});
+  Template.fromJSON({}).hasOutput('output', {});
+  Template.fromJSON({}).hasMapping('mapping', {});
+  Template.fromJSON({}).hasCondition('condition', {});
+  Template.fromString('{}').templateMatches({});
+  Annotations.fromStack({}).hasError('*', 'error');
+  Annotations.fromStack({}).hasNoError('*', 'error');
+  Annotations.fromStack({}).hasWarning('*', 'warning');
+  Annotations.fromStack({}).hasNoWarning('*', 'warning');
+  Annotations.fromStack({}).hasInfo('*', 'info');
+  Annotations.fromStack({}).hasNoInfo('*', 'info');
+  Tags.fromStack({}).hasValues({});
+  Tags.fromStack({}).hasNone();
+});
+`,
+        },
+        {
+          code: `
 import { test, expect } from 'bun:test';
 
 test('includes a Bun expectation', () => {
@@ -676,6 +702,32 @@ test('recognizes typed AWS CDK template assertions', () => {
 `,
         },
         {
+          code: `
+import test from 'node:test';
+import { Annotations, Tags, Template } from 'aws-cdk-lib/assertions';
+
+test('recognizes typed AWS CDK assertion APIs', () => {
+  Template.fromStack({}).resourcePropertiesCountIs('AWS::S3::Bucket', {}, 1);
+  Template.fromJSON({}).hasResource('AWS::S3::Bucket', {});
+  Template.fromJSON({}).allResources('AWS::S3::Bucket', {});
+  Template.fromJSON({}).allResourcesProperties('AWS::S3::Bucket', {});
+  Template.fromJSON({}).hasParameter('parameter', {});
+  Template.fromJSON({}).hasOutput('output', {});
+  Template.fromJSON({}).hasMapping('mapping', {});
+  Template.fromJSON({}).hasCondition('condition', {});
+  Template.fromString('{}').templateMatches({});
+  Annotations.fromStack({}).hasError('*', 'error');
+  Annotations.fromStack({}).hasNoError('*', 'error');
+  Annotations.fromStack({}).hasWarning('*', 'warning');
+  Annotations.fromStack({}).hasNoWarning('*', 'warning');
+  Annotations.fromStack({}).hasInfo('*', 'info');
+  Annotations.fromStack({}).hasNoInfo('*', 'info');
+  Tags.fromStack({}).hasValues({});
+  Tags.fromStack({}).hasNone();
+});
+`,
+        },
+        {
           code: `import { Mock } from "vitest";
           const input = Math.sqrt(4)
 describe('no import from test library', () => {
@@ -1095,6 +1147,19 @@ import { Template } from 'aws-cdk-lib/assertions';
 
 test('does not treat Template setup as an assertion', () => {
   Template.fromStack({});
+});
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import test from 'node:test';
+import { Template } from 'aws-cdk-lib/assertions';
+
+test('does not treat AWS CDK template query APIs as assertions', () => {
+  Template.fromJSON({}).findResources('AWS::S3::Bucket');
+  Template.fromString('{}').toJSON();
+  Template.fromStack({}).getResourceId('AWS::S3::Bucket');
 });
 `,
           errors: 1,

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -38,6 +38,7 @@ import * as Vitest from './vitest.js';
 import * as Supertest from './supertest.js';
 import * as Cypress from './cypress.js';
 import * as Uvu from './uvu.js';
+import * as AwsCdk from './aws-cdk.js';
 import { getParent } from './ancestor.js';
 import { getFullyQualifiedName, importsOrDependsOnModule } from './module.js';
 import { getFullyQualifiedNameTS, importsModuleTS } from './module-ts.js';
@@ -53,6 +54,7 @@ const ASSERTION_LIBRARIES = [
   'bun:test',
   'node:assert',
   'node:assert/strict',
+  'aws-cdk-lib/assertions',
   'uvu/assert',
 ];
 // runners that expose assertion APIs as globals (no import required).
@@ -190,6 +192,7 @@ const SCRIPT_CAPABLE_DETECTORS: AssertionDetector[] = [
   Supertest.isAssertion,
   isFunctionCallFromNodeAssert,
   Uvu.isAssertion,
+  AwsCdk.isAssertion,
 ];
 
 const RUNNER_BOUND_DETECTORS: AssertionDetector[] = [
@@ -268,6 +271,7 @@ export function isTSAssertion(services: ParserServicesWithTypeInformation, node:
     Supertest.isTSAssertion(services, node) ||
     Vitest.isTSAssertion(services, node) ||
     Uvu.isTSAssertion(services, node) ||
+    AwsCdk.isTSAssertion(services, node) ||
     Cypress.isTSAssertion(node)
   );
 }

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -54,11 +54,21 @@ const ASSERTION_LIBRARIES = [
   'bun:test',
   'node:assert',
   'node:assert/strict',
-  'aws-cdk-lib/assertions',
   'uvu/assert',
 ];
 // runners that expose assertion APIs as globals (no import required).
 const GLOBAL_ASSERTION_DEPENDENCIES = ['jasmine', 'jest', 'cypress', '@playwright/test'];
+
+/**
+ * Assertion libraries with no script-capable / runner-bound classification yet.
+ *
+ * Whether a library's assertions work without a test runner (see
+ * {@link SCRIPT_CAPABLE_DETECTORS}) simply has no answer for the libraries listed here, so
+ * callers that reason about that classification must not use them — until the library is
+ * classified and moved into the arrays above. Callers that only need the plain "is this an
+ * assertion?" boolean are unaffected and free to include them.
+ */
+const UNCLASSIFIED_LIBRARIES = ['aws-cdk-lib/assertions'];
 
 const SUPPORTED_TEST_FRAMEWORK_IMPORTS = [
   '@jest/globals',
@@ -159,6 +169,19 @@ export function hasSupportedAssertionLibrary(context: Rule.RuleContext): boolean
   return importsOrDependsOnModule(context, ASSERTION_LIBRARIES, GLOBAL_ASSERTION_DEPENDENCIES);
 }
 
+/**
+ * Like {@link hasSupportedAssertionLibrary}, but also accepts the
+ * {@link UNCLASSIFIED_LIBRARIES}. Only for callers that do not reason about the
+ * script-capable / runner-bound classification.
+ */
+export function hasAssertionLibraryIncludingUnclassified(context: Rule.RuleContext): boolean {
+  return importsOrDependsOnModule(
+    context,
+    [...ASSERTION_LIBRARIES, ...UNCLASSIFIED_LIBRARIES],
+    GLOBAL_ASSERTION_DEPENDENCIES,
+  );
+}
+
 export function hasSupportedTestFramework(context: Rule.RuleContext): boolean {
   return importsOrDependsOnModule(
     context,
@@ -180,6 +203,9 @@ type AssertionDetector = (context: Rule.RuleContext, node: estree.Node) => boole
  * usable in a plain `node file.js`. Runner-bound — vitest, cypress, global
  * `expect*(...)` chains — only exist because a runner executes the file.
  *
+ * Libraries that have not been classified yet are listed in {@link UNCLASSIFIED_LIBRARIES}
+ * instead, and are invisible to both predicates here.
+ *
  * Classification is by library, not syntax: a chai `expect(x).to.equal(y)` is also
  * matched by the name-based global-`expect` detector (on the outer `.to.equal(...)`
  * call), so the script-capable Chai detector (on the inner `chai.expect(...)` call)
@@ -192,7 +218,6 @@ const SCRIPT_CAPABLE_DETECTORS: AssertionDetector[] = [
   Supertest.isAssertion,
   isFunctionCallFromNodeAssert,
   Uvu.isAssertion,
-  AwsCdk.isAssertion,
 ];
 
 const RUNNER_BOUND_DETECTORS: AssertionDetector[] = [
@@ -208,11 +233,22 @@ const ASSERTION_DETECTORS: AssertionDetector[] = [
 
 /**
  * Whether the given AST node is an assertion call, recognised across chai,
- * sinon, vitest, supertest, cypress, global `expect*(...)` chains and node
+ * sinon, vitest, supertest, cypress, uvu, global `expect*(...)` chains and node
  * `assert`. Pure-AST: does not require type information.
  */
 export function isAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
   return ASSERTION_DETECTORS.some(detect => detect(context, node));
+}
+
+/**
+ * Like {@link isAssertion}, but also matches the {@link UNCLASSIFIED_LIBRARIES}. Only for callers
+ * that do not reason about the script-capable / runner-bound classification.
+ */
+export function isAssertionIncludingUnclassified(
+  context: Rule.RuleContext,
+  node: estree.Node,
+): boolean {
+  return isAssertion(context, node) || AwsCdk.isAssertion(context, node);
 }
 
 /**
@@ -271,24 +307,28 @@ export function isTSAssertion(services: ParserServicesWithTypeInformation, node:
     Supertest.isTSAssertion(services, node) ||
     Vitest.isTSAssertion(services, node) ||
     Uvu.isTSAssertion(services, node) ||
-    Cypress.isTSAssertion(node) ||
-    AwsCdk.isTSAssertion(services, node)
+    Cypress.isTSAssertion(node)
   );
 }
 
 /**
- * Like {@link isTSAssertion}, but also follows a unique assignment through the ESTree scope.
+ * Like {@link isTSAssertion}, but also matches the {@link UNCLASSIFIED_LIBRARIES}. Only for callers
+ * that do not reason about the script-capable / runner-bound classification.
  *
- * This is currently used only for AWS CDK assertion objects assigned in test setup.
+ * The last operand is an assignment fallback, library-agnostic by design: the type-aware resolver
+ * only follows declaration initializers, so any library whose assertion object is assigned in test
+ * setup (rather than declared with an initializer) needs it. AWS CDK is simply the only one that
+ * does today.
  */
-export function isTSAssertionWithAssignmentFallback(
+export function isTSAssertionIncludingUnclassified(
+  context: Rule.RuleContext,
   services: ParserServicesWithTypeInformation,
   node: ts.Node,
-  context: Rule.RuleContext,
 ): boolean {
   return (
     isTSAssertion(services, node) ||
-    AwsCdk.isTSAssertionWithAssignmentFallback(services, node, context)
+    AwsCdk.isTSAssertion(services, node) ||
+    AwsCdk.isTSAssertionWithAssignmentFallback(context, services, node)
   );
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -279,7 +279,7 @@ export function isTSAssertion(services: ParserServicesWithTypeInformation, node:
 /**
  * Like {@link isTSAssertion}, but also follows a unique assignment through the ESTree scope.
  *
- * This is currently needed only for AWS CDK assertions initialized in test setup.
+ * This is currently used only for AWS CDK assertion objects assigned in test setup.
  */
 export function isTSAssertionWithAssignmentFallback(
   services: ParserServicesWithTypeInformation,

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -38,7 +38,7 @@ import * as Vitest from './vitest.js';
 import * as Supertest from './supertest.js';
 import * as Cypress from './cypress.js';
 import * as Uvu from './uvu.js';
-import * as AwsCdk from './aws-cdk.js';
+import * as AwsCdk from './assertions-aws-cdk.js';
 import { getParent } from './ancestor.js';
 import { getFullyQualifiedName, importsOrDependsOnModule } from './module.js';
 import { getFullyQualifiedNameTS, importsModuleTS } from './module-ts.js';
@@ -261,6 +261,10 @@ export function isIncompleteShouldAccess(context: Rule.RuleContext, node: estree
 /**
  * Type-checker-aware counterpart of {@link isAssertion}, operating on TypeScript
  * AST nodes. Used when parser services are available to follow resolved types.
+ *
+ * `context` is optional only for callers that have no rule context (helper unit tests).
+ * Omitting it disables the detectors that need to fall back to the ESTree name resolver,
+ * so rules must always pass it.
  */
 export function isTSAssertion(
   services: ParserServicesWithTypeInformation,
@@ -275,8 +279,9 @@ export function isTSAssertion(
     Supertest.isTSAssertion(services, node) ||
     Vitest.isTSAssertion(services, node) ||
     Uvu.isTSAssertion(services, node) ||
-    AwsCdk.isTSAssertion(services, node, context) ||
-    Cypress.isTSAssertion(node)
+    Cypress.isTSAssertion(node) ||
+    // Last: the only detector that may fall back to the (more expensive) ESTree name resolver.
+    (context !== undefined && AwsCdk.isTSAssertion(services, node, context))
   );
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -261,16 +261,8 @@ export function isIncompleteShouldAccess(context: Rule.RuleContext, node: estree
 /**
  * Type-checker-aware counterpart of {@link isAssertion}, operating on TypeScript
  * AST nodes. Used when parser services are available to follow resolved types.
- *
- * `context` is optional only for callers that have no rule context (helper unit tests).
- * Omitting it disables the detectors that need to fall back to the ESTree name resolver,
- * so rules must always pass it.
  */
-export function isTSAssertion(
-  services: ParserServicesWithTypeInformation,
-  node: ts.Node,
-  context?: Rule.RuleContext,
-): boolean {
+export function isTSAssertion(services: ParserServicesWithTypeInformation, node: ts.Node): boolean {
   return (
     isGlobalTSAssertion(services, node) ||
     isExtendedTSShouldAccess(node) ||
@@ -280,8 +272,23 @@ export function isTSAssertion(
     Vitest.isTSAssertion(services, node) ||
     Uvu.isTSAssertion(services, node) ||
     Cypress.isTSAssertion(node) ||
-    // Last: the only detector that may fall back to the (more expensive) ESTree name resolver.
-    (context !== undefined && AwsCdk.isTSAssertion(services, node, context))
+    AwsCdk.isTSAssertion(services, node)
+  );
+}
+
+/**
+ * Like {@link isTSAssertion}, but also follows a unique assignment through the ESTree scope.
+ *
+ * This is currently needed only for AWS CDK assertions initialized in test setup.
+ */
+export function isTSAssertionWithAssignmentFallback(
+  services: ParserServicesWithTypeInformation,
+  node: ts.Node,
+  context: Rule.RuleContext,
+): boolean {
+  return (
+    isTSAssertion(services, node) ||
+    AwsCdk.isTSAssertionWithAssignmentFallback(services, node, context)
   );
 }
 

--- a/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertion-detection.ts
@@ -262,7 +262,11 @@ export function isIncompleteShouldAccess(context: Rule.RuleContext, node: estree
  * Type-checker-aware counterpart of {@link isAssertion}, operating on TypeScript
  * AST nodes. Used when parser services are available to follow resolved types.
  */
-export function isTSAssertion(services: ParserServicesWithTypeInformation, node: ts.Node): boolean {
+export function isTSAssertion(
+  services: ParserServicesWithTypeInformation,
+  node: ts.Node,
+  context?: Rule.RuleContext,
+): boolean {
   return (
     isGlobalTSAssertion(services, node) ||
     isExtendedTSShouldAccess(node) ||
@@ -271,7 +275,7 @@ export function isTSAssertion(services: ParserServicesWithTypeInformation, node:
     Supertest.isTSAssertion(services, node) ||
     Vitest.isTSAssertion(services, node) ||
     Uvu.isTSAssertion(services, node) ||
-    AwsCdk.isTSAssertion(services, node) ||
+    AwsCdk.isTSAssertion(services, node, context) ||
     Cypress.isTSAssertion(node)
   );
 }

--- a/packages/analysis/src/jsts/rules/helpers/assertions-aws-cdk.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions-aws-cdk.ts
@@ -60,9 +60,9 @@ export function isTSAssertion(services: ParserServicesWithTypeInformation, node:
 }
 
 export function isTSAssertionWithAssignmentFallback(
+  context: Rule.RuleContext,
   services: ParserServicesWithTypeInformation,
   node: ts.Node,
-  context: Rule.RuleContext,
 ): boolean {
   if (node.kind !== ts.SyntaxKind.CallExpression) {
     return false;
@@ -75,6 +75,10 @@ export function isTSAssertionWithAssignmentFallback(
   // The type-aware resolver only follows declaration initializers. `isAssertion` delegates to
   // `getFullyQualifiedName`, whose ESTree scope resolver follows a variable's unique write, such
   // as an assertion object assigned in `beforeEach`.
+  // The map only holds nodes converted from the linted file, so `undefined` here means `node`
+  // belongs to another file (the caller follows calls into their implementation) and the
+  // `context`-bound scope resolver could not be used on it anyway. The cast is the usual
+  // TSESTree-to-ESTree widening: `isAssertion` only reads `type` and the shared node shape.
   const estreeNode = services.tsNodeToESTreeNodeMap.get(node);
   return estreeNode !== undefined && isAssertion(context, estreeNode as estree.Node);
 }

--- a/packages/analysis/src/jsts/rules/helpers/assertions-aws-cdk.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions-aws-cdk.ts
@@ -52,16 +52,20 @@ export function isAssertion(context: Rule.RuleContext, node: estree.Node): boole
   return node.type === 'CallExpression' && isFQNAssertion(getFullyQualifiedName(context, node));
 }
 
-export function isTSAssertion(
+export function isTSAssertion(services: ParserServicesWithTypeInformation, node: ts.Node): boolean {
+  if (node.kind !== ts.SyntaxKind.CallExpression) {
+    return false;
+  }
+  return isFQNAssertion(getFullyQualifiedNameTS(services, node));
+}
+
+export function isTSAssertionWithAssignmentFallback(
   services: ParserServicesWithTypeInformation,
   node: ts.Node,
   context: Rule.RuleContext,
 ): boolean {
   if (node.kind !== ts.SyntaxKind.CallExpression) {
     return false;
-  }
-  if (isFQNAssertion(getFullyQualifiedNameTS(services, node))) {
-    return true;
   }
   // The ESTree fallback below resolves names by walking scopes on every call expression, so it is
   // gated on the file actually importing the module. `importsModuleTS` caches per source file.

--- a/packages/analysis/src/jsts/rules/helpers/assertions-aws-cdk.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions-aws-cdk.ts
@@ -19,7 +19,9 @@ import type estree from 'estree';
 import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
 import ts from 'typescript';
 import { getFullyQualifiedName } from './module.js';
-import { getFullyQualifiedNameTS } from './module-ts.js';
+import { getFullyQualifiedNameTS, importsModuleTS } from './module-ts.js';
+
+const ASSERTIONS_MODULE = 'aws-cdk-lib/assertions';
 
 const TEMPLATE_ASSERTION_METHOD_NAMES = new Set([
   'resourceCountIs',
@@ -53,7 +55,7 @@ export function isAssertion(context: Rule.RuleContext, node: estree.Node): boole
 export function isTSAssertion(
   services: ParserServicesWithTypeInformation,
   node: ts.Node,
-  context?: Rule.RuleContext,
+  context: Rule.RuleContext,
 ): boolean {
   if (node.kind !== ts.SyntaxKind.CallExpression) {
     return false;
@@ -61,7 +63,9 @@ export function isTSAssertion(
   if (isFQNAssertion(getFullyQualifiedNameTS(services, node))) {
     return true;
   }
-  if (context === undefined) {
+  // The ESTree fallback below resolves names by walking scopes on every call expression, so it is
+  // gated on the file actually importing the module. `importsModuleTS` caches per source file.
+  if (!importsModuleTS(node.getSourceFile(), [ASSERTIONS_MODULE])) {
     return false;
   }
   // The type-aware resolver only follows declaration initializers. Reuse the ESTree resolver to
@@ -70,7 +74,7 @@ export function isTSAssertion(
   return estreeNode !== undefined && isAssertion(context, estreeNode as estree.Node);
 }
 
-function isFQNAssertion(fqn: string | null): boolean {
+function isFQNAssertion(fqn: string | null | undefined): boolean {
   const normalized = fqn?.replaceAll('/', '.');
   if (normalized === undefined) {
     return false;

--- a/packages/analysis/src/jsts/rules/helpers/assertions-aws-cdk.ts
+++ b/packages/analysis/src/jsts/rules/helpers/assertions-aws-cdk.ts
@@ -72,8 +72,9 @@ export function isTSAssertionWithAssignmentFallback(
   if (!importsModuleTS(node.getSourceFile(), [ASSERTIONS_MODULE])) {
     return false;
   }
-  // The type-aware resolver only follows declaration initializers. Reuse the ESTree resolver to
-  // follow a unique later assignment, such as an assertion object initialized in `beforeEach`.
+  // The type-aware resolver only follows declaration initializers. `isAssertion` delegates to
+  // `getFullyQualifiedName`, whose ESTree scope resolver follows a variable's unique write, such
+  // as an assertion object assigned in `beforeEach`.
   const estreeNode = services.tsNodeToESTreeNodeMap.get(node);
   return estreeNode !== undefined && isAssertion(context, estreeNode as estree.Node);
 }

--- a/packages/analysis/src/jsts/rules/helpers/aws-cdk.ts
+++ b/packages/analysis/src/jsts/rules/helpers/aws-cdk.ts
@@ -8,8 +8,8 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * Sonar Source-Available License Version 1 for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/

--- a/packages/analysis/src/jsts/rules/helpers/aws-cdk.ts
+++ b/packages/analysis/src/jsts/rules/helpers/aws-cdk.ts
@@ -21,8 +21,30 @@ import ts from 'typescript';
 import { getFullyQualifiedName } from './module.js';
 import { getFullyQualifiedNameTS } from './module-ts.js';
 
-const ASSERTION_METHOD_NAMES = new Set(['hasResourceProperties', 'resourceCountIs']);
-const TEMPLATE_PREFIX = 'aws-cdk-lib.assertions.Template.fromStack.';
+const TEMPLATE_ASSERTION_METHOD_NAMES = new Set([
+  'resourceCountIs',
+  'resourcePropertiesCountIs',
+  'hasResourceProperties',
+  'hasResource',
+  'allResources',
+  'allResourcesProperties',
+  'hasParameter',
+  'hasOutput',
+  'hasMapping',
+  'hasCondition',
+  'templateMatches',
+]);
+
+const ASSERTION_METHODS_BY_FACTORY = new Map<string, ReadonlySet<string>>([
+  ['aws-cdk-lib.assertions.Template.fromStack', TEMPLATE_ASSERTION_METHOD_NAMES],
+  ['aws-cdk-lib.assertions.Template.fromJSON', TEMPLATE_ASSERTION_METHOD_NAMES],
+  ['aws-cdk-lib.assertions.Template.fromString', TEMPLATE_ASSERTION_METHOD_NAMES],
+  [
+    'aws-cdk-lib.assertions.Annotations.fromStack',
+    new Set(['hasError', 'hasNoError', 'hasWarning', 'hasNoWarning', 'hasInfo', 'hasNoInfo']),
+  ],
+  ['aws-cdk-lib.assertions.Tags.fromStack', new Set(['hasValues', 'hasNone'])],
+]);
 
 export function isAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
   return node.type === 'CallExpression' && isFQNAssertion(getFullyQualifiedName(context, node));
@@ -37,9 +59,12 @@ export function isTSAssertion(services: ParserServicesWithTypeInformation, node:
 
 function isFQNAssertion(fqn: string | null): boolean {
   const normalized = fqn?.replaceAll('/', '.');
-  return (
-    normalized !== undefined &&
-    normalized.startsWith(TEMPLATE_PREFIX) &&
-    ASSERTION_METHOD_NAMES.has(normalized.slice(TEMPLATE_PREFIX.length))
-  );
+  if (normalized === undefined) {
+    return false;
+  }
+
+  const lastDot = normalized.lastIndexOf('.');
+  const factory = normalized.slice(0, lastDot);
+  const method = normalized.slice(lastDot + 1);
+  return ASSERTION_METHODS_BY_FACTORY.get(factory)?.has(method) ?? false;
 }

--- a/packages/analysis/src/jsts/rules/helpers/aws-cdk.ts
+++ b/packages/analysis/src/jsts/rules/helpers/aws-cdk.ts
@@ -1,0 +1,45 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Sonar Source-Available License Version 1 for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { Rule } from 'eslint';
+import type estree from 'estree';
+import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
+import ts from 'typescript';
+import { getFullyQualifiedName } from './module.js';
+import { getFullyQualifiedNameTS } from './module-ts.js';
+
+const ASSERTION_METHOD_NAMES = new Set(['hasResourceProperties', 'resourceCountIs']);
+const TEMPLATE_PREFIX = 'aws-cdk-lib.assertions.Template.fromStack.';
+
+export function isAssertion(context: Rule.RuleContext, node: estree.Node): boolean {
+  return node.type === 'CallExpression' && isFQNAssertion(getFullyQualifiedName(context, node));
+}
+
+export function isTSAssertion(services: ParserServicesWithTypeInformation, node: ts.Node): boolean {
+  return (
+    node.kind === ts.SyntaxKind.CallExpression &&
+    isFQNAssertion(getFullyQualifiedNameTS(services, node))
+  );
+}
+
+function isFQNAssertion(fqn: string | null): boolean {
+  const normalized = fqn?.replaceAll('/', '.');
+  return (
+    normalized !== undefined &&
+    normalized.startsWith(TEMPLATE_PREFIX) &&
+    ASSERTION_METHOD_NAMES.has(normalized.slice(TEMPLATE_PREFIX.length))
+  );
+}

--- a/packages/analysis/src/jsts/rules/helpers/aws-cdk.ts
+++ b/packages/analysis/src/jsts/rules/helpers/aws-cdk.ts
@@ -50,11 +50,24 @@ export function isAssertion(context: Rule.RuleContext, node: estree.Node): boole
   return node.type === 'CallExpression' && isFQNAssertion(getFullyQualifiedName(context, node));
 }
 
-export function isTSAssertion(services: ParserServicesWithTypeInformation, node: ts.Node): boolean {
-  return (
-    node.kind === ts.SyntaxKind.CallExpression &&
-    isFQNAssertion(getFullyQualifiedNameTS(services, node))
-  );
+export function isTSAssertion(
+  services: ParserServicesWithTypeInformation,
+  node: ts.Node,
+  context?: Rule.RuleContext,
+): boolean {
+  if (node.kind !== ts.SyntaxKind.CallExpression) {
+    return false;
+  }
+  if (isFQNAssertion(getFullyQualifiedNameTS(services, node))) {
+    return true;
+  }
+  if (context === undefined) {
+    return false;
+  }
+  // The type-aware resolver only follows declaration initializers. Reuse the ESTree resolver to
+  // follow a unique later assignment, such as an assertion object initialized in `beforeEach`.
+  const estreeNode = services.tsNodeToESTreeNodeMap.get(node);
+  return estreeNode !== undefined && isAssertion(context, estreeNode as estree.Node);
 }
 
 function isFQNAssertion(fqn: string | null): boolean {


### PR DESCRIPTION
## Summary

- recognize AWS CDK Template assertions from aws-cdk-lib/assertions in S2699
- support hasResourceProperties and resourceCountIs from Template.fromStack
- cover ordinary, type-aware, and setup-only boundary cases

## Root cause

S2699 did not recognize aws-cdk-lib/assertions as an assertion library, and its Template assertion calls were absent from both assertion-detection paths.

## Validation

- npx tsx --test packages/analysis/src/jsts/rules/S2699/unit.test.ts
- npm run bbf
- npx prettier --check packages/analysis/src/jsts/rules/helpers/assertion-detection.ts packages/analysis/src/jsts/rules/helpers/aws-cdk.ts packages/analysis/src/jsts/rules/S2699/unit.test.ts
- git diff --check a19f17468...HEAD