### PR TITLE
JS-2285 Centralize Maven rule generation

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -225,8 +225,10 @@ The `sonar-plugin` reactor builds modules in this order:
 5. `sonar-javascript-plugin`
 6. `standalone`
 
-`javascript-checks` stays before `bridge` because bridge generation consumes rule metadata prepared
-earlier in the build. The explicit RSPEC refresh path is not part of this normal reactor flow.
+Shared rule metadata and Java rule classes are generated once by the `sonar-plugin` aggregator
+before the child modules build. The bridge therefore does not need an artificial dependency on
+`javascript-checks` to order metadata generation. The explicit RSPEC refresh path is not part of
+this normal reactor flow.
 
 ## Fast Java iteration flags
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -320,7 +320,7 @@ Because of that, a common workflow is:
 `initialize`
 
 - validates quickfix declarations
-- generates and reads `node-info.properties` for the plugin module
+- generates `node-info.properties` for the plugin module
 
 `generate-sources`
 
@@ -329,6 +329,7 @@ Because of that, a common workflow is:
 
 `generate-resources`
 
+- reads the plugin module's generated `node-info.properties`
 - runs `npm run generate-meta`
 - runs `npm run generate-java-rule-classes`
 - builds, bundles, and packs the bridge

--- a/sonar-plugin/bridge/pom.xml
+++ b/sonar-plugin/bridge/pom.xml
@@ -19,12 +19,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>api</artifactId>
     </dependency>
-    <!-- Build-order dependency: javascript-checks runs generate-meta before bridge compiles -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>javascript-checks</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api</artifactId>

--- a/sonar-plugin/javascript-checks/pom.xml
+++ b/sonar-plugin/javascript-checks/pom.xml
@@ -45,40 +45,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>3.5.0</version>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>${maven.multiModuleProjectDirectory}/resources/rule-data</directory>
-            </fileset>
-            <fileset>
-              <directory>${project.basedir}/src/main/resources</directory>
-              <includes>
-                <include>org/sonar/l10n/javascript/rules/javascript/*.html</include>
-                <include>rspec.sha</include>
-              </includes>
-            </fileset>
-            <fileset>
-              <directory>${project.basedir}/../css/src/main/resources</directory>
-              <includes>
-                <include>org/sonar/l10n/css/rules/css/*.html</include>
-                <include>rspec.sha</include>
-              </includes>
-            </fileset>
-            <fileset>
-              <directory>${maven.multiModuleProjectDirectory}/packages/analysis/src/jsts/rules</directory>
-              <includes>
-                <include>**/generated-meta.ts</include>
-                <include>metas.ts</include>
-                <include>plugin-rules.ts</include>
-                <include>rules.ts</include>
-              </includes>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${jacoco.version}</version>
@@ -88,43 +54,6 @@
             <exclude>org/sonar/javascript/checks/S*</exclude>
           </excludes>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.6.3</version>
-        <executions>
-          <execution>
-            <id>Generate rule metadata</id>
-            <phase>${node.build.phase}</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>npm</executable>
-              <workingDirectory>../..</workingDirectory>
-              <arguments>
-                <argument>run</argument>
-                <argument>generate-meta</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>Generate the Java Check classes</id>
-            <phase>${java.generation.phase}</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>npm</executable>
-              <workingDirectory>../..</workingDirectory>
-              <arguments>
-                <argument>run</argument>
-                <argument>generate-java-rule-classes</argument>
-              </arguments>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/sonar-plugin/pom.xml
+++ b/sonar-plugin/pom.xml
@@ -38,6 +38,84 @@
     <module>standalone</module>
   </modules>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.5.0</version>
+        <inherited>false</inherited>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${project.basedir}/../resources/rule-data</directory>
+            </fileset>
+            <fileset>
+              <directory>${project.basedir}/javascript-checks/src/main/resources</directory>
+              <includes>
+                <include>org/sonar/l10n/javascript/rules/javascript/*.html</include>
+                <include>rspec.sha</include>
+              </includes>
+            </fileset>
+            <fileset>
+              <directory>${project.basedir}/css/src/main/resources</directory>
+              <includes>
+                <include>org/sonar/l10n/css/rules/css/*.html</include>
+                <include>rspec.sha</include>
+              </includes>
+            </fileset>
+            <fileset>
+              <directory>${project.basedir}/../packages/analysis/src/jsts/rules</directory>
+              <includes>
+                <include>**/generated-meta.ts</include>
+                <include>metas.ts</include>
+                <include>plugin-rules.ts</include>
+                <include>rules.ts</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.3</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>Generate rule metadata</id>
+            <phase>${node.build.phase}</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>npm</executable>
+              <workingDirectory>${project.basedir}/..</workingDirectory>
+              <arguments>
+                <argument>run</argument>
+                <argument>generate-meta</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>Generate the Java Check classes</id>
+            <phase>${java.generation.phase}</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>npm</executable>
+              <workingDirectory>${project.basedir}/..</workingDirectory>
+              <arguments>
+                <argument>run</argument>
+                <argument>generate-java-rule-classes</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>skip-nodejs</id>

--- a/sonar-plugin/sonar-javascript-plugin/pom.xml
+++ b/sonar-plugin/sonar-javascript-plugin/pom.xml
@@ -211,7 +211,10 @@
         <version>1.3.0</version>
         <executions>
           <execution>
-            <phase>${node.init.phase}</phase>
+            <id>Read Node.js properties node-info.properties</id>
+            <!-- Maven orders plugins by their position in the effective POM, so read the file in a
+                 later phase than the exec-maven-plugin execution that generates it. -->
+            <phase>${node.build.phase}</phase>
             <goals>
               <goal>read-project-properties</goal>
             </goals>


### PR DESCRIPTION
Part of

## Context

Rule metadata and generated Java rule classes are shared build inputs: they are produced from repository-level sources and consumed by several modules. Previously, however, their cleanup and generation were attached to the `javascript-checks` module.

That made a leaf module responsible for reactor-wide outputs. It also forced `bridge` to declare a `provided` dependency on `javascript-checks` even though bridge neither compiles against nor packages that artifact. The dependency existed only to make Maven build `javascript-checks` first so its generation side effects happened before bridge compilation.

That was a build-order hack:

- the dependency graph described a relationship that does not exist in the code
- `-pl sonar-plugin/bridge -am` unnecessarily pulled `javascript-checks` into the reactor
- another consumer would have needed another artificial dependency
- module declaration order alone would not be a safe replacement, especially with parallel Maven builds

## Goal

Give shared generation one explicit owner, run it exactly once before child modules consume its outputs, and keep the Maven dependency graph limited to real artifact dependencies.

## How it works

The `sonar-plugin` aggregator is the parent of the plugin modules, so Maven builds that project before its children. This PR moves the shared clean and generation executions to that aggregator and marks them `inherited=false`, which makes them run once on the aggregator instead of once per child module.

| Phase | Owner | Responsibility |
| --- | --- | --- |
| `clean` | `sonar-plugin` aggregator | Remove repository-wide generated rule data, metadata, HTML, and Java-generation inputs once |
| `initialize` | `sonar-javascript-plugin` | Validate quick-fix metadata and generate that module's `node-info.properties` |
| `generate-sources` | Child modules | Generate protobuf Java sources where needed |
| `generate-resources` | `sonar-plugin` aggregator | Run `generate-meta` and `generate-java-rule-classes` once, before child modules build |
| `generate-resources` | `sonar-javascript-plugin` | Read the `node-info.properties` generated during `initialize` |
| `process-resources` and later | Child modules | Copy/package generated resources, compile, test, and assemble artifacts |

The existing phase properties still control the fast paths. For example, `-Dskip-nodejs` maps the relevant Node phases to `none`, while `-Dskip-java-generation` disables only Java rule-class generation.

With generation owned by the aggregator, the artificial `bridge -> javascript-checks` dependency can be removed. A bridge-only `-pl ... -am` build still runs the parent aggregator's shared generation, but no longer builds the unrelated checks artifact.

## Why the Node properties phase also changes

The first parallel CI run exposed a separate implicit ordering assumption. The plugin module generated and read `node-info.properties` in the same `initialize` phase. That happened to work only because `exec-maven-plugin` appeared before `properties-maven-plugin` in the old effective POM.

Declaring `exec-maven-plugin` on the parent aggregator changed how Maven merged the effective child POM, so the properties reader ran first on both Linux and Windows. The build then failed because the file did not exist yet.

Reordering plugin declarations would preserve the same fragile, same-phase dependency and could be changed again by parent-POM merging. Instead, generation remains in `initialize` and reading moves to `generate-resources`. Maven lifecycle phase ordering now expresses the dependency directly. The property is only needed later during packaging, so it is still loaded in time, and using `${node.build.phase}` preserves the `-Dskip-nodejs` behavior.

## Why this is more Maven-oriented

- reactor-wide side effects belong to the aggregator that owns the reactor
- `inherited=false` expresses “run once” directly
- real artifact dependencies describe the reactor graph; side effects do not masquerade as dependencies
- lifecycle phases express producer-before-consumer ordering instead of relying on effective-POM plugin order
- targeted and parallel builds follow the same explicit model
- cleanup and generation now have a single owner

## Validation

- `mvn clean verify -Psbom -T1C -DskipTests`
- `mvn clean package -pl sonar-plugin/javascript-checks,sonar-plugin/bridge,sonar-plugin/css -am -DskipTests`
- `mvn clean package -pl sonar-plugin/bridge -am -DskipTests`
- `mvn clean package -pl sonar-plugin/bridge -am -DskipTests -Dskip-nodejs`
- `mvn clean package -pl sonar-plugin/bridge -am -DskipTests -Dskip-java-generation`
- `npm run bbf`
- `npx prettier --check docs/BUILD.md`
- `git diff --check`
- fresh CI: both `Build SonarJS on Linux` and `Build SonarJS on Windows` passed