### PR TITLE
JS-2284 Centralize rule key validation

### DIFF
--- a/tools/count-rules.ts
+++ b/tools/count-rules.ts
@@ -16,6 +16,7 @@
  */
 import path from 'node:path/posix';
 import fs from 'node:fs/promises';
+import { isRuleKey } from './rule-key.js';
 
 /**
  * Script to count the rules in SonarJS for CSS, JS and TS and update the README.md file.
@@ -89,7 +90,7 @@ async function getJsonFiles(pathToRules: string) {
   const filenames = await fs.readdir(pathToRules);
   return Promise.all(
     filenames
-      .filter(filename => filename.endsWith('.json') && filename.length <= 'S1234.json'.length)
+      .filter(filename => filename.endsWith('.json') && isRuleKey(path.basename(filename, '.json')))
       .map(async file => JSON.parse(await fs.readFile(path.join(pathToRules, file), 'utf-8'))),
   );
 }

--- a/tools/helpers.ts
+++ b/tools/helpers.ts
@@ -24,8 +24,8 @@ import { ESLintConfiguration } from '../packages/analysis/src/jsts/rules/helpers
 import type { DefaultQualityProfiles } from '../packages/analysis/src/jsts/rules/quality-profiles.js';
 import { mkdir } from 'node:fs/promises';
 import prettierPluginJava from 'prettier-plugin-java';
+import { isRuleKey } from './rule-key.js';
 
-export const ruleRegex = /^S\d+/;
 const DIRNAME = dirname(fileURLToPath(import.meta.url));
 const REPOSITORY_ROOT = join(DIRNAME, '..');
 export const TS_TEMPLATES_FOLDER = join(DIRNAME, 'templates', 'ts');
@@ -204,7 +204,7 @@ export async function getRuleMetadata(sonarKey: string) {
 export async function listRulesDir() {
   const files = await readdir(RULES_FOLDER, { withFileTypes: true });
   return files
-    .filter(file => ruleRegex.test(file.name) && file.isDirectory())
+    .filter(file => isRuleKey(file.name) && file.isDirectory())
     .map(file => file.name)
     .sort(sonarKeySorter);
 }

--- a/tools/new-rule.mts
+++ b/tools/new-rule.mts
@@ -15,8 +15,9 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { checkbox, input, select } from '@inquirer/prompts';
-import { ruleRegex, verifyRuleName } from './helpers.js';
+import { verifyRuleName } from './helpers.js';
 import { createNewRule } from './create-rule-boilerplate.js';
+import { isRuleKey, ruleKeyRegex } from './rule-key.js';
 
 const sonarKey = await input({ message: 'Enter the Sonar key for the new rule (SXXXX)' });
 const eslintId = await input({ message: 'Enter the ESLint ID for the rule' });
@@ -77,8 +78,8 @@ const hasSecondaries = await select({
 });
 
 function verifyRspecId(sonarKey: string) {
-  if (!ruleRegex.exec(sonarKey)) {
-    throw new Error(`Invalid rspec key: it should match ${ruleRegex}, but got "${sonarKey}"`);
+  if (!isRuleKey(sonarKey)) {
+    throw new Error(`Invalid rspec key: it should match ${ruleKeyRegex}, but got "${sonarKey}"`);
   }
 }
 

--- a/tools/rule-key.ts
+++ b/tools/rule-key.ts
@@ -1,0 +1,22 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+export const ruleKeyRegex = /^S\d+$/;
+
+export function isRuleKey(value: string) {
+  return ruleKeyRegex.test(value);
+}


### PR DESCRIPTION
Part of

## Summary

- centralize Sonar rule-key validation in one exact predicate
- use it when discovering rule directories, validating new-rule input, and counting metadata
- reject prefix matches and unrelated short JSON filenames consistently

## Validation

- `npm run count-rules` (counts unchanged)
- `npm run bbf`
- `npx knip --no-gitignore`
- `git diff --check`