### PR TITLE
JS-2279 Keep README generation out of Maven builds

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -146,7 +146,9 @@ Local builds and CI do not consume RSPEC data the same way:
   `rspec-rule-data-${github.sha}` artifact. Downstream jobs use that refreshed artifact instead of
   the tracked JSON from the branch.
 - The nightly `generated_files_freshness` workflow keeps the tracked JSON on `master` reasonably
-  fresh, but pull request CI does not wait for those tracked files to be updated.
+  fresh, but pull request CI does not wait for those tracked files to be updated. That job also
+  regenerates the tracked README files and opens or updates the generated-files PR. README
+  generation is intentionally not part of the normal Maven lifecycle.
 
 Because of that, pull request CI can fail even when the tracked JSON in the branch still looks
 consistent.
@@ -241,7 +243,6 @@ It skips:
 - `tools/sync-nodejs-versions.mjs`
 - `npm run generate-meta`
 - `npm run generate-java-rule-classes`
-- `npm run count-rules`
 - bridge `npm run bridge:compile`
 - bridge `npm run bridge:bundle`
 - bridge `npm pack`
@@ -328,7 +329,6 @@ Because of that, a common workflow is:
 
 - runs `npm run generate-meta`
 - runs `npm run generate-java-rule-classes`
-- runs `npm run count-rules`
 - builds, bundles, and packs the bridge
 - generates `bridge/src/main/resources/org/sonar/plugins/javascript/bridge/node-info.properties`
 

--- a/sonar-plugin/javascript-checks/pom.xml
+++ b/sonar-plugin/javascript-checks/pom.xml
@@ -124,21 +124,6 @@
               </arguments>
             </configuration>
           </execution>
-          <execution>
-            <id>Update README with rule counts</id>
-            <phase>${node.build.phase}</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>npm</executable>
-              <workingDirectory>../..</workingDirectory>
-              <arguments>
-                <argument>run</argument>
-                <argument>count-rules</argument>
-              </arguments>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
Part of [JS-2211](https://sonarsource.atlassian.net/browse/JS-2211)

## Why

The `javascript-checks` Maven lifecycle ran `npm run count-rules` during every normal build. That command rewrites the root README rule counts, even though the README is neither a build input nor an artifact required to compile or package SonarJS.

The nightly `generated_files_freshness` job already owns this synchronization. It refreshes RSPEC data, regenerates the tracked documentation, and opens or updates a generated-files PR. Because it runs on a schedule, RSPEC-only changes still propagate to SonarJS even when the SonarJS codebase is unchanged.

## What changed

- Remove `count-rules` from the normal Maven lifecycle.
- Keep the `count-rules` npm command and its explicit nightly workflow invocation.
- Document that README regeneration belongs to the scheduled generated-files refresh.

No README content changes in this PR.

## Verification

- `npm ci`
- `npm run bbf`
- `mvn -pl sonar-plugin/javascript-checks -am -DskipTests package`
- `npm run count-rules`
- `npx prettier --check docs/BUILD.md`


[JS-2211]: https://sonarsource.atlassian.net/browse/JS-2211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ