### PR TITLE
JS-2250 Fix bump-versions workflow to produce semantic snapshot versions

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -28,7 +28,11 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          snapshot_version="${VERSION}-SNAPSHOT"
+          version="${VERSION}"
+          if [[ "$version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            version="${version}.0"
+          fi
+          snapshot_version="${version}-SNAPSHOT"
           # Update the revision property in root pom.xml to the new snapshot version
           sed -i "s/<revision>.*-SNAPSHOT<\/revision>/<revision>${snapshot_version}<\/revision>/" pom.xml
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
## Summary
- In `.github/workflows/bump-versions.yml`, normalize 2-part version numbers (e.g. `13.7`) received from the automated release workflow to 3-part versions (`13.7.0`) before appending `-SNAPSHOT`.
- This ensures that automatic version bump PRs (`Prepare next development iteration`) produce valid `<revision>13.7.0-SNAPSHOT</revision>` entries in `pom.xml`.

## Jira
- [JS-2250](https://sonarsource.atlassian.net/browse/JS-2250)

## Test Plan
- Verified regex normalization behavior against `13.7` -> `13.7.0-SNAPSHOT`, `13.7.0` -> `13.7.0-SNAPSHOT`, and `13.7.1` -> `13.7.1-SNAPSHOT`.

[JS-2250]: https://sonarsource.atlassian.net/browse/JS-2250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ