### PR TITLE
BUILD-12287 Move Linux GitHub-hosted jobs to WarpBuild

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -68,7 +68,7 @@ jobs:
       pm-email: "geoffray.adde@sonarsource.com"
       slack-channel: "squad-corelang-releases"
       release-automation-secret-name: "SonarJS-release-automation"
-      runner-environment: "github-ubuntu-latest-s"
+      runner-environment: "warp-custom-ubuntu-24-04"
       verbose: true
       use-jira-sandbox: false
       is-draft-release: false
@@ -77,7 +77,7 @@ jobs:
     name: Derive SQAA build number
     needs: release
     if: ${{ needs.release.result == 'success' && github.event.inputs.sqaa-integration == 'true' }}
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     outputs:
       build-number: ${{ steps.derive.outputs.build-number }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,7 @@ jobs:
           retention-days: 1
 
   build_eslint_plugin:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     needs: [setup, prepare_rspec_rule_data]
     name: Build ESLint Plugin
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -332,7 +332,7 @@ jobs:
           retention-days: 1
 
   generated_files_freshness:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     needs: [prepare_rspec_rule_data, build_eslint_plugin]
     name: Generated Files Freshness
     if: github.event_name == 'schedule'
@@ -374,7 +374,7 @@ jobs:
           delete-branch: true
 
   test_eslint_plugin:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: ESLint Plugin Test - ESLint ${{ matrix.eslint-version }} Node ${{ matrix.node-version }}
     needs: [setup, build_eslint_plugin]
     permissions: *read_permissions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -379,6 +379,7 @@ jobs:
     needs: [setup, build_eslint_plugin]
     permissions: *read_permissions
     strategy:
+      fail-fast: false
       matrix:
         include:
           - eslint-version: 10
@@ -413,6 +414,16 @@ jobs:
             echo "::error file=$TARBALL::Missing ESLint plugin tarball"
             exit 1
           fi
+      - id: secrets
+        name: Access vault secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/${{ github.repository_owner }}-${{ github.event.repository.name }}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+      - name: Configure npm registry
+        run: |
+          npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+          npm config set registry https://repox.jfrog.io/artifactory/api/npm/npm/
       - name: Test ESLint Plugin
         run: |
           cd its/eslint${{ matrix.eslint-version }}-plugin-sonarjs

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   cleanup:
     name: Cleanup PR caches and artifacts
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       actions: write
     steps:


### PR DESCRIPTION
## Summary
- Move remaining generic Linux GitHub-hosted jobs from `github-ubuntu-latest-s` to WarpBuild `warp-custom-ubuntu-24-04`.
- Covers Build ESLint plugin jobs, PR cache cleanup, and automated-release runner selection.
- Leaves `release_eslint_plugin.yml` on a GitHub-hosted runner because npm Trusted Publishers require that.

Parent: https://sonarsource.atlassian.net/browse/BUILD-12260
Sub-task: https://sonarsource.atlassian.net/browse/BUILD-12287

## Test plan
- [ ] Confirm the PR Build workflow schedules `build_eslint_plugin` and `test_eslint_plugin` on `warp-custom-ubuntu-24-04`
- [ ] Confirm those jobs succeed (runtime, queue time, no new failures)
- [ ] Confirm `pr-cleanup.yml` still uses a Warp Linux runner
- [ ] Do not change `release_eslint_plugin.yml`