### PR TITLE
JS-2228 Fix S125 with TypeScript project service

### DIFF
--- a/packages/analysis/src/jsts/rules/S125/rule.ts
+++ b/packages/analysis/src/jsts/rules/S125/rule.ts
@@ -180,6 +180,7 @@ function containsCode(value: string, context: Rule.RuleContext) {
     filePath: `placeholder${path.extname(context.filename)}`,
     programs: undefined,
     project: undefined,
+    projectService: undefined,
   };
   //In case of Vue parser: we will use the JS/TS parser instead of the Vue parser
   const parser = context.languageOptions?.parserOptions?.parser ?? context.languageOptions?.parser;

--- a/packages/analysis/src/jsts/rules/S125/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S125/unit.test.ts
@@ -19,6 +19,39 @@ import { rule } from './rule.js';
 import { describe, it } from 'node:test';
 
 describe('S125', () => {
+  it('detects commented-out code with TypeScript project service', () => {
+    const ruleTester = new NoTypeCheckingRuleTester({
+      parserOptions: {
+        projectService: true,
+      },
+    });
+    ruleTester.run('Sections of code should not be commented out', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: `
+export const activeCode = (a: number, b: number): number => a + b;
+
+// const total = computeTotal(amount, rate);`,
+          errors: [
+            {
+              messageId: 'commentedCode',
+              suggestions: [
+                {
+                  desc: 'Remove this commented out code',
+                  output: `
+export const activeCode = (a: number, b: number): number => a + b;
+
+`,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('S125', () => {
     const ruleTester = new NoTypeCheckingRuleTester();
     ruleTester.run('Sections of code should not be commented out', rule, {


### PR DESCRIPTION
## Summary
- Restore S125 detection of commented-out code when TypeScript-ESLint project service is enabled.
- Keep synthetic comment parsing independent of project-service file ownership.
- Add regression coverage using an in-project TypeScript source file.

## Root cause
S125 re-parsed comments through a synthetic placeholder filename after clearing project and programs, but retained projectService. TypeScript-ESLint rejected the synthetic non-project file and S125 treated the parse failure as non-code.

## Validation
- npx tsx --test packages/analysis/src/jsts/rules/S125/unit.test.ts
- npm run bbf
- git diff --check