### PR TITLE
JS-2246: Fix S9135 false positive after nested objects are replaced

### DIFF
--- a/packages/analysis/src/jsts/rules/S9135/rule.ts
+++ b/packages/analysis/src/jsts/rules/S9135/rule.ts
@@ -19,11 +19,14 @@
 import type { Rule } from 'eslint';
 import type estree from 'estree';
 import {
+  FUNCTION_NODES,
   getUniqueWriteReference,
   getVariableFromName,
+  isIdentifier,
   unwrapTypeScriptExpression,
 } from '../helpers/ast.js';
 import { getParent } from '../helpers/ancestor.js';
+import { areEquivalent } from '../helpers/equivalence.js';
 import { report, toSecondaryLocation } from '../helpers/location.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { generateMeta } from '../helpers/generate-meta.js';
@@ -44,10 +47,15 @@ const CLONE_LIBRARIES = new Map<string, 'lodash' | 'underscore'>([
 
 type MutationNode = estree.AssignmentExpression | estree.UpdateExpression | estree.UnaryExpression;
 
+type IsolationKind = 'deep' | 'shallow';
+
 type StaticMemberChain = {
   root: estree.Identifier;
   depth: number;
 };
+
+const DEEP_CLONE_FQNS = new Set(['lodash.cloneDeep', 'lodash-es.cloneDeep']);
+const SHALLOW_CLONE_FQNS = new Set(['lodash.clone', 'lodash-es.clone', 'underscore.clone']);
 
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta, { hasSuggestions: true }),
@@ -98,6 +106,10 @@ function checkMutation(
 
   const argument = cloneCall.arguments[0];
   if (argument === undefined || argument.type === 'SpreadElement') {
+    return;
+  }
+
+  if (hasIsolatingPrefixAssignment(context, mutatedNode, mutation)) {
     return;
   }
 
@@ -217,4 +229,185 @@ function hasNoTokensAfter(context: Rule.RuleContext, node: estree.Node): boolean
   const source = context.sourceCode.getText();
   const lineEnd = source.indexOf('\n', range[1]);
   return source.slice(range[1], lineEnd === -1 ? source.length : lineEnd).trim() === '';
+}
+
+function hasIsolatingPrefixAssignment(
+  context: Rule.RuleContext,
+  mutatedNode: estree.Node,
+  mutation: MutationNode,
+): boolean {
+  const target = unwrapTypeScriptExpression(mutatedNode);
+  if (target.type !== 'MemberExpression') {
+    return false;
+  }
+
+  let extraDepth = 1;
+  let prefix: estree.Node = unwrapTypeScriptExpression(target.object);
+
+  while (prefix.type === 'MemberExpression') {
+    const isolation = findDominatingIsolation(context, prefix, mutation);
+    if (isolation === 'deep' || (isolation === 'shallow' && extraDepth === 1)) {
+      return true;
+    }
+    extraDepth += 1;
+    prefix = unwrapTypeScriptExpression(prefix.object);
+  }
+
+  return false;
+}
+
+function findDominatingIsolation(
+  context: Rule.RuleContext,
+  prefix: estree.Node,
+  mutation: MutationNode,
+): IsolationKind | undefined {
+  let current: estree.Node | undefined = mutation;
+  let best: IsolationKind | undefined;
+
+  while (current !== undefined) {
+    const parent = getParent(context, current);
+    if (parent === undefined || FUNCTION_NODES.includes(parent.type)) {
+      break;
+    }
+
+    if (parent.type === 'SequenceExpression') {
+      const index = parent.expressions.indexOf(current as estree.Expression);
+      if (index > 0) {
+        best = strongerIsolation(
+          best,
+          isolationInNodes(parent.expressions.slice(0, index), prefix, context),
+        );
+      }
+    } else {
+      const statements = getBlockStatements(parent);
+      if (statements !== undefined) {
+        const index = statements.indexOf(current);
+        if (index > 0) {
+          best = strongerIsolation(
+            best,
+            isolationInStatements(statements.slice(0, index), prefix, context),
+          );
+        }
+      }
+    }
+
+    if (best === 'deep') {
+      return 'deep';
+    }
+    current = parent;
+  }
+
+  return best;
+}
+
+function getBlockStatements(node: estree.Node): estree.Node[] | undefined {
+  if (node.type === 'BlockStatement' || node.type === 'Program') {
+    return node.body;
+  }
+  if (node.type === 'SwitchCase') {
+    return node.consequent;
+  }
+  return undefined;
+}
+
+function isolationInStatements(
+  statements: estree.Node[],
+  prefix: estree.Node,
+  context: Rule.RuleContext,
+): IsolationKind | undefined {
+  let best: IsolationKind | undefined;
+  for (const statement of statements) {
+    best = strongerIsolation(best, statementAssignsPrefix(statement, prefix, context));
+    if (best === 'deep') {
+      return 'deep';
+    }
+  }
+  return best;
+}
+
+function isolationInNodes(
+  nodes: estree.Node[],
+  prefix: estree.Node,
+  context: Rule.RuleContext,
+): IsolationKind | undefined {
+  let best: IsolationKind | undefined;
+  for (const node of nodes) {
+    best = strongerIsolation(best, expressionAssignsPrefix(node, prefix, context));
+    if (best === 'deep') {
+      return 'deep';
+    }
+  }
+  return best;
+}
+
+function statementAssignsPrefix(
+  statement: estree.Node,
+  prefix: estree.Node,
+  context: Rule.RuleContext,
+): IsolationKind | undefined {
+  if (statement.type === 'ExpressionStatement') {
+    return expressionAssignsPrefix(statement.expression, prefix, context);
+  }
+  if (statement.type === 'BlockStatement') {
+    return isolationInStatements(statement.body, prefix, context);
+  }
+  return undefined;
+}
+
+function expressionAssignsPrefix(
+  expression: estree.Node,
+  prefix: estree.Node,
+  context: Rule.RuleContext,
+): IsolationKind | undefined {
+  const value = unwrapTypeScriptExpression(expression);
+  if (value.type === 'SequenceExpression') {
+    return isolationInNodes(value.expressions, prefix, context);
+  }
+  if (value.type !== 'AssignmentExpression') {
+    return undefined;
+  }
+  if (
+    !areEquivalent(
+      unwrapTypeScriptExpression(value.left),
+      unwrapTypeScriptExpression(prefix),
+      context.sourceCode,
+    )
+  ) {
+    return undefined;
+  }
+  return getFreshObjectIsolation(context, value.right);
+}
+
+function getFreshObjectIsolation(
+  context: Rule.RuleContext,
+  rhs: estree.Node,
+): IsolationKind | undefined {
+  const value = unwrapTypeScriptExpression(rhs);
+  if (value.type === 'ObjectExpression' || value.type === 'ArrayExpression') {
+    return 'shallow';
+  }
+  if (value.type !== 'CallExpression') {
+    return undefined;
+  }
+  if (isIdentifier(value.callee, 'structuredClone')) {
+    return 'deep';
+  }
+  const fqn = getFullyQualifiedName(context, value.callee) ?? '';
+  if (DEEP_CLONE_FQNS.has(fqn)) {
+    return 'deep';
+  }
+  if (SHALLOW_CLONE_FQNS.has(fqn)) {
+    return 'shallow';
+  }
+  return undefined;
+}
+
+function strongerIsolation(
+  current: IsolationKind | undefined,
+  candidate: IsolationKind | undefined,
+): IsolationKind | undefined {
+  if (current === 'deep' || candidate === 'deep') {
+    return 'deep';
+  }
+  return candidate ?? current;
 }

--- a/packages/analysis/src/jsts/rules/S9135/rule.ts
+++ b/packages/analysis/src/jsts/rules/S9135/rule.ts
@@ -367,19 +367,41 @@ function expressionAssignsPrefix(
   if (value.type !== 'AssignmentExpression') {
     return undefined;
   }
-  if (
-    !areEquivalent(
-      unwrapTypeScriptExpression(value.left),
-      unwrapTypeScriptExpression(prefix),
-      context.sourceCode,
-    )
-  ) {
+  if (!isSameBoundMember(value.left, prefix, context)) {
     return undefined;
   }
   if (value.operator !== '=') {
     return null;
   }
   return getFreshObjectIsolation(context, value.right) ?? null;
+}
+
+function isSameBoundMember(
+  assignmentLeft: estree.Node,
+  prefix: estree.Node,
+  context: Rule.RuleContext,
+): boolean {
+  const left = unwrapTypeScriptExpression(assignmentLeft);
+  const target = unwrapTypeScriptExpression(prefix);
+  if (!areEquivalent(left, target, context.sourceCode)) {
+    return false;
+  }
+  const leftRoot = getStaticRootIdentifier(left);
+  const prefixRoot = getStaticRootIdentifier(target);
+  if (leftRoot === undefined || prefixRoot === undefined) {
+    return false;
+  }
+  const leftVariable = getVariableFromName(context, leftRoot.name, leftRoot);
+  const prefixVariable = getVariableFromName(context, prefixRoot.name, prefixRoot);
+  return leftVariable !== undefined && leftVariable === prefixVariable;
+}
+
+function getStaticRootIdentifier(node: estree.Node): estree.Identifier | undefined {
+  let current: estree.Node = unwrapTypeScriptExpression(node);
+  while (current.type === 'MemberExpression') {
+    current = unwrapTypeScriptExpression(current.object);
+  }
+  return current.type === 'Identifier' ? current : undefined;
 }
 
 function getFreshObjectIsolation(

--- a/packages/analysis/src/jsts/rules/S9135/rule.ts
+++ b/packages/analysis/src/jsts/rules/S9135/rule.ts
@@ -271,25 +271,9 @@ function findDominatingIsolation(
       break;
     }
 
-    if (parent.type === 'SequenceExpression') {
-      const index = parent.expressions.indexOf(current as estree.Expression);
-      if (index > 0) {
-        const candidate = isolationInNodes(parent.expressions.slice(0, index), prefix, context);
-        if (latest === undefined && candidate !== undefined) {
-          latest = candidate;
-        }
-      }
-    } else {
-      const statements = getBlockStatements(parent);
-      if (statements !== undefined) {
-        const index = statements.indexOf(current);
-        if (index > 0) {
-          const candidate = isolationInStatements(statements.slice(0, index), prefix, context);
-          if (latest === undefined && candidate !== undefined) {
-            latest = candidate;
-          }
-        }
-      }
+    const candidate = getPriorIsolation(context, parent, current, prefix);
+    if (latest === undefined && candidate !== undefined) {
+      latest = candidate;
     }
 
     if (latest === 'deep') {
@@ -299,6 +283,27 @@ function findDominatingIsolation(
   }
 
   return latest === null ? undefined : latest;
+}
+
+function getPriorIsolation(
+  context: Rule.RuleContext,
+  parent: estree.Node,
+  current: estree.Node,
+  prefix: estree.Node,
+): PrefixIsolation {
+  if (parent.type === 'SequenceExpression') {
+    const index = parent.expressions.indexOf(current as estree.Expression);
+    return index > 0
+      ? isolationInNodes(parent.expressions.slice(0, index), prefix, context)
+      : undefined;
+  }
+
+  const statements = getBlockStatements(parent);
+  if (statements === undefined) {
+    return undefined;
+  }
+  const index = statements.indexOf(current);
+  return index > 0 ? isolationInStatements(statements.slice(0, index), prefix, context) : undefined;
 }
 
 function getBlockStatements(node: estree.Node): estree.Node[] | undefined {

--- a/packages/analysis/src/jsts/rules/S9135/rule.ts
+++ b/packages/analysis/src/jsts/rules/S9135/rule.ts
@@ -48,6 +48,7 @@ const CLONE_LIBRARIES = new Map<string, 'lodash' | 'underscore'>([
 type MutationNode = estree.AssignmentExpression | estree.UpdateExpression | estree.UnaryExpression;
 
 type IsolationKind = 'deep' | 'shallow';
+type PrefixIsolation = IsolationKind | null | undefined;
 
 type StaticMemberChain = {
   root: estree.Identifier;
@@ -262,7 +263,7 @@ function findDominatingIsolation(
   mutation: MutationNode,
 ): IsolationKind | undefined {
   let current: estree.Node | undefined = mutation;
-  let best: IsolationKind | undefined;
+  let latest: PrefixIsolation;
 
   while (current !== undefined) {
     const parent = getParent(context, current);
@@ -273,31 +274,31 @@ function findDominatingIsolation(
     if (parent.type === 'SequenceExpression') {
       const index = parent.expressions.indexOf(current as estree.Expression);
       if (index > 0) {
-        best = strongerIsolation(
-          best,
-          isolationInNodes(parent.expressions.slice(0, index), prefix, context),
-        );
+        const candidate = isolationInNodes(parent.expressions.slice(0, index), prefix, context);
+        if (latest === undefined && candidate !== undefined) {
+          latest = candidate;
+        }
       }
     } else {
       const statements = getBlockStatements(parent);
       if (statements !== undefined) {
         const index = statements.indexOf(current);
         if (index > 0) {
-          best = strongerIsolation(
-            best,
-            isolationInStatements(statements.slice(0, index), prefix, context),
-          );
+          const candidate = isolationInStatements(statements.slice(0, index), prefix, context);
+          if (latest === undefined && candidate !== undefined) {
+            latest = candidate;
+          }
         }
       }
     }
 
-    if (best === 'deep') {
+    if (latest === 'deep') {
       return 'deep';
     }
     current = parent;
   }
 
-  return best;
+  return latest === null ? undefined : latest;
 }
 
 function getBlockStatements(node: estree.Node): estree.Node[] | undefined {
@@ -314,37 +315,37 @@ function isolationInStatements(
   statements: estree.Node[],
   prefix: estree.Node,
   context: Rule.RuleContext,
-): IsolationKind | undefined {
-  let best: IsolationKind | undefined;
+): PrefixIsolation {
+  let latest: PrefixIsolation;
   for (const statement of statements) {
-    best = strongerIsolation(best, statementAssignsPrefix(statement, prefix, context));
-    if (best === 'deep') {
-      return 'deep';
+    const candidate = statementAssignsPrefix(statement, prefix, context);
+    if (candidate !== undefined) {
+      latest = candidate;
     }
   }
-  return best;
+  return latest;
 }
 
 function isolationInNodes(
   nodes: estree.Node[],
   prefix: estree.Node,
   context: Rule.RuleContext,
-): IsolationKind | undefined {
-  let best: IsolationKind | undefined;
+): PrefixIsolation {
+  let latest: PrefixIsolation;
   for (const node of nodes) {
-    best = strongerIsolation(best, expressionAssignsPrefix(node, prefix, context));
-    if (best === 'deep') {
-      return 'deep';
+    const candidate = expressionAssignsPrefix(node, prefix, context);
+    if (candidate !== undefined) {
+      latest = candidate;
     }
   }
-  return best;
+  return latest;
 }
 
 function statementAssignsPrefix(
   statement: estree.Node,
   prefix: estree.Node,
   context: Rule.RuleContext,
-): IsolationKind | undefined {
+): PrefixIsolation {
   if (statement.type === 'ExpressionStatement') {
     return expressionAssignsPrefix(statement.expression, prefix, context);
   }
@@ -358,7 +359,7 @@ function expressionAssignsPrefix(
   expression: estree.Node,
   prefix: estree.Node,
   context: Rule.RuleContext,
-): IsolationKind | undefined {
+): PrefixIsolation {
   const value = unwrapTypeScriptExpression(expression);
   if (value.type === 'SequenceExpression') {
     return isolationInNodes(value.expressions, prefix, context);
@@ -375,7 +376,10 @@ function expressionAssignsPrefix(
   ) {
     return undefined;
   }
-  return getFreshObjectIsolation(context, value.right);
+  if (value.operator !== '=') {
+    return null;
+  }
+  return getFreshObjectIsolation(context, value.right) ?? null;
 }
 
 function getFreshObjectIsolation(
@@ -400,14 +404,4 @@ function getFreshObjectIsolation(
     return 'shallow';
   }
   return undefined;
-}
-
-function strongerIsolation(
-  current: IsolationKind | undefined,
-  candidate: IsolationKind | undefined,
-): IsolationKind | undefined {
-  if (current === 'deep' || candidate === 'deep') {
-    return 'deep';
-  }
-  return candidate ?? current;
 }

--- a/packages/analysis/src/jsts/rules/S9135/rule.ts
+++ b/packages/analysis/src/jsts/rules/S9135/rule.ts
@@ -25,7 +25,7 @@ import {
   isIdentifier,
   unwrapTypeScriptExpression,
 } from '../helpers/ast.js';
-import { getParent } from '../helpers/ancestor.js';
+import { childrenOf, getParent } from '../helpers/ancestor.js';
 import { areEquivalent } from '../helpers/equivalence.js';
 import { report, toSecondaryLocation } from '../helpers/location.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
@@ -357,7 +357,10 @@ function statementAssignsPrefix(
   if (statement.type === 'BlockStatement') {
     return isolationInStatements(statement.body, prefix, context);
   }
-  return undefined;
+  if (statement.type === 'LabeledStatement') {
+    return statementAssignsPrefix(statement.body, prefix, context);
+  }
+  return containsPrefixWrite(statement, prefix, context) ? null : undefined;
 }
 
 function expressionAssignsPrefix(
@@ -369,16 +372,47 @@ function expressionAssignsPrefix(
   if (value.type === 'SequenceExpression') {
     return isolationInNodes(value.expressions, prefix, context);
   }
-  if (value.type !== 'AssignmentExpression') {
-    return undefined;
+  if (value.type === 'AssignmentExpression') {
+    if (isSameBoundMember(value.left, prefix, context)) {
+      if (value.operator !== '=') {
+        return null;
+      }
+      return getFreshObjectIsolation(context, value.right) ?? null;
+    }
+    return containsPrefixWrite(value.right, prefix, context) ? null : undefined;
   }
-  if (!isSameBoundMember(value.left, prefix, context)) {
-    return undefined;
+  return containsPrefixWrite(value, prefix, context) ? null : undefined;
+}
+
+function containsPrefixWrite(
+  node: estree.Node,
+  prefix: estree.Node,
+  context: Rule.RuleContext,
+): boolean {
+  const current = unwrapTypeScriptExpression(node);
+  if (FUNCTION_NODES.includes(current.type)) {
+    return false;
   }
-  if (value.operator !== '=') {
-    return null;
+  if (isPrefixWrite(current, prefix, context)) {
+    return true;
   }
-  return getFreshObjectIsolation(context, value.right) ?? null;
+  return childrenOf(current, context.sourceCode.visitorKeys).some((child: estree.Node) =>
+    containsPrefixWrite(child, prefix, context),
+  );
+}
+
+function isPrefixWrite(node: estree.Node, prefix: estree.Node, context: Rule.RuleContext): boolean {
+  if (node.type === 'AssignmentExpression') {
+    return isSameBoundMember(node.left, prefix, context);
+  }
+  if (node.type === 'UpdateExpression') {
+    return isSameBoundMember(node.argument, prefix, context);
+  }
+  return (
+    node.type === 'UnaryExpression' &&
+    node.operator === 'delete' &&
+    isSameBoundMember(node.argument, prefix, context)
+  );
 }
 
 function isSameBoundMember(

--- a/packages/analysis/src/jsts/rules/S9135/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S9135/unit.test.ts
@@ -120,6 +120,16 @@ if (enabled) {
 }
 `,
         },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+{
+  copy.address = _.cloneDeep(user.address);
+}
+copy.address.city = 'Geneva'; // Compliant: same binding
+`,
+        },
       ],
       invalid: [
         {
@@ -518,6 +528,27 @@ copy.address.city = 'Geneva';
 import _ from 'lodash';
 const copy = _.clone(user);
 copy.address ??= {};
+copy.address.city = 'Geneva';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address &&= {};
+copy.address.city = 'Geneva';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+{
+  const copy = other;
+  copy.address = _.cloneDeep(user.address);
+}
 copy.address.city = 'Geneva';
 `,
           errors: 1,

--- a/packages/analysis/src/jsts/rules/S9135/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S9135/unit.test.ts
@@ -75,6 +75,51 @@ const copy = _.clone(user);
 copy[address].city = 'Geneva';
 `,
         },
+        {
+          code: `
+import _ from 'lodash';
+const config = _.clone(tlConfig);
+if (offset) {
+  config.time = _.cloneDeep(tlConfig.time);
+  config.time.from = offsetTime(config.time.from, offset); // Compliant: nested object replaced
+  config.time.to = offsetTime(config.time.to, offset);
+}
+`,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = structuredClone(user.address);
+copy.address.city = 'Geneva'; // Compliant: nested object replaced
+`,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = {};
+copy.address.city = 'Geneva'; // Compliant: nested object replaced
+`,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.clone(user.address);
+copy.address.city = 'Geneva'; // Compliant: one-level write on replaced object
+`,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+if (enabled) {
+  copy.address.geo.lat = 1; // Compliant: dominating deep clone
+}
+`,
+        },
       ],
       invalid: [
         {
@@ -422,6 +467,42 @@ const result = (copy.address.city = 'Geneva'); // NOSONAR: shared nested state i
               ],
             },
           ],
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+if (!copy.address) copy.address = {};
+copy.address.city = 'Geneva';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.meta = _.cloneDeep(user.meta);
+copy.address.city = 'Geneva';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address.city = 'Geneva';
+copy.address = _.cloneDeep(user.address);
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.clone(user.address);
+copy.address.geo.lat = 1;
+`,
+          errors: 1,
         },
       ],
     });

--- a/packages/analysis/src/jsts/rules/S9135/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S9135/unit.test.ts
@@ -563,6 +563,85 @@ copy.address.city = 'Geneva';
 `,
           errors: 1,
         },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+if (cond) { copy.address = user.address; }
+copy.address.city = 'a';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+try { copy.address = user.address; } catch (e) {}
+copy.address.city = 'a';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+for (const x of xs) { copy.address = user.address; }
+copy.address.city = 'a';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+switch (cond) { case 1: copy.address = user.address; }
+copy.address.city = 'a';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+label: copy.address = user.address;
+copy.address.city = 'a';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+cond && (copy.address = user.address);
+copy.address.city = 'a';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+cond ? (copy.address = user.address) : 0;
+copy.address.city = 'a';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+if (cond) copy.address = _.cloneDeep(user.address);
+copy.address.city = 'Geneva';
+`,
+          errors: 1,
+        },
       ],
     });
   });

--- a/packages/analysis/src/jsts/rules/S9135/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S9135/unit.test.ts
@@ -504,6 +504,34 @@ copy.address.geo.lat = 1;
 `,
           errors: 1,
         },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address ||= {};
+copy.address.city = 'Geneva';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address ??= {};
+copy.address.city = 'Geneva';
+`,
+          errors: 1,
+        },
+        {
+          code: `
+import _ from 'lodash';
+const copy = _.clone(user);
+copy.address = _.cloneDeep(user.address);
+copy.address = user.address;
+copy.address.city = 'Geneva';
+`,
+          errors: 1,
+        },
       ],
     });
   });


### PR DESCRIPTION
## Summary
- S9135 no longer reports nested writes when a dominating assignment already replaced that nested object with `_.cloneDeep()`, `structuredClone()`, `_.clone()`, or an object/array literal.
- Conditional replacements still report, so a write after `if (!copy.address) copy.address = {}` remains an issue.
- Adds unit coverage for`clone` then `cloneDeep` then nested write false positive.

Jira: https://sonarsource.atlassian.net/browse/JS-2246

## Test plan
- [x] `npx tsx --test packages/analysis/src/jsts/rules/S9135/**/*.test.ts`
- [ ] Confirm CI unit tests and ruling jobs stay green