### PR TITLE
JS-2217: Fix S8980 false positive for renderHook result actions

### DIFF
--- a/packages/analysis/src/jsts/rules/S8980/cb.fixture.tsx
+++ b/packages/analysis/src/jsts/rules/S8980/cb.fixture.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 function Form() {
@@ -35,6 +35,31 @@ function doesNotUseTestingLibrary() {
 function wrapsNonTestingLibraryCode() {
     act(() => {
         onlyNonTestingLibraryCode();
+    });
+}
+
+function flushesHookStateBeforeReadingIt(id: string | undefined) {
+    const { result } = renderHook(() => ({ dismiss: (_id: string) => {} }));
+
+    act(() => {
+        if (id) result.current.dismiss(id);
+    });
+}
+
+function flushesHookStateAndRenders(id: string | undefined) {
+    const { result } = renderHook(() => ({ dismiss: (_id: string) => {} }));
+
+    act(() => {
+        if (id) result.current.dismiss(id);
+        render(<Form />);
+    });
+}
+
+function rerendersHook(id: string | undefined) {
+    const { rerender } = renderHook(() => ({}));
+
+    act(() => { // Noncompliant {{Remove this redundant `act()` call; the wrapped call already flushes its own updates.}}
+        if (id) rerender();
     });
 }
 

--- a/packages/analysis/src/jsts/rules/S8980/cb.test.ts
+++ b/packages/analysis/src/jsts/rules/S8980/cb.test.ts
@@ -16,9 +16,36 @@
  */
 // https://sonarsource.github.io/rspec/#/rspec/S8980/javascript
 import { test } from '../../../../tests/jsts/tools/testers/comment-based/checker.js';
+import { NoTypeCheckingRuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
+import { rules as testingLibraryRules } from '../external/testing-library.js';
 import { rule } from './index.js';
 import { describe } from 'node:test';
 import * as meta from './generated-meta.js';
+
+const upstreamRule = testingLibraryRules['no-unnecessary-act'];
+
+// Sentinel: upstream treats a conditional hook action as no non-Testing-Library call.
+describe('S8980 upstream sentinel', () => {
+  const ruleTester = new NoTypeCheckingRuleTester();
+  ruleTester.run('no-unnecessary-act', upstreamRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          import { act, renderHook } from '@testing-library/react';
+          declare const id: string | undefined;
+          const { result } = renderHook(() => ({ dismiss: (_id: string) => {} }));
+
+          act(() => {
+            if (id) result.current.dismiss(id);
+          });
+        `,
+        options: [{ isStrict: false }],
+        errors: [{ messageId: 'noUnnecessaryActTestingLibraryUtil' }],
+      },
+    ],
+  });
+});
 
 describe(`Rule S8980`, () => {
   test(meta, rule, import.meta.dirname);

--- a/packages/analysis/src/jsts/rules/S8980/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S8980/decorator.ts
@@ -48,11 +48,18 @@ const RECOGNIZED_MODULE_PREFIXES = [
   '@testing-library.user-event',
   'react-dom.test-utils',
 ];
+const RENDER_HOOK_RESULT_FQN = '@testing-library.react.renderHook.result';
+
+function isRenderHookResultCall(context: Rule.RuleContext, node: estree.Node): boolean {
+  const fqn = getFullyQualifiedName(context, node);
+  return fqn === RENDER_HOOK_RESULT_FQN || fqn?.startsWith(`${RENDER_HOOK_RESULT_FQN}.`) === true;
+}
 
 function isRecognizedTestingLibraryCall(context: Rule.RuleContext, node: estree.Node): boolean {
   const fqn = getFullyQualifiedName(context, node);
   return (
     fqn != null &&
+    !isRenderHookResultCall(context, node) &&
     RECOGNIZED_MODULE_PREFIXES.some(prefix => fqn === prefix || fqn.startsWith(`${prefix}.`))
   );
 }
@@ -120,7 +127,10 @@ function actCallbackHasNoRecognizedTestingLibraryCall(
     return false;
   }
   const calls = collectCallExpressions(callback.body);
-  return !calls.some(call => isRecognizedTestingLibraryCall(context, call));
+  return (
+    calls.some(call => isRenderHookResultCall(context, call)) ||
+    !calls.some(call => isRecognizedTestingLibraryCall(context, call))
+  );
 }
 
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {


### PR DESCRIPTION
## Summary

- Treat calls through `renderHook(...).result.current` as tested-hook actions rather than Testing Library utilities.
- Keep reports for genuine `renderHook` utilities such as `rerender()`.
- Cover the upstream conditional regression, a mixed callback, and the `rerender()` boundary.

## Root cause

The upstream non-strict rule does not classify conditional hook-result actions as non-Testing-Library calls. It consequently reports a necessary `act()` before the hook state is read. SonarJS now recognizes the fully-qualified renderHook result path and suppresses that report, including mixed callbacks.

## Links

- Jira: https://sonarsource.atlassian.net/browse/JS-2217

## Verification

- `./run-node node_modules/tsx/dist/cli.mjs --test packages/analysis/src/jsts/rules/S8980/cb.test.ts`
- `npm run bbf`
- `uc check --base origin/master` (type check, unit tests, and lint passed; pre-PR issue check was pending)
- `./run-node node_modules/tsx/dist/cli.mjs --tsconfig packages/tsconfig.test.json --test packages/ruling/projects/searchkit.ruling.test.ts`