### PR TITLE
JS-2227 Bump SonarJS to 13.6.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   </issueManagement>
 
   <properties>
-    <revision>13.5.0-SNAPSHOT</revision>
+    <revision>13.6.0-SNAPSHOT</revision>
     <gitRepositoryName>SonarJS</gitRepositoryName>
     <license.title>SonarQube JavaScript Plugin</license.title>
     <!-- Version corresponds to SQ 9.9 LTS -->


### PR DESCRIPTION
## Summary

Bump the root Maven revision from `13.5.0-SNAPSHOT` to `13.6.0-SNAPSHOT` after the 13.5 release.

This prevents the next Automated Release from attempting to reuse the already released 13.5 version.

## Validation

- `mvn --batch-mode validate`