### PR TITLE
JS-2286 Make RSPEC refresh lifecycle ordering explicit

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -101,8 +101,8 @@ Refresh tracked RSPEC rule data explicitly:
 npm run rspec:refresh
 ```
 
-That refresh uses a dedicated root Maven profile. It syncs RSPEC once and generates both JavaScript
-and CSS rule data from the same checkout.
+That refresh uses a dedicated root Maven profile. It syncs RSPEC once during `generate-resources`,
+then deploys the JavaScript and CSS rule data during `process-resources`.
 
 Override the default RSPEC branch for one refresh run:
 
@@ -338,9 +338,9 @@ Because of that, a common workflow is:
 Explicit RSPEC refresh
 
 - `npm run rspec:refresh`
-- runs a root, non-recursive Maven profile
-- syncs RSPEC once for JavaScript and CSS
-- runs `npm run deploy-rule-data`
+- runs a root-owned, non-recursive Maven profile
+- syncs RSPEC once for JavaScript and CSS during `generate-resources`
+- runs `npm run deploy-rule-data` during `process-resources`
 - does not depend on the `javascript-checks` module lifecycle or hidden file-missing profiles
 
 `process-resources`

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -53,9 +53,9 @@ To refresh the tracked RSPEC rule data explicitly, run:
 npm run rspec:refresh
 ```
 
-That command uses a root, non-recursive Maven profile dedicated to RSPEC refresh. It performs one
-RSPEC sync for both JavaScript and CSS, then deploys the generated JSON and HTML into the tracked
-plugin resource directories.
+That command uses a root-owned, non-recursive Maven profile dedicated to RSPEC refresh. It performs
+one RSPEC sync for both JavaScript and CSS during `generate-resources`, then deploys the generated
+JSON and HTML into the tracked plugin resource directories during `process-resources`.
 
 On an unpinned branch, it refreshes to the latest intended RSPEC revision using either your GitHub
 CLI auth or `GITHUB_TOKEN`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check-format": "prettier --list-different .",
     "new-rule": "tsx tools/new-rule.mts",
     "generate-meta": "tsx tools/generate-meta.ts",
-    "rspec:refresh": "mvn -q -ntp -N -P rspec-refresh -DskipTests generate-resources",
+    "rspec:refresh": "mvn -q -ntp -N -P rspec-refresh -DskipTests process-resources",
     "validate-quickfix": "tsx tools/validate-quickfix.ts",
     "generate-java-rule-classes": "tsx tools/generate-java-rule-classes-cli.ts",
     "ruling": "tsx --tsconfig packages/tsconfig.test.json --test packages/ruling/projects/*.ruling.test.ts",

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,7 @@
             <groupId>org.sonarsource.rspec</groupId>
             <artifactId>rspec-maven-plugin</artifactId>
             <version>${rspec-maven-plugin.version}</version>
+            <inherited>false</inherited>
             <configuration>
               <githubToken>${env.GITHUB_TOKEN}</githubToken>
               <rspecSha>${rspec.sha}</rspecSha>
@@ -441,10 +442,11 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
+            <inherited>false</inherited>
             <executions>
               <execution>
                 <id>deploy-rule-data</id>
-                <phase>generate-resources</phase>
+                <phase>process-resources</phase>
                 <goals>
                   <goal>exec</goal>
                 </goals>


### PR DESCRIPTION
Part of 

## Context

The explicit RSPEC refresh has two dependent Maven steps:

1. `rspec-maven-plugin` downloads JavaScript and CSS rule data.
2. `npm run deploy-rule-data` consumes that data and copies it into the tracked resource directories.

Both executions were bound to `generate-resources`. Maven orders different plugins in the same
phase according to their position in the effective POM, so correctness implicitly depended on
plugin ordering. The refresh plugins were also inheritable; the npm command's `-N` flag was the
only thing preventing those executions from appearing in every child module.

## Change

- Keep RSPEC generation in `generate-resources`.
- Move deployment to the following `process-resources` phase.
- Make `npm run rspec:refresh` run through `process-resources` so both steps execute.
- Mark both refresh plugins as non-inherited, making the root POM their explicit owner.
- Document the phase split in the canonical build documentation.

## Why this is better

Maven completes every execution in `generate-resources` before entering `process-resources`, so the
producer-consumer relationship is now represented by lifecycle phases instead of effective-POM
ordering. Root ownership is encoded in the POM rather than relying on the wrapper command for
correctness; `-N` remains as an efficient way to invoke only the root refresh lifecycle.

## Validation

- `npm ci`
- `npm run bbf`
- `npm run rspec:refresh`
- root and child effective-POM inspection (refresh executions are absent from child modules)
- `mvn -ntp -N -P rspec-refresh -DskipTests validate`
