### PR TITLE
JS-2280 Fix S7785 false positive for promise chains stored for later consumption

### DIFF
--- a/packages/analysis/src/jsts/rules/S7785/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7785/decorator.ts
@@ -31,9 +31,9 @@ import {
 import * as meta from './generated-meta.js';
 
 /**
- * A TypeScript assertion wrapper (`x as T`, `x satisfies T`, `x!`, `<T>x`) forces a contextual
- * type onto the wrapped expression without actually consuming or awaiting it. Such a chain is
- * still floating, so the assertion must not be mistaken for storage-for-later-consumption.
+ * A TypeScript assertion wrapper (`x as T`, `x satisfies T`, `x!`, `<T>x`) only pins the type of
+ * the wrapped expression; it neither consumes nor awaits it. Such wrappers must be looked through
+ * to find the node that occupies the real syntactic slot when deciding whether a chain is stored.
  */
 function isAssertionWrapper(node: Rule.Node) {
   const type = node.type as string;
@@ -99,11 +99,21 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
           // Suppress when the chain is handed off to a Promise/PromiseLike-typed destination
           // (a typed call argument or assignment target) to be awaited later, rather than
           // floating at the top level.
-          const isStoredForLaterConsumption =
-            chainCall?.type === 'CallExpression' &&
-            chainCall.callee === memberExpr &&
-            !isAssertionWrapper(chainCall.parent) &&
-            isContextualTypeThenable(chainCall, services);
+          let isStoredForLaterConsumption = false;
+          if (chainCall?.type === 'CallExpression' && chainCall.callee === memberExpr) {
+            // A TS assertion (`as`/`satisfies`/`!`/`<T>`) does not consume the chain and only
+            // pins its type, so look through any assertion wrappers to the node that occupies
+            // the real syntactic slot before reading the contextual type of that slot. This
+            // keeps a floating `chain as Promise<T>;` reported while still suppressing a chain
+            // that is both asserted and genuinely stored (e.g. `sink = chain as Promise<T>`).
+            let consumed: Rule.Node = chainCall;
+            let parent: Rule.Node | null = consumed.parent;
+            while (parent && isAssertionWrapper(parent)) {
+              consumed = parent;
+              parent = consumed.parent;
+            }
+            isStoredForLaterConsumption = isContextualTypeThenable(consumed, services);
+          }
           if (!isStoredForLaterConsumption) {
             context.report(descriptor);
           }

--- a/packages/analysis/src/jsts/rules/S7785/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7785/decorator.ts
@@ -21,7 +21,13 @@ import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { interceptReport } from '../helpers/decorators/interceptor.js';
 import { isRequiredParserServices } from '../helpers/parser-services.js';
-import { getTypeFromTreeNode, isAny, isThenable, typeHasMethod } from '../helpers/type.js';
+import {
+  getTypeFromTreeNode,
+  isAny,
+  isContextualTypeThenable,
+  isThenable,
+  typeHasMethod,
+} from '../helpers/type.js';
 import * as meta from './generated-meta.js';
 
 /**
@@ -73,11 +79,19 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
         const isThenableType = isThenable(receiver, services);
         const supportsReportedMethod =
           methodName === 'then' || typeHasMethod(receiver, methodName, services);
-        if (isThenableType && supportsReportedMethod) {
+        const chainCall = memberExpr.parent;
+        // Suppress when the chain is handed off to a Promise/PromiseLike-typed destination
+        // (a typed call argument or assignment target) to be awaited later, rather than
+        // floating at the top level.
+        const isStoredForLaterConsumption =
+          chainCall?.type === 'CallExpression' &&
+          chainCall.callee === memberExpr &&
+          isContextualTypeThenable(chainCall, services);
+        if (isThenableType && supportsReportedMethod && !isStoredForLaterConsumption) {
           context.report(descriptor);
         }
 
-        // Suppress otherwise (e.g. ZodString, unknown).
+        // Suppress otherwise (e.g. ZodString, unknown, or stored for later consumption).
       } else {
         context.report(descriptor);
       }

--- a/packages/analysis/src/jsts/rules/S7785/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7785/decorator.ts
@@ -31,6 +31,21 @@ import {
 import * as meta from './generated-meta.js';
 
 /**
+ * A TypeScript assertion wrapper (`x as T`, `x satisfies T`, `x!`, `<T>x`) forces a contextual
+ * type onto the wrapped expression without actually consuming or awaiting it. Such a chain is
+ * still floating, so the assertion must not be mistaken for storage-for-later-consumption.
+ */
+function isAssertionWrapper(node: Rule.Node) {
+  const type = node.type as string;
+  return (
+    type === 'TSAsExpression' ||
+    type === 'TSSatisfiesExpression' ||
+    type === 'TSNonNullExpression' ||
+    type === 'TSTypeAssertion'
+  );
+}
+
+/**
  * Decorates the unicorn/prefer-top-level-await rule to suppress false positives for synchronous
  * APIs that overlap with Promise methods when type information is available.
  *
@@ -87,6 +102,7 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
           const isStoredForLaterConsumption =
             chainCall?.type === 'CallExpression' &&
             chainCall.callee === memberExpr &&
+            !isAssertionWrapper(chainCall.parent) &&
             isContextualTypeThenable(chainCall, services);
           if (!isStoredForLaterConsumption) {
             context.report(descriptor);

--- a/packages/analysis/src/jsts/rules/S7785/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7785/decorator.ts
@@ -21,6 +21,7 @@ import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { interceptReport } from '../helpers/decorators/interceptor.js';
 import { isRequiredParserServices } from '../helpers/parser-services.js';
+import type { RequiredParserServices } from '../helpers/parser-services.js';
 import {
   getTypeFromTreeNode,
   isAny,
@@ -46,6 +47,87 @@ function isAssertionWrapper(node: Rule.Node) {
 }
 
 /**
+ * Determines whether the promise chain rooted at `memberExpr` is handed off to a
+ * Promise/PromiseLike-typed destination (a typed call argument or assignment target)
+ * to be awaited later, rather than floating at the top level.
+ *
+ * A TS assertion (`as`/`satisfies`/`!`/`<T>`) does not consume the chain and only pins
+ * its type, so look through any assertion wrappers to the node that occupies the real
+ * syntactic slot before reading the contextual type of that slot. This keeps a floating
+ * `chain as Promise<T>;` reported while still suppressing a chain that is both asserted
+ * and genuinely stored (e.g. `sink = chain as Promise<T>`).
+ */
+function isStoredForLaterConsumption(
+  memberExpr: estree.MemberExpression & Rule.NodeParentExtension,
+  services: RequiredParserServices,
+): boolean {
+  const chainCall = memberExpr.parent;
+  if (chainCall?.type !== 'CallExpression' || chainCall.callee !== memberExpr) {
+    return false;
+  }
+  let consumed: Rule.Node = chainCall;
+  let parent: Rule.Node | null = consumed.parent;
+  while (parent && isAssertionWrapper(parent)) {
+    consumed = parent;
+    parent = consumed.parent;
+  }
+  return isContextualTypeThenable(consumed, services);
+}
+
+/**
+ * Decides whether a 'promise' report should be raised. Returns true to report and false
+ * to suppress the false positive. Non-'promise' reports (iife/identifier) and untyped
+ * analysis always pass through unchanged.
+ */
+function shouldReportPromiseChain(
+  context: Rule.RuleContext,
+  descriptor: Rule.ReportDescriptor,
+): boolean {
+  // Only filter 'promise' reports (.then/.catch/.finally chains).
+  // Let iife and identifier reports pass through unchanged.
+  if (
+    !('messageId' in descriptor) ||
+    descriptor.messageId !== 'promise' ||
+    !('node' in descriptor)
+  ) {
+    return true;
+  }
+
+  const methodNode = descriptor.node as estree.Identifier;
+  const methodName = methodNode.name; // 'then', 'catch', or 'finally'
+  const memberExpr = (methodNode as Rule.Node).parent;
+  if (memberExpr?.type !== 'MemberExpression') {
+    return true;
+  }
+
+  const services = context.sourceCode.parserServices;
+  if (!isRequiredParserServices(services)) {
+    return true;
+  }
+
+  // Type-checker mode: use structural assignability to PromiseLike / Promise.
+  const receiver = memberExpr.object;
+  const type = getTypeFromTreeNode(receiver, services);
+  if (isAny(type)) {
+    // 'any' could be a Promise — warn conservatively.
+    return true;
+  }
+
+  // Thenable types can be awaited. For `catch`/`finally`, also require
+  // that the reported method exists on the receiver type.
+  const isThenableType = isThenable(receiver, services);
+  const supportsReportedMethod =
+    methodName === 'then' || typeHasMethod(receiver, methodName, services);
+  if (!isThenableType || !supportsReportedMethod) {
+    // Suppress otherwise (e.g. ZodString, unknown).
+    return false;
+  }
+
+  // Suppress when the chain is stored for later consumption rather than floating.
+  return !isStoredForLaterConsumption(memberExpr, services);
+}
+
+/**
  * Decorates the unicorn/prefer-top-level-await rule to suppress false positives for synchronous
  * APIs that overlap with Promise methods when type information is available.
  *
@@ -53,77 +135,12 @@ function isAssertionWrapper(node: Rule.Node) {
  * Zod/schema suppression is now provided upstream by Unicorn.
  */
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
-  const intercepted = interceptReport(
+  return interceptReport(
     { ...rule, meta: generateMeta(meta, rule.meta) },
     (context, descriptor) => {
-      // Only filter 'promise' reports (.then/.catch/.finally chains).
-      // Let iife and identifier reports pass through unchanged.
-      if (!('messageId' in descriptor) || descriptor.messageId !== 'promise') {
-        context.report(descriptor);
-        return;
-      }
-
-      if (!('node' in descriptor)) {
-        context.report(descriptor);
-        return;
-      }
-
-      const methodNode = descriptor.node as estree.Identifier;
-      const methodName = methodNode.name; // 'then', 'catch', or 'finally'
-      const memberExpr = (methodNode as Rule.Node).parent;
-
-      if (memberExpr?.type !== 'MemberExpression') {
-        context.report(descriptor);
-        return;
-      }
-
-      const receiver = memberExpr.object;
-      const services = context.sourceCode.parserServices;
-
-      if (isRequiredParserServices(services)) {
-        // Type-checker mode: use structural assignability to PromiseLike / Promise.
-        const type = getTypeFromTreeNode(receiver, services);
-        if (isAny(type)) {
-          // 'any' could be a Promise — warn conservatively.
-          context.report(descriptor);
-          return;
-        }
-
-        // Thenable types can be awaited. For `catch`/`finally`, also require
-        // that the reported method exists on the receiver type.
-        const isThenableType = isThenable(receiver, services);
-        const supportsReportedMethod =
-          methodName === 'then' || typeHasMethod(receiver, methodName, services);
-        if (isThenableType && supportsReportedMethod) {
-          const chainCall = memberExpr.parent;
-          // Suppress when the chain is handed off to a Promise/PromiseLike-typed destination
-          // (a typed call argument or assignment target) to be awaited later, rather than
-          // floating at the top level.
-          let isStoredForLaterConsumption = false;
-          if (chainCall?.type === 'CallExpression' && chainCall.callee === memberExpr) {
-            // A TS assertion (`as`/`satisfies`/`!`/`<T>`) does not consume the chain and only
-            // pins its type, so look through any assertion wrappers to the node that occupies
-            // the real syntactic slot before reading the contextual type of that slot. This
-            // keeps a floating `chain as Promise<T>;` reported while still suppressing a chain
-            // that is both asserted and genuinely stored (e.g. `sink = chain as Promise<T>`).
-            let consumed: Rule.Node = chainCall;
-            let parent: Rule.Node | null = consumed.parent;
-            while (parent && isAssertionWrapper(parent)) {
-              consumed = parent;
-              parent = consumed.parent;
-            }
-            isStoredForLaterConsumption = isContextualTypeThenable(consumed, services);
-          }
-          if (!isStoredForLaterConsumption) {
-            context.report(descriptor);
-          }
-        }
-
-        // Suppress otherwise (e.g. ZodString, unknown, or stored for later consumption).
-      } else {
+      if (shouldReportPromiseChain(context, descriptor)) {
         context.report(descriptor);
       }
     },
   );
-  return intercepted;
 }

--- a/packages/analysis/src/jsts/rules/S7785/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7785/decorator.ts
@@ -79,16 +79,18 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
         const isThenableType = isThenable(receiver, services);
         const supportsReportedMethod =
           methodName === 'then' || typeHasMethod(receiver, methodName, services);
-        const chainCall = memberExpr.parent;
-        // Suppress when the chain is handed off to a Promise/PromiseLike-typed destination
-        // (a typed call argument or assignment target) to be awaited later, rather than
-        // floating at the top level.
-        const isStoredForLaterConsumption =
-          chainCall?.type === 'CallExpression' &&
-          chainCall.callee === memberExpr &&
-          isContextualTypeThenable(chainCall, services);
-        if (isThenableType && supportsReportedMethod && !isStoredForLaterConsumption) {
-          context.report(descriptor);
+        if (isThenableType && supportsReportedMethod) {
+          const chainCall = memberExpr.parent;
+          // Suppress when the chain is handed off to a Promise/PromiseLike-typed destination
+          // (a typed call argument or assignment target) to be awaited later, rather than
+          // floating at the top level.
+          const isStoredForLaterConsumption =
+            chainCall?.type === 'CallExpression' &&
+            chainCall.callee === memberExpr &&
+            isContextualTypeThenable(chainCall, services);
+          if (!isStoredForLaterConsumption) {
+            context.report(descriptor);
+          }
         }
 
         // Suppress otherwise (e.g. ZodString, unknown, or stored for later consumption).

--- a/packages/analysis/src/jsts/rules/S7785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7785/unit.test.ts
@@ -167,6 +167,18 @@ describe('S7785', () => {
           code: `const holder: { promise: Promise<number> } = { promise: Promise.resolve(0) };
                  holder.promise = Promise.resolve(42).then(x => x).catch(() => 0);`,
         },
+        {
+          // Suppress: chain is both asserted (`as`) and genuinely stored — the assignment to a
+          // Promise-typed target is the real consumer, so the assertion must not force a report
+          code: `let sink: Promise<number>;
+                 sink = Promise.resolve(42).then(x => x).catch(() => 0) as Promise<number>;`,
+        },
+        {
+          // Suppress: chain is both asserted and passed to a Promise-typed parameter — still
+          // handed off for later consumption, the assertion is incidental
+          code: `function doWork(arg: Promise<number>) {}
+                 doWork(Promise.resolve(42).then(x => x).catch(() => 0) as Promise<number>);`,
+        },
       ],
       invalid: [
         {

--- a/packages/analysis/src/jsts/rules/S7785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7785/unit.test.ts
@@ -167,13 +167,6 @@ describe('S7785', () => {
           code: `const holder: { promise: Promise<number> } = { promise: Promise.resolve(0) };
                  holder.promise = Promise.resolve(42).then(x => x).catch(() => 0);`,
         },
-        {
-          // Suppress: chain returned from a function whose declared return type is Promise —
-          // the contextual type from the return statement confirms it's forwarded, not floating
-          code: `function getValue(): Promise<number> {
-                   return Promise.resolve(42).then(x => x).catch(() => 0);
-                 }`,
-        },
       ],
       invalid: [
         {
@@ -235,6 +228,17 @@ describe('S7785', () => {
           // Warn: destination variable is typed but not Promise-typed — still floating
           code: `let sink: unknown;
                  sink = Promise.resolve(42).then(x => x).catch(() => 0);`,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // Warn: `as` assertion forces a Promise contextual type but nothing consumes the
+          // chain — it is still floating, so the assertion must not suppress the report
+          code: `Promise.resolve(42).then(x => x) as Promise<number>;`,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // Warn: `satisfies` assertion likewise does not consume the floating chain
+          code: `Promise.resolve(42).then(x => x) satisfies Promise<number>;`,
           errors: [{ messageId: 'promise' }],
         },
       ],

--- a/packages/analysis/src/jsts/rules/S7785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7785/unit.test.ts
@@ -15,11 +15,40 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rule } from './index.js';
+import { rules } from '../external/unicorn.js';
 import {
   NoTypeCheckingRuleTester,
   RuleTester,
 } from '../../../../tests/jsts/tools/testers/rule-tester.js';
 import { describe, it } from 'node:test';
+
+const upstreamRule = rules['prefer-top-level-await'];
+
+// Sentinel: verify that the upstream ESLint rule still raises on the patterns our decorator fixes.
+// If this test starts failing (i.e., the upstream rule no longer reports these patterns),
+// it signals that the decorator's isStoredForLaterConsumption suppression can be safely removed.
+describe('S7785 upstream sentinel', () => {
+  it('upstream prefer-top-level-await raises on chains handed to a Promise-typed destination that decorator suppresses', () => {
+    const ruleTester = new RuleTester();
+    ruleTester.run('prefer-top-level-await', upstreamRule, {
+      valid: [],
+      invalid: [
+        // typed call argument — suppressed by decorator, raised by upstream
+        {
+          code: `function doWork(arg: Promise<number>) {}
+                 doWork(Promise.resolve(42).then(x => x).catch(() => 0));`,
+          errors: 1,
+        },
+        // typed assignment target — suppressed by decorator, raised by upstream
+        {
+          code: `const holder: { promise: Promise<number> } = { promise: Promise.resolve(0) };
+                 holder.promise = Promise.resolve(42).then(x => x).catch(() => 0);`,
+          errors: 1,
+        },
+      ],
+    });
+  });
+});
 
 describe('S7785', () => {
   it('should report in ES modules (sourceType: module)', () => {

--- a/packages/analysis/src/jsts/rules/S7785/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7785/unit.test.ts
@@ -126,6 +126,25 @@ describe('S7785', () => {
                  const schema = new Schema();
                  schema.finally(() => {});`,
         },
+        {
+          // FP repro: chain passed to a parameter explicitly typed as Promise —
+          // intentionally handed off to be awaited later, not a floating top-level chain
+          code: `function doWork(arg: Promise<number>) {}
+                 doWork(Promise.resolve(42).then(x => x).catch(() => 0));`,
+        },
+        {
+          // FP repro: chain assigned to a property explicitly typed as Promise —
+          // intentionally stored to be awaited later, not a floating top-level chain
+          code: `const holder: { promise: Promise<number> } = { promise: Promise.resolve(0) };
+                 holder.promise = Promise.resolve(42).then(x => x).catch(() => 0);`,
+        },
+        {
+          // Suppress: chain returned from a function whose declared return type is Promise —
+          // the contextual type from the return statement confirms it's forwarded, not floating
+          code: `function getValue(): Promise<number> {
+                   return Promise.resolve(42).then(x => x).catch(() => 0);
+                 }`,
+        },
       ],
       invalid: [
         {
@@ -175,6 +194,18 @@ describe('S7785', () => {
           // Warn: 'any' type — warn conservatively since it may be a Promise
           code: `declare const x: any;
                  x.then(console.log);`,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // Warn: destination parameter is typed but not Promise-typed — still floating
+          code: `function log(arg: unknown) {}
+                 log(Promise.resolve(42).then(x => x).catch(() => 0));`,
+          errors: [{ messageId: 'promise' }],
+        },
+        {
+          // Warn: destination variable is typed but not Promise-typed — still floating
+          code: `let sink: unknown;
+                 sink = Promise.resolve(42).then(x => x).catch(() => 0);`,
           errors: [{ messageId: 'promise' }],
         },
       ],

--- a/packages/analysis/src/jsts/rules/helpers/type.ts
+++ b/packages/analysis/src/jsts/rules/helpers/type.ts
@@ -177,6 +177,17 @@ export function isThenable(node: estree.Node, services: RequiredParserServices) 
 }
 
 /**
+ * Returns true when `node`'s contextual type - the type expected by its surrounding position,
+ * e.g. a typed call argument or an assignment target - is thenable.
+ */
+export function isContextualTypeThenable(node: estree.Node, services: RequiredParserServices) {
+  const mapped = services.esTreeNodeToTSNodeMap.get(node as TSESTree.Node);
+  const checker = services.program.getTypeChecker();
+  const contextualType = checker.getContextualType(mapped as ts.Expression);
+  return contextualType != null && hasThenMethod(contextualType, checker);
+}
+
+/**
  * Returns true when any constituent of the type resolved by `node` is thenable.
  */
 export function isThenableOrThenableUnion(node: estree.Node, services: RequiredParserServices) {


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Rule Updates:**
    - Fixed false positives in `S7785` for promise chains stored or passed for later consumption by checking contextual types via `isContextualTypeThenable` in `decorator.ts` and `type.ts`

<sub>This will update automatically on new commits.</sub>