### PR TITLE
JS-2261 Skip project analysis when all files are cached

### DIFF
--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -442,6 +442,12 @@ public class BridgeServerImpl implements BridgeServer {
   @Override
   public void analyzeProject(ProjectAnalysisHandler handler) {
     var grpcRequest = enrichAnalyzeProjectRequest(handler.getRequest());
+    if (grpcRequest.getFilesCount() == 0) {
+      LOG.debug("Skipping project analysis because there are no files to analyze");
+      handler.getFuture().complete(null);
+      ensureProjectAnalysisCompleted(handler);
+      return;
+    }
     var analyzeContext = Context.current().withCancellation();
     var finished = new AtomicBoolean(false);
     var cancellationWatcher = startStreamCancellationWatcher(handler, analyzeContext, finished);

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -601,6 +601,27 @@ class BridgeServerImplTest {
   }
 
   @Test
+  void should_skip_streaming_analysis_when_there_are_no_files_to_analyze() {
+    bridgeServer = createUnitBridgeServer();
+    var future = new CompletableFuture<Void>();
+    var handler = mock(ProjectAnalysisHandler.class);
+    when(handler.getRequest()).thenReturn(AnalyzeProjectRequest.getDefaultInstance());
+    when(handler.getFuture()).thenReturn(future);
+
+    try (MockedStatic<AnalyzeProjectServiceGrpc> mockedGrpc = mockStatic(
+      AnalyzeProjectServiceGrpc.class
+    )) {
+      bridgeServer.analyzeProject(handler);
+
+      mockedGrpc.verifyNoInteractions();
+      assertThat(future).isCompleted();
+      assertThat(logTester.logs(DEBUG)).contains(
+        "Skipping project analysis because there are no files to analyze"
+      );
+    }
+  }
+
+  @Test
   void should_cancel_streaming_analysis_while_waiting_for_the_next_message() throws Exception {
     bridgeServer = createBridgeServer("slowStream.js", SHORT_STARTUP_TIMEOUT_SECONDS);
     bridgeServer.startServer(serverConfig);
@@ -658,10 +679,11 @@ class BridgeServerImplTest {
     var stub = mock(AnalyzeProjectServiceGrpc.AnalyzeProjectServiceBlockingStub.class);
 
     var future = new CompletableFuture<Void>();
+    var request = createProjectRequest(createInputFile(), false);
     var handler = new ProjectAnalysisHandler() {
       @Override
       public AnalyzeProjectRequest getRequest() {
-        return AnalyzeProjectRequest.getDefaultInstance();
+        return request;
       }
 
       @Override
@@ -712,10 +734,11 @@ class BridgeServerImplTest {
     bridgeServer = createUnitBridgeServer();
     var stub = mock(AnalyzeProjectServiceGrpc.AnalyzeProjectServiceBlockingStub.class);
     var future = new CompletableFuture<Void>();
+    var request = createProjectRequest(createInputFile(), false);
     var handler = new ProjectAnalysisHandler() {
       @Override
       public AnalyzeProjectRequest getRequest() {
-        return AnalyzeProjectRequest.getDefaultInstance();
+        return request;
       }
 
       @Override


### PR DESCRIPTION
Part of

Fixes the all-cache-hit project-analysis path reported in the [community thread](https://community.sonarsource.com/t/sonarjs-13-3-0-cache-hit-unknown-file-path-bug-report/186535).

When request construction consumes every input from the analysis cache, the resulting project-analysis request has no files. We now complete that analysis locally instead of starting an empty streaming gRPC call. Cache replay still happens while the request is built, so cached issues, CPD tokens, and ASTs continue to be processed.

The regression test verifies that an empty request completes without creating an `AnalyzeProjectServiceGrpc` stub. Existing transport-error tests now use non-empty requests so they continue to exercise the transport path.

Tested with:

```text
mvn -pl sonar-plugin/bridge -am -Dskip-nodejs -Dskip-java-generation "-Dtest=BridgeServerImplTest" "-Dsurefire.failIfNoSpecifiedTests=false" test
```
