### PR TITLE
JS-2298 Don't raise S2486 when the unused catch clause contains only comments

### DIFF
--- a/its/ruling/src/test/expected/angular.js/javascript-S2486.json
+++ b/its/ruling/src/test/expected/angular.js/javascript-S2486.json
@@ -2,9 +2,6 @@
 "angular.js:src/Angular.js": [
 1154
 ],
-"angular.js:src/ng/compile.js": [
-2778
-],
 "angular.js:src/ngSanitize/sanitize.js": [
 478
 ]

--- a/its/ruling/src/test/expected/console/typescript-S2486.json
+++ b/its/ruling/src/test/expected/console/typescript-S2486.json
@@ -6,9 +6,6 @@
 142
 ],
 "console:src/views/PermissionsView/PermissionPopup/ast.ts": [
-29,
-55,
-86,
 126
 ]
 }

--- a/its/ruling/src/test/expected/console/typescript-S2486.json
+++ b/its/ruling/src/test/expected/console/typescript-S2486.json
@@ -6,6 +6,9 @@
 142
 ],
 "console:src/views/PermissionsView/PermissionPopup/ast.ts": [
+29,
+55,
+86,
 126
 ]
 }

--- a/its/ruling/src/test/expected/courselit/typescript-S2486.json
+++ b/its/ruling/src/test/expected/courselit/typescript-S2486.json
@@ -1,7 +1,4 @@
 {
-"courselit:apps/web/components/admin/courses/lesson-editor.tsx": [
-168
-],
 "courselit:apps/web/components/admin/media/media-preview.tsx": [
 102
 ],

--- a/its/ruling/src/test/expected/desktop/typescript-S2486.json
+++ b/its/ruling/src/test/expected/desktop/typescript-S2486.json
@@ -3,8 +3,7 @@
 37
 ],
 "desktop:app/src/lib/api.ts": [
-1155,
-1204
+1155
 ],
 "desktop:app/src/lib/ci-checks/ci-checks.ts": [
 81
@@ -30,9 +29,6 @@
 ],
 "desktop:app/src/main-process/exception-reporting.ts": [
 82
-],
-"desktop:app/src/main-process/log.ts": [
-80
 ],
 "desktop:app/src/main-process/main.ts": [
 261

--- a/its/ruling/src/test/expected/eigen/typescript-S2486.json
+++ b/its/ruling/src/test/expected/eigen/typescript-S2486.json
@@ -5,14 +5,8 @@
 "eigen:src/app/Scenes/MyAccount/MyAccountDeleteAccount.tsx": [
 122
 ],
-"eigen:src/app/Scenes/MyAccount/updateMyUserProfile.ts": [
-68
-],
 "eigen:src/app/relay/RelayCache.ts": [
 59
-],
-"eigen:src/app/store/persistence.ts": [
-58
 ],
 "eigen:src/app/utils/LinkedAccounts/facebook.ts": [
 81

--- a/its/ruling/src/test/expected/rxjs/typescript-S2486.json
+++ b/its/ruling/src/test/expected/rxjs/typescript-S2486.json
@@ -1,6 +1,5 @@
 {
 "rxjs:src/observable/dom/AjaxObservable.ts": [
-49,
 54
 ]
 }

--- a/its/ruling/src/test/expected/sonar-web/javascript-S2486.json
+++ b/its/ruling/src/test/expected/sonar-web/javascript-S2486.json
@@ -1,8 +1,5 @@
 {
 "sonar-web:src/main/js/components/common/file-upload.js": [
 33
-],
-"sonar-web:src/main/js/components/workspace/models/items.js": [
-24
 ]
 }

--- a/its/ruling/src/test/expected/tailwindcss/javascript-S2486.json
+++ b/its/ruling/src/test/expected/tailwindcss/javascript-S2486.json
@@ -5,9 +5,6 @@
 "tailwindcss:src/index.postcss7.js": [
 43
 ],
-"tailwindcss:src/lib/getModuleDependencies.js": [
-32
-],
 "tailwindcss:src/plugins/gradientColorStops.js": [
 21
 ],

--- a/packages/analysis/src/jsts/rules/S2486/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S2486/cb.fixture.js
@@ -1,9 +1,9 @@
 function f() {
     try {
         doSomething();
-    } catch (err) { // Compliant
+    } catch (err) {
 
-    }
+    } // Compliant: try guards a single simple statement
 }
 
 function g() {
@@ -11,9 +11,9 @@ function g() {
         if (condition) {
             doSomething();
         }
-    } catch (err) { // Compliant
+    } catch (err) {
 
-    }
+    } // Compliant: try guards a single simple statement
 }
 
 function h() {
@@ -22,7 +22,7 @@ function h() {
         doSomethingElse();
     } catch (err) {
 
-    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
+    } // Noncompliant@-2 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
 }
 
 function i() {
@@ -36,25 +36,25 @@ function i() {
 function assignmentBody() {
     try {
         n = String(name || "");
-    } catch (err) { // Compliant
+    } catch (err) {
 
-    }
+    } // Compliant: try guards a single simple statement
 }
 
 function variableDeclarationBody() {
     try {
         const parsed = JSON.parse(raw);
-    } catch (err) { // Compliant
+    } catch (err) {
 
-    }
+    } // Compliant: try guards a single simple statement
 }
 
 function throwBody() {
     try {
         throw new Error("boom");
-    } catch (err) { // Compliant
+    } catch (err) {
 
-    }
+    } // Compliant: try guards a single simple statement
 }
 
 function nestedTryBody() {
@@ -64,16 +64,16 @@ function nestedTryBody() {
         } catch (inner) {
             handle(inner);
         }
-    } catch (err) { // Compliant
+    } catch (err) {
 
-    }
+    } // Compliant: try guards a single simple statement
 }
 
 function emptyTryBody() {
     try {
     } catch (err) {
 
-    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
+    } // Noncompliant@-2 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
 }
 
 function forLoopBody() {
@@ -84,7 +84,7 @@ function forLoopBody() {
         }
     } catch (err) {
 
-    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
+    } // Noncompliant@-2 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
 }
 
 function whileLoopBody() {
@@ -94,7 +94,7 @@ function whileLoopBody() {
         }
     } catch (err) {
 
-    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
+    } // Noncompliant@-2 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
 }
 
 function switchBody() {
@@ -105,7 +105,7 @@ function switchBody() {
         }
     } catch (err) {
 
-    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
+    } // Noncompliant@-2 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
 }
 
 function blockBody() {
@@ -116,7 +116,7 @@ function blockBody() {
         }
     } catch (err) {
 
-    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
+    } // Noncompliant@-2 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
 }
 
 function labeledLoopBody() {
@@ -126,45 +126,24 @@ function labeledLoopBody() {
         }
     } catch (err) {
 
-    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
+    } // Noncompliant@-2 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
 }
 
 function commentOnlySingleLine() {
     try {
         doSomething();
         doSomethingElse();
-    } catch (err) { // Compliant
+    } catch (err) {
         // ignored on purpose
-    }
-}
-
-function commentOnlyMultiLine() {
-    try {
-        doSomething();
-        doSomethingElse();
-    } catch (err) { // Compliant
-        // This exception is
-        // ignored on purpose
-    }
+    } // Compliant
 }
 
 function commentAndCodeSingleLine() {
     try {
         doSomething();
         doSomethingElse();
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+    } catch (err) { // Noncompliant {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
         // does not use err
-        doCleanup();
-    }
-}
-
-function commentAndCodeMultiLine() {
-    try {
-        doSomething();
-        doSomethingElse();
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
-        // This cleanup logic
-        // does not reference err
         doCleanup();
     }
 }
@@ -173,21 +152,9 @@ function blockCommentOnlySingleLine() {
     try {
         doSomething();
         doSomethingElse();
-    } catch (err) { // Compliant
+    } catch (err) {
         /* ignored on purpose */
-    }
-}
-
-function blockCommentOnlyMultiLine() {
-    try {
-        doSomething();
-        doSomethingElse();
-    } catch (err) { // Compliant
-        /*
-         * This exception is
-         * ignored on purpose
-         */
-    }
+    } // Compliant
 }
 
 function commentOnlySameLine() {
@@ -205,20 +172,54 @@ function blockCommentOnlySameLine() {
     } catch (err) { /* documented */ }
 }
 
-function commentTrailingCodeSameLine() {
-    try {
-        doSomething();
-        doSomethingElse();
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
-        doCleanup(); // some comment
-    }
-}
-
 function noBindingCatch() {
     try {
         doSomething();
         return 0;
-    } catch { // Compliant, no exception parameter is declared
+    } catch {
         return -1;
+    } // Compliant, no exception parameter is declared
+}
+
+function destructuredParamCatch() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch ({ message }) {
+    } // Compliant, catch clause parameter is not a simple identifier
+}
+
+function pragmaOnlyCatch() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) {
+        // eslint-disable-next-line no-empty
+    } // Compliant: comment content is not inspected beyond being non-empty
+}
+
+function emptyCommentCatch() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) {
+        //
+    } // Noncompliant@-2 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
+}
+
+function emptyStatementWithComment() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // Noncompliant {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
+        ; // c
     }
+}
+
+function commentBetweenParamAndBody() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) /* c */ {
+    } // Noncompliant@-1 {{Handle this exception, don't catch it at all, or explain in a comment why it is ignored.}}
 }

--- a/packages/analysis/src/jsts/rules/S2486/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S2486/cb.fixture.js
@@ -128,3 +128,73 @@ function labeledLoopBody() {
 
     }
 }
+
+function commentOnlySingleLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // Compliant
+        // ignored on purpose
+    }
+}
+
+function commentOnlyMultiLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // Compliant
+        // This exception is
+        // ignored on purpose
+    }
+}
+
+function commentAndCodeSingleLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+        // does not use err
+        doCleanup();
+    }
+}
+
+function commentAndCodeMultiLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+        // This cleanup logic
+        // does not reference err
+        doCleanup();
+    }
+}
+
+function blockCommentOnlySingleLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // Compliant
+        /* ignored on purpose */
+    }
+}
+
+function blockCommentOnlyMultiLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // Compliant
+        /*
+         * This exception is
+         * ignored on purpose
+         */
+    }
+}
+
+function noBindingCatch() {
+    try {
+        doSomething();
+        return 0;
+    } catch { // Compliant, no exception parameter is declared
+        return -1;
+    }
+}

--- a/packages/analysis/src/jsts/rules/S2486/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S2486/cb.fixture.js
@@ -20,9 +20,9 @@ function h() {
     try {
         doSomething();
         doSomethingElse();
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+    } catch (err) {
 
-    }
+    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
 }
 
 function i() {
@@ -71,9 +71,9 @@ function nestedTryBody() {
 
 function emptyTryBody() {
     try {
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+    } catch (err) {
 
-    }
+    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
 }
 
 function forLoopBody() {
@@ -82,9 +82,9 @@ function forLoopBody() {
             doSomething(x);
             doSomethingElse(x);
         }
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+    } catch (err) {
 
-    }
+    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
 }
 
 function whileLoopBody() {
@@ -92,9 +92,9 @@ function whileLoopBody() {
         while (condition()) {
             doSomething();
         }
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+    } catch (err) {
 
-    }
+    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
 }
 
 function switchBody() {
@@ -103,9 +103,9 @@ function switchBody() {
             case 'a': stepOne(); stepTwo(); break;
             default: fallback();
         }
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+    } catch (err) {
 
-    }
+    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
 }
 
 function blockBody() {
@@ -114,9 +114,9 @@ function blockBody() {
             doSomething();
             doSomethingElse();
         }
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+    } catch (err) {
 
-    }
+    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
 }
 
 function labeledLoopBody() {
@@ -124,9 +124,9 @@ function labeledLoopBody() {
         outer: for (const x of xs) {
             doSomething(x);
         }
-    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+    } catch (err) {
 
-    }
+    } // Noncompliant@-2 {{Handle this exception or don't catch it at all.}}
 }
 
 function commentOnlySingleLine() {
@@ -187,6 +187,30 @@ function blockCommentOnlyMultiLine() {
          * This exception is
          * ignored on purpose
          */
+    }
+}
+
+function commentOnlySameLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // documented
+    }
+}
+
+function blockCommentOnlySameLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { /* documented */ }
+}
+
+function commentTrailingCodeSameLine() {
+    try {
+        doSomething();
+        doSomethingElse();
+    } catch (err) { // Noncompliant {{Handle this exception or don't catch it at all.}}
+        doCleanup(); // some comment
     }
 }
 

--- a/packages/analysis/src/jsts/rules/S2486/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2486/rule.ts
@@ -44,6 +44,16 @@ function isSingleSimpleStatement(body: estree.Statement[]): boolean {
   return !NON_SIMPLE_STATEMENT_TYPES.has(stmt.type);
 }
 
+function isDocumentedEmptyCatch(context: Rule.RuleContext, node: estree.CatchClause): boolean {
+  if (node.body.body.length !== 0) {
+    return false;
+  }
+  const openingBraceLine = node.body.loc!.start.line;
+  return context.sourceCode
+    .getCommentsInside(node.body)
+    .some(comment => comment.loc!.start.line > openingBraceLine);
+}
+
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta, {
     messages: {
@@ -58,7 +68,10 @@ export const rule: Rule.RuleModule = {
         const variable = getVariableFromScope(scope, param.name);
         if (variable?.references.length === 0) {
           const tryStatement = getParent(context, node) as estree.TryStatement;
-          if (!isSingleSimpleStatement(tryStatement.block.body)) {
+          if (
+            !isDocumentedEmptyCatch(context, node) &&
+            !isSingleSimpleStatement(tryStatement.block.body)
+          ) {
             context.report({
               messageId: 'handleException',
               node,

--- a/packages/analysis/src/jsts/rules/S2486/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2486/rule.ts
@@ -45,13 +45,17 @@ function isSingleSimpleStatement(body: estree.Statement[]): boolean {
 }
 
 function isDocumentedEmptyCatch(context: Rule.RuleContext, node: estree.CatchClause): boolean {
-  return node.body.body.length === 0 && context.sourceCode.getCommentsInside(node.body).length > 0;
+  return (
+    node.body.body.length === 0 &&
+    context.sourceCode.getCommentsInside(node.body).some(comment => comment.value.trim().length > 0)
+  );
 }
 
 export const rule: Rule.RuleModule = {
   meta: generateMeta(meta, {
     messages: {
-      handleException: "Handle this exception or don't catch it at all.",
+      handleException:
+        "Handle this exception, don't catch it at all, or explain in a comment why it is ignored.",
     },
   }),
   create(context: Rule.RuleContext) {

--- a/packages/analysis/src/jsts/rules/S2486/rule.ts
+++ b/packages/analysis/src/jsts/rules/S2486/rule.ts
@@ -45,13 +45,7 @@ function isSingleSimpleStatement(body: estree.Statement[]): boolean {
 }
 
 function isDocumentedEmptyCatch(context: Rule.RuleContext, node: estree.CatchClause): boolean {
-  if (node.body.body.length !== 0) {
-    return false;
-  }
-  const openingBraceLine = node.body.loc!.start.line;
-  return context.sourceCode
-    .getCommentsInside(node.body)
-    .some(comment => comment.loc!.start.line > openingBraceLine);
+  return node.body.body.length === 0 && context.sourceCode.getCommentsInside(node.body).length > 0;
 }
 
 export const rule: Rule.RuleModule = {


### PR DESCRIPTION
Part of JS-2298

Rspec PR: https://github.com/SonarSource/rspec/pull/7955

## What

`S2486` no longer raises when an unused `catch` clause is empty apart from comments. A `catch` block that contains no statements but holds at least one non-blank comment is treated as documented, and therefore compliant.

The issue message now offers the comment as a third way to resolve the issue: *"Handle this exception, don't catch it at all, or explain in a comment why it is ignored."*

## Notes

Comment **content** is not inspected beyond being non-empty. This is a deliberate call, matching ESLint core's `no-empty` and the other analyzers (`java`, `csharp`, `python`, `dart`, `rpg`): linter directives (e.g. `// eslint-disable-next-line no-empty`) and commented-out code (e.g. `// setError(err.message)`) will therefore also suppress the rule. Filtering directive prefixes was considered and rejected — it would be a maintained list that drifts and diverges from the other analyzers.

A comment with no textual content (a bare `//`) does **not** count as documentation and still raises.

----
## Summary by Gitar

- **Bug Fixes:**
    - Updated `S2486` rule to suppress warnings when an unused `catch` clause contains only comments
    - Added comprehensive test fixtures covering single-line, multi-line, and block comment variations

<sub>This will update automatically on new commits.</sub>
