### PR TITLE
JS-2171 Revert analyzer commons configurations to public release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@eslint-community/regexpp": "4.12.2",
         "@grpc/grpc-js": "1.14.4",
         "@protobufjs/base64": "1.1.2",
-        "@sonarsource/analyzer-commons-configurations": "2.29.0-5144",
+        "@sonarsource/analyzer-commons-configurations": "2.29.0-5138",
         "@stylistic/eslint-plugin": "5.10.0",
         "@stylistic/stylelint-plugin": "5.2.1",
         "@typescript-eslint/eslint-plugin": "8.65.0",
@@ -4051,9 +4051,9 @@
       }
     },
     "node_modules/@sonarsource/analyzer-commons-configurations": {
-      "version": "2.29.0-5144",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@sonarsource/analyzer-commons-configurations/-/analyzer-commons-configurations-2.29.0-5144.tgz",
-      "integrity": "sha512-4eELSqEaZQ1zxQzmogV62qEhXTWLo0nu5Ly2qo+vVjHHThmcta2A3A74ss2pP5EoeKpB8QF2+NRj22BKl0NUWw==",
+      "version": "2.29.0-5138",
+      "resolved": "https://registry.npmjs.org/@sonarsource/analyzer-commons-configurations/-/analyzer-commons-configurations-2.29.0-5138.tgz",
+      "integrity": "sha512-krvuxh2FInFxdFD1HZtCGOOJtPmdxl24iR1ZKJ1q7ZLhegFyZDNVu9KO8NG8iue5dDWo9RjkT0oX3Gn+B0Igbg==",
       "license": "LGPL-3.0-only"
     },
     "node_modules/@stylistic/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@eslint-community/regexpp": "4.12.2",
     "@grpc/grpc-js": "1.14.4",
     "@protobufjs/base64": "1.1.2",
-    "@sonarsource/analyzer-commons-configurations": "2.29.0-5144",
+    "@sonarsource/analyzer-commons-configurations": "2.29.0-5138",
     "@stylistic/eslint-plugin": "5.10.0",
     "@stylistic/stylelint-plugin": "5.2.1",
     "@typescript-eslint/eslint-plugin": "8.65.0",


### PR DESCRIPTION
## Summary

Revert `@sonarsource/analyzer-commons-configurations` from `2.29.0-5144` to the latest public npm release, `2.29.0-5138`.

## Root cause

Renovate PR #7663 selected build `2.29.0-5144` from Repox. That build was not published to npmjs.org, while the ESLint plugin integration tests install the generated plugin tarball from the public npm registry. This caused `npm install` to fail with `ETARGET` before the ESLint 8/9/10 tests could run, including on #7507.

The lockfile now points back to the public `registry.npmjs.org` artifact and its published integrity.

## Verification

- `npm install --package-lock-only --ignore-scripts --offline`
- `git diff --check`
- Parsed `package.json` and `package-lock.json` to confirm all dependency entries resolve to public `2.29.0-5138`