### PR TITLE
JS-2260 Avoid error logs for recoverable parsing failures

### DIFF
--- a/packages/analysis/src/contracts/project-analysis.ts
+++ b/packages/analysis/src/contracts/project-analysis.ts
@@ -18,9 +18,7 @@ import { APIError, ErrorCode } from './error.js';
 import { handleError } from '../../../shared/src/helpers/error.js';
 
 type ParsingErrorCode =
-  | ErrorCode.Parsing
-  | ErrorCode.FailingTypeScript
-  | ErrorCode.LinterInitialization;
+  ErrorCode.Parsing | ErrorCode.FailingTypeScript | ErrorCode.LinterInitialization;
 
 export type ParsingErrorLanguage = 'js' | 'ts' | 'css';
 
@@ -53,12 +51,13 @@ export function toProjectFailureResult(
 ): ProjectFailureResult {
   if (failure instanceof APIError) {
     if (isParsingErrorCode(failure.code)) {
-      const { error } = handleError(failure);
+      const message =
+        failure.code === ErrorCode.Parsing ? failure.message : handleError(failure).error;
       return {
         issues: [],
         parsingErrors: [
           {
-            message: error,
+            message,
             code: failure.code,
             line: failure.data?.line,
             column: failure.data?.column,

--- a/packages/analysis/src/contracts/project-analysis.ts
+++ b/packages/analysis/src/contracts/project-analysis.ts
@@ -37,36 +37,36 @@ type ProjectParsingResult = {
 
 export type ProjectFailureResult = ProjectParsingResult | { error: string };
 
-function isParsingErrorCode(code: ErrorCode | undefined): code is ParsingErrorCode {
-  return (
-    code === ErrorCode.Parsing ||
-    code === ErrorCode.FailingTypeScript ||
-    code === ErrorCode.LinterInitialization
-  );
-}
-
 export function toProjectFailureResult(
   failure: unknown,
   language: ParsingErrorLanguage,
 ): ProjectFailureResult {
   if (failure instanceof APIError) {
-    if (isParsingErrorCode(failure.code)) {
-      const message =
-        failure.code === ErrorCode.Parsing ? failure.message : handleError(failure).error;
-      return {
-        issues: [],
-        parsingErrors: [
-          {
-            message,
-            code: failure.code,
-            line: failure.data?.line,
-            column: failure.data?.column,
-            language,
-          },
-        ],
-      };
+    const { code } = failure;
+    let message: string;
+    switch (code) {
+      case ErrorCode.Parsing:
+        message = failure.message;
+        break;
+      case ErrorCode.FailingTypeScript:
+      case ErrorCode.LinterInitialization:
+        message = handleError(failure).error;
+        break;
+      default:
+        return handleError(failure);
     }
-    return handleError(failure);
+    return {
+      issues: [],
+      parsingErrors: [
+        {
+          message,
+          code,
+          line: failure.data?.line,
+          column: failure.data?.column,
+          language,
+        },
+      ],
+    };
   }
 
   if (failure instanceof Error) {

--- a/packages/analysis/tests/contracts/project-analysis.test.ts
+++ b/packages/analysis/tests/contracts/project-analysis.test.ts
@@ -20,12 +20,14 @@ import { APIError, ErrorCode } from '../../src/contracts/error.js';
 import { toProjectFailureResult } from '../../src/contracts/project-analysis.js';
 
 describe('toProjectFailureResult', () => {
-  it('should convert parsing API errors to parsingErrors and log stack trace', ({ mock }) => {
+  it('should convert parsing API errors to parsingErrors without logging stack trace', ({
+    mock,
+  }) => {
     const apiError = APIError.parsingError('Unexpected token', { line: 7, column: 3 });
     apiError.stack = 'stack-trace';
     console.error = mock.fn(() => {}) as Mock<typeof console.error>;
 
-    expect(toProjectFailureResult(apiError, 'ts')).toEqual({
+    expect(toProjectFailureResult(apiError, 'css')).toEqual({
       issues: [],
       parsingErrors: [
         {
@@ -33,6 +35,26 @@ describe('toProjectFailureResult', () => {
           code: ErrorCode.Parsing,
           line: 7,
           column: 3,
+          language: 'css',
+        },
+      ],
+    });
+    expect((console.error as Mock<typeof console.error>).mock.calls).toHaveLength(0);
+  });
+
+  it('should log stack trace for non-recoverable API errors', ({ mock }) => {
+    const apiError = APIError.failingTypeScriptError('TypeScript failure');
+    apiError.stack = 'stack-trace';
+    console.error = mock.fn(() => {}) as Mock<typeof console.error>;
+
+    expect(toProjectFailureResult(apiError, 'ts')).toEqual({
+      issues: [],
+      parsingErrors: [
+        {
+          message: 'TypeScript failure',
+          code: ErrorCode.FailingTypeScript,
+          line: undefined,
+          column: undefined,
           language: 'ts',
         },
       ],


### PR DESCRIPTION
Part of

## Summary

- avoid logging stack traces at error level for recoverable parsing failures
- preserve stack logging for non-recoverable TypeScript and linter failures
- add regression coverage for both paths

## Why

Recoverable parsing failures are returned to the scanner and subsequently logged as warnings. Logging their stack to stderr first causes Azure DevOps to add `##[error]` annotations to otherwise successful analyses.

Community report: https://community.sonarsource.com/t/server-2026-4-enterprise-javascript-typescript-css-sensor-logs-non-fatal-parse-issue-a-error/187134/2

## Tests

- `npm run bbf`
- `npm run bridge:test` (2313 tests passed)
