### PR TITLE
JS-2310 Fix S1848 DOM-derived constructor arguments

### DIFF
--- a/packages/analysis/src/jsts/rules/S1848/false-positives/helpers.ts
+++ b/packages/analysis/src/jsts/rules/S1848/false-positives/helpers.ts
@@ -1,0 +1,74 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import type { Scope } from 'eslint';
+import type estree from 'estree';
+
+/**
+ * Returns the nearest enclosing function, module, or global scope.
+ */
+export function getNearestFunctionScope(scope: Scope.Scope): Scope.Scope {
+  let current = scope;
+  while (current.type !== 'function' && current.type !== 'module' && current.type !== 'global') {
+    if (!current.upper) {
+      return current;
+    }
+    current = current.upper;
+  }
+  return current;
+}
+
+/**
+ * Returns a variable's sole write reference before a given identifier use.
+ */
+export function getUniqueWriteReferenceBefore(
+  variable: Scope.Variable,
+  node: estree.Identifier,
+): Scope.Reference | undefined {
+  const useStart = node.range?.[0];
+  const writeReferences = variable.references.filter(reference => {
+    const writeEnd = reference.identifier.range?.[1];
+    return (
+      reference.isWrite() &&
+      writeEnd !== undefined &&
+      useStart !== undefined &&
+      writeEnd <= useStart
+    );
+  });
+  return writeReferences.length === 1 ? writeReferences[0] : undefined;
+}
+
+/**
+ * Unwraps TypeScript type assertions to get the underlying expression.
+ * Handles TypeScript expression wrappers: TSAsExpression (`x as Type`),
+ * TSTypeAssertion (`<Type>x`), and TSNonNullExpression (`x!`), as well as
+ * ChainExpression (`x?.property`) produced by optional chaining; unwrapping it returns the
+ * contained optional MemberExpression (`x?.property`), not its object (`x`).
+ */
+export function unwrapTypeAssertion(node: estree.Node): estree.Node {
+  const nodeType = node.type as string;
+  if (
+    nodeType === 'TSAsExpression' ||
+    nodeType === 'TSTypeAssertion' ||
+    nodeType === 'TSNonNullExpression' ||
+    nodeType === 'ChainExpression'
+  ) {
+    const expr = (node as unknown as { expression: estree.Node }).expression;
+    return expr ? unwrapTypeAssertion(expr) : node;
+  }
+  return node;
+}

--- a/packages/analysis/src/jsts/rules/S1848/false-positives/helpers.ts
+++ b/packages/analysis/src/jsts/rules/S1848/false-positives/helpers.ts
@@ -33,6 +33,30 @@ export function getNearestFunctionScope(scope: Scope.Scope): Scope.Scope {
 }
 
 /**
+ * Returns whether a variable is written exactly once in its entire lifetime
+ * (e.g. a `const`, or a `let`/`var` that is never reassigned). Such a binding
+ * has only one possible value once its write executes, so its value can be
+ * trusted across function boundaries regardless of when a reader closure runs.
+ */
+export function hasSingleWrite(variable: Scope.Variable): boolean {
+  return variable.references.filter(reference => reference.isWrite()).length === 1;
+}
+
+/**
+ * Returns whether `scope` is `ancestor` or is nested within it.
+ */
+export function isDescendantOrSameScope(scope: Scope.Scope, ancestor: Scope.Scope): boolean {
+  let current: Scope.Scope | null = scope;
+  while (current) {
+    if (current === ancestor) {
+      return true;
+    }
+    current = current.upper;
+  }
+  return false;
+}
+
+/**
  * Returns a variable's sole write reference before a given identifier use.
  */
 export function getUniqueWriteReferenceBefore(

--- a/packages/analysis/src/jsts/rules/S1848/false-positives/helpers.ts
+++ b/packages/analysis/src/jsts/rules/S1848/false-positives/helpers.ts
@@ -17,6 +17,7 @@
 
 import type { Scope } from 'eslint';
 import type estree from 'estree';
+import { unwrapTypeScriptExpression } from '../../helpers/ast.js';
 
 /**
  * Returns the nearest enclosing function, module, or global scope.
@@ -59,6 +60,10 @@ export function isDescendantOrSameScope(scope: Scope.Scope, ancestor: Scope.Scop
 
 /**
  * Returns a variable's sole write reference before a given identifier use.
+ * Unlike the generic `getUniqueWriteReference` in `helpers/ast.ts` (which finds
+ * a variable's one and only write in its entire lifetime), this also accepts
+ * a `node` to bound the search to writes preceding that specific use, which
+ * this rule's cross-function scope check relies on.
  */
 export function getUniqueWriteReferenceBefore(
   variable: Scope.Variable,
@@ -78,22 +83,17 @@ export function getUniqueWriteReferenceBefore(
 }
 
 /**
- * Unwraps TypeScript type assertions to get the underlying expression.
- * Handles TypeScript expression wrappers: TSAsExpression (`x as Type`),
- * TSTypeAssertion (`<Type>x`), and TSNonNullExpression (`x!`), as well as
- * ChainExpression (`x?.property`) produced by optional chaining; unwrapping it returns the
- * contained optional MemberExpression (`x?.property`), not its object (`x`).
+ * Unwraps TypeScript type assertions (delegating to the shared
+ * `unwrapTypeScriptExpression`, which handles TSAsExpression, TSSatisfiesExpression,
+ * TSTypeAssertion, and TSNonNullExpression) as well as ChainExpression (`x?.property`)
+ * produced by optional chaining; unwrapping it returns the contained optional
+ * MemberExpression (`x?.property`), not its object (`x`). The two kinds of wrapper
+ * can nest in either order, so this alternates between them until neither applies.
  */
 export function unwrapTypeAssertion(node: estree.Node): estree.Node {
-  const nodeType = node.type as string;
-  if (
-    nodeType === 'TSAsExpression' ||
-    nodeType === 'TSTypeAssertion' ||
-    nodeType === 'TSNonNullExpression' ||
-    nodeType === 'ChainExpression'
-  ) {
-    const expr = (node as unknown as { expression: estree.Node }).expression;
-    return expr ? unwrapTypeAssertion(expr) : node;
+  let current = unwrapTypeScriptExpression(node);
+  while (current.type === 'ChainExpression') {
+    current = unwrapTypeScriptExpression(current.expression);
   }
-  return node;
+  return current;
 }

--- a/packages/analysis/src/jsts/rules/S1848/false-positives/helpers.ts
+++ b/packages/analysis/src/jsts/rules/S1848/false-positives/helpers.ts
@@ -36,7 +36,8 @@ export function getNearestFunctionScope(scope: Scope.Scope): Scope.Scope {
  * Returns whether a variable is written exactly once in its entire lifetime
  * (e.g. a `const`, or a `let`/`var` that is never reassigned). Such a binding
  * has only one possible value once its write executes, so its value can be
- * trusted across function boundaries regardless of when a reader closure runs.
+ * trusted from a reader nested inside the write's function scope, as long as
+ * the write also textually precedes the read.
  */
 export function hasSingleWrite(variable: Scope.Variable): boolean {
   return variable.references.filter(reference => reference.isWrite()).length === 1;

--- a/packages/analysis/src/jsts/rules/S1848/false-positives/trusted-dom-bindings.ts
+++ b/packages/analysis/src/jsts/rules/S1848/false-positives/trusted-dom-bindings.ts
@@ -1,0 +1,55 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import type { Scope } from 'eslint';
+import { getVariableFromScope, isIdentifier, isRequireModule } from '../../helpers/ast.js';
+import { unwrapTypeAssertion } from './helpers.js';
+
+export function isTrustedJQueryBinding(scope: Scope.Scope, name: string): boolean {
+  const variable = getVariableFromScope(scope, name);
+  if (!variable?.defs.length) {
+    return true;
+  }
+
+  return variable.defs.some(def => {
+    if (def.type === 'ImportBinding') {
+      return def.parent.type === 'ImportDeclaration' && def.parent.source.value === 'jquery';
+    }
+    return (
+      def.type === 'Variable' &&
+      def.node.init?.type === 'CallExpression' &&
+      isRequireModule(def.node.init, 'jquery')
+    );
+  });
+}
+
+export function isTrustedDocumentBinding(scope: Scope.Scope): boolean {
+  const variable = getVariableFromScope(scope, 'document');
+  if (!variable?.defs.length) {
+    return true;
+  }
+
+  return variable.defs.some(def => {
+    const init = def.type === 'Variable' ? unwrapTypeAssertion(def.node.init ?? def.node) : undefined;
+    return (
+      init?.type === 'MemberExpression' &&
+      isIdentifier(init.object, 'window') &&
+      isIdentifier(init.property, 'document') &&
+      !getVariableFromScope(scope, 'window')?.defs.length
+    );
+  });
+}

--- a/packages/analysis/src/jsts/rules/S1848/false-positives/trusted-dom-bindings.ts
+++ b/packages/analysis/src/jsts/rules/S1848/false-positives/trusted-dom-bindings.ts
@@ -19,7 +19,26 @@ import type { Scope } from 'eslint';
 import { getVariableFromScope, isIdentifier, isRequireModule } from '../../helpers/ast.js';
 import { unwrapTypeAssertion } from './helpers.js';
 
-export function isTrustedJQueryBinding(scope: Scope.Scope, name: string): boolean {
+/**
+ * Returns whether a `Variable`-def's declaration is an ambient, type-only
+ * declaration (`declare const $: JQueryStatic;`). A plain uninitialized binding
+ * (`let $;`) or a for-of/for-in binding also has a null `init`, so the TypeScript
+ * `declare` flag - not a null init - is what actually distinguishes the two.
+ */
+function isAmbientDeclaration(def: Scope.Definition & { type: 'Variable' }): boolean {
+  return (def.parent as { declare?: boolean } | null)?.declare === true;
+}
+
+export function isTrustedJQueryBinding(
+  scope: Scope.Scope,
+  name: string,
+  seen: Set<string> = new Set(),
+): boolean {
+  if (seen.has(name)) {
+    return false;
+  }
+  seen.add(name);
+
   const variable = getVariableFromScope(scope, name);
   if (!variable?.defs.length) {
     return true;
@@ -33,14 +52,13 @@ export function isTrustedJQueryBinding(scope: Scope.Scope, name: string): boolea
       return false;
     }
     if (def.node.init == null) {
-      // Ambient/type-only declaration, e.g. `declare const $: JQueryStatic;`
-      return true;
+      return isAmbientDeclaration(def);
     }
     const init = unwrapTypeAssertion(def.node.init);
     return (
       (init.type === 'CallExpression' && isRequireModule(init, 'jquery')) ||
-      // `const $ = jQuery;` aliasing the (untouched) jQuery global
-      (isIdentifier(init, 'jQuery') && !getVariableFromScope(scope, 'jQuery')?.defs.length)
+      // `const $ = jQuery;` aliasing an already-trusted jQuery binding
+      (isIdentifier(init, 'jQuery') && isTrustedJQueryBinding(scope, 'jQuery', seen))
     );
   });
 }
@@ -57,8 +75,7 @@ export function isTrustedDocumentBinding(scope: Scope.Scope): boolean {
       return false;
     }
     if (def.node.init == null) {
-      // Ambient/type-only declaration, e.g. `declare const document: Document;`
-      return true;
+      return isAmbientDeclaration(def);
     }
     if (!windowNotShadowed) {
       return false;

--- a/packages/analysis/src/jsts/rules/S1848/false-positives/trusted-dom-bindings.ts
+++ b/packages/analysis/src/jsts/rules/S1848/false-positives/trusted-dom-bindings.ts
@@ -29,10 +29,18 @@ export function isTrustedJQueryBinding(scope: Scope.Scope, name: string): boolea
     if (def.type === 'ImportBinding') {
       return def.parent.type === 'ImportDeclaration' && def.parent.source.value === 'jquery';
     }
+    if (def.type !== 'Variable') {
+      return false;
+    }
+    if (def.node.init == null) {
+      // Ambient/type-only declaration, e.g. `declare const $: JQueryStatic;`
+      return true;
+    }
+    const init = unwrapTypeAssertion(def.node.init);
     return (
-      def.type === 'Variable' &&
-      def.node.init?.type === 'CallExpression' &&
-      isRequireModule(def.node.init, 'jquery')
+      (init.type === 'CallExpression' && isRequireModule(init, 'jquery')) ||
+      // `const $ = jQuery;` aliasing the (untouched) jQuery global
+      (isIdentifier(init, 'jQuery') && !getVariableFromScope(scope, 'jQuery')?.defs.length)
     );
   });
 }
@@ -42,14 +50,32 @@ export function isTrustedDocumentBinding(scope: Scope.Scope): boolean {
   if (!variable?.defs.length) {
     return true;
   }
+  const windowNotShadowed = !getVariableFromScope(scope, 'window')?.defs.length;
 
   return variable.defs.some(def => {
-    const init = def.type === 'Variable' ? unwrapTypeAssertion(def.node.init ?? def.node) : undefined;
-    return (
-      init?.type === 'MemberExpression' &&
-      isIdentifier(init.object, 'window') &&
-      isIdentifier(init.property, 'document') &&
-      !getVariableFromScope(scope, 'window')?.defs.length
-    );
+    if (def.type !== 'Variable') {
+      return false;
+    }
+    if (def.node.init == null) {
+      // Ambient/type-only declaration, e.g. `declare const document: Document;`
+      return true;
+    }
+    if (!windowNotShadowed) {
+      return false;
+    }
+    const init = unwrapTypeAssertion(def.node.init);
+    if (init.type === 'MemberExpression') {
+      return isIdentifier(init.object, 'window') && isIdentifier(init.property, 'document');
+    }
+    if (def.node.id.type === 'ObjectPattern' && isIdentifier(init, 'window')) {
+      // `const { document } = window;`
+      return def.node.id.properties.some(
+        property =>
+          property.type === 'Property' &&
+          !property.computed &&
+          isIdentifier(property.key, 'document'),
+      );
+    }
+    return false;
   });
 }

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -20,7 +20,6 @@ import type { Rule, Scope } from 'eslint';
 import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
-import { getVariableFromIdentifier } from '../helpers/reaching-definitions.js';
 import {
   getVariableFromName,
   getVariableFromScope,
@@ -406,19 +405,20 @@ function isVariableFromDomSelection(
   scope: Scope.Scope,
   visitedVariables: Set<Scope.Variable>,
 ): boolean {
-  const variable = getVariableFromIdentifier(node, scope);
+  const variable = getVariableFromScope(scope, node.name);
   if (!variable || visitedVariables.has(variable)) {
     return false;
   }
   visitedVariables.add(variable);
 
   // A read from a nested function can happen before or after a write in the
-  // enclosing function, so source order cannot prove a reassignable variable's
-  // value. A single-write binding (const, or a let/var written only once) has
-  // only one possible value once its write executes, and a read nested inside
-  // (or in) the write's own function is guaranteed to observe it, so the
-  // scope check only needs to require that the read stays within the write's
-  // function rather than matching it exactly.
+  // enclosing function, so source order alone cannot prove a reassignable
+  // variable's value. A single-write binding (const, or a let/var written only
+  // once) has only one possible value once its write executes; requiring that
+  // write to also precede the read lexically (below) guarantees any later
+  // closure execution observes it, so the scope check only needs to require
+  // that the read stays within the write's function rather than matching it
+  // exactly.
   const singleWrite = hasSingleWrite(variable);
   const readFunctionScope = getNearestFunctionScope(scope);
   const declFunctionScope = getNearestFunctionScope(variable.scope);
@@ -444,8 +444,15 @@ function isVariableFromDomSelection(
   }
 
   // Follow a local initializer only. This permits DOM-derived member/call chains
-  // without performing interprocedural analysis.
-  return containsDomSelection(unwrapTypeAssertion(writeReference.writeExpr), scope, visitedVariables);
+  // without performing interprocedural analysis. The write expression must be
+  // resolved in the scope where the write happens, not where the read happens,
+  // because a single-write binding may be read from a nested (possibly shadowing)
+  // function scope.
+  return containsDomSelection(
+    unwrapTypeAssertion(writeReference.writeExpr),
+    writeReference.from,
+    visitedVariables,
+  );
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -21,7 +21,12 @@ import type estree from 'estree';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { getVariableFromIdentifier } from '../helpers/reaching-definitions.js';
-import { getVariableFromName, getVariableFromScope, isIdentifier } from '../helpers/ast.js';
+import {
+  getVariableFromName,
+  getVariableFromScope,
+  isIdentifier,
+  isRequireModule,
+} from '../helpers/ast.js';
 import * as meta from './generated-meta.js';
 
 /**
@@ -343,6 +348,7 @@ function containsDomSelection(
   scope: Scope.Scope,
   visitedVariables = new Set<Scope.Variable>(),
 ): boolean {
+  node = unwrapTypeAssertion(node);
   if (node.type === 'CallExpression') {
     return (
       isDomSelectionCall(node, scope) ||
@@ -396,7 +402,16 @@ function isVariableFromDomSelection(
   }
   visitedVariables.add(variable);
 
-  const writeReferences = variable.references.filter(reference => reference.isWrite());
+  const writeReferences = variable.references.filter(reference => {
+    const writeEnd = reference.identifier.range?.[1];
+    const useStart = node.range?.[0];
+    return (
+      reference.isWrite() &&
+      writeEnd !== undefined &&
+      useStart !== undefined &&
+      writeEnd <= useStart
+    );
+  });
   const definition = variable.defs.find(def => def.type === 'Variable' && def.node.init);
   if (
     writeReferences.length !== 1 ||
@@ -413,12 +428,17 @@ function isVariableFromDomSelection(
 
 /**
  * Unwraps TypeScript type assertions to get the underlying expression.
- * Handles: x as Type, <Type>x
+ * Handles: x as Type, <Type>x, x!, and optional chains.
  */
 function unwrapTypeAssertion(node: estree.Node): estree.Node {
   // TypeScript AST types TSAsExpression and TSTypeAssertion are not in estree
   const nodeType = node.type as string;
-  if (nodeType === 'TSAsExpression' || nodeType === 'TSTypeAssertion') {
+  if (
+    nodeType === 'TSAsExpression' ||
+    nodeType === 'TSTypeAssertion' ||
+    nodeType === 'TSNonNullExpression' ||
+    nodeType === 'ChainExpression'
+  ) {
     const expr = (node as unknown as { expression: estree.Node }).expression;
     return expr ? unwrapTypeAssertion(expr) : node;
   }
@@ -435,7 +455,7 @@ function isDomSelectionCall(node: estree.CallExpression, scope: Scope.Scope): bo
 
   // Check for $() or jQuery()
   if (isIdentifier(callee, ...JQUERY_IDENTIFIERS)) {
-    return !getVariableFromScope(scope, callee.name)?.defs.length;
+    return isTrustedJQueryBinding(scope, callee.name);
   }
 
   // Check for *.querySelector, *.getElementById, etc. on any object
@@ -446,7 +466,7 @@ function isDomSelectionCall(node: estree.CallExpression, scope: Scope.Scope): bo
   ) {
     if (
       isIdentifier(callee.object, 'document') &&
-      getVariableFromScope(scope, callee.object.name)?.defs.length
+      !isTrustedDocumentBinding(scope)
     ) {
       return false;
     }
@@ -463,4 +483,39 @@ function isDomSelectionCall(node: estree.CallExpression, scope: Scope.Scope): bo
   }
 
   return false;
+}
+
+function isTrustedJQueryBinding(scope: Scope.Scope, name: string): boolean {
+  const variable = getVariableFromScope(scope, name);
+  if (!variable?.defs.length) {
+    return true;
+  }
+
+  return variable.defs.some(def => {
+    if (def.type === 'ImportBinding') {
+      return def.parent.type === 'ImportDeclaration' && def.parent.source.value === 'jquery';
+    }
+    return (
+      def.type === 'Variable' &&
+      def.node.init?.type === 'CallExpression' &&
+      isRequireModule(def.node.init, 'jquery')
+    );
+  });
+}
+
+function isTrustedDocumentBinding(scope: Scope.Scope): boolean {
+  const variable = getVariableFromScope(scope, 'document');
+  if (!variable?.defs.length) {
+    return true;
+  }
+
+  return variable.defs.some(def => {
+    const init = def.type === 'Variable' ? unwrapTypeAssertion(def.node.init ?? def.node) : undefined;
+    return (
+      init?.type === 'MemberExpression' &&
+      isIdentifier(init.object, 'window') &&
+      isIdentifier(init.property, 'document') &&
+      !getVariableFromScope(scope, 'window')?.defs.length
+    );
+  });
 }

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -22,6 +22,7 @@ import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { getVariableFromIdentifier } from '../helpers/reaching-definitions.js';
 import {
+  getUniqueWriteReference,
   getVariableFromName,
   getVariableFromScope,
   isIdentifier,
@@ -402,9 +403,42 @@ function isVariableFromDomSelection(
   }
   visitedVariables.add(variable);
 
+  // When the read happens inside a function nested below the variable's own
+  // declaring function (e.g. a helper invoked later), lexical write/read
+  // order no longer reflects execution order, so fall back to requiring a
+  // single write across the whole variable lifetime instead of "before use".
+  const isDeferredRead = nearestFunctionScope(scope) !== nearestFunctionScope(variable.scope);
+
+  const writeExpr = isDeferredRead
+    ? getUniqueWriteReference(variable)
+    : getUniqueWriteReferenceBefore(variable, node);
+  if (!writeExpr) {
+    return false;
+  }
+
+  // Follow a local initializer only. This permits DOM-derived member/call chains
+  // without performing interprocedural analysis.
+  return containsDomSelection(unwrapTypeAssertion(writeExpr), scope, visitedVariables);
+}
+
+function nearestFunctionScope(scope: Scope.Scope): Scope.Scope {
+  let current = scope;
+  while (current.type !== 'function' && current.type !== 'module' && current.type !== 'global') {
+    if (!current.upper) {
+      return current;
+    }
+    current = current.upper;
+  }
+  return current;
+}
+
+function getUniqueWriteReferenceBefore(
+  variable: Scope.Variable,
+  node: estree.Identifier,
+): estree.Node | undefined {
+  const useStart = node.range?.[0];
   const writeReferences = variable.references.filter(reference => {
     const writeEnd = reference.identifier.range?.[1];
-    const useStart = node.range?.[0];
     return (
       reference.isWrite() &&
       writeEnd !== undefined &&
@@ -412,18 +446,7 @@ function isVariableFromDomSelection(
       writeEnd <= useStart
     );
   });
-  const definition = variable.defs.find(def => def.type === 'Variable' && def.node.init);
-  if (
-    writeReferences.length !== 1 ||
-    definition?.type !== 'Variable' ||
-    !definition.node.init
-  ) {
-    return false;
-  }
-
-  // Follow a local initializer only. This permits DOM-derived member/call chains
-  // without performing interprocedural analysis.
-  return containsDomSelection(unwrapTypeAssertion(definition.node.init), scope, visitedVariables);
+  return writeReferences.length === 1 ? writeReferences[0].writeExpr ?? undefined : undefined;
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -338,34 +338,45 @@ function hasDomSelectionArgument(node: estree.NewExpression, context: Rule.RuleC
  * Recursively checks if a node contains a DOM selection call.
  * Also resolves variables to check if they were initialized from DOM selection.
  */
-function containsDomSelection(node: estree.Node, scope: Scope.Scope): boolean {
+function containsDomSelection(
+  node: estree.Node,
+  scope: Scope.Scope,
+  visitedVariables = new Set<Scope.Variable>(),
+): boolean {
   if (node.type === 'CallExpression') {
-    return isDomSelectionCall(node);
+    return (
+      isDomSelectionCall(node, scope) ||
+      (node.callee.type === 'MemberExpression' &&
+        containsDomSelection(node.callee.object, scope, visitedVariables))
+    );
   }
   if (node.type === 'Identifier') {
     // Resolve variable to check its initializer
-    return isVariableFromDomSelection(node, scope);
+    return isVariableFromDomSelection(node, scope, visitedVariables);
   }
   if (node.type === 'MemberExpression') {
     // Check if object is a DOM selection call (e.g., document.querySelector(...).dataset)
-    return containsDomSelection(node.object, scope);
+    return containsDomSelection(node.object, scope, visitedVariables);
   }
   if (node.type === 'ObjectExpression') {
     // Check properties for DOM selection calls (e.g., {element: $('foo')})
     return node.properties.some(prop => {
       if (prop.type === 'Property') {
-        return containsDomSelection(prop.value, scope);
+        return containsDomSelection(prop.value, scope, visitedVariables);
       }
       return false;
     });
   }
   if (node.type === 'ArrayExpression') {
     // Check array elements for DOM selection calls (e.g., [$('foo'), $('bar')])
-    return node.elements.some(elem => elem !== null && containsDomSelection(elem, scope));
+    return node.elements.some(
+      elem => elem !== null && containsDomSelection(elem, scope, visitedVariables),
+    );
   }
   if (node.type === 'ConditionalExpression') {
     return (
-      containsDomSelection(node.consequent, scope) || containsDomSelection(node.alternate, scope)
+      containsDomSelection(node.consequent, scope, visitedVariables) ||
+      containsDomSelection(node.alternate, scope, visitedVariables)
     );
   }
   return false;
@@ -374,22 +385,26 @@ function containsDomSelection(node: estree.Node, scope: Scope.Scope): boolean {
 /**
  * Checks if a variable was initialized from a DOM selection call.
  */
-function isVariableFromDomSelection(node: estree.Identifier, scope: Scope.Scope): boolean {
+function isVariableFromDomSelection(
+  node: estree.Identifier,
+  scope: Scope.Scope,
+  visitedVariables: Set<Scope.Variable>,
+): boolean {
   const variable = getVariableFromIdentifier(node, scope);
-  if (!variable) {
+  if (!variable || visitedVariables.has(variable)) {
     return false;
   }
-  // Check each definition of the variable
-  for (const def of variable.defs) {
-    if (def.type === 'Variable' && def.node.init) {
-      // Check if the initializer is a DOM selection call (possibly wrapped in type assertion)
-      const initExpr = unwrapTypeAssertion(def.node.init);
-      if (initExpr.type === 'CallExpression' && isDomSelectionCall(initExpr)) {
-        return true;
-      }
-    }
+  visitedVariables.add(variable);
+
+  const writeReferences = variable.references.filter(reference => reference.isWrite());
+  const definition = variable.defs.find(def => def.type === 'Variable' && def.node.init);
+  if (writeReferences.length !== 1 || !definition || definition.type !== 'Variable') {
+    return false;
   }
-  return false;
+
+  // Follow a local initializer only. This permits DOM-derived member/call chains
+  // without performing interprocedural analysis.
+  return containsDomSelection(unwrapTypeAssertion(definition.node.init!), scope, visitedVariables);
 }
 
 /**
@@ -411,12 +426,12 @@ function unwrapTypeAssertion(node: estree.Node): estree.Node {
  * Matches: document.querySelector, document.getElementById, $(), jQuery(), this.$(),
  * and any call to DOM selection methods on any object (e.g., myDocument.querySelector)
  */
-function isDomSelectionCall(node: estree.CallExpression): boolean {
+function isDomSelectionCall(node: estree.CallExpression, scope: Scope.Scope): boolean {
   const { callee } = node;
 
   // Check for $() or jQuery()
   if (isIdentifier(callee, ...JQUERY_IDENTIFIERS)) {
-    return true;
+    return !getVariableFromScope(scope, callee.name)?.defs.length;
   }
 
   // Check for *.querySelector, *.getElementById, etc. on any object
@@ -425,6 +440,12 @@ function isDomSelectionCall(node: estree.CallExpression): boolean {
     callee.type === 'MemberExpression' &&
     isIdentifier(callee.property, ...DOM_SELECTION_METHODS)
   ) {
+    if (
+      isIdentifier(callee.object, 'document') &&
+      getVariableFromScope(scope, callee.object.name)?.defs.length
+    ) {
+      return false;
+    }
     return true;
   }
 

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -22,12 +22,19 @@ import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { getVariableFromIdentifier } from '../helpers/reaching-definitions.js';
 import {
-  getUniqueWriteReference,
   getVariableFromName,
   getVariableFromScope,
   isIdentifier,
-  isRequireModule,
 } from '../helpers/ast.js';
+import {
+  getNearestFunctionScope,
+  getUniqueWriteReferenceBefore,
+  unwrapTypeAssertion,
+} from './false-positives/helpers.js';
+import {
+  isTrustedDocumentBinding,
+  isTrustedJQueryBinding,
+} from './false-positives/trusted-dom-bindings.js';
 import * as meta from './generated-meta.js';
 
 /**
@@ -403,69 +410,24 @@ function isVariableFromDomSelection(
   }
   visitedVariables.add(variable);
 
-  // When the read happens inside a function nested below the variable's own
-  // declaring function (e.g. a helper invoked later), lexical write/read
-  // order no longer reflects execution order, so fall back to requiring a
-  // single write across the whole variable lifetime instead of "before use".
-  const isDeferredRead = nearestFunctionScope(scope) !== nearestFunctionScope(variable.scope);
+  // A read from a nested function can happen before or after a write in the
+  // enclosing function, so source order cannot prove the variable's value.
+  const readFunctionScope = getNearestFunctionScope(scope);
+  if (readFunctionScope !== getNearestFunctionScope(variable.scope)) {
+    return false;
+  }
 
-  const writeExpr = isDeferredRead
-    ? getUniqueWriteReference(variable)
-    : getUniqueWriteReferenceBefore(variable, node);
-  if (!writeExpr) {
+  const writeReference = getUniqueWriteReferenceBefore(variable, node);
+  if (
+    !writeReference?.writeExpr ||
+    getNearestFunctionScope(writeReference.from) !== readFunctionScope
+  ) {
     return false;
   }
 
   // Follow a local initializer only. This permits DOM-derived member/call chains
   // without performing interprocedural analysis.
-  return containsDomSelection(unwrapTypeAssertion(writeExpr), scope, visitedVariables);
-}
-
-function nearestFunctionScope(scope: Scope.Scope): Scope.Scope {
-  let current = scope;
-  while (current.type !== 'function' && current.type !== 'module' && current.type !== 'global') {
-    if (!current.upper) {
-      return current;
-    }
-    current = current.upper;
-  }
-  return current;
-}
-
-function getUniqueWriteReferenceBefore(
-  variable: Scope.Variable,
-  node: estree.Identifier,
-): estree.Node | undefined {
-  const useStart = node.range?.[0];
-  const writeReferences = variable.references.filter(reference => {
-    const writeEnd = reference.identifier.range?.[1];
-    return (
-      reference.isWrite() &&
-      writeEnd !== undefined &&
-      useStart !== undefined &&
-      writeEnd <= useStart
-    );
-  });
-  return writeReferences.length === 1 ? writeReferences[0].writeExpr ?? undefined : undefined;
-}
-
-/**
- * Unwraps TypeScript type assertions to get the underlying expression.
- * Handles: x as Type, <Type>x, x!, and optional chains.
- */
-function unwrapTypeAssertion(node: estree.Node): estree.Node {
-  // TypeScript AST types TSAsExpression and TSTypeAssertion are not in estree
-  const nodeType = node.type as string;
-  if (
-    nodeType === 'TSAsExpression' ||
-    nodeType === 'TSTypeAssertion' ||
-    nodeType === 'TSNonNullExpression' ||
-    nodeType === 'ChainExpression'
-  ) {
-    const expr = (node as unknown as { expression: estree.Node }).expression;
-    return expr ? unwrapTypeAssertion(expr) : node;
-  }
-  return node;
+  return containsDomSelection(unwrapTypeAssertion(writeReference.writeExpr), scope, visitedVariables);
 }
 
 /**
@@ -487,10 +449,7 @@ function isDomSelectionCall(node: estree.CallExpression, scope: Scope.Scope): bo
     callee.type === 'MemberExpression' &&
     isIdentifier(callee.property, ...DOM_SELECTION_METHODS)
   ) {
-    if (
-      isIdentifier(callee.object, 'document') &&
-      !isTrustedDocumentBinding(scope)
-    ) {
+    if (isIdentifier(callee.object, 'document') && !isTrustedDocumentBinding(scope)) {
       return false;
     }
     return true;
@@ -506,39 +465,4 @@ function isDomSelectionCall(node: estree.CallExpression, scope: Scope.Scope): bo
   }
 
   return false;
-}
-
-function isTrustedJQueryBinding(scope: Scope.Scope, name: string): boolean {
-  const variable = getVariableFromScope(scope, name);
-  if (!variable?.defs.length) {
-    return true;
-  }
-
-  return variable.defs.some(def => {
-    if (def.type === 'ImportBinding') {
-      return def.parent.type === 'ImportDeclaration' && def.parent.source.value === 'jquery';
-    }
-    return (
-      def.type === 'Variable' &&
-      def.node.init?.type === 'CallExpression' &&
-      isRequireModule(def.node.init, 'jquery')
-    );
-  });
-}
-
-function isTrustedDocumentBinding(scope: Scope.Scope): boolean {
-  const variable = getVariableFromScope(scope, 'document');
-  if (!variable?.defs.length) {
-    return true;
-  }
-
-  return variable.defs.some(def => {
-    const init = def.type === 'Variable' ? unwrapTypeAssertion(def.node.init ?? def.node) : undefined;
-    return (
-      init?.type === 'MemberExpression' &&
-      isIdentifier(init.object, 'window') &&
-      isIdentifier(init.property, 'document') &&
-      !getVariableFromScope(scope, 'window')?.defs.length
-    );
-  });
 }

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -398,13 +398,17 @@ function isVariableFromDomSelection(
 
   const writeReferences = variable.references.filter(reference => reference.isWrite());
   const definition = variable.defs.find(def => def.type === 'Variable' && def.node.init);
-  if (writeReferences.length !== 1 || !definition || definition.type !== 'Variable') {
+  if (
+    writeReferences.length !== 1 ||
+    definition?.type !== 'Variable' ||
+    !definition.node.init
+  ) {
     return false;
   }
 
   // Follow a local initializer only. This permits DOM-derived member/call chains
   // without performing interprocedural analysis.
-  return containsDomSelection(unwrapTypeAssertion(definition.node.init!), scope, visitedVariables);
+  return containsDomSelection(unwrapTypeAssertion(definition.node.init), scope, visitedVariables);
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S1848/rule.ts
+++ b/packages/analysis/src/jsts/rules/S1848/rule.ts
@@ -29,6 +29,8 @@ import {
 import {
   getNearestFunctionScope,
   getUniqueWriteReferenceBefore,
+  hasSingleWrite,
+  isDescendantOrSameScope,
   unwrapTypeAssertion,
 } from './false-positives/helpers.js';
 import {
@@ -411,16 +413,32 @@ function isVariableFromDomSelection(
   visitedVariables.add(variable);
 
   // A read from a nested function can happen before or after a write in the
-  // enclosing function, so source order cannot prove the variable's value.
+  // enclosing function, so source order cannot prove a reassignable variable's
+  // value. A single-write binding (const, or a let/var written only once) has
+  // only one possible value once its write executes, and a read nested inside
+  // (or in) the write's own function is guaranteed to observe it, so the
+  // scope check only needs to require that the read stays within the write's
+  // function rather than matching it exactly.
+  const singleWrite = hasSingleWrite(variable);
   const readFunctionScope = getNearestFunctionScope(scope);
-  if (readFunctionScope !== getNearestFunctionScope(variable.scope)) {
+  const declFunctionScope = getNearestFunctionScope(variable.scope);
+  if (
+    singleWrite
+      ? !isDescendantOrSameScope(readFunctionScope, declFunctionScope)
+      : readFunctionScope !== declFunctionScope
+  ) {
     return false;
   }
 
   const writeReference = getUniqueWriteReferenceBefore(variable, node);
+  if (!writeReference?.writeExpr) {
+    return false;
+  }
+  const writeFunctionScope = getNearestFunctionScope(writeReference.from);
   if (
-    !writeReference?.writeExpr ||
-    getNearestFunctionScope(writeReference.from) !== readFunctionScope
+    singleWrite
+      ? !isDescendantOrSameScope(readFunctionScope, writeFunctionScope)
+      : writeFunctionScope !== readFunctionScope
   ) {
     return false;
   }

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -236,6 +236,12 @@ new Notice('Hello from Obsidian plugin!');`,
 new Widget(element);`,
           },
           {
+            // DOM attachment: variable initialized from a selected canvas context
+            code: `const canvas = document.querySelector('#chart');
+const context = canvas.getContext('2d');
+new Chart(context);`,
+          },
+          {
             // DOM attachment: variable with TypeScript type assertion
             code: `const el = document.getElementById('app') as HTMLElement;
 new AppController(el);`,
@@ -354,6 +360,38 @@ new DragInstance(params, startEvent, eBody);`,
           {
             // Local window parameter must not suppress window.ClipboardJS
             code: `function bind(window) { new window.ClipboardJS('.copy-button'); }`,
+            errors: 1,
+          },
+          {
+            // Reassigned DOM selection must not suppress the report
+            code: `let canvas = document.querySelector('#chart');
+canvas = unrelated;
+const context = canvas.getContext('2d');
+new Chart(context);`,
+            errors: 1,
+          },
+          {
+            // Local document objects must not suppress the report
+            code: `const document = { querySelector: () => ({ getContext: () => ({}) }) };
+const canvas = document.querySelector('#chart');
+const context = canvas.getContext('2d');
+new Chart(context);`,
+            errors: 1,
+          },
+          {
+            // Local $ functions must not suppress the report through a variable chain
+            code: `const $ = () => ({ getContext: () => ({}) });
+const canvas = $('#chart');
+const context = canvas.getContext('2d');
+new Chart(context);`,
+            errors: 1,
+          },
+          {
+            // Local jQuery functions must not suppress the report through a variable chain
+            code: `const jQuery = () => ({ getContext: () => ({}) });
+const canvas = jQuery('#chart');
+const context = canvas.getContext('2d');
+new Chart(context);`,
             errors: 1,
           },
           {

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -257,6 +257,23 @@ new Widget(jQuery('#container'));`,
 new Widget(document.querySelector('#container'));`,
           },
           {
+            // DOM attachment: document destructured from window
+            code: `const { document } = window;
+new Widget(document.querySelector('#container'));`,
+          },
+          {
+            // DOM attachment: jQuery aliased to the untouched global
+            code: `const $ = jQuery;
+new Widget($('#container'));`,
+          },
+          {
+            // DOM attachment: ambient type-only jQuery/document declarations
+            code: `declare const $: JQueryStatic;
+declare const document: Document;
+new Widget($('#container'));
+new OtherWidget(document.querySelector('#container'));`,
+          },
+          {
             // DOM attachment: optional chained DOM-derived context
             code: `new Chart(document.querySelector('#chart')?.getContext('2d'));`,
           },

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -303,6 +303,21 @@ new DragInstance(params, startEvent, eBody);`,
             // Global-form exception: paperScope.* global namespace
             code: `new paperScope.Path.Line({ from: [0, 0], to: [40, 40], strokeColor: 'black' });`,
           },
+          {
+            // DOM attachment: const selected once at module scope, used in a later event handler
+            code: `const chart = document.querySelector('#chart');
+document.getElementById('btn').addEventListener('click', () => {
+  new Chart(chart);
+});`,
+          },
+          {
+            // DOM attachment: single-write const captured by a nested function
+            code: `const element = document.querySelector('.widget');
+function createWidget() {
+  new Widget(element);
+}
+createWidget();`,
+          },
         ],
         invalid: [
           {
@@ -402,21 +417,28 @@ new Chart(context);`,
             errors: 1,
           },
           {
-            // A captured DOM-derived variable cannot prove the argument is DOM-derived.
-            code: `const element = document.querySelector('.widget');
-function createWidget() {
-  new Widget(element);
-}
-createWidget();`,
-            errors: 1,
-          },
-          {
-            // A DOM-derived write in a nested function cannot prove the argument is DOM-derived.
+            // A DOM-derived write in a nested function cannot prove the argument is DOM-derived:
+            // the write's function scope is nested below the read's, so nothing guarantees it
+            // ran before this read.
             code: `let element;
 function setElement() {
   element = document.querySelector('.widget');
 }
 new Widget(element);`,
+            errors: 1,
+          },
+          {
+            // A reassignable (multi-write) variable read from a nested function still cannot
+            // be trusted, even though one of its writes is DOM-derived.
+            code: `let element = document.querySelector('.widget');
+function reset() {
+  element = null;
+}
+function createWidget() {
+  new Widget(element);
+}
+reset();
+createWidget();`,
             errors: 1,
           },
           {

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -242,6 +242,37 @@ const context = canvas.getContext('2d');
 new Chart(context);`,
           },
           {
+            // DOM attachment: imported jQuery selector
+            code: `import $ from 'jquery';
+new Widget($('#container'));`,
+          },
+          {
+            // DOM attachment: CommonJS jQuery selector
+            code: `const jQuery = require('jquery');
+new Widget(jQuery('#container'));`,
+          },
+          {
+            // DOM attachment: document alias in browser wrappers
+            code: `const document = window.document;
+new Widget(document.querySelector('#container'));`,
+          },
+          {
+            // DOM attachment: optional chained DOM-derived context
+            code: `new Chart(document.querySelector('#chart')?.getContext('2d'));`,
+          },
+          {
+            // DOM attachment: non-null asserted DOM selection variable
+            code: `const canvas = document.querySelector('#chart')!;
+const context = canvas.getContext('2d');
+new Chart(context);`,
+          },
+          {
+            // DOM attachment: reassignment after the constructor does not affect its argument
+            code: `let canvas = document.querySelector('#chart');
+new Chart(canvas);
+canvas = null;`,
+          },
+          {
             // DOM attachment: variable with TypeScript type assertion
             code: `const el = document.getElementById('app') as HTMLElement;
 new AppController(el);`,

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -267,6 +267,12 @@ new Widget(document.querySelector('#container'));`,
 new Widget($('#container'));`,
           },
           {
+            // DOM attachment: jQuery aliased to an already-trusted import binding
+            code: `import jQuery from 'jquery';
+const $ = jQuery;
+new Widget($('#container'));`,
+          },
+          {
             // DOM attachment: ambient type-only jQuery/document declarations
             code: `declare const $: JQueryStatic;
 declare const document: Document;
@@ -501,6 +507,27 @@ new Chart(context);`,
 const canvas = jQuery('#chart');
 const context = canvas.getContext('2d');
 new Chart(context);`,
+            errors: 1,
+          },
+          {
+            // A plain uninitialized `$` is not an ambient declaration and must not be trusted
+            code: `let $;
+$ = getUntrustedValue();
+new Widget($('#container'));`,
+            errors: 1,
+          },
+          {
+            // A plain uninitialized `document` is not an ambient declaration and must not be trusted
+            code: `let document;
+document = getUntrustedValue();
+new Widget(document.querySelector('#container'));`,
+            errors: 1,
+          },
+          {
+            // A for-of bound `document` is not an ambient declaration and must not be trusted
+            code: `for (const document of untrustedList) {
+  new Widget(document.querySelector('#container'));
+}`,
             errors: 1,
           },
           {

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -318,6 +318,27 @@ function createWidget() {
 }
 createWidget();`,
           },
+          {
+            // DOM attachment: write expression must resolve in its own scope, not the
+            // reader's, even when the reader shadows an identifier used by the write
+            code: `const element = document.querySelector('.widget');
+function f() {
+  const document = { querySelector: () => ({}) };
+  new Widget(element);
+}
+f();`,
+          },
+          {
+            // DOM attachment: single-write const read from two nested function levels deep
+            code: `const element = document.querySelector('.widget');
+function outer() {
+  function inner() {
+    new Widget(element);
+  }
+  inner();
+}
+outer();`,
+          },
         ],
         invalid: [
           {

--- a/packages/analysis/src/jsts/rules/S1848/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S1848/unit.test.ts
@@ -402,6 +402,24 @@ new Chart(context);`,
             errors: 1,
           },
           {
+            // A captured DOM-derived variable cannot prove the argument is DOM-derived.
+            code: `const element = document.querySelector('.widget');
+function createWidget() {
+  new Widget(element);
+}
+createWidget();`,
+            errors: 1,
+          },
+          {
+            // A DOM-derived write in a nested function cannot prove the argument is DOM-derived.
+            code: `let element;
+function setElement() {
+  element = document.querySelector('.widget');
+}
+new Widget(element);`,
+            errors: 1,
+          },
+          {
             // Local document objects must not suppress the report
             code: `const document = { querySelector: () => ({ getContext: () => ({}) }) };
 const canvas = document.querySelector('#chart');


### PR DESCRIPTION
## Summary

- Follow trusted DOM-selection provenance through chained member/call expressions and single-write local bindings.
- Keep S1848 reporting for reassigned values and locally shadowed `document`, `$`, and `jQuery` selector-like APIs.

## Scope

Jira: JS-2310
Rule keys: `javascript:S1848`, `typescript:S1848`

## Peach baselines

- `JS-2310-javascript-S1848-peach-before-20260825T155949Z.csv` (Jira attachment 304028)
- `JS-2310-typescript-S1848-peach-before-20260825T155949Z.csv` (Jira attachment 304029)

## Validation

- `npx tsx --tsconfig packages/tsconfig.test.json --test packages/analysis/src/jsts/rules/S1848/unit.test.ts`
- `npm run bbf`
- `npm run bridge:test`