### PR TITLE
JS-2198 Block PR merges on failed ESLint plugin consumer checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -379,6 +379,7 @@ jobs:
     needs: [setup, build_eslint_plugin]
     permissions: *read_permissions
     strategy:
+      fail-fast: false
       matrix:
         include:
           - eslint-version: 10
@@ -1176,12 +1177,16 @@ jobs:
       - ruling
       - js_ts_ruling
     if: >-
-      !failure() && !cancelled() &&
+      always() &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     permissions: *read_permissions
     env: *shared_build_number
     steps:
       - *checkout
+      - name: Validate upstream jobs
+        env:
+          NEEDS_CONTEXT: ${{ toJson(needs) }}
+        run: node tools/validate-workflow-needs.mjs
       - name: Reject root rspec.sha
         if: >-
           (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'master') ||

--- a/tools/tests/validate-workflow-needs.test.ts
+++ b/tools/tests/validate-workflow-needs.test.ts
@@ -1,0 +1,72 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { describe, it } from 'node:test';
+import { expect } from 'expect';
+import {
+  formatBlockingNeeds,
+  getBlockingNeeds,
+  parseNeedsContext,
+} from '../validate-workflow-needs.mjs';
+
+describe('validate workflow needs', () => {
+  it('should parse a serialized needs context', () => {
+    expect(
+      parseNeedsContext(
+        JSON.stringify({
+          build: { result: 'success' },
+          test_eslint_plugin: { result: 'failure' },
+        }),
+      ),
+    ).toEqual({
+      build: { result: 'success' },
+      test_eslint_plugin: { result: 'failure' },
+    });
+  });
+
+  it('should reject non-object needs contexts', () => {
+    expect(() => parseNeedsContext('[]')).toThrow('NEEDS_CONTEXT must decode to an object');
+    expect(() => parseNeedsContext('null')).toThrow('NEEDS_CONTEXT must decode to an object');
+  });
+
+  it('should keep only failure and cancelled upstream jobs', () => {
+    expect(
+      getBlockingNeeds({
+        build: { result: 'success' },
+        generated_files_freshness: { result: 'skipped' },
+        test_eslint_plugin: { result: 'failure' },
+        qa_windows: { result: 'cancelled' },
+        malformed: {},
+      }),
+    ).toEqual([
+      { jobId: 'test_eslint_plugin', result: 'failure' },
+      { jobId: 'qa_windows', result: 'cancelled' },
+    ]);
+  });
+
+  it('should format a clear blocking summary', () => {
+    expect(
+      formatBlockingNeeds([
+        { jobId: 'test_eslint_plugin', result: 'failure' },
+        { jobId: 'plugin_qa_win', result: 'cancelled' },
+      ]),
+    ).toBe(
+      'Promotion is blocked because required upstream jobs did not complete successfully:\n' +
+        '- test_eslint_plugin: failure\n' +
+        '- plugin_qa_win: cancelled',
+    );
+  });
+});

--- a/tools/validate-workflow-needs.mjs
+++ b/tools/validate-workflow-needs.mjs
@@ -1,0 +1,83 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { pathToFileURL } from 'node:url';
+
+const nonBlockingResults = new Set(['success', 'skipped']);
+
+/**
+ * Parses the serialized GitHub Actions needs context.
+ * @param {string} serializedNeedsContext JSON-encoded needs context
+ * @returns {Record<string, { result?: string }>} parsed needs context
+ */
+export function parseNeedsContext(serializedNeedsContext) {
+  const needsContext = JSON.parse(serializedNeedsContext);
+
+  if (needsContext === null || typeof needsContext !== 'object' || Array.isArray(needsContext)) {
+    throw new Error('NEEDS_CONTEXT must decode to an object');
+  }
+
+  return needsContext;
+}
+
+/**
+ * Extracts upstream jobs whose results should block promotion.
+ * @param {Record<string, { result?: string }>} needsContext GitHub Actions needs context
+ * @returns {{ jobId: string; result: string }[]} blocking upstream jobs
+ */
+export function getBlockingNeeds(needsContext) {
+  return Object.entries(needsContext).flatMap(([jobId, need]) => {
+    const result = need?.result;
+
+    if (typeof result !== 'string' || nonBlockingResults.has(result)) {
+      return [];
+    }
+
+    return [{ jobId, result }];
+  });
+}
+
+/**
+ * Formats a promotion-blocking needs summary.
+ * @param {{ jobId: string; result: string }[]} blockingNeeds blocking upstream jobs
+ * @returns {string} human-readable blocking summary
+ */
+export function formatBlockingNeeds(blockingNeeds) {
+  return [
+    'Promotion is blocked because required upstream jobs did not complete successfully:',
+    ...blockingNeeds.map(blockingNeed => `- ${blockingNeed.jobId}: ${blockingNeed.result}`),
+  ].join('\n');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const serializedNeedsContext = process.env.NEEDS_CONTEXT;
+
+    if (!serializedNeedsContext) {
+      throw new Error('NEEDS_CONTEXT must be set');
+    }
+
+    const blockingNeeds = getBlockingNeeds(parseNeedsContext(serializedNeedsContext));
+
+    if (blockingNeeds.length > 0) {
+      throw new Error(formatBlockingNeeds(blockingNeeds));
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
This makes failed ESLint plugin consumer checks block PR promotion instead of slipping through as a green required gate. It also keeps all ESLint consumer matrix legs visible so the PR status reflects the real failure set.

## Changes
- run the `promote` job unconditionally after its dependencies complete and fail it explicitly when any needed job ends in `failure` or `cancelled`
- add a small tested helper that validates the GitHub Actions `needs` context and prints a targeted blocking message
- disable fail-fast on the ESLint plugin consumer matrix so all three ESLint versions report their status on the PR

:warning::warning: This is not ready for review :warning::warning:
