### PR TITLE
JS-2297 Bump build JDK from Java 17 to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
 
     <artifactsToPublish>${project.groupId}:sonar-javascript-plugin:jar,${project.groupId}:sonar-javascript-plugin:json:cyclonedx</artifactsToPublish>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <maven.compiler.release>17</maven.compiler.release>
-    <jdk.min.version>17</jdk.min.version>
+    <maven.compiler.release>21</maven.compiler.release>
+    <jdk.min.version>21</jdk.min.version>
     <jacoco.version>0.8.15</jacoco.version>
     <version.surefire.plugin>3.1.2</version.surefire.plugin>
     <!-- FIXME fix javadoc errors -->


### PR DESCRIPTION
## Summary

Found via an org-wide Java-version audit: the CI toolchain already runs JDK 21 (see the inline mise config in `.github/workflows/build.yml`, used by all jobs; one QA job even uses `alpine/java:22-jdk`), but the root `pom.xml` still declared a Java 17 build target. This bumps the build configuration to match what CI actually uses.

## Changes

- `pom.xml`: `maven.compiler.release` 17 → 21
- `pom.xml`: `jdk.min.version` 17 → 21

No nested module POMs override these properties, so no further changes were needed.

## Test plan

- [ ] CI build passes on the updated JDK target