### PR TITLE
JS-2210 Add S8785 AWS CDK regression coverage

### DIFF
--- a/packages/analysis/src/jsts/rules/S8785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8785/unit.test.ts
@@ -534,8 +534,11 @@ describe('suite', () => {
           errors: [{ messageId: 'asyncHelperCall' }],
         },
         {
-          // AWS CDK assertion boundary
+          // AWS CDK assertion boundary: the assertion must not be resolved as a local helper,
+          // while the adjacent local async helper is still reported.
           code: `import { describe, it } from 'mocha';
+import { Stack } from 'aws-cdk-lib';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Template } from 'aws-cdk-lib/assertions';
 
 async function registerTests() {
@@ -544,7 +547,11 @@ async function registerTests() {
 }
 
 describe('stack', () => {
-  Template.fromStack({}).hasResourceProperties('AWS::S3::Bucket', {});
+  const stack = new Stack();
+  new Bucket(stack, 'Bucket', { bucketName: 'example-bucket' });
+  Template.fromStack(stack).hasResourceProperties('AWS::S3::Bucket', {
+    BucketName: 'example-bucket',
+  });
   registerTests();
 });`,
           errors: [{ messageId: 'asyncHelperCall' }],

--- a/packages/analysis/src/jsts/rules/S8785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S8785/unit.test.ts
@@ -534,6 +534,22 @@ describe('suite', () => {
           errors: [{ messageId: 'asyncHelperCall' }],
         },
         {
+          // AWS CDK assertion boundary
+          code: `import { describe, it } from 'mocha';
+import { Template } from 'aws-cdk-lib/assertions';
+
+async function registerTests() {
+  await Promise.resolve();
+  it('dropped', () => {});
+}
+
+describe('stack', () => {
+  Template.fromStack({}).hasResourceProperties('AWS::S3::Bucket', {});
+  registerTests();
+});`,
+          errors: [{ messageId: 'asyncHelperCall' }],
+        },
+        {
           // User-defined async helper named after a framework hook (e.g. 'before') must be
           // reported — the bare-name match against TEST_FRAMEWORK_STRUCTURE_FUNCTIONS must not
           // exempt it without verifying import provenance.


### PR DESCRIPTION
Part of JS-2210

## Summary

- Add typed S8785 regression coverage for an AWS CDK assertion inside a Mocha suite.
- Keep an adjacent unsafe async helper reported with exactly one `asyncHelperCall` issue.
- Make no production, shared-helper, metadata, or public API changes.

## Impact

This is characterization coverage only. It pins the existing contract that AWS CDK assertions do not change S8785's issue set.

## Verification

- `npx tsx --test packages/analysis/src/jsts/rules/S8785/unit.test.ts`
- `npm run bbf`
- `git diff --check origin/master...HEAD`

## Ruling expectation

The CI JS/TS ruling must show no S8785 issue-set movement. Unexpected ruling changes will not be synchronized.