### PR TITLE
JS-2299 DOC Update README JDK prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to report a bug, request a feature, or provide other kind of feedbac
 
 To work on this project, it is required to have the following tools installed:
 
-- [JDK 17](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/what-is-corretto-17.html)
+- [JDK 21](https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/what-is-corretto-21.html)
 - [Node.js](https://nodejs.org/en) >= 22
 - [npm](https://www.npmjs.com/) >= 8
 - [Maven](https://maven.apache.org/) >= 3.8


### PR DESCRIPTION
## Summary

Follow-up to #7800, which raised the project build JDK from 17 to 21 but did not update the README prerequisite.

- update the contributing prerequisite from JDK 17 to JDK 21
- update the Corretto documentation link to version 21

## Test plan

- [x] git diff --check