### PR TITLE
JS-2226 Bump SonarJS to 13.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   </issueManagement>
 
   <properties>
-    <revision>13.4.0-SNAPSHOT</revision>
+    <revision>13.5.0-SNAPSHOT</revision>
     <gitRepositoryName>SonarJS</gitRepositoryName>
     <license.title>SonarQube JavaScript Plugin</license.title>
     <!-- Version corresponds to SQ 9.9 LTS -->


### PR DESCRIPTION
Bumps the root Maven revision from 13.4.0-SNAPSHOT to 13.5.0-SNAPSHOT so the next Automated Release resolves a 13.5 build instead of reusing 13.4.

Validation: mvn --batch-mode validate