### PR TITLE
JS-2282 Make Java rule generator safe to import

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "generate-meta": "tsx tools/generate-meta.ts",
     "rspec:refresh": "mvn -q -ntp -N -P rspec-refresh -DskipTests generate-resources",
     "validate-quickfix": "tsx tools/validate-quickfix.ts",
-    "generate-java-rule-classes": "tsx tools/generate-java-rule-classes.ts",
+    "generate-java-rule-classes": "tsx tools/generate-java-rule-classes-cli.ts",
     "ruling": "tsx --tsconfig packages/tsconfig.test.json --test packages/ruling/projects/*.ruling.test.ts",
     "ruling-sync": "node .github/actions/ruling_bot/sync-results.mjs packages/ruling/actual its/ruling/src/test/expected",
     "bridge:compile:ts5": "npm run grpc:generate-proto && tsc -b packages && npm run grpc:copy-proto",

--- a/tools/generate-java-rule-classes-cli.ts
+++ b/tools/generate-java-rule-classes-cli.ts
@@ -1,0 +1,19 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { generateJavaRuleClasses } from './generate-java-rule-classes.js';
+
+await generateJavaRuleClasses();

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -277,58 +277,60 @@ function generateJavaScriptProfileRuleKeys(profiles: QualityProfileRuleKeys<'js'
     .join(',');
 }
 
-const allChecks = [];
-const javaScriptRuleProfiles: RuleQualityProfileMetadata<'js' | 'ts'>[] = [];
+async function generateJavaScriptRuleClasses() {
+  const allChecks = [];
+  const javaScriptRuleProfiles: RuleQualityProfileMetadata<'js' | 'ts'>[] = [];
 
-for (const file of await listRulesDir()) {
-  if (file === 'S1541') {
-    allChecks.push(`${file}Js`);
-    allChecks.push(`${file}Ts`);
-  } else {
-    allChecks.push(file);
+  for (const file of await listRulesDir()) {
+    if (file === 'S1541') {
+      allChecks.push(`${file}Js`);
+      allChecks.push(`${file}Ts`);
+    } else {
+      allChecks.push(file);
+    }
+
+    const metadata = await generateJavaCheckClass(file);
+    javaScriptRuleProfiles.push({
+      ruleKey: file,
+      compatibleLanguages: metadata.compatibleLanguages,
+      defaultQualityProfiles: metadata.defaultQualityProfiles,
+    });
   }
 
-  const metadata = await generateJavaCheckClass(file);
-  javaScriptRuleProfiles.push({
-    ruleKey: file,
-    compatibleLanguages: metadata.compatibleLanguages,
-    defaultQualityProfiles: metadata.defaultQualityProfiles,
+  await generateParsingErrorClass();
+  allChecks.push('S2260');
+  const parsingErrorMetadata = await getRspecMeta('S2260', {
+    compatibleLanguages: ['js', 'ts'],
   });
+  javaScriptRuleProfiles.push({
+    ruleKey: 'S2260',
+    compatibleLanguages: parsingErrorMetadata.compatibleLanguages,
+    defaultQualityProfiles: parsingErrorMetadata.defaultQualityProfiles,
+  });
+
+  const javaScriptProfileRuleKeys = buildQualityProfileRuleKeys(
+    javaScriptRuleProfiles,
+    ['js', 'ts'],
+    sonarKeySorter,
+  );
+
+  await inflateTemplateToFile(
+    join(JAVA_TEMPLATES_FOLDER, 'allchecks.template'),
+    join(JAVA_CHECKS_FOLDER, 'AllChecks.java'),
+    {
+      ___JAVACHECKS_CLASSES___: allChecks
+        .toSorted(sonarKeySorter)
+        .map(rule => `${rule}.class`)
+        .join(','),
+      ___DEFAULT_QUALITY_PROFILE_NAMES___: javaStringCollection('List', [
+        ...javaScriptProfileRuleKeys.keys(),
+      ]),
+      ___DEFAULT_QUALITY_PROFILE_RULE_KEYS___:
+        generateJavaScriptProfileRuleKeys(javaScriptProfileRuleKeys),
+      ___HEADER___: header,
+    },
+  );
 }
-
-await generateParsingErrorClass();
-allChecks.push('S2260');
-const parsingErrorMetadata = await getRspecMeta('S2260', {
-  compatibleLanguages: ['js', 'ts'],
-});
-javaScriptRuleProfiles.push({
-  ruleKey: 'S2260',
-  compatibleLanguages: parsingErrorMetadata.compatibleLanguages,
-  defaultQualityProfiles: parsingErrorMetadata.defaultQualityProfiles,
-});
-
-const javaScriptProfileRuleKeys = buildQualityProfileRuleKeys(
-  javaScriptRuleProfiles,
-  ['js', 'ts'],
-  sonarKeySorter,
-);
-
-await inflateTemplateToFile(
-  join(JAVA_TEMPLATES_FOLDER, 'allchecks.template'),
-  join(JAVA_CHECKS_FOLDER, 'AllChecks.java'),
-  {
-    ___JAVACHECKS_CLASSES___: allChecks
-      .toSorted(sonarKeySorter)
-      .map(rule => `${rule}.class`)
-      .join(','),
-    ___DEFAULT_QUALITY_PROFILE_NAMES___: javaStringCollection('List', [
-      ...javaScriptProfileRuleKeys.keys(),
-    ]),
-    ___DEFAULT_QUALITY_PROFILE_RULE_KEYS___:
-      generateJavaScriptProfileRuleKeys(javaScriptProfileRuleKeys),
-    ___HEADER___: header,
-  },
-);
 
 // ===== CSS rule class generation =====
 
@@ -759,84 +761,93 @@ function generateCssRuleTestBody(
   return { perRuleTests: testMethods.join('\n'), rulesWithOptionsClasses, propertiesCount };
 }
 
-// Group cssRulesMeta by sqKey; multi-member groups become single multi-binding classes
-const cssRuleGroups = new Map<string, CssRuleMeta[]>();
-for (const rule of cssRulesMeta) {
-  const group = cssRuleGroups.get(rule.sqKey) ?? [];
-  group.push(rule);
-  cssRuleGroups.set(rule.sqKey, group);
-}
-const cssMultiBindingGroups = new Map(
-  [...cssRuleGroups.entries()].filter(([, metas]) => metas.length > 1),
-);
-
-for (const [sqKey, metas] of cssRuleGroups) {
-  if (metas.length === 1) {
-    await generateCssJavaCheckClass(metas[0]);
-  } else {
-    await generateCssMultiBindingJavaCheckClass(sqKey, metas);
+async function generateCssRuleClasses() {
+  // Group cssRulesMeta by sqKey; multi-member groups become single multi-binding classes
+  const cssRuleGroups = new Map<string, CssRuleMeta[]>();
+  for (const rule of cssRulesMeta) {
+    const group = cssRuleGroups.get(rule.sqKey) ?? [];
+    group.push(rule);
+    cssRuleGroups.set(rule.sqKey, group);
   }
-}
-await generateCssParsingErrorClass();
+  const cssMultiBindingGroups = new Map(
+    [...cssRuleGroups.entries()].filter(([, metas]) => metas.length > 1),
+  );
 
-// Generate CssRules.java
-const sortedCssRuleKeys = [
-  ...new Set([...cssRulesMeta.map(rule => rule.sqKey), CSS_PARSING_ERROR_RULE_KEY]),
-].toSorted(sonarKeySorter);
-
-const cssRuleProfiles: RuleQualityProfileMetadata<'css'>[] = [];
-for (const ruleKey of sortedCssRuleKeys) {
-  const defaultQualityProfiles = await getCssRspecDefaultQualityProfiles(ruleKey);
-  if (defaultQualityProfiles !== undefined && !Array.isArray(defaultQualityProfiles)) {
-    throw new Error(`Language-specific quality profiles are not supported for CSS rule ${ruleKey}`);
+  for (const [sqKey, metas] of cssRuleGroups) {
+    if (metas.length === 1) {
+      await generateCssJavaCheckClass(metas[0]);
+    } else {
+      await generateCssMultiBindingJavaCheckClass(sqKey, metas);
+    }
   }
-  cssRuleProfiles.push({
-    ruleKey,
-    compatibleLanguages: ['css'],
-    defaultQualityProfiles,
-  });
+  await generateCssParsingErrorClass();
+
+  // Generate CssRules.java
+  const sortedCssRuleKeys = [
+    ...new Set([...cssRulesMeta.map(rule => rule.sqKey), CSS_PARSING_ERROR_RULE_KEY]),
+  ].toSorted(sonarKeySorter);
+
+  const cssRuleProfiles: RuleQualityProfileMetadata<'css'>[] = [];
+  for (const ruleKey of sortedCssRuleKeys) {
+    const defaultQualityProfiles = await getCssRspecDefaultQualityProfiles(ruleKey);
+    if (defaultQualityProfiles !== undefined && !Array.isArray(defaultQualityProfiles)) {
+      throw new Error(
+        `Language-specific quality profiles are not supported for CSS rule ${ruleKey}`,
+      );
+    }
+    cssRuleProfiles.push({
+      ruleKey,
+      compatibleLanguages: ['css'],
+      defaultQualityProfiles,
+    });
+  }
+  const cssProfileRuleKeys = buildQualityProfileRuleKeys(cssRuleProfiles, ['css'], sonarKeySorter);
+  const generatedCssProfileRuleKeys = [...cssProfileRuleKeys]
+    .map(
+      ([profileName, rulesByLanguage]) =>
+        `Map.entry("${escapeJavaString(profileName)}", ${javaStringCollection(
+          'List',
+          rulesByLanguage.get('css') ?? [],
+        )})`,
+    )
+    .join(',');
+
+  const cssRuleImports = sortedCssRuleKeys
+    .map(ruleKey => `import org.sonar.css.rules.${ruleKey};`)
+    .join('\n');
+
+  const cssRuleClasses = sortedCssRuleKeys.map(ruleKey => `${ruleKey}.class`).join(',\n        ');
+
+  await inflateTemplateToFile(
+    join(JAVA_TEMPLATES_FOLDER, 'css-rules.template'),
+    join(CSS_JAVA_FOLDER, 'CssRules.java'),
+    {
+      ___HEADER___: header,
+      ___IMPORTS___: cssRuleImports,
+      ___RULE_CLASSES___: cssRuleClasses,
+      ___DEFAULT_QUALITY_PROFILE_RULE_KEYS___: generatedCssProfileRuleKeys,
+    },
+  );
+
+  // Generate CssRuleTest.java
+  const { perRuleTests, rulesWithOptionsClasses, propertiesCount } = generateCssRuleTestBody(
+    cssRulesMeta,
+    cssMultiBindingGroups,
+  );
+
+  await inflateTemplateToFile(
+    join(JAVA_TEMPLATES_FOLDER, 'css-rule-test.template'),
+    join(CSS_JAVA_TEST_FOLDER, 'CssRuleTest.java'),
+    {
+      ___HEADER___: header,
+      ___RULES_WITH_OPTIONS_CLASSES___: rulesWithOptionsClasses,
+      ___RULES_PROPERTIES_COUNT___: String(propertiesCount),
+      ___PER_RULE_TESTS___: perRuleTests,
+    },
+  );
 }
-const cssProfileRuleKeys = buildQualityProfileRuleKeys(cssRuleProfiles, ['css'], sonarKeySorter);
-const generatedCssProfileRuleKeys = [...cssProfileRuleKeys]
-  .map(
-    ([profileName, rulesByLanguage]) =>
-      `Map.entry("${escapeJavaString(profileName)}", ${javaStringCollection(
-        'List',
-        rulesByLanguage.get('css') ?? [],
-      )})`,
-  )
-  .join(',');
 
-const cssRuleImports = sortedCssRuleKeys
-  .map(ruleKey => `import org.sonar.css.rules.${ruleKey};`)
-  .join('\n');
-
-const cssRuleClasses = sortedCssRuleKeys.map(ruleKey => `${ruleKey}.class`).join(',\n        ');
-
-await inflateTemplateToFile(
-  join(JAVA_TEMPLATES_FOLDER, 'css-rules.template'),
-  join(CSS_JAVA_FOLDER, 'CssRules.java'),
-  {
-    ___HEADER___: header,
-    ___IMPORTS___: cssRuleImports,
-    ___RULE_CLASSES___: cssRuleClasses,
-    ___DEFAULT_QUALITY_PROFILE_RULE_KEYS___: generatedCssProfileRuleKeys,
-  },
-);
-
-// Generate CssRuleTest.java
-const { perRuleTests, rulesWithOptionsClasses, propertiesCount } = generateCssRuleTestBody(
-  cssRulesMeta,
-  cssMultiBindingGroups,
-);
-
-await inflateTemplateToFile(
-  join(JAVA_TEMPLATES_FOLDER, 'css-rule-test.template'),
-  join(CSS_JAVA_TEST_FOLDER, 'CssRuleTest.java'),
-  {
-    ___HEADER___: header,
-    ___RULES_WITH_OPTIONS_CLASSES___: rulesWithOptionsClasses,
-    ___RULES_PROPERTIES_COUNT___: String(propertiesCount),
-    ___PER_RULE_TESTS___: perRuleTests,
-  },
-);
+export async function generateJavaRuleClasses() {
+  await generateJavaScriptRuleClasses();
+  await generateCssRuleClasses();
+}

--- a/tools/generate-java-rule-classes.ts
+++ b/tools/generate-java-rule-classes.ts
@@ -57,7 +57,7 @@ const JAVA_CHECKS_FOLDER = join(
   'checks',
 );
 
-export async function generateParsingErrorClass() {
+async function generateParsingErrorClass() {
   await inflateTemplateToFile(
     join(JAVA_TEMPLATES_FOLDER, 'parsingError.template'),
     join(JAVA_CHECKS_FOLDER, `S2260.java`),


### PR DESCRIPTION
Part of

## Why

`create-rule-boilerplate.ts` imports `generateJavaCheckClass()` so it can generate the Java class for one newly scaffolded rule. That boilerplate module is used by both `new-rule.mts` and `new-plugin.ts` through `createNewRule()`.

Before this change, importing `create-rule-boilerplate.ts` also evaluated the top-level orchestration in `generate-java-rule-classes.ts`. As a result, starting either `new-rule` or `new-plugin` regenerated every JavaScript and CSS Java rule class before `createNewRule()` explicitly generated the class for the requested rule.

## What changed

- move full JavaScript and CSS generation orchestration behind `generateJavaRuleClasses()`
- add a thin CLI entry point for the existing `generate-java-rule-classes` npm command
- keep `generateJavaCheckClass()` as the focused API used by `create-rule-boilerplate.ts`
- make importing the reusable generator module side-effect free

## Validation

- `npm ci`
- `npm run bbf`
- `npm run generate-java-rule-classes`
- verified the generated Java file hash is unchanged: `4e75a7d9c9da1cc43e8c4e8597dab311f472f3798db8c5df3d44148bf8ab7b90`
- verified importing `create-rule-boilerplate.ts` does not modify generated Java files
- `npx prettier --check package.json tools/generate-java-rule-classes.ts tools/generate-java-rule-classes-cli.ts`