### PR TITLE
JS-2240 S2819: Avoid false positives for Worker message handlers

### DIFF
--- a/packages/analysis/src/jsts/rules/S2819/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2819/rule.ts
@@ -99,9 +99,11 @@ function checkPostMessageCall(callExpr: estree.CallExpression, context: Rule.Rul
 function checkAddEventListenerCall(callExpr: estree.CallExpression, context: Rule.RuleContext) {
   const { callee, arguments: args } = callExpr;
   if (
+    callee.type !== 'MemberExpression' ||
     !isWindowObject(callee, context) ||
     args.length < 2 ||
-    !isMessageTypeEvent(args[0], context)
+    !isMessageTypeEvent(args[0], context) ||
+    isWindowAliasedToWorkerGlobal(callee.object, context)
   ) {
     return;
   }

--- a/packages/analysis/src/jsts/rules/S2819/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2819/unit.test.ts
@@ -241,6 +241,40 @@ describe('S2819', () => {
         },
         {
           code: `
+      if (typeof window === 'undefined') {
+        window = self;
+      }
+      window.addEventListener("message", function(event) {
+        console.log(event.data);
+      });
+            `,
+        },
+        {
+          code: `
+      if (typeof window === 'undefined') {
+        window = global;
+      }
+      window.addEventListener("message", function(event) {
+        console.log(event.data);
+      });
+            `,
+        },
+        {
+          // the shape found in the wild: shim and addEventListener inside a module factory
+          code: `
+      define(function (require, exports, module) {
+        if (typeof window == "undefined") {
+          if (typeof self != "undefined") window = self;
+          if (typeof global != "undefined") window = global;
+        }
+        window.addEventListener("message", function (event) {
+          console.log(event.data);
+        });
+      });
+            `,
+        },
+        {
+          code: `
       window.addEventListener("missing listener");
       window.addEventListener("message", "not a function");
       not_a_win_dow.addEventListener("message", () => {});
@@ -409,6 +443,15 @@ describe('S2819', () => {
         console.log(event.data);
       };
       window.addEventListener("message", handleMessage);
+            `,
+          errors: [{ messageId: 'verifyOrigin' }],
+        },
+        {
+          code: `
+      const window = self;
+      window.addEventListener("message", function(event) {
+        console.log(event.data);
+      });
             `,
           errors: [{ messageId: 'verifyOrigin' }],
         },


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Bug Fixes:**
    - Avoid false positives for `Worker` message handlers by checking `isWindowAliasedToWorkerGlobal` in `rule.ts`.

<sub>This will update automatically on new commits.</sub>