### PR TITLE
JS-2288: Suppress S6757 false positives in class members

### DIFF
--- a/packages/analysis/src/jsts/rules/S6757/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6757/decorator.ts
@@ -48,21 +48,33 @@ function isThisMemberExpression(
 }
 
 function isLexicallyBoundToClassMember(node: TSESTree.MemberExpression): boolean {
+  let previous: TSESTree.Node = node;
+
   for (const current of ancestorsChain(node, new Set<string>())) {
     if (isClassMember(current)) {
-      return true;
+      // Only the member value owns the instance receiver. A computed key or a member
+      // decorator is evaluated in the enclosing scope, which may be a functional component.
+      return previous === current.value;
     }
 
     if (isNonLexicalFunctionBoundary(current)) {
       return false;
     }
+
+    previous = current;
   }
 
   return false;
 }
 
-function isClassMember(node: TSESTree.Node): boolean {
-  return node.type === 'MethodDefinition' || node.type === 'PropertyDefinition';
+function isClassMember(
+  node: TSESTree.Node,
+): node is TSESTree.MethodDefinition | TSESTree.PropertyDefinition | TSESTree.AccessorProperty {
+  return (
+    node.type === 'MethodDefinition' ||
+    node.type === 'PropertyDefinition' ||
+    node.type === 'AccessorProperty'
+  );
 }
 
 function isNonLexicalFunctionBoundary(node: TSESTree.Node): boolean {

--- a/packages/analysis/src/jsts/rules/S6757/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S6757/decorator.ts
@@ -18,11 +18,9 @@
 
 import type { TSESTree } from '@typescript-eslint/utils';
 import type { Rule } from 'eslint';
-import type estree from 'estree';
-import { ancestorsChain, findFirstMatchingAncestor } from '../helpers/ancestor.js';
+import { ancestorsChain } from '../helpers/ancestor.js';
 import { interceptReportForReact } from '../helpers/decorators/interceptor.js';
 import { generateMeta } from '../helpers/generate-meta.js';
-import { isReactClassComponent } from '../helpers/react/component-analysis.js';
 import * as meta from './generated-meta.js';
 
 export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
@@ -34,7 +32,7 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
     (context, reportDescriptor) => {
       const { node } = reportDescriptor as { node?: TSESTree.Node };
 
-      if (isThisMemberExpression(node) && isLexicallyBoundToReactClassComponent(node)) {
+      if (isThisMemberExpression(node) && isLexicallyBoundToClassMember(node)) {
         return;
       }
 
@@ -49,15 +47,10 @@ function isThisMemberExpression(
   return node?.type === 'MemberExpression' && node.object.type === 'ThisExpression';
 }
 
-function isLexicallyBoundToReactClassComponent(node: TSESTree.MemberExpression): boolean {
+function isLexicallyBoundToClassMember(node: TSESTree.MemberExpression): boolean {
   for (const current of ancestorsChain(node, new Set<string>())) {
     if (isClassMember(current)) {
-      const enclosingClass = findFirstMatchingAncestor(
-        current,
-        ancestor => ancestor.type === 'ClassDeclaration' || ancestor.type === 'ClassExpression',
-      );
-
-      return enclosingClass !== undefined && isReactClassComponent(enclosingClass as estree.Node);
+      return true;
     }
 
     if (isNonLexicalFunctionBoundary(current)) {

--- a/packages/analysis/src/jsts/rules/S6757/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6757/unit.test.ts
@@ -116,6 +116,17 @@ class RenderArrowCallbackExample extends React.Component {
           `,
         },
         {
+          // Compliant: getter owns the receiver through its arrow closure.
+          code: `
+class View {
+  get rows() {
+    const Row = item => <span>{this.format(item)}</span>;
+    return <section>{[1].map(Row)}</section>;
+  }
+}
+          `,
+        },
+        {
           // Compliant: class state
           code: `
 const Component = class {};
@@ -246,10 +257,67 @@ function MyComponent() {
           errors: 1,
         },
         {
+          // Noncompliant: computed auto-accessor keys are evaluated in the enclosing scope.
+          code: `
+function MyComponent() {
+  class Holder {
+    accessor [this.props.key] = 1;
+  }
+
+  return <div>{Holder.name}</div>;
+}
+          `,
+          errors: 1,
+        },
+        {
+          // Noncompliant: static blocks currently do not own the receiver.
+          code: `
+function MyComponent() {
+  class Holder {
+    static {
+      this.x;
+    }
+  }
+
+  return <div>{Holder.name}</div>;
+}
+          `,
+          errors: 1,
+        },
+        {
+          // Noncompliant: member decorators are evaluated in the enclosing scope.
+          code: `
+function MyComponent() {
+  class Holder {
+    @this.decorate
+    field = 1;
+  }
+
+  return <div>{Holder.name}</div>;
+}
+          `,
+          errors: 1,
+        },
+        {
           code: `
 function FunctionalComponent() {
   const value = this.props.value;
   return <div>{value}</div>;
+}
+          `,
+          errors: 1,
+        },
+        {
+          // Noncompliant: a function expression creates its own receiver boundary.
+          code: `
+class Service {
+  build() {
+    const Row = function () {
+      return <li>{this.props.value}</li>;
+    };
+
+    return <Row />;
+  }
 }
           `,
           errors: 1,

--- a/packages/analysis/src/jsts/rules/S6757/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6757/unit.test.ts
@@ -53,6 +53,48 @@ describe('S6757', () => {
     ruleTester.run('Stateless functional components should not use `this`', rule, {
       valid: [
         {
+          // Compliant: `this` is lexically owned by an ordinary class method.
+          code: `
+class View {
+  render() {
+    const Row = item => <span>{this.format(item)}</span>;
+    return <section>{[1].map(Row)}</section>;
+  }
+}
+          `,
+        },
+        {
+          // Compliant: arrow closure preserves the ordinary class instance receiver.
+          code: `
+class NonReactView extends View {
+  render() {
+    const Row = item => <span>{this.props.format(item)}</span>;
+    return <section>{this.items.map(Row)}</section>;
+  }
+}
+          `,
+        },
+        {
+          // Compliant: nested ordinary class member owns the receiver through its arrow closure.
+          code: `
+const React = { Component: class {} };
+class View {}
+
+class Outer extends React.Component {
+  render() {
+    class Inner extends View {
+      draw() {
+        const Row = item => <span>{this.props.format(item)}</span>;
+        return <section>{this.items.map(Row)}</section>;
+      }
+    }
+
+    return new Inner().draw();
+  }
+}
+          `,
+        },
+        {
           // Compliant: class callback
           code: `
 const React = { Component: class {} };
@@ -167,37 +209,6 @@ class ComponentWithNestedFunction extends React.Component {
     }
 
     return <NestedComponent />;
-  }
-}
-          `,
-          errors: 1,
-        },
-        {
-          code: `
-class NonReactView extends View {
-  render() {
-    const Row = item => <span>{this.props.format(item)}</span>;
-    return <section>{this.items.map(Row)}</section>;
-  }
-}
-          `,
-          errors: 1,
-        },
-        {
-          code: `
-const React = { Component: class {} };
-class View {}
-
-class Outer extends React.Component {
-  render() {
-    class Inner extends View {
-      draw() {
-        const Row = item => <span>{this.props.format(item)}</span>;
-        return <section>{this.items.map(Row)}</section>;
-      }
-    }
-
-    return new Inner().draw();
   }
 }
           `,

--- a/packages/analysis/src/jsts/rules/S6757/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S6757/unit.test.ts
@@ -137,7 +137,10 @@ class MethodReturnsArrowRendererExample extends Component {
           `,
         },
         {
-          // Compliant: class property
+          // Compliant: class property.
+          // Regression guard only: upstream never classifies a class-field arrow as a
+          // component, so this case does not reach the decorator. See the next case for
+          // actual `PropertyDefinition` coverage.
           code: `
 const React = { Component: class {} };
 
@@ -145,6 +148,30 @@ class PropertyArrowRendererExample extends React.Component {
   renderItem = () => (
     <li>{this.props.value}</li>
   );
+}
+          `,
+        },
+        {
+          // Compliant: an auto-accessor field owns the receiver just like a plain field.
+          code: `
+class Service {
+  accessor make = () => {
+    const Row = item => <li>{this.props.format(item)}</li>;
+    return Row;
+  };
+}
+          `,
+        },
+        {
+          // Compliant: class-field initializer owns the receiver for the arrow component
+          // it builds. Upstream reports here, so this exercises the `PropertyDefinition`
+          // branch of the decorator.
+          code: `
+class Service {
+  make = () => {
+    const Row = item => <li>{this.props.format(item)}</li>;
+    return Row;
+  };
 }
           `,
         },
@@ -190,10 +217,55 @@ class SettingsPanel extends PureComponent {
       ],
       invalid: [
         {
+          // Noncompliant: a computed member key is evaluated in the enclosing component scope,
+          // so `this` is the functional component receiver, not the class instance.
+          code: `
+function MyComponent() {
+  class Holder {
+    [this.props.key]() {
+      return 1;
+    }
+  }
+
+  return <div>{Holder.name}</div>;
+}
+          `,
+          errors: 1,
+        },
+        {
+          // Noncompliant: same for a computed class-field key.
+          code: `
+function MyComponent() {
+  class Holder {
+    [this.props.key] = 1;
+  }
+
+  return <div>{Holder.name}</div>;
+}
+          `,
+          errors: 1,
+        },
+        {
           code: `
 function FunctionalComponent() {
   const value = this.props.value;
   return <div>{value}</div>;
+}
+          `,
+          errors: 1,
+        },
+        {
+          // Noncompliant: a nested function declaration creates its own `this`, so the
+          // boundary holds in ordinary classes too, not only in React components.
+          code: `
+class Service {
+  build() {
+    function Row() {
+      return <li>{this.props.value}</li>;
+    }
+
+    return <Row />;
+  }
 }
           `,
           errors: 1,


### PR DESCRIPTION
## Jira
JS-2288

## Scope
Suppress this reports lexically owned by any class member, including arrow closures. Retain reports across nested non-arrow function boundaries and in functional components.

## Validation
- npx tsx --test packages/analysis/src/jsts/rules/S6757/**/*.test.ts
- npm run bbf

## Peach baselines
- JS-2288-javascript-S6757-peach-before-20260820T092204Z.csv
- JS-2288-typescript-S6757-peach-before-20260820T092204Z.csv

No RSPEC change required.