### PR TITLE
JS-2326: Queue concurrent analyze-project requests

### DIFF
--- a/docs/grpc-analyze-project-migration.md
+++ b/docs/grpc-analyze-project-migration.md
@@ -203,8 +203,9 @@ The old heartbeat ping is replaced by a long-lived `Lease` stream.
 - A cancellation acknowledgement only confirms that the cancellation signal was accepted. The queue
   advances only after the active analysis finishes, so analyses never overlap in the worker.
 - Cancellation does not shut down the gRPC server. If an analysis is stuck and cannot reach a
-  cancellation checkpoint, the queue remains blocked; recovering from that case requires supervised
-  worker replacement rather than tearing down the server and its Java client connection.
+  cancellation checkpoint, its execution and queued successors remain blocked. No recovery for that
+  case is implemented today; supervised worker replacement would be required and is out of scope for
+  this migration.
 
 ### Worker Decision
 

--- a/docs/grpc-analyze-project-migration.md
+++ b/docs/grpc-analyze-project-migration.md
@@ -200,9 +200,11 @@ The old heartbeat ping is replaced by a long-lived `Lease` stream.
   - Calling `CancelAnalysis` targets whichever request is active at that moment and never cancels a
     pending request.
 - If both paths target the same active request, the worker cancellation signal is deduplicated.
-- If cancellation is not acknowledged, or the active analysis does not finish within the two-minute
-  cancellation grace period, the server shuts down and rejects queued requests so that the Java
-  owner can recover instead of waiting forever.
+- A cancellation acknowledgement only confirms that the cancellation signal was accepted. The queue
+  advances only after the active analysis finishes, so analyses never overlap in the worker.
+- Cancellation does not shut down the gRPC server. If an analysis is stuck and cannot reach a
+  cancellation checkpoint, the queue remains blocked; recovering from that case requires supervised
+  worker replacement rather than tearing down the server and its Java client connection.
 
 ### Worker Decision
 

--- a/docs/grpc-analyze-project-migration.md
+++ b/docs/grpc-analyze-project-migration.md
@@ -191,10 +191,13 @@ The old heartbeat ping is replaced by a long-lived `Lease` stream.
 ### Cancellation
 
 - Runtime analysis stays single-flight.
-- Java cancellation triggers `CancelAnalysis`, and the Node worker stops the active analysis.
-- Concurrent analyze-project requests are rejected with gRPC `RESOURCE_EXHAUSTED`.
-- A replacement request submitted while cancellation is in progress waits for the active worker
-  request to complete before it acquires the analysis slot.
+- Analyze-project requests are queued in arrival order while another analysis is active.
+- The pending queue is bounded because requests can retain project file contents in memory;
+  requests beyond its capacity are rejected with gRPC `RESOURCE_EXHAUSTED`.
+- Cancelling an analyze-project transport call removes that request from the queue, or asks the
+  Node worker to stop it when it is active. `CancelAnalysis` explicitly targets the active request.
+- If an active analysis does not finish within the cancellation grace period, the server shuts
+  down and rejects queued requests so that the Java owner can recover instead of waiting forever.
 
 ### Worker Decision
 

--- a/docs/grpc-analyze-project-migration.md
+++ b/docs/grpc-analyze-project-migration.md
@@ -196,8 +196,9 @@ The old heartbeat ping is replaced by a long-lived `Lease` stream.
   requests beyond its capacity are rejected with gRPC `RESOURCE_EXHAUSTED`.
 - Cancelling an analyze-project transport call removes that request from the queue, or asks the
   Node worker to stop it when it is active. `CancelAnalysis` explicitly targets the active request.
-- If an active analysis does not finish within the cancellation grace period, the server shuts
-  down and rejects queued requests so that the Java owner can recover instead of waiting forever.
+- If cancellation is not acknowledged, or the active analysis does not finish within the two-minute
+  cancellation grace period, the server shuts down and rejects queued requests so that the Java
+  owner can recover instead of waiting forever.
 
 ### Worker Decision
 

--- a/docs/grpc-analyze-project-migration.md
+++ b/docs/grpc-analyze-project-migration.md
@@ -193,6 +193,8 @@ The old heartbeat ping is replaced by a long-lived `Lease` stream.
 - Runtime analysis stays single-flight.
 - Java cancellation triggers `CancelAnalysis`, and the Node worker stops the active analysis.
 - Concurrent analyze-project requests are rejected with gRPC `RESOURCE_EXHAUSTED`.
+- A replacement request submitted while cancellation is in progress waits for the active worker
+  request to complete before it acquires the analysis slot.
 
 ### Worker Decision
 

--- a/docs/grpc-analyze-project-migration.md
+++ b/docs/grpc-analyze-project-migration.md
@@ -194,8 +194,12 @@ The old heartbeat ping is replaced by a long-lived `Lease` stream.
 - Analyze-project requests are queued in arrival order while another analysis is active.
 - The pending queue is bounded because requests can retain project file contents in memory;
   requests beyond its capacity are rejected with gRPC `RESOURCE_EXHAUSTED`.
-- Cancelling an analyze-project transport call removes that request from the queue, or asks the
-  Node worker to stop it when it is active. `CancelAnalysis` explicitly targets the active request.
+- The two cancellation paths are intentionally distinct:
+  - Cancelling an `AnalyzeProject` or `AnalyzeProjectUnary` transport call targets only that submitted
+    request. It removes the request when pending, or asks the Node worker to stop it when active.
+  - Calling `CancelAnalysis` targets whichever request is active at that moment and never cancels a
+    pending request.
+- If both paths target the same active request, the worker cancellation signal is deduplicated.
 - If cancellation is not acknowledged, or the active analysis does not finish within the two-minute
   cancellation grace period, the server shuts down and rejects queued requests so that the Java
   owner can recover instead of waiting forever.

--- a/packages/analysis/src/analyzeProject.ts
+++ b/packages/analysis/src/analyzeProject.ts
@@ -66,10 +66,12 @@ export async function withAnalysisCancellation<T>(operation: () => Promise<T>): 
   }
 }
 
-export function cancelAnalysis() {
-  if (analysisStatus) {
-    analysisStatus.cancelled = true;
+export function cancelAnalysis(): boolean {
+  if (!analysisStatus) {
+    return false;
   }
+  analysisStatus.cancelled = true;
+  return true;
 }
 
 export function isAnalysisCancelled() {

--- a/packages/analysis/src/analyzeProject.ts
+++ b/packages/analysis/src/analyzeProject.ts
@@ -42,16 +42,38 @@ import {
   resetProjectAnalysisTelemetry,
 } from './telemetry.js';
 
-const analysisStatus = {
-  cancelled: false,
+type AnalysisStatus = {
+  cancelled: boolean;
 };
 
+let analysisStatus: AnalysisStatus | undefined;
+
+/**
+ * Runs an operation in a fresh cancellation scope.
+ *
+ * Request handlers can use this to make cancellation effective while they prepare an analysis,
+ * before calling {@link analyzeProject}.
+ */
+export async function withAnalysisCancellation<T>(operation: () => Promise<T>): Promise<T> {
+  const currentAnalysisStatus: AnalysisStatus = { cancelled: false };
+  analysisStatus = currentAnalysisStatus;
+  try {
+    return await operation();
+  } finally {
+    if (analysisStatus === currentAnalysisStatus) {
+      analysisStatus = undefined;
+    }
+  }
+}
+
 export function cancelAnalysis() {
-  analysisStatus.cancelled = true;
+  if (analysisStatus) {
+    analysisStatus.cancelled = true;
+  }
 }
 
 export function isAnalysisCancelled() {
-  return analysisStatus.cancelled;
+  return analysisStatus?.cancelled ?? false;
 }
 
 /**
@@ -67,7 +89,19 @@ export async function analyzeProject(
   configuration: Configuration,
   incrementalResultsChannel?: (result: WsIncrementalResult) => void,
 ): Promise<ProjectAnalysisOutput> {
-  analysisStatus.cancelled = false;
+  if (!analysisStatus) {
+    return withAnalysisCancellation(() =>
+      analyzeProjectWithCancellation(input, configuration, incrementalResultsChannel),
+    );
+  }
+  return analyzeProjectWithCancellation(input, configuration, incrementalResultsChannel);
+}
+
+async function analyzeProjectWithCancellation(
+  input: ProjectAnalysisInput,
+  configuration: Configuration,
+  incrementalResultsChannel?: (result: WsIncrementalResult) => void,
+): Promise<ProjectAnalysisOutput> {
   const { rules, bundles, rulesWorkdir } = input;
   const filesToAnalyze = sourceFileStore.getFiles();
 
@@ -156,7 +190,7 @@ export async function analyzeProject(
     }
   }
   progressReport.stop();
-  if (analysisStatus.cancelled) {
+  if (isAnalysisCancelled()) {
     error('Analysis has been cancelled');
     incrementalResultsChannel?.({ messageType: 'cancelled' });
   } else {

--- a/packages/grpc/src/analyze-project-handle-request.ts
+++ b/packages/grpc/src/analyze-project-handle-request.ts
@@ -77,10 +77,13 @@ export async function handleAnalyzeProjectRequest(
         });
       }
       case 'on-cancel-analysis': {
-        cancelAnalysis();
-        // This internal request only acknowledges that the cancel signal was delivered.
-        // The public CancelAnalysis RPC computes the outward-facing { cancelled } response.
-        return { type: 'success', result: undefined };
+        return cancelAnalysis()
+          ? { type: 'success', result: undefined }
+          : {
+              type: 'failure',
+              error: serializeError(new Error('No analysis to cancel')),
+              reason: 'runtime',
+            };
       }
       default: {
         // Handle unknown request types

--- a/packages/grpc/src/analyze-project-handle-request.ts
+++ b/packages/grpc/src/analyze-project-handle-request.ts
@@ -15,7 +15,11 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 
-import { analyzeProject, cancelAnalysis } from '../../analysis/src/analyzeProject.js';
+import {
+  analyzeProject,
+  cancelAnalysis,
+  withAnalysisCancellation,
+} from '../../analysis/src/analyzeProject.js';
 import { logHeapStatistics } from './analyze-project-memory.js';
 import {
   type AnalyzeProjectIncrementalEvent,
@@ -41,34 +45,36 @@ export async function handleAnalyzeProjectRequest(
   try {
     switch (request.type) {
       case 'on-analyze-project': {
-        logHeapStatistics(workerData?.debugMemory);
-        const sanitizedInput = await normalizeAnalyzeProjectRequest(request.data);
-        const wrappedIncrementalResultsChannel = incrementalResultsChannel
-          ? (event: AnalyzeProjectIncrementalEvent['event']) =>
-              incrementalResultsChannel({
-                event,
-                pathMap: sanitizedInput.pathMap,
-              })
-          : undefined;
+        return await withAnalysisCancellation(async () => {
+          logHeapStatistics(workerData?.debugMemory);
+          const sanitizedInput = await normalizeAnalyzeProjectRequest(request.data);
+          const wrappedIncrementalResultsChannel = incrementalResultsChannel
+            ? (event: AnalyzeProjectIncrementalEvent['event']) =>
+                incrementalResultsChannel({
+                  event,
+                  pathMap: sanitizedInput.pathMap,
+                })
+            : undefined;
 
-        const output = await analyzeProject(
-          {
-            rules: sanitizedInput.rules,
-            cssRules: sanitizedInput.cssRules,
-            bundles: sanitizedInput.bundles,
-            rulesWorkdir: sanitizedInput.rulesWorkdir,
-          },
-          sanitizedInput.configuration,
-          wrappedIncrementalResultsChannel,
-        );
-        logHeapStatistics(workerData?.debugMemory);
-        return {
-          type: 'success',
-          result: {
-            output,
-            pathMap: sanitizedInput.pathMap,
-          },
-        };
+          const output = await analyzeProject(
+            {
+              rules: sanitizedInput.rules,
+              cssRules: sanitizedInput.cssRules,
+              bundles: sanitizedInput.bundles,
+              rulesWorkdir: sanitizedInput.rulesWorkdir,
+            },
+            sanitizedInput.configuration,
+            wrappedIncrementalResultsChannel,
+          );
+          logHeapStatistics(workerData?.debugMemory);
+          return {
+            type: 'success',
+            result: {
+              output,
+              pathMap: sanitizedInput.pathMap,
+            },
+          };
+        });
       }
       case 'on-cancel-analysis': {
         cancelAnalysis();

--- a/packages/grpc/src/analyze-project-server-lifecycle.ts
+++ b/packages/grpc/src/analyze-project-server-lifecycle.ts
@@ -39,7 +39,14 @@ type HandleRequestInCurrentThread = (
   incrementalResultsChannel?: (result: AnalyzeProjectIncrementalEvent) => void,
 ) => Promise<RequestResult<AnalyzeProjectResponse | void>>;
 
+type AnalysisCompletion = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
 type AnalyzeProjectServerState = {
+  analysisCancellationRequested: boolean;
+  analysisCompletion: AnalysisCompletion | null;
   analysisInProgress: boolean;
   leaseCall: grpc.ServerDuplexStream<LeaseRequest, LeaseResponse> | null;
   nextWorkerRequestId: number;
@@ -125,6 +132,8 @@ export async function waitForWorkerCompletion(
 
 export function createServerState(): AnalyzeProjectServerState {
   return {
+    analysisCancellationRequested: false,
+    analysisCompletion: null,
     analysisInProgress: false,
     leaseCall: null,
     nextWorkerRequestId: 0,

--- a/packages/grpc/src/analyze-project-server-lifecycle.ts
+++ b/packages/grpc/src/analyze-project-server-lifecycle.ts
@@ -32,7 +32,6 @@ import type {
   AnalyzeProjectWorkerOutMessage,
 } from './analyze-project-worker/messages.js';
 import {
-  ANALYSIS_CANCELLATION_GRACE_MS,
   AnalysisRequestQueue,
   MAX_PENDING_ANALYSIS_REQUESTS,
 } from './analyze-project-server-queue.js';
@@ -129,20 +128,12 @@ export async function waitForWorkerCompletion(
 }
 
 export function createServerState({
-  cancellationGraceMs = ANALYSIS_CANCELLATION_GRACE_MS,
   maxPendingAnalysisRequests = MAX_PENDING_ANALYSIS_REQUESTS,
-  onCancellationFailure = () => {},
 }: {
-  cancellationGraceMs?: number;
   maxPendingAnalysisRequests?: number;
-  onCancellationFailure?: () => void | Promise<void>;
 } = {}): AnalyzeProjectServerState {
   return {
-    analysisQueue: new AnalysisRequestQueue(
-      maxPendingAnalysisRequests,
-      cancellationGraceMs,
-      onCancellationFailure,
-    ),
+    analysisQueue: new AnalysisRequestQueue(maxPendingAnalysisRequests),
     leaseCall: null,
     nextWorkerRequestId: 0,
     shuttingDown: false,

--- a/packages/grpc/src/analyze-project-server-lifecycle.ts
+++ b/packages/grpc/src/analyze-project-server-lifecycle.ts
@@ -32,10 +32,12 @@ import type {
   AnalyzeProjectWorkerOutMessage,
 } from './analyze-project-worker/messages.js';
 import {
-  ANALYSIS_CANCELLATION_TIMEOUT_MS,
+  ANALYSIS_CANCELLATION_GRACE_MS,
   AnalysisRequestQueue,
   MAX_PENDING_ANALYSIS_REQUESTS,
 } from './analyze-project-server-queue.js';
+
+const WORKER_RESPONSE_TIMEOUT_MS = 15_000;
 
 type HandleRequestInCurrentThread = (
   request: AnalyzeProjectRuntimeRequest,
@@ -127,19 +129,19 @@ export async function waitForWorkerCompletion(
 }
 
 export function createServerState({
-  cancellationTimeoutMs = ANALYSIS_CANCELLATION_TIMEOUT_MS,
+  cancellationGraceMs = ANALYSIS_CANCELLATION_GRACE_MS,
   maxPendingAnalysisRequests = MAX_PENDING_ANALYSIS_REQUESTS,
-  onCancellationTimeout = () => {},
+  onCancellationFailure = () => {},
 }: {
-  cancellationTimeoutMs?: number;
+  cancellationGraceMs?: number;
   maxPendingAnalysisRequests?: number;
-  onCancellationTimeout?: () => void | Promise<void>;
+  onCancellationFailure?: () => void | Promise<void>;
 } = {}): AnalyzeProjectServerState {
   return {
     analysisQueue: new AnalysisRequestQueue(
       maxPendingAnalysisRequests,
-      cancellationTimeoutMs,
-      onCancellationTimeout,
+      cancellationGraceMs,
+      onCancellationFailure,
     ),
     leaseCall: null,
     nextWorkerRequestId: 0,
@@ -237,7 +239,7 @@ export function createLifecycle({
       requestId,
       () =>
         worker.postMessage({ type: 'cancel', requestId } satisfies AnalyzeProjectWorkerInMessage),
-      ANALYSIS_CANCELLATION_TIMEOUT_MS,
+      WORKER_RESPONSE_TIMEOUT_MS,
     );
     return completion.type === 'cancel-complete' && completion.result.type === 'success';
   };

--- a/packages/grpc/src/analyze-project-server-lifecycle.ts
+++ b/packages/grpc/src/analyze-project-server-lifecycle.ts
@@ -31,23 +31,19 @@ import type {
   AnalyzeProjectWorkerInMessage,
   AnalyzeProjectWorkerOutMessage,
 } from './analyze-project-worker/messages.js';
-
-const WORKER_RESPONSE_TIMEOUT_MS = 15_000;
+import {
+  ANALYSIS_CANCELLATION_TIMEOUT_MS,
+  AnalysisRequestQueue,
+  MAX_PENDING_ANALYSIS_REQUESTS,
+} from './analyze-project-server-queue.js';
 
 type HandleRequestInCurrentThread = (
   request: AnalyzeProjectRuntimeRequest,
   incrementalResultsChannel?: (result: AnalyzeProjectIncrementalEvent) => void,
 ) => Promise<RequestResult<AnalyzeProjectResponse | void>>;
 
-type AnalysisCompletion = {
-  promise: Promise<void>;
-  resolve: () => void;
-};
-
 type AnalyzeProjectServerState = {
-  analysisCancellationRequested: boolean;
-  analysisCompletion: AnalysisCompletion | null;
-  analysisInProgress: boolean;
+  analysisQueue: AnalysisRequestQueue;
   leaseCall: grpc.ServerDuplexStream<LeaseRequest, LeaseResponse> | null;
   nextWorkerRequestId: number;
   shuttingDown: boolean;
@@ -130,11 +126,21 @@ export async function waitForWorkerCompletion(
   });
 }
 
-export function createServerState(): AnalyzeProjectServerState {
+export function createServerState({
+  cancellationTimeoutMs = ANALYSIS_CANCELLATION_TIMEOUT_MS,
+  maxPendingAnalysisRequests = MAX_PENDING_ANALYSIS_REQUESTS,
+  onCancellationTimeout = () => {},
+}: {
+  cancellationTimeoutMs?: number;
+  maxPendingAnalysisRequests?: number;
+  onCancellationTimeout?: () => void | Promise<void>;
+} = {}): AnalyzeProjectServerState {
   return {
-    analysisCancellationRequested: false,
-    analysisCompletion: null,
-    analysisInProgress: false,
+    analysisQueue: new AnalysisRequestQueue(
+      maxPendingAnalysisRequests,
+      cancellationTimeoutMs,
+      onCancellationTimeout,
+    ),
     leaseCall: null,
     nextWorkerRequestId: 0,
     shuttingDown: false,
@@ -164,10 +170,10 @@ function clearStartupShutdownTimeout(state: AnalyzeProjectServerState) {
 async function cancelAnalysisOnShutdown(
   handleRequestInCurrentThread: HandleRequestInCurrentThread,
   newWorkerRequestId: () => string,
-  state: AnalyzeProjectServerState,
+  hadActiveAnalysis: boolean,
   worker?: Worker,
 ) {
-  if (!state.analysisInProgress) {
+  if (!hadActiveAnalysis) {
     return;
   }
 
@@ -231,7 +237,7 @@ export function createLifecycle({
       requestId,
       () =>
         worker.postMessage({ type: 'cancel', requestId } satisfies AnalyzeProjectWorkerInMessage),
-      WORKER_RESPONSE_TIMEOUT_MS,
+      ANALYSIS_CANCELLATION_TIMEOUT_MS,
     );
     return completion.type === 'cancel-complete' && completion.result.type === 'success';
   };
@@ -258,7 +264,14 @@ export function createLifecycle({
     clearStartupShutdownTimeout(state);
     closeLeaseCall();
     unregisterGarbageCollectionObserver();
-    await cancelAnalysisOnShutdown(handleRequestInCurrentThread, newWorkerRequestId, state, worker);
+    const hadActiveAnalysis = state.analysisQueue.hasActive;
+    state.analysisQueue.close();
+    await cancelAnalysisOnShutdown(
+      handleRequestInCurrentThread,
+      newWorkerRequestId,
+      hadActiveAnalysis,
+      worker,
+    );
     await closeWorker(worker);
 
     server.forceShutdown();

--- a/packages/grpc/src/analyze-project-server-queue.ts
+++ b/packages/grpc/src/analyze-project-server-queue.ts
@@ -170,11 +170,25 @@ export class AnalysisRequestQueue {
     }
 
     if (!entry.cancellationResult) {
+      let cancellationResult: Promise<boolean>;
       try {
-        entry.cancellationResult = Promise.resolve(entry.requestCancellation());
+        cancellationResult = Promise.resolve(entry.requestCancellation());
       } catch (error) {
-        entry.cancellationResult = Promise.reject(error);
+        cancellationResult = Promise.reject(error);
       }
+      entry.cancellationResult = cancellationResult;
+      void cancellationResult.then(
+        acknowledged => {
+          if (!acknowledged && entry.cancellationResult === cancellationResult) {
+            entry.cancellationResult = undefined;
+          }
+        },
+        () => {
+          if (entry.cancellationResult === cancellationResult) {
+            entry.cancellationResult = undefined;
+          }
+        },
+      );
     }
     return { active: true, result: entry.cancellationResult };
   }

--- a/packages/grpc/src/analyze-project-server-queue.ts
+++ b/packages/grpc/src/analyze-project-server-queue.ts
@@ -1,0 +1,201 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+export const ANALYSIS_CANCELLATION_TIMEOUT_MS = 15_000;
+export const MAX_PENDING_ANALYSIS_REQUESTS = 16;
+
+export class AnalysisQueueClosedError extends Error {
+  constructor() {
+    super('Analyze-project request queue is closed');
+  }
+}
+
+export class AnalysisRequestCancelledError extends Error {
+  constructor() {
+    super('Analyze-project request was cancelled before it started');
+  }
+}
+
+type AnalysisCancellation = { active: false } | { active: true; result: Promise<boolean> };
+
+type AnalysisQueueEntry = {
+  cancellationResult?: Promise<boolean>;
+  cancellationTimeout?: NodeJS.Timeout;
+  reject: (error: unknown) => void;
+  requestCancellation: () => Promise<boolean>;
+  resolve: (result: unknown) => void;
+  run: () => Promise<unknown>;
+  state: 'active' | 'pending' | 'settled';
+};
+
+export type AnalysisQueueSubmission<T> = {
+  cancel: () => AnalysisCancellation;
+  result: Promise<T>;
+};
+
+export type AnalysisQueueAdmission<T> =
+  | { accepted: true; submission: AnalysisQueueSubmission<T> }
+  | { accepted: false; reason: 'closed' | 'full' };
+
+export class AnalysisRequestQueue {
+  private active: AnalysisQueueEntry | undefined;
+  private closed = false;
+  private readonly pending: AnalysisQueueEntry[] = [];
+
+  constructor(
+    private readonly maxPending = MAX_PENDING_ANALYSIS_REQUESTS,
+    private readonly cancellationTimeoutMs = ANALYSIS_CANCELLATION_TIMEOUT_MS,
+    private readonly onCancellationTimeout: () => void | Promise<void> = () => {},
+  ) {
+    if (!Number.isInteger(maxPending) || maxPending < 0) {
+      throw new Error('Maximum pending analysis requests must be a non-negative integer');
+    }
+  }
+
+  enqueue<T>(
+    run: () => Promise<T>,
+    requestCancellation: () => Promise<boolean>,
+  ): AnalysisQueueAdmission<T> {
+    if (this.closed) {
+      return { accepted: false, reason: 'closed' };
+    }
+    if (this.active && this.pending.length >= this.maxPending) {
+      return { accepted: false, reason: 'full' };
+    }
+
+    let resolve!: (result: T) => void;
+    let reject!: (error: unknown) => void;
+    const result = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    const entry: AnalysisQueueEntry = {
+      reject,
+      requestCancellation,
+      resolve: value => resolve(value as T),
+      run,
+      state: this.active ? 'pending' : 'active',
+    };
+
+    if (this.active) {
+      this.pending.push(entry);
+    } else {
+      this.start(entry);
+    }
+
+    return {
+      accepted: true,
+      submission: {
+        cancel: () => this.cancel(entry),
+        result,
+      },
+    };
+  }
+
+  cancelActive(): AnalysisCancellation {
+    return this.active ? this.cancel(this.active) : { active: false };
+  }
+
+  close() {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    const error = new AnalysisQueueClosedError();
+    const entries = this.active ? [this.active, ...this.pending] : [...this.pending];
+    this.active = undefined;
+    this.pending.length = 0;
+    for (const entry of entries) {
+      this.clearCancellationTimeout(entry);
+      entry.state = 'settled';
+      entry.reject(error);
+    }
+  }
+
+  get hasActive() {
+    return this.active !== undefined;
+  }
+
+  get pendingCount() {
+    return this.pending.length;
+  }
+
+  private start(entry: AnalysisQueueEntry) {
+    entry.state = 'active';
+    this.active = entry;
+    let execution: Promise<unknown>;
+    try {
+      execution = entry.run();
+    } catch (error) {
+      execution = Promise.reject(error);
+    }
+    void execution.then(
+      result => this.complete(entry, () => entry.resolve(result)),
+      error => this.complete(entry, () => entry.reject(error)),
+    );
+  }
+
+  private complete(entry: AnalysisQueueEntry, settle: () => void) {
+    if (entry.state !== 'active' || this.active !== entry) {
+      return;
+    }
+    this.clearCancellationTimeout(entry);
+    entry.state = 'settled';
+    this.active = undefined;
+    const next = this.pending.shift();
+    if (next) {
+      this.start(next);
+    }
+    settle();
+  }
+
+  private cancel(entry: AnalysisQueueEntry): AnalysisCancellation {
+    if (entry.state === 'pending') {
+      const index = this.pending.indexOf(entry);
+      if (index !== -1) {
+        this.pending.splice(index, 1);
+      }
+      entry.state = 'settled';
+      entry.reject(new AnalysisRequestCancelledError());
+      return { active: false };
+    }
+    if (entry.state !== 'active' || this.active !== entry) {
+      return { active: false };
+    }
+
+    if (!entry.cancellationResult) {
+      try {
+        entry.cancellationResult = Promise.resolve(entry.requestCancellation());
+      } catch (error) {
+        entry.cancellationResult = Promise.reject(error);
+      }
+      if (this.cancellationTimeoutMs > 0) {
+        entry.cancellationTimeout = setTimeout(() => {
+          void Promise.resolve(this.onCancellationTimeout()).catch(() => {});
+        }, this.cancellationTimeoutMs);
+      }
+    }
+    return { active: true, result: entry.cancellationResult };
+  }
+
+  private clearCancellationTimeout(entry: AnalysisQueueEntry) {
+    if (entry.cancellationTimeout) {
+      clearTimeout(entry.cancellationTimeout);
+      entry.cancellationTimeout = undefined;
+    }
+  }
+}

--- a/packages/grpc/src/analyze-project-server-queue.ts
+++ b/packages/grpc/src/analyze-project-server-queue.ts
@@ -15,7 +15,6 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 
-export const ANALYSIS_CANCELLATION_GRACE_MS = 120_000;
 export const MAX_PENDING_ANALYSIS_REQUESTS = 4;
 
 export class AnalysisQueueClosedError extends Error {
@@ -33,9 +32,7 @@ export class AnalysisTransportCancelledError extends Error {
 type ActiveAnalysisCancellation = { active: false } | { active: true; result: Promise<boolean> };
 
 type AnalysisQueueEntry = {
-  cancellationEscalated?: boolean;
   cancellationResult?: Promise<boolean>;
-  cancellationGraceTimeout?: NodeJS.Timeout;
   reject: (error: unknown) => void;
   requestCancellation: () => Promise<boolean>;
   resolve: (result: unknown) => void;
@@ -57,11 +54,7 @@ export class AnalysisRequestQueue {
   private closed = false;
   private readonly pending: AnalysisQueueEntry[] = [];
 
-  constructor(
-    private readonly maxPending = MAX_PENDING_ANALYSIS_REQUESTS,
-    private readonly cancellationGraceMs = ANALYSIS_CANCELLATION_GRACE_MS,
-    private readonly onCancellationFailure: () => void | Promise<void> = () => {},
-  ) {
+  constructor(private readonly maxPending = MAX_PENDING_ANALYSIS_REQUESTS) {
     if (!Number.isInteger(maxPending) || maxPending < 0) {
       throw new Error('Maximum pending analysis requests must be a non-negative integer');
     }
@@ -121,7 +114,6 @@ export class AnalysisRequestQueue {
     this.active = undefined;
     this.pending.length = 0;
     for (const entry of entries) {
-      this.clearCancellationGraceTimeout(entry);
       entry.state = 'settled';
       entry.reject(error);
     }
@@ -154,7 +146,6 @@ export class AnalysisRequestQueue {
     if (entry.state !== 'active' || this.active !== entry) {
       return;
     }
-    this.clearCancellationGraceTimeout(entry);
     entry.state = 'settled';
     this.active = undefined;
     const next = this.pending.shift();
@@ -184,37 +175,7 @@ export class AnalysisRequestQueue {
       } catch (error) {
         entry.cancellationResult = Promise.reject(error);
       }
-      void entry.cancellationResult.then(
-        acknowledged => {
-          if (!acknowledged) {
-            this.escalateCancellation(entry);
-          }
-        },
-        () => this.escalateCancellation(entry),
-      );
-      if (this.cancellationGraceMs > 0) {
-        entry.cancellationGraceTimeout = setTimeout(
-          () => this.escalateCancellation(entry),
-          this.cancellationGraceMs,
-        );
-      }
     }
     return { active: true, result: entry.cancellationResult };
-  }
-
-  private escalateCancellation(entry: AnalysisQueueEntry) {
-    if (entry.cancellationEscalated || entry.state !== 'active' || this.active !== entry) {
-      return;
-    }
-    entry.cancellationEscalated = true;
-    this.clearCancellationGraceTimeout(entry);
-    void Promise.resolve(this.onCancellationFailure()).catch(() => {});
-  }
-
-  private clearCancellationGraceTimeout(entry: AnalysisQueueEntry) {
-    if (entry.cancellationGraceTimeout) {
-      clearTimeout(entry.cancellationGraceTimeout);
-      entry.cancellationGraceTimeout = undefined;
-    }
   }
 }

--- a/packages/grpc/src/analyze-project-server-queue.ts
+++ b/packages/grpc/src/analyze-project-server-queue.ts
@@ -15,8 +15,8 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 
-export const ANALYSIS_CANCELLATION_TIMEOUT_MS = 15_000;
-export const MAX_PENDING_ANALYSIS_REQUESTS = 16;
+export const ANALYSIS_CANCELLATION_GRACE_MS = 120_000;
+export const MAX_PENDING_ANALYSIS_REQUESTS = 4;
 
 export class AnalysisQueueClosedError extends Error {
   constructor() {
@@ -33,8 +33,9 @@ export class AnalysisRequestCancelledError extends Error {
 type AnalysisCancellation = { active: false } | { active: true; result: Promise<boolean> };
 
 type AnalysisQueueEntry = {
+  cancellationEscalated?: boolean;
   cancellationResult?: Promise<boolean>;
-  cancellationTimeout?: NodeJS.Timeout;
+  cancellationGraceTimeout?: NodeJS.Timeout;
   reject: (error: unknown) => void;
   requestCancellation: () => Promise<boolean>;
   resolve: (result: unknown) => void;
@@ -58,8 +59,8 @@ export class AnalysisRequestQueue {
 
   constructor(
     private readonly maxPending = MAX_PENDING_ANALYSIS_REQUESTS,
-    private readonly cancellationTimeoutMs = ANALYSIS_CANCELLATION_TIMEOUT_MS,
-    private readonly onCancellationTimeout: () => void | Promise<void> = () => {},
+    private readonly cancellationGraceMs = ANALYSIS_CANCELLATION_GRACE_MS,
+    private readonly onCancellationFailure: () => void | Promise<void> = () => {},
   ) {
     if (!Number.isInteger(maxPending) || maxPending < 0) {
       throw new Error('Maximum pending analysis requests must be a non-negative integer');
@@ -120,7 +121,7 @@ export class AnalysisRequestQueue {
     this.active = undefined;
     this.pending.length = 0;
     for (const entry of entries) {
-      this.clearCancellationTimeout(entry);
+      this.clearCancellationGraceTimeout(entry);
       entry.state = 'settled';
       entry.reject(error);
     }
@@ -153,7 +154,7 @@ export class AnalysisRequestQueue {
     if (entry.state !== 'active' || this.active !== entry) {
       return;
     }
-    this.clearCancellationTimeout(entry);
+    this.clearCancellationGraceTimeout(entry);
     entry.state = 'settled';
     this.active = undefined;
     const next = this.pending.shift();
@@ -183,19 +184,37 @@ export class AnalysisRequestQueue {
       } catch (error) {
         entry.cancellationResult = Promise.reject(error);
       }
-      if (this.cancellationTimeoutMs > 0) {
-        entry.cancellationTimeout = setTimeout(() => {
-          void Promise.resolve(this.onCancellationTimeout()).catch(() => {});
-        }, this.cancellationTimeoutMs);
+      void entry.cancellationResult.then(
+        acknowledged => {
+          if (!acknowledged) {
+            this.escalateCancellation(entry);
+          }
+        },
+        () => this.escalateCancellation(entry),
+      );
+      if (this.cancellationGraceMs > 0) {
+        entry.cancellationGraceTimeout = setTimeout(
+          () => this.escalateCancellation(entry),
+          this.cancellationGraceMs,
+        );
       }
     }
     return { active: true, result: entry.cancellationResult };
   }
 
-  private clearCancellationTimeout(entry: AnalysisQueueEntry) {
-    if (entry.cancellationTimeout) {
-      clearTimeout(entry.cancellationTimeout);
-      entry.cancellationTimeout = undefined;
+  private escalateCancellation(entry: AnalysisQueueEntry) {
+    if (entry.cancellationEscalated || entry.state !== 'active' || this.active !== entry) {
+      return;
+    }
+    entry.cancellationEscalated = true;
+    this.clearCancellationGraceTimeout(entry);
+    void Promise.resolve(this.onCancellationFailure()).catch(() => {});
+  }
+
+  private clearCancellationGraceTimeout(entry: AnalysisQueueEntry) {
+    if (entry.cancellationGraceTimeout) {
+      clearTimeout(entry.cancellationGraceTimeout);
+      entry.cancellationGraceTimeout = undefined;
     }
   }
 }

--- a/packages/grpc/src/analyze-project-server-queue.ts
+++ b/packages/grpc/src/analyze-project-server-queue.ts
@@ -24,13 +24,13 @@ export class AnalysisQueueClosedError extends Error {
   }
 }
 
-export class AnalysisRequestCancelledError extends Error {
+export class AnalysisTransportCancelledError extends Error {
   constructor() {
-    super('Analyze-project request was cancelled before it started');
+    super('Analyze-project transport was cancelled before its request started');
   }
 }
 
-type AnalysisCancellation = { active: false } | { active: true; result: Promise<boolean> };
+type ActiveAnalysisCancellation = { active: false } | { active: true; result: Promise<boolean> };
 
 type AnalysisQueueEntry = {
   cancellationEscalated?: boolean;
@@ -44,7 +44,7 @@ type AnalysisQueueEntry = {
 };
 
 export type AnalysisQueueSubmission<T> = {
-  cancel: () => AnalysisCancellation;
+  cancelTransportCall: () => ActiveAnalysisCancellation;
   result: Promise<T>;
 };
 
@@ -101,14 +101,14 @@ export class AnalysisRequestQueue {
     return {
       accepted: true,
       submission: {
-        cancel: () => this.cancel(entry),
+        cancelTransportCall: () => this.cancelEntry(entry),
         result,
       },
     };
   }
 
-  cancelActive(): AnalysisCancellation {
-    return this.active ? this.cancel(this.active) : { active: false };
+  cancelActiveAnalysis(): ActiveAnalysisCancellation {
+    return this.active ? this.cancelEntry(this.active) : { active: false };
   }
 
   close() {
@@ -164,14 +164,14 @@ export class AnalysisRequestQueue {
     settle();
   }
 
-  private cancel(entry: AnalysisQueueEntry): AnalysisCancellation {
+  private cancelEntry(entry: AnalysisQueueEntry): ActiveAnalysisCancellation {
     if (entry.state === 'pending') {
       const index = this.pending.indexOf(entry);
       if (index !== -1) {
         this.pending.splice(index, 1);
       }
       entry.state = 'settled';
-      entry.reject(new AnalysisRequestCancelledError());
+      entry.reject(new AnalysisTransportCancelledError());
       return { active: false };
     }
     if (entry.state !== 'active' || this.active !== entry) {

--- a/packages/grpc/src/analyze-project-server.ts
+++ b/packages/grpc/src/analyze-project-server.ts
@@ -60,6 +60,45 @@ type AnalyzeProjectServerResult = {
   serverClosed: Promise<void>;
 };
 
+type AnalyzeProjectServerState = AnalyzeProjectImplementationDependencies['state'];
+
+/** Waits for cancellation handoff, but rejects genuine concurrent analysis. */
+async function acquireAnalysisSlot(
+  state: AnalyzeProjectServerState,
+  onAcquired: () => void = () => {},
+): Promise<boolean> {
+  while (state.analysisInProgress) {
+    if (!state.analysisCancellationRequested || !state.analysisCompletion) {
+      return false;
+    }
+    await state.analysisCompletion.promise;
+  }
+
+  state.analysisInProgress = true;
+  state.analysisCancellationRequested = false;
+  let resolveAnalysisCompletion!: () => void;
+  const analysisCompletion = new Promise<void>(resolve => {
+    resolveAnalysisCompletion = resolve;
+  });
+  state.analysisCompletion = { promise: analysisCompletion, resolve: resolveAnalysisCompletion };
+  onAcquired();
+  return true;
+}
+
+function requestAnalysisCancellation(state: AnalyzeProjectServerState) {
+  if (state.analysisInProgress) {
+    state.analysisCancellationRequested = true;
+  }
+}
+
+function releaseAnalysisSlot(state: AnalyzeProjectServerState) {
+  const analysisCompletion = state.analysisCompletion;
+  state.analysisCancellationRequested = false;
+  state.analysisCompletion = null;
+  state.analysisInProgress = false;
+  analysisCompletion?.resolve();
+}
+
 function createAnalyzeProjectStreamHandler({
   handleRequestInCurrentThread,
   lifecycle,
@@ -67,8 +106,29 @@ function createAnalyzeProjectStreamHandler({
   state,
   worker,
 }: AnalyzeProjectImplementationDependencies) {
-  return (call: grpc.ServerWritableStream<AnalyzeProjectRequest, AnalyzeProjectStreamResponse>) => {
-    if (state.analysisInProgress) {
+  return async (
+    call: grpc.ServerWritableStream<AnalyzeProjectRequest, AnalyzeProjectStreamResponse>,
+  ) => {
+    let completed = false;
+    let cancelled = false;
+    let ownsAnalysisSlot = false;
+    let onWorkerMessage: ((message: AnalyzeProjectWorkerOutMessage) => void) | undefined;
+
+    call.on('cancelled', () => {
+      cancelled = true;
+      if (!ownsAnalysisSlot || completed) {
+        return;
+      }
+      requestAnalysisCancellation(state);
+      void lifecycle.requestCancel().catch(error => {
+        debug(`Failed to cancel analyze-project request: ${error}`);
+      });
+    });
+
+    if (!(await acquireAnalysisSlot(state, () => (ownsAnalysisSlot = true)))) {
+      if (cancelled) {
+        return;
+      }
       failStreamingCall(
         call,
         toGrpcError('Another analysis is already running', grpc.status.RESOURCE_EXHAUSTED),
@@ -76,21 +136,22 @@ function createAnalyzeProjectStreamHandler({
       return;
     }
 
-    state.analysisInProgress = true;
+    if (cancelled) {
+      releaseAnalysisSlot(state);
+      return;
+    }
+
     const requestId = newWorkerRequestId();
-    let completed = false;
-    let cancelled = false;
-    let onWorkerMessage: ((message: AnalyzeProjectWorkerOutMessage) => void) | undefined;
 
     const complete = () => {
       if (completed) {
         return;
       }
       completed = true;
-      state.analysisInProgress = false;
       if (worker && onWorkerMessage) {
         worker.off('message', onWorkerMessage);
       }
+      releaseAnalysisSlot(state);
     };
 
     const finish = (error?: grpc.ServiceError) => {
@@ -137,16 +198,6 @@ function createAnalyzeProjectStreamHandler({
         debug(`Failed to end analyze-project stream response: ${e}`);
       }
     };
-
-    call.on('cancelled', () => {
-      cancelled = true;
-      if (completed) {
-        return;
-      }
-      void lifecycle.requestCancel().catch(error => {
-        debug(`Failed to cancel analyze-project request: ${error}`);
-      });
-    });
 
     if (worker) {
       onWorkerMessage = (message: AnalyzeProjectWorkerOutMessage) => {
@@ -207,12 +258,16 @@ function createAnalyzeProjectUnaryHandler({
     call: grpc.ServerUnaryCall<AnalyzeProjectRequest, AnalyzeProjectUnaryResponse>,
     callback: grpc.sendUnaryData<AnalyzeProjectUnaryResponse>,
   ) => {
-    if (state.analysisInProgress) {
+    if (!(await acquireAnalysisSlot(state))) {
       callback(toGrpcError('Another analysis is already running', grpc.status.RESOURCE_EXHAUSTED));
       return;
     }
 
-    state.analysisInProgress = true;
+    if (call.cancelled) {
+      releaseAnalysisSlot(state);
+      return;
+    }
+
     try {
       if (worker) {
         const result = (
@@ -259,7 +314,7 @@ function createAnalyzeProjectUnaryHandler({
     } catch (e) {
       callback(toGrpcError(e instanceof Error ? e.message : String(e)));
     } finally {
-      state.analysisInProgress = false;
+      releaseAnalysisSlot(state);
     }
   };
 }
@@ -273,6 +328,7 @@ function createCancelAnalysisHandler({
     callback: grpc.sendUnaryData<CancelAnalysisResponse>,
   ) => {
     const hadActiveAnalysis = state.analysisInProgress;
+    requestAnalysisCancellation(state);
     try {
       const cancelled = await lifecycle.requestCancel();
       callback(null, {

--- a/packages/grpc/src/analyze-project-server.ts
+++ b/packages/grpc/src/analyze-project-server.ts
@@ -118,6 +118,9 @@ function createAnalyzeProjectStreamHandler({
         cancelSubmission(submission);
       }
     });
+    if (cancelled) {
+      return;
+    }
 
     const writeResponse = (response: AnalyzeProjectStreamResponse) => {
       if (cancelled) {
@@ -237,6 +240,9 @@ function createAnalyzeProjectUnaryHandler({
         cancelSubmission(submission);
       }
     });
+    if (cancelled) {
+      return;
+    }
 
     const admission = state.analysisQueue.enqueue(
       async () => {
@@ -375,6 +381,7 @@ function createAnalyzeProjectImplementation(
 
 export const analyzeProjectServerInternals = {
   createAnalyzeProjectStreamHandler,
+  createAnalyzeProjectUnaryHandler,
   createLifecycle,
   waitForWorkerCompletion,
 };
@@ -397,9 +404,9 @@ export async function startAnalyzeProjectServer(
     resolveClosed = resolve;
   });
   const server = new grpc.Server(GRPC_SERVER_OPTIONS);
-  let handleCancellationTimeout = () => {};
+  let handleCancellationFailure = () => {};
   const state = createServerState({
-    onCancellationTimeout: () => handleCancellationTimeout(),
+    onCancellationFailure: () => handleCancellationFailure(),
   });
   const handleRequestInCurrentThread = createHandleRequestInCurrentThread(workerData);
   const newWorkerRequestId = () => getNextWorkerRequestId(state);
@@ -413,8 +420,8 @@ export async function startAnalyzeProjectServer(
     unregisterGarbageCollectionObserver,
     worker,
   });
-  handleCancellationTimeout = () => {
-    void lifecycle.shutdown('analysis cancellation timeout');
+  handleCancellationFailure = () => {
+    void lifecycle.shutdown('analysis cancellation failed');
   };
 
   attachWorkerLifecycleHandlers(worker, lifecycle, state);

--- a/packages/grpc/src/analyze-project-server.ts
+++ b/packages/grpc/src/analyze-project-server.ts
@@ -53,50 +53,50 @@ import {
   waitForWorkerCompletion,
   type AnalyzeProjectImplementationDependencies,
 } from './analyze-project-server-lifecycle.js';
+import {
+  AnalysisQueueClosedError,
+  AnalysisRequestCancelledError,
+  type AnalysisQueueSubmission,
+} from './analyze-project-server-queue.js';
 type UnaryCompleteMessage = Extract<AnalyzeProjectWorkerOutMessage, { type: 'unary-complete' }>;
+type StreamCompleteMessage = Extract<AnalyzeProjectWorkerOutMessage, { type: 'stream-complete' }>;
 
 type AnalyzeProjectServerResult = {
   server: grpc.Server;
   serverClosed: Promise<void>;
 };
 
-type AnalyzeProjectServerState = AnalyzeProjectImplementationDependencies['state'];
-
-/** Waits for cancellation handoff, but rejects genuine concurrent analysis. */
-async function acquireAnalysisSlot(
-  state: AnalyzeProjectServerState,
-  onAcquired: () => void = () => {},
-): Promise<boolean> {
-  while (state.analysisInProgress) {
-    if (!state.analysisCancellationRequested || !state.analysisCompletion) {
-      return false;
-    }
-    await state.analysisCompletion.promise;
+function toAnalysisServiceError(error: unknown): grpc.ServiceError {
+  if (error instanceof AnalysisQueueClosedError) {
+    return toGrpcError(error.message, grpc.status.UNAVAILABLE);
   }
-
-  state.analysisInProgress = true;
-  state.analysisCancellationRequested = false;
-  let resolveAnalysisCompletion!: () => void;
-  const analysisCompletion = new Promise<void>(resolve => {
-    resolveAnalysisCompletion = resolve;
-  });
-  state.analysisCompletion = { promise: analysisCompletion, resolve: resolveAnalysisCompletion };
-  onAcquired();
-  return true;
+  if (error instanceof AnalysisRequestCancelledError) {
+    return toGrpcError(error.message, grpc.status.CANCELLED);
+  }
+  if (
+    error instanceof Error &&
+    'code' in error &&
+    typeof error.code === 'number' &&
+    'details' in error
+  ) {
+    return error as grpc.ServiceError;
+  }
+  return toGrpcError(error instanceof Error ? error.message : String(error));
 }
 
-function requestAnalysisCancellation(state: AnalyzeProjectServerState) {
-  if (state.analysisInProgress) {
-    state.analysisCancellationRequested = true;
-  }
+function queueAdmissionError(reason: 'closed' | 'full') {
+  return reason === 'full'
+    ? toGrpcError('Analyze-project request queue is full', grpc.status.RESOURCE_EXHAUSTED)
+    : toGrpcError('Analyze-project request queue is closed', grpc.status.UNAVAILABLE);
 }
 
-function releaseAnalysisSlot(state: AnalyzeProjectServerState) {
-  const analysisCompletion = state.analysisCompletion;
-  state.analysisCancellationRequested = false;
-  state.analysisCompletion = null;
-  state.analysisInProgress = false;
-  analysisCompletion?.resolve();
+function cancelSubmission<T>(submission: AnalysisQueueSubmission<T>) {
+  const cancellation = submission.cancel();
+  if (cancellation.active) {
+    void cancellation.result.catch(error => {
+      debug(`Failed to cancel analyze-project request: ${error}`);
+    });
+  }
 }
 
 function createAnalyzeProjectStreamHandler({
@@ -109,62 +109,15 @@ function createAnalyzeProjectStreamHandler({
   return async (
     call: grpc.ServerWritableStream<AnalyzeProjectRequest, AnalyzeProjectStreamResponse>,
   ) => {
-    let completed = false;
-    let cancelled = false;
-    let ownsAnalysisSlot = false;
-    let onWorkerMessage: ((message: AnalyzeProjectWorkerOutMessage) => void) | undefined;
+    let cancelled = Boolean(call.cancelled);
+    let submission: AnalysisQueueSubmission<void> | undefined;
 
     call.on('cancelled', () => {
       cancelled = true;
-      if (!ownsAnalysisSlot || completed) {
-        return;
+      if (submission) {
+        cancelSubmission(submission);
       }
-      requestAnalysisCancellation(state);
-      void lifecycle.requestCancel().catch(error => {
-        debug(`Failed to cancel analyze-project request: ${error}`);
-      });
     });
-
-    if (!(await acquireAnalysisSlot(state, () => (ownsAnalysisSlot = true)))) {
-      if (cancelled) {
-        return;
-      }
-      failStreamingCall(
-        call,
-        toGrpcError('Another analysis is already running', grpc.status.RESOURCE_EXHAUSTED),
-      );
-      return;
-    }
-
-    if (cancelled) {
-      releaseAnalysisSlot(state);
-      return;
-    }
-
-    const requestId = newWorkerRequestId();
-
-    const complete = () => {
-      if (completed) {
-        return;
-      }
-      completed = true;
-      if (worker && onWorkerMessage) {
-        worker.off('message', onWorkerMessage);
-      }
-      releaseAnalysisSlot(state);
-    };
-
-    const finish = (error?: grpc.ServiceError) => {
-      // Release the single-analysis slot before ending the gRPC call. The Java client can
-      // observe end-of-stream and immediately start the next module analysis before this
-      // event-loop turn finishes, so ending first can transiently expose a false overlap.
-      complete();
-      if (error) {
-        failResponse(error);
-      } else {
-        endResponse();
-      }
-    };
 
     const writeResponse = (response: AnalyzeProjectStreamResponse) => {
       if (cancelled) {
@@ -199,57 +152,74 @@ function createAnalyzeProjectStreamHandler({
       }
     };
 
-    if (worker) {
-      onWorkerMessage = (message: AnalyzeProjectWorkerOutMessage) => {
-        if (message.requestId !== requestId) {
-          return;
-        }
-        switch (message.type) {
-          case 'event':
-            writeResponse(message.response);
-            return;
-          case 'stream-complete':
-            if (message.result.type === 'failure') {
-              finish(toGrpcErrorFromFailure(message.result));
-              return;
+    const admission = state.analysisQueue.enqueue(
+      async () => {
+        if (worker) {
+          const requestId = newWorkerRequestId();
+          const onWorkerMessage = (message: AnalyzeProjectWorkerOutMessage) => {
+            if (message.type === 'event' && message.requestId === requestId) {
+              writeResponse(message.response);
             }
-            finish();
+          };
+          worker.on('message', onWorkerMessage);
+          try {
+            const completion = (await waitForWorkerCompletion(
+              worker,
+              'stream-complete',
+              requestId,
+              () =>
+                // Structured clone strips protobufjs Long helpers (for example int64
+                // maxFileSize), so worker normalization also accepts plain Long-shaped values.
+                worker.postMessage({
+                  type: 'analyze-stream',
+                  requestId,
+                  request: call.request,
+                } satisfies AnalyzeProjectWorkerInMessage),
+            )) as StreamCompleteMessage;
+            if (completion.result.type === 'failure') {
+              throw toGrpcErrorFromFailure(completion.result);
+            }
             return;
-          default:
-            return;
+          } finally {
+            worker.off('message', onWorkerMessage);
+          }
         }
-      };
 
-      worker.on('message', onWorkerMessage);
-      // Structured clone strips protobufjs Long helpers (for example int64 maxFileSize), so
-      // request normalization in the worker must also accept plain { low, high, unsigned } values.
-      worker.postMessage({
-        type: 'analyze-stream',
-        requestId,
-        request: call.request,
-      } satisfies AnalyzeProjectWorkerInMessage);
+        const result = await handleRequestInCurrentThread(
+          { type: 'on-analyze-project', data: call.request },
+          event => writeResponse(toAnalyzeProjectStreamResponse(event.event, event.pathMap)),
+        );
+        if (result.type === 'failure') {
+          throw toGrpcErrorFromFailure(result);
+        }
+      },
+      () => lifecycle.requestCancel(),
+    );
+    if (!admission.accepted) {
+      if (!cancelled) {
+        failResponse(queueAdmissionError(admission.reason));
+      }
       return;
     }
 
-    void handleRequestInCurrentThread({ type: 'on-analyze-project', data: call.request }, event =>
-      writeResponse(toAnalyzeProjectStreamResponse(event.event, event.pathMap)),
-    )
-      .then(result => {
-        if (result.type === 'failure') {
-          finish(toGrpcErrorFromFailure(result));
-        } else {
-          finish();
-        }
-      })
-      .catch(error => {
-        finish(toGrpcError(error instanceof Error ? error.message : String(error)));
-      })
-      .finally(complete);
+    submission = admission.submission;
+    if (cancelled) {
+      cancelSubmission(submission);
+    }
+    try {
+      await submission.result;
+      endResponse();
+    } catch (error) {
+      if (!cancelled) {
+        failResponse(toAnalysisServiceError(error));
+      }
+    }
   };
 }
 
 function createAnalyzeProjectUnaryHandler({
   handleRequestInCurrentThread,
+  lifecycle,
   newWorkerRequestId,
   state,
   worker,
@@ -258,18 +228,32 @@ function createAnalyzeProjectUnaryHandler({
     call: grpc.ServerUnaryCall<AnalyzeProjectRequest, AnalyzeProjectUnaryResponse>,
     callback: grpc.sendUnaryData<AnalyzeProjectUnaryResponse>,
   ) => {
-    if (!(await acquireAnalysisSlot(state))) {
-      callback(toGrpcError('Another analysis is already running', grpc.status.RESOURCE_EXHAUSTED));
-      return;
-    }
+    let cancelled = Boolean(call.cancelled);
+    let submission: AnalysisQueueSubmission<AnalyzeProjectUnaryResponse> | undefined;
 
-    if (call.cancelled) {
-      releaseAnalysisSlot(state);
-      return;
-    }
+    call.on('cancelled', () => {
+      cancelled = true;
+      if (submission) {
+        cancelSubmission(submission);
+      }
+    });
 
-    try {
-      if (worker) {
+    const admission = state.analysisQueue.enqueue(
+      async () => {
+        if (!worker) {
+          const result = await handleRequestInCurrentThread({
+            type: 'on-analyze-project',
+            data: call.request,
+          });
+          if (result.type === 'failure') {
+            throw toGrpcErrorFromFailure(result);
+          }
+          if (result.result == null) {
+            throw toGrpcError('Missing analyze-project unary result');
+          }
+          return toAnalyzeProjectUnaryResponse(result.result.output, result.result.pathMap);
+        }
+
         const result = (
           await (() => {
             const requestId = newWorkerRequestId();
@@ -283,57 +267,51 @@ function createAnalyzeProjectUnaryHandler({
           })()
         ).result;
         if (result.type === 'failure') {
-          callback(toGrpcErrorFromFailure(result));
-          return;
+          throw toGrpcErrorFromFailure(result);
         }
-
         if (result.result == null) {
-          callback(toGrpcError('Missing analyze-project unary result'));
-          return;
+          throw toGrpcError('Missing analyze-project unary result');
         }
-
-        callback(null, result.result);
-        return;
+        return result.result;
+      },
+      () => lifecycle.requestCancel(),
+    );
+    if (!admission.accepted) {
+      if (!cancelled) {
+        callback(queueAdmissionError(admission.reason));
       }
+      return;
+    }
 
-      const result = await handleRequestInCurrentThread({
-        type: 'on-analyze-project',
-        data: call.request,
-      });
-      if (result.type === 'failure') {
-        callback(toGrpcErrorFromFailure(result));
-        return;
+    submission = admission.submission;
+    if (cancelled) {
+      cancelSubmission(submission);
+    }
+    try {
+      const result = await submission.result;
+      if (!cancelled) {
+        callback(null, result);
       }
-
-      if (result.result == null) {
-        callback(toGrpcError('Missing analyze-project unary result'));
-        return;
+    } catch (error) {
+      if (!cancelled) {
+        callback(toAnalysisServiceError(error));
       }
-
-      callback(null, toAnalyzeProjectUnaryResponse(result.result.output, result.result.pathMap));
-    } catch (e) {
-      callback(toGrpcError(e instanceof Error ? e.message : String(e)));
-    } finally {
-      releaseAnalysisSlot(state);
     }
   };
 }
 
-function createCancelAnalysisHandler({
-  lifecycle,
-  state,
-}: AnalyzeProjectImplementationDependencies) {
+function createCancelAnalysisHandler({ state }: AnalyzeProjectImplementationDependencies) {
   return async (
     _: grpc.ServerUnaryCall<CancelAnalysisRequest, CancelAnalysisResponse>,
     callback: grpc.sendUnaryData<CancelAnalysisResponse>,
   ) => {
-    const hadActiveAnalysis = state.analysisInProgress;
-    requestAnalysisCancellation(state);
+    const cancellation = state.analysisQueue.cancelActive();
+    if (!cancellation.active) {
+      callback(null, { cancelled: false });
+      return;
+    }
     try {
-      const cancelled = await lifecycle.requestCancel();
-      callback(null, {
-        cancelled: hadActiveAnalysis && cancelled,
-      });
+      callback(null, { cancelled: await cancellation.result });
     } catch (e) {
       callback(toGrpcError(e instanceof Error ? e.message : String(e)));
     }
@@ -419,7 +397,10 @@ export async function startAnalyzeProjectServer(
     resolveClosed = resolve;
   });
   const server = new grpc.Server(GRPC_SERVER_OPTIONS);
-  const state = createServerState();
+  let handleCancellationTimeout = () => {};
+  const state = createServerState({
+    onCancellationTimeout: () => handleCancellationTimeout(),
+  });
   const handleRequestInCurrentThread = createHandleRequestInCurrentThread(workerData);
   const newWorkerRequestId = () => getNextWorkerRequestId(state);
   const lifecycle = createLifecycle({
@@ -432,6 +413,9 @@ export async function startAnalyzeProjectServer(
     unregisterGarbageCollectionObserver,
     worker,
   });
+  handleCancellationTimeout = () => {
+    void lifecycle.shutdown('analysis cancellation timeout');
+  };
 
   attachWorkerLifecycleHandlers(worker, lifecycle, state);
   server.addService(

--- a/packages/grpc/src/analyze-project-server.ts
+++ b/packages/grpc/src/analyze-project-server.ts
@@ -404,10 +404,7 @@ export async function startAnalyzeProjectServer(
     resolveClosed = resolve;
   });
   const server = new grpc.Server(GRPC_SERVER_OPTIONS);
-  let handleCancellationFailure = () => {};
-  const state = createServerState({
-    onCancellationFailure: () => handleCancellationFailure(),
-  });
+  const state = createServerState();
   const handleRequestInCurrentThread = createHandleRequestInCurrentThread(workerData);
   const newWorkerRequestId = () => getNextWorkerRequestId(state);
   const lifecycle = createLifecycle({
@@ -420,9 +417,6 @@ export async function startAnalyzeProjectServer(
     unregisterGarbageCollectionObserver,
     worker,
   });
-  handleCancellationFailure = () => {
-    void lifecycle.shutdown('analysis cancellation failed');
-  };
 
   attachWorkerLifecycleHandlers(worker, lifecycle, state);
   server.addService(

--- a/packages/grpc/src/analyze-project-server.ts
+++ b/packages/grpc/src/analyze-project-server.ts
@@ -55,7 +55,7 @@ import {
 } from './analyze-project-server-lifecycle.js';
 import {
   AnalysisQueueClosedError,
-  AnalysisRequestCancelledError,
+  AnalysisTransportCancelledError,
   type AnalysisQueueSubmission,
 } from './analyze-project-server-queue.js';
 type UnaryCompleteMessage = Extract<AnalyzeProjectWorkerOutMessage, { type: 'unary-complete' }>;
@@ -70,7 +70,7 @@ function toAnalysisServiceError(error: unknown): grpc.ServiceError {
   if (error instanceof AnalysisQueueClosedError) {
     return toGrpcError(error.message, grpc.status.UNAVAILABLE);
   }
-  if (error instanceof AnalysisRequestCancelledError) {
+  if (error instanceof AnalysisTransportCancelledError) {
     return toGrpcError(error.message, grpc.status.CANCELLED);
   }
   if (
@@ -90,11 +90,11 @@ function queueAdmissionError(reason: 'closed' | 'full') {
     : toGrpcError('Analyze-project request queue is closed', grpc.status.UNAVAILABLE);
 }
 
-function cancelSubmission<T>(submission: AnalysisQueueSubmission<T>) {
-  const cancellation = submission.cancel();
+function cancelSubmissionForTransportCall<T>(submission: AnalysisQueueSubmission<T>) {
+  const cancellation = submission.cancelTransportCall();
   if (cancellation.active) {
     void cancellation.result.catch(error => {
-      debug(`Failed to cancel analyze-project request: ${error}`);
+      debug(`Failed to propagate analyze-project transport cancellation: ${error}`);
     });
   }
 }
@@ -109,21 +109,21 @@ function createAnalyzeProjectStreamHandler({
   return async (
     call: grpc.ServerWritableStream<AnalyzeProjectRequest, AnalyzeProjectStreamResponse>,
   ) => {
-    let cancelled = Boolean(call.cancelled);
+    let transportCancelled = Boolean(call.cancelled);
     let submission: AnalysisQueueSubmission<void> | undefined;
 
     call.on('cancelled', () => {
-      cancelled = true;
+      transportCancelled = true;
       if (submission) {
-        cancelSubmission(submission);
+        cancelSubmissionForTransportCall(submission);
       }
     });
-    if (cancelled) {
+    if (transportCancelled) {
       return;
     }
 
     const writeResponse = (response: AnalyzeProjectStreamResponse) => {
-      if (cancelled) {
+      if (transportCancelled) {
         return;
       }
       try {
@@ -134,7 +134,7 @@ function createAnalyzeProjectStreamHandler({
     };
 
     const failResponse = (error: grpc.ServiceError) => {
-      if (cancelled) {
+      if (transportCancelled) {
         return;
       }
       try {
@@ -145,7 +145,7 @@ function createAnalyzeProjectStreamHandler({
     };
 
     const endResponse = () => {
-      if (cancelled) {
+      if (transportCancelled) {
         return;
       }
       try {
@@ -199,21 +199,21 @@ function createAnalyzeProjectStreamHandler({
       () => lifecycle.requestCancel(),
     );
     if (!admission.accepted) {
-      if (!cancelled) {
+      if (!transportCancelled) {
         failResponse(queueAdmissionError(admission.reason));
       }
       return;
     }
 
     submission = admission.submission;
-    if (cancelled) {
-      cancelSubmission(submission);
+    if (transportCancelled) {
+      cancelSubmissionForTransportCall(submission);
     }
     try {
       await submission.result;
       endResponse();
     } catch (error) {
-      if (!cancelled) {
+      if (!transportCancelled) {
         failResponse(toAnalysisServiceError(error));
       }
     }
@@ -231,16 +231,16 @@ function createAnalyzeProjectUnaryHandler({
     call: grpc.ServerUnaryCall<AnalyzeProjectRequest, AnalyzeProjectUnaryResponse>,
     callback: grpc.sendUnaryData<AnalyzeProjectUnaryResponse>,
   ) => {
-    let cancelled = Boolean(call.cancelled);
+    let transportCancelled = Boolean(call.cancelled);
     let submission: AnalysisQueueSubmission<AnalyzeProjectUnaryResponse> | undefined;
 
     call.on('cancelled', () => {
-      cancelled = true;
+      transportCancelled = true;
       if (submission) {
-        cancelSubmission(submission);
+        cancelSubmissionForTransportCall(submission);
       }
     });
-    if (cancelled) {
+    if (transportCancelled) {
       return;
     }
 
@@ -283,23 +283,23 @@ function createAnalyzeProjectUnaryHandler({
       () => lifecycle.requestCancel(),
     );
     if (!admission.accepted) {
-      if (!cancelled) {
+      if (!transportCancelled) {
         callback(queueAdmissionError(admission.reason));
       }
       return;
     }
 
     submission = admission.submission;
-    if (cancelled) {
-      cancelSubmission(submission);
+    if (transportCancelled) {
+      cancelSubmissionForTransportCall(submission);
     }
     try {
       const result = await submission.result;
-      if (!cancelled) {
+      if (!transportCancelled) {
         callback(null, result);
       }
     } catch (error) {
-      if (!cancelled) {
+      if (!transportCancelled) {
         callback(toAnalysisServiceError(error));
       }
     }
@@ -311,7 +311,7 @@ function createCancelAnalysisHandler({ state }: AnalyzeProjectImplementationDepe
     _: grpc.ServerUnaryCall<CancelAnalysisRequest, CancelAnalysisResponse>,
     callback: grpc.sendUnaryData<CancelAnalysisResponse>,
   ) => {
-    const cancellation = state.analysisQueue.cancelActive();
+    const cancellation = state.analysisQueue.cancelActiveAnalysis();
     if (!cancellation.active) {
       callback(null, { cancelled: false });
       return;

--- a/packages/grpc/src/proto/analyze-project.proto
+++ b/packages/grpc/src/proto/analyze-project.proto
@@ -10,8 +10,12 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 
 service AnalyzeProjectService {
+  // Analysis calls are executed one at a time in arrival order. The server keeps a bounded
+  // pending queue and returns RESOURCE_EXHAUSTED only when that queue is full.
   rpc AnalyzeProject(AnalyzeProjectRequest) returns (stream AnalyzeProjectStreamResponse);
   rpc AnalyzeProjectUnary(AnalyzeProjectRequest) returns (AnalyzeProjectUnaryResponse);
+  // Cancels the active analysis. Cancelling an AnalyzeProject or AnalyzeProjectUnary transport
+  // call instead cancels that specific request, including while it is still queued.
   rpc CancelAnalysis(CancelAnalysisRequest) returns (CancelAnalysisResponse);
   rpc Lease(stream LeaseRequest) returns (stream LeaseResponse);
 }

--- a/packages/grpc/src/proto/analyze-project.proto
+++ b/packages/grpc/src/proto/analyze-project.proto
@@ -12,10 +12,12 @@ import "google/protobuf/struct.proto";
 service AnalyzeProjectService {
   // Analysis calls are executed one at a time in arrival order. The server keeps a bounded
   // pending queue and returns RESOURCE_EXHAUSTED only when that queue is full.
+  // Cancelling either RPC transport cancels only that submitted request: a pending request is
+  // removed from the queue, while an active request asks the worker to stop its analysis.
   rpc AnalyzeProject(AnalyzeProjectRequest) returns (stream AnalyzeProjectStreamResponse);
   rpc AnalyzeProjectUnary(AnalyzeProjectRequest) returns (AnalyzeProjectUnaryResponse);
-  // Cancels the active analysis. Cancelling an AnalyzeProject or AnalyzeProjectUnary transport
-  // call instead cancels that specific request, including while it is still queued.
+  // Explicitly cancels whichever analysis is active. This is distinct from transport cancellation
+  // above and never targets a pending request.
   rpc CancelAnalysis(CancelAnalysisRequest) returns (CancelAnalysisResponse);
   rpc Lease(stream LeaseRequest) returns (stream LeaseResponse);
 }

--- a/packages/grpc/tests/analyze-project-handle-request.test.ts
+++ b/packages/grpc/tests/analyze-project-handle-request.test.ts
@@ -1,0 +1,69 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import { describe, it } from 'node:test';
+import { expect } from 'expect';
+import {
+  handleAnalyzeProjectRequest,
+  type WorkerData,
+} from '../src/analyze-project-handle-request.js';
+import type { AnalyzeProjectIncrementalEvent } from '../src/analyze-project-request.js';
+import { sonarjs as analyzeProjectProto } from '../src/proto/analyze-project.js';
+
+const workerData: WorkerData = { debugMemory: false };
+type AnalyzeProjectRequest = analyzeProjectProto.analyzeproject.v1.IAnalyzeProjectRequest;
+
+function createAnalyzeProjectRequest(): AnalyzeProjectRequest {
+  return {
+    configuration: {
+      baseDir: '/project',
+    },
+    files: {},
+    rules: [],
+    cssRules: [],
+    bundles: [],
+  };
+}
+
+describe('analyze-project request handler', () => {
+  it('should preserve cancellation received while normalizing a request', async () => {
+    const events: AnalyzeProjectIncrementalEvent[] = [];
+    const analysisResult = handleAnalyzeProjectRequest(
+      { type: 'on-analyze-project', data: createAnalyzeProjectRequest() },
+      workerData,
+      event => events.push(event),
+    );
+
+    const cancellationResult = await handleAnalyzeProjectRequest(
+      { type: 'on-cancel-analysis' },
+      workerData,
+    );
+
+    expect(cancellationResult).toEqual({ result: undefined, type: 'success' });
+    expect(await analysisResult).toMatchObject({ type: 'success' });
+    expect(events.map(({ event }) => event)).toEqual([{ messageType: 'cancelled' }]);
+
+    const nextEvents: AnalyzeProjectIncrementalEvent[] = [];
+    await handleAnalyzeProjectRequest(
+      { type: 'on-analyze-project', data: createAnalyzeProjectRequest() },
+      workerData,
+      event => nextEvents.push(event),
+    );
+
+    expect(nextEvents.map(({ event }) => event.messageType)).toEqual(['meta']);
+  });
+});

--- a/packages/grpc/tests/analyze-project-handle-request.test.ts
+++ b/packages/grpc/tests/analyze-project-handle-request.test.ts
@@ -31,6 +31,7 @@ function createAnalyzeProjectRequest(): AnalyzeProjectRequest {
   return {
     configuration: {
       baseDir: '/project',
+      canAccessFileSystem: false,
     },
     files: {},
     rules: [],

--- a/packages/grpc/tests/analyze-project-server-queue.test.ts
+++ b/packages/grpc/tests/analyze-project-server-queue.test.ts
@@ -15,7 +15,6 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 
-import { setTimeout as delay } from 'node:timers/promises';
 import { describe, it } from 'node:test';
 import { expect } from 'expect';
 import {
@@ -157,33 +156,36 @@ describe('analyze-project request queue', () => {
     });
   });
 
-  it('should report when a transport-cancelled analysis does not finish', async () => {
-    const cancellationGraceExceeded = createDeferred<void>();
+  it('should keep queued analyses blocked until the cancelled active analysis finishes', async () => {
     const activeRelease = createDeferred<void>();
-    let cancellationRequests = 0;
-    const queue = new AnalysisRequestQueue(1, 5, () => cancellationGraceExceeded.resolve());
+    let pendingStarted = false;
+    const queue = new AnalysisRequestQueue();
     const active = acceptedSubmission(
       queue.enqueue(
         () => activeRelease.promise,
+        async () => true,
+      ),
+    );
+    const pending = acceptedSubmission(
+      queue.enqueue(
         async () => {
-          cancellationRequests += 1;
-          return true;
+          pendingStarted = true;
         },
+        async () => true,
       ),
     );
 
     const cancellation = active.cancelTransportCall();
     expect(cancellation.active).toBe(true);
-    await Promise.race([
-      cancellationGraceExceeded.promise,
-      delay(1_000).then(() => {
-        throw new Error('Timed out waiting for cancellation grace period');
-      }),
-    ]);
-    activeRelease.resolve();
-    await active.result;
+    if (cancellation.active) {
+      await expect(cancellation.result).resolves.toBe(true);
+    }
+    expect(pendingStarted).toBe(false);
 
-    expect(cancellationRequests).toBe(1);
+    activeRelease.resolve();
+    await Promise.all([active.result, pending.result]);
+
+    expect(pendingStarted).toBe(true);
   });
 
   it('should deduplicate transport and explicit active-analysis cancellation', async () => {
@@ -211,27 +213,5 @@ describe('analyze-project request queue', () => {
     await active.result;
 
     expect(cancellationRequests).toBe(1);
-  });
-
-  it('should report when transport cancellation is not acknowledged', async () => {
-    const cancellationFailure = createDeferred<void>();
-    const activeRelease = createDeferred<void>();
-    const queue = new AnalysisRequestQueue(1, 1_000, () => cancellationFailure.resolve());
-    const active = acceptedSubmission(
-      queue.enqueue(
-        () => activeRelease.promise,
-        async () => false,
-      ),
-    );
-
-    active.cancelTransportCall();
-    await Promise.race([
-      cancellationFailure.promise,
-      delay(100).then(() => {
-        throw new Error('Timed out waiting for cancellation failure');
-      }),
-    ]);
-    activeRelease.resolve();
-    await active.result;
   });
 });

--- a/packages/grpc/tests/analyze-project-server-queue.test.ts
+++ b/packages/grpc/tests/analyze-project-server-queue.test.ts
@@ -158,10 +158,10 @@ describe('analyze-project request queue', () => {
   });
 
   it('should report when a cancelled analysis does not finish', async () => {
-    const cancellationTimeout = createDeferred<void>();
+    const cancellationGraceExceeded = createDeferred<void>();
     const activeRelease = createDeferred<void>();
     let cancellationRequests = 0;
-    const queue = new AnalysisRequestQueue(1, 5, () => cancellationTimeout.resolve());
+    const queue = new AnalysisRequestQueue(1, 5, () => cancellationGraceExceeded.resolve());
     const active = acceptedSubmission(
       queue.enqueue(
         () => activeRelease.promise,
@@ -177,14 +177,36 @@ describe('analyze-project request queue', () => {
     expect(firstCancellation.active).toBe(true);
     expect(secondCancellation.active).toBe(true);
     await Promise.race([
-      cancellationTimeout.promise,
+      cancellationGraceExceeded.promise,
       delay(1_000).then(() => {
-        throw new Error('Timed out waiting for cancellation timeout');
+        throw new Error('Timed out waiting for cancellation grace period');
       }),
     ]);
     activeRelease.resolve();
     await active.result;
 
     expect(cancellationRequests).toBe(1);
+  });
+
+  it('should report when cancellation is not acknowledged', async () => {
+    const cancellationFailure = createDeferred<void>();
+    const activeRelease = createDeferred<void>();
+    const queue = new AnalysisRequestQueue(1, 1_000, () => cancellationFailure.resolve());
+    const active = acceptedSubmission(
+      queue.enqueue(
+        () => activeRelease.promise,
+        async () => false,
+      ),
+    );
+
+    active.cancel();
+    await Promise.race([
+      cancellationFailure.promise,
+      delay(100).then(() => {
+        throw new Error('Timed out waiting for cancellation failure');
+      }),
+    ]);
+    activeRelease.resolve();
+    await active.result;
   });
 });

--- a/packages/grpc/tests/analyze-project-server-queue.test.ts
+++ b/packages/grpc/tests/analyze-project-server-queue.test.ts
@@ -20,7 +20,7 @@ import { describe, it } from 'node:test';
 import { expect } from 'expect';
 import {
   AnalysisQueueClosedError,
-  AnalysisRequestCancelledError,
+  AnalysisTransportCancelledError,
   AnalysisRequestQueue,
   type AnalysisQueueAdmission,
   type AnalysisQueueSubmission,
@@ -69,7 +69,7 @@ describe('analyze-project request queue', () => {
     }
   });
 
-  it('should remove a cancelled pending analysis', async () => {
+  it('should remove a transport-cancelled pending analysis', async () => {
     const activeRelease = createDeferred<void>();
     let pendingStarted = false;
     const queue = new AnalysisRequestQueue();
@@ -88,8 +88,8 @@ describe('analyze-project request queue', () => {
       ),
     );
 
-    expect(pending.cancel()).toEqual({ active: false });
-    await expect(pending.result).rejects.toBeInstanceOf(AnalysisRequestCancelledError);
+    expect(pending.cancelTransportCall()).toEqual({ active: false });
+    await expect(pending.result).rejects.toBeInstanceOf(AnalysisTransportCancelledError);
     activeRelease.resolve();
     await active.result;
 
@@ -157,7 +157,7 @@ describe('analyze-project request queue', () => {
     });
   });
 
-  it('should report when a cancelled analysis does not finish', async () => {
+  it('should report when a transport-cancelled analysis does not finish', async () => {
     const cancellationGraceExceeded = createDeferred<void>();
     const activeRelease = createDeferred<void>();
     let cancellationRequests = 0;
@@ -172,10 +172,8 @@ describe('analyze-project request queue', () => {
       ),
     );
 
-    const firstCancellation = active.cancel();
-    const secondCancellation = active.cancel();
-    expect(firstCancellation.active).toBe(true);
-    expect(secondCancellation.active).toBe(true);
+    const cancellation = active.cancelTransportCall();
+    expect(cancellation.active).toBe(true);
     await Promise.race([
       cancellationGraceExceeded.promise,
       delay(1_000).then(() => {
@@ -188,7 +186,34 @@ describe('analyze-project request queue', () => {
     expect(cancellationRequests).toBe(1);
   });
 
-  it('should report when cancellation is not acknowledged', async () => {
+  it('should deduplicate transport and explicit active-analysis cancellation', async () => {
+    const activeRelease = createDeferred<void>();
+    let cancellationRequests = 0;
+    const queue = new AnalysisRequestQueue();
+    const active = acceptedSubmission(
+      queue.enqueue(
+        () => activeRelease.promise,
+        async () => {
+          cancellationRequests += 1;
+          return true;
+        },
+      ),
+    );
+
+    const transportCancellation = active.cancelTransportCall();
+    const explicitCancellation = queue.cancelActiveAnalysis();
+    expect(transportCancellation.active).toBe(true);
+    expect(explicitCancellation.active).toBe(true);
+    if (transportCancellation.active && explicitCancellation.active) {
+      await Promise.all([transportCancellation.result, explicitCancellation.result]);
+    }
+    activeRelease.resolve();
+    await active.result;
+
+    expect(cancellationRequests).toBe(1);
+  });
+
+  it('should report when transport cancellation is not acknowledged', async () => {
     const cancellationFailure = createDeferred<void>();
     const activeRelease = createDeferred<void>();
     const queue = new AnalysisRequestQueue(1, 1_000, () => cancellationFailure.resolve());
@@ -199,7 +224,7 @@ describe('analyze-project request queue', () => {
       ),
     );
 
-    active.cancel();
+    active.cancelTransportCall();
     await Promise.race([
       cancellationFailure.promise,
       delay(100).then(() => {

--- a/packages/grpc/tests/analyze-project-server-queue.test.ts
+++ b/packages/grpc/tests/analyze-project-server-queue.test.ts
@@ -1,0 +1,190 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+import { setTimeout as delay } from 'node:timers/promises';
+import { describe, it } from 'node:test';
+import { expect } from 'expect';
+import {
+  AnalysisQueueClosedError,
+  AnalysisRequestCancelledError,
+  AnalysisRequestQueue,
+  type AnalysisQueueAdmission,
+  type AnalysisQueueSubmission,
+} from '../src/analyze-project-server-queue.js';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function acceptedSubmission<T>(admission: AnalysisQueueAdmission<T>): AnalysisQueueSubmission<T> {
+  if (!admission.accepted) {
+    throw new Error(`Expected queue admission, got ${admission.reason}`);
+  }
+  return admission.submission;
+}
+
+describe('analyze-project request queue', () => {
+  it('should run queued analyses in arrival order', async () => {
+    const releases = [createDeferred<void>(), createDeferred<void>(), createDeferred<void>()];
+    const started: number[] = [];
+    const queue = new AnalysisRequestQueue();
+    const submissions = releases.map((release, index) =>
+      acceptedSubmission(
+        queue.enqueue(
+          async () => {
+            started.push(index);
+            await release.promise;
+            return index;
+          },
+          async () => true,
+        ),
+      ),
+    );
+
+    expect(started).toEqual([0]);
+    for (let index = 0; index < releases.length; index++) {
+      releases[index].resolve();
+      await submissions[index].result;
+      expect(started).toEqual(Array.from({ length: index + 2 }, (_, i) => i).slice(0, 3));
+    }
+  });
+
+  it('should remove a cancelled pending analysis', async () => {
+    const activeRelease = createDeferred<void>();
+    let pendingStarted = false;
+    const queue = new AnalysisRequestQueue();
+    const active = acceptedSubmission(
+      queue.enqueue(
+        () => activeRelease.promise,
+        async () => true,
+      ),
+    );
+    const pending = acceptedSubmission(
+      queue.enqueue(
+        async () => {
+          pendingStarted = true;
+        },
+        async () => true,
+      ),
+    );
+
+    expect(pending.cancel()).toEqual({ active: false });
+    await expect(pending.result).rejects.toBeInstanceOf(AnalysisRequestCancelledError);
+    activeRelease.resolve();
+    await active.result;
+
+    expect(pendingStarted).toBe(false);
+    expect(queue.pendingCount).toBe(0);
+  });
+
+  it('should reject admission when the pending queue is full', async () => {
+    const activeRelease = createDeferred<void>();
+    const queue = new AnalysisRequestQueue(1);
+    const active = acceptedSubmission(
+      queue.enqueue(
+        () => activeRelease.promise,
+        async () => true,
+      ),
+    );
+    const pending = acceptedSubmission(
+      queue.enqueue(
+        async () => {},
+        async () => true,
+      ),
+    );
+
+    expect(
+      queue.enqueue(
+        async () => {},
+        async () => true,
+      ),
+    ).toEqual({
+      accepted: false,
+      reason: 'full',
+    });
+    activeRelease.resolve();
+    await Promise.all([active.result, pending.result]);
+  });
+
+  it('should reject active and pending analyses when the queue closes', async () => {
+    const queue = new AnalysisRequestQueue();
+    const active = acceptedSubmission(
+      queue.enqueue(
+        () => new Promise<void>(() => {}),
+        async () => true,
+      ),
+    );
+    const pending = acceptedSubmission(
+      queue.enqueue(
+        async () => {},
+        async () => true,
+      ),
+    );
+    const activeResult = expect(active.result).rejects.toBeInstanceOf(AnalysisQueueClosedError);
+    const pendingResult = expect(pending.result).rejects.toBeInstanceOf(AnalysisQueueClosedError);
+
+    queue.close();
+
+    await Promise.all([activeResult, pendingResult]);
+    expect(
+      queue.enqueue(
+        async () => {},
+        async () => true,
+      ),
+    ).toEqual({
+      accepted: false,
+      reason: 'closed',
+    });
+  });
+
+  it('should report when a cancelled analysis does not finish', async () => {
+    const cancellationTimeout = createDeferred<void>();
+    const activeRelease = createDeferred<void>();
+    let cancellationRequests = 0;
+    const queue = new AnalysisRequestQueue(1, 5, () => cancellationTimeout.resolve());
+    const active = acceptedSubmission(
+      queue.enqueue(
+        () => activeRelease.promise,
+        async () => {
+          cancellationRequests += 1;
+          return true;
+        },
+      ),
+    );
+
+    const firstCancellation = active.cancel();
+    const secondCancellation = active.cancel();
+    expect(firstCancellation.active).toBe(true);
+    expect(secondCancellation.active).toBe(true);
+    await Promise.race([
+      cancellationTimeout.promise,
+      delay(1_000).then(() => {
+        throw new Error('Timed out waiting for cancellation timeout');
+      }),
+    ]);
+    activeRelease.resolve();
+    await active.result;
+
+    expect(cancellationRequests).toBe(1);
+  });
+});

--- a/packages/grpc/tests/analyze-project-server-queue.test.ts
+++ b/packages/grpc/tests/analyze-project-server-queue.test.ts
@@ -214,4 +214,64 @@ describe('analyze-project request queue', () => {
 
     expect(cancellationRequests).toBe(1);
   });
+
+  it('should retry active cancellation after it is not acknowledged', async () => {
+    const activeRelease = createDeferred<void>();
+    let cancellationRequests = 0;
+    const queue = new AnalysisRequestQueue();
+    const active = acceptedSubmission(
+      queue.enqueue(
+        () => activeRelease.promise,
+        async () => ++cancellationRequests > 1,
+      ),
+    );
+
+    const firstCancellation = queue.cancelActiveAnalysis();
+    expect(firstCancellation.active).toBe(true);
+    if (firstCancellation.active) {
+      await expect(firstCancellation.result).resolves.toBe(false);
+    }
+    const secondCancellation = queue.cancelActiveAnalysis();
+    expect(secondCancellation.active).toBe(true);
+    if (secondCancellation.active) {
+      await expect(secondCancellation.result).resolves.toBe(true);
+    }
+
+    activeRelease.resolve();
+    await active.result;
+    expect(cancellationRequests).toBe(2);
+  });
+
+  it('should retry active cancellation after signaling fails', async () => {
+    const activeRelease = createDeferred<void>();
+    let cancellationRequests = 0;
+    const queue = new AnalysisRequestQueue();
+    const active = acceptedSubmission(
+      queue.enqueue(
+        () => activeRelease.promise,
+        async () => {
+          cancellationRequests += 1;
+          if (cancellationRequests === 1) {
+            throw new Error('Cancellation signal failed');
+          }
+          return true;
+        },
+      ),
+    );
+
+    const firstCancellation = queue.cancelActiveAnalysis();
+    expect(firstCancellation.active).toBe(true);
+    if (firstCancellation.active) {
+      await expect(firstCancellation.result).rejects.toThrow('Cancellation signal failed');
+    }
+    const secondCancellation = queue.cancelActiveAnalysis();
+    expect(secondCancellation.active).toBe(true);
+    if (secondCancellation.active) {
+      await expect(secondCancellation.result).resolves.toBe(true);
+    }
+
+    activeRelease.resolve();
+    await active.result;
+    expect(cancellationRequests).toBe(2);
+  });
 });

--- a/packages/grpc/tests/analyze-project-server.test.ts
+++ b/packages/grpc/tests/analyze-project-server.test.ts
@@ -61,6 +61,10 @@ type CancelAnalysisRequest = analyzeProjectProto.analyzeproject.v1.ICancelAnalys
 type CancelAnalysisResponse = analyzeProjectProto.analyzeproject.v1.ICancelAnalysisResponse;
 type LeaseRequest = analyzeProjectProto.analyzeproject.v1.ILeaseRequest;
 type LeaseResponse = analyzeProjectProto.analyzeproject.v1.ILeaseResponse;
+type AnalyzeWorkerRequest = Extract<
+  AnalyzeProjectWorkerInMessage,
+  { type: 'analyze-stream' | 'analyze-unary' }
+>;
 const { AnalysisMode, FileType, JsTsLanguage } = analyzeProjectProto.analyzeproject.v1;
 
 function createAnalyzeProjectClient(port: number) {
@@ -154,6 +158,24 @@ function createAnalyzeProjectClient(port: number) {
     UNLIMITED_GRPC_MESSAGE_OPTIONS,
   ) as grpc.Client;
 
+  const startAnalyzeProjectUnary = (request: AnalyzeProjectRequest) => {
+    const response = createDeferred<AnalyzeProjectUnaryResponse>();
+    const call = client.makeUnaryRequest(
+      analyzeProjectUnaryMethodDefinition.path,
+      analyzeProjectUnaryMethodDefinition.requestSerialize,
+      analyzeProjectUnaryMethodDefinition.responseDeserialize,
+      request,
+      (error: grpc.ServiceError | null, result?: AnalyzeProjectUnaryResponse) => {
+        if (error) {
+          response.reject(error);
+        } else {
+          response.resolve(result!);
+        }
+      },
+    );
+    return { call, response: response.promise };
+  };
+
   return {
     startAnalyzeProject: (request: AnalyzeProjectRequest) =>
       client.makeServerStreamRequest(
@@ -189,21 +211,7 @@ function createAnalyzeProjectClient(port: number) {
         });
       })(),
     analyzeProjectUnary: (request: AnalyzeProjectRequest) =>
-      new Promise<AnalyzeProjectUnaryResponse>((resolve, reject) => {
-        client.makeUnaryRequest(
-          analyzeProjectUnaryMethodDefinition.path,
-          analyzeProjectUnaryMethodDefinition.requestSerialize,
-          analyzeProjectUnaryMethodDefinition.responseDeserialize,
-          request,
-          (error: grpc.ServiceError | null, response?: AnalyzeProjectUnaryResponse) => {
-            if (error) {
-              reject(error);
-            } else {
-              resolve(response!);
-            }
-          },
-        );
-      }),
+      startAnalyzeProjectUnary(request).response,
     cancelAnalysis: (request: CancelAnalysisRequest = {}) =>
       new Promise<CancelAnalysisResponse>((resolve, reject) => {
         client.makeUnaryRequest(
@@ -226,6 +234,7 @@ function createAnalyzeProjectClient(port: number) {
         leaseMethodDefinition.requestSerialize,
         leaseMethodDefinition.responseDeserialize,
       ),
+    startAnalyzeProjectUnary,
     close: () => client.close(),
   };
 }
@@ -436,20 +445,40 @@ class FakeAnalyzeProjectStreamCall extends EventEmitter {
 }
 
 function createUnitServerState({
-  analysisInProgress = false,
+  activeAnalysis = false,
+  cancellationTimeoutMs,
   leaseCall = null,
+  maxPendingAnalysisRequests,
+  onCancellationTimeout,
   startupShutdownTimeout = null,
 }: {
-  analysisInProgress?: boolean;
+  activeAnalysis?: boolean;
+  cancellationTimeoutMs?: number;
   leaseCall?: { end: () => void } | null;
+  maxPendingAnalysisRequests?: number;
+  onCancellationTimeout?: () => void | Promise<void>;
   startupShutdownTimeout?: NodeJS.Timeout | null;
 } = {}) {
-  return {
-    ...createServerState(),
-    analysisInProgress,
+  const state = {
+    ...createServerState({
+      cancellationTimeoutMs,
+      maxPendingAnalysisRequests,
+      onCancellationTimeout,
+    }),
     leaseCall: leaseCall as unknown as grpc.ServerDuplexStream<LeaseRequest, LeaseResponse> | null,
     startupShutdownTimeout,
   };
+  if (activeAnalysis) {
+    const admission = state.analysisQueue.enqueue(
+      () => new Promise<void>(() => {}),
+      async () => true,
+    );
+    if (!admission.accepted) {
+      throw new Error('Failed to activate analysis queue for test');
+    }
+    void admission.submission.result.catch(() => {});
+  }
+  return state;
 }
 
 type ServerMode = {
@@ -738,59 +767,53 @@ describe('analyze-project gRPC server', () => {
     }
   });
 
-  it('should reject concurrent unary requests while a stream is active', async () => {
-    const streamRequestId = createDeferred<string>();
+  it('should queue concurrent stream and unary requests in arrival order', async () => {
+    const startedRequests = [
+      createDeferred<AnalyzeWorkerRequest>(),
+      createDeferred<AnalyzeWorkerRequest>(),
+      createDeferred<AnalyzeWorkerRequest>(),
+    ];
+    let startedRequestCount = 0;
     const worker = new FakeWorker(message => {
-      if (message.type === 'analyze-stream') {
-        streamRequestId.resolve(message.requestId);
+      if (message.type === 'analyze-stream' || message.type === 'analyze-unary') {
+        startedRequests[startedRequestCount++].resolve(message);
       }
     });
 
     await withAnalyzeProjectServer(worker as unknown as Worker, async client => {
-      const streamCall = client.startAnalyzeProject(createAnalyzeProjectRequest());
-      const responsesPromise = client.readAnalyzeProject(streamCall);
-      const requestId = await streamRequestId.promise;
+      const firstCall = client.startAnalyzeProject(createAnalyzeProjectRequest());
+      const firstResponses = client.readAnalyzeProject(firstCall);
+      const firstRequest = await startedRequests[0].promise;
+      const unaryResponse = client.analyzeProjectUnary(createAnalyzeProjectRequest());
+      const lastCall = client.startAnalyzeProject(createAnalyzeProjectRequest());
+      const lastResponses = client.readAnalyzeProject(lastCall);
+      await delay(0);
 
-      await expect(client.analyzeProjectUnary(createAnalyzeProjectRequest())).rejects.toMatchObject(
-        {
-          code: grpc.status.RESOURCE_EXHAUSTED,
-          details: 'Another analysis is already running',
-        },
-      );
-
+      expect(startedRequestCount).toBe(1);
       worker.emitMessage({
-        requestId,
+        requestId: firstRequest.requestId,
         result: { result: undefined, type: 'success' },
         type: 'stream-complete',
       });
-      await responsesPromise;
-    });
-  });
+      await firstResponses;
 
-  it('should reject concurrent stream requests while a stream is active', async () => {
-    const streamRequestId = createDeferred<string>();
-    const worker = new FakeWorker(message => {
-      if (message.type === 'analyze-stream') {
-        streamRequestId.resolve(message.requestId);
-      }
-    });
-
-    await withAnalyzeProjectServer(worker as unknown as Worker, async client => {
-      const streamCall = client.startAnalyzeProject(createAnalyzeProjectRequest());
-      const activeResponsesPromise = client.readAnalyzeProject(streamCall);
-      const requestId = await streamRequestId.promise;
-
-      await expect(client.analyzeProject(createAnalyzeProjectRequest())).rejects.toMatchObject({
-        code: grpc.status.RESOURCE_EXHAUSTED,
-        details: 'Another analysis is already running',
-      });
-
+      const secondRequest = await startedRequests[1].promise;
+      expect(secondRequest.type).toBe('analyze-unary');
       worker.emitMessage({
-        requestId,
+        requestId: secondRequest.requestId,
+        result: { result: createAnalyzeProjectUnaryResponse(), type: 'success' },
+        type: 'unary-complete',
+      });
+      await unaryResponse;
+
+      const thirdRequest = await startedRequests[2].promise;
+      expect(thirdRequest.type).toBe('analyze-stream');
+      worker.emitMessage({
+        requestId: thirdRequest.requestId,
         result: { result: undefined, type: 'success' },
         type: 'stream-complete',
       });
-      await activeResponsesPromise;
+      await lastResponses;
     });
   });
 
@@ -860,10 +883,195 @@ describe('analyze-project gRPC server', () => {
     await delay(0);
 
     expect(replacementCall.ended).toBe(true);
-    expect(state.analysisInProgress).toBe(false);
+    expect(state.analysisQueue.hasActive).toBe(false);
   });
 
-  it('should release the analysis slot before ending a completed stream', async t => {
+  it('should remove a cancelled request from the pending queue', async () => {
+    const startedRequests = [createDeferred<string>(), createDeferred<string>()];
+    let startedRequestCount = 0;
+    let cancelCalls = 0;
+    const worker = new FakeWorker(message => {
+      if (message.type === 'analyze-stream') {
+        startedRequests[startedRequestCount++].resolve(message.requestId);
+      }
+    });
+    const state = createUnitServerState();
+    const streamHandler = analyzeProjectServerInternals.createAnalyzeProjectStreamHandler({
+      handleRequestInCurrentThread: async () => {
+        throw new Error('Unexpected in-process analyze-project request');
+      },
+      lifecycle: {
+        clearStartupShutdownTimeout: () => {},
+        requestCancel: async () => {
+          cancelCalls += 1;
+          return true;
+        },
+        scheduleStartupShutdownTimeout: () => {},
+        shutdown: async () => {},
+      },
+      newWorkerRequestId: (() => {
+        let requestId = 0;
+        return () => String(++requestId);
+      })(),
+      state,
+      worker: worker as unknown as Worker,
+    });
+    const activeCall = new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest());
+    const cancelledCall = new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest());
+    const nextCall = new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest());
+
+    void streamHandler(
+      activeCall as unknown as grpc.ServerWritableStream<
+        AnalyzeProjectRequest,
+        AnalyzeProjectStreamResponse
+      >,
+    );
+    const activeRequestId = await startedRequests[0].promise;
+    void streamHandler(
+      cancelledCall as unknown as grpc.ServerWritableStream<
+        AnalyzeProjectRequest,
+        AnalyzeProjectStreamResponse
+      >,
+    );
+    cancelledCall.emit('cancelled');
+    void streamHandler(
+      nextCall as unknown as grpc.ServerWritableStream<
+        AnalyzeProjectRequest,
+        AnalyzeProjectStreamResponse
+      >,
+    );
+
+    expect(state.analysisQueue.pendingCount).toBe(1);
+    expect(cancelCalls).toBe(0);
+    worker.emitMessage({
+      requestId: activeRequestId,
+      result: { result: undefined, type: 'success' },
+      type: 'stream-complete',
+    });
+    const nextRequestId = await startedRequests[1].promise;
+    worker.emitMessage({
+      requestId: nextRequestId,
+      result: { result: undefined, type: 'success' },
+      type: 'stream-complete',
+    });
+    await delay(0);
+
+    expect(cancelledCall.ended).toBe(false);
+    expect(nextCall.ended).toBe(true);
+    expect(state.analysisQueue.hasActive).toBe(false);
+  });
+
+  it('should reject requests when the pending queue is full', async () => {
+    const requestIds: string[] = [];
+    const worker = new FakeWorker(message => {
+      if (message.type === 'analyze-stream') {
+        requestIds.push(message.requestId);
+      }
+    });
+    const state = createUnitServerState({ maxPendingAnalysisRequests: 1 });
+    const streamHandler = analyzeProjectServerInternals.createAnalyzeProjectStreamHandler({
+      handleRequestInCurrentThread: async () => {
+        throw new Error('Unexpected in-process analyze-project request');
+      },
+      lifecycle: {
+        clearStartupShutdownTimeout: () => {},
+        requestCancel: async () => true,
+        scheduleStartupShutdownTimeout: () => {},
+        shutdown: async () => {},
+      },
+      newWorkerRequestId: (() => {
+        let requestId = 0;
+        return () => String(++requestId);
+      })(),
+      state,
+      worker: worker as unknown as Worker,
+    });
+    const calls = [
+      new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest()),
+      new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest()),
+      new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest()),
+    ];
+
+    for (const call of calls) {
+      void streamHandler(
+        call as unknown as grpc.ServerWritableStream<
+          AnalyzeProjectRequest,
+          AnalyzeProjectStreamResponse
+        >,
+      );
+    }
+    await delay(0);
+
+    expect(calls[2].error).toMatchObject({
+      code: grpc.status.RESOURCE_EXHAUSTED,
+      details: 'Analyze-project request queue is full',
+    });
+    worker.emitMessage({
+      requestId: requestIds[0],
+      result: { result: undefined, type: 'success' },
+      type: 'stream-complete',
+    });
+    await delay(0);
+    worker.emitMessage({
+      requestId: requestIds[1],
+      result: { result: undefined, type: 'success' },
+      type: 'stream-complete',
+    });
+    await delay(0);
+
+    expect(calls[0].ended).toBe(true);
+    expect(calls[1].ended).toBe(true);
+  });
+
+  it('should cancel an active unary request before starting the next request', async () => {
+    const unaryRequestId = createDeferred<string>();
+    const replacementRequestId = createDeferred<string>();
+    let replacementStarted = false;
+    const worker = new FakeWorker(message => {
+      if (message.type === 'analyze-unary') {
+        unaryRequestId.resolve(message.requestId);
+      } else if (message.type === 'analyze-stream') {
+        replacementStarted = true;
+        replacementRequestId.resolve(message.requestId);
+      } else if (message.type === 'cancel') {
+        worker.emitMessage({
+          requestId: message.requestId,
+          result: { result: undefined, type: 'success' },
+          type: 'cancel-complete',
+        });
+      }
+    });
+
+    await withAnalyzeProjectServer(worker as unknown as Worker, async client => {
+      const unary = client.startAnalyzeProjectUnary(createAnalyzeProjectRequest());
+      const activeRequestId = await unaryRequestId.promise;
+      const cancelledResponse = expect(unary.response).rejects.toMatchObject({
+        code: grpc.status.CANCELLED,
+      });
+      unary.call.cancel();
+      const replacementCall = client.startAnalyzeProject(createAnalyzeProjectRequest());
+      const replacementResponses = client.readAnalyzeProject(replacementCall);
+      await delay(0);
+
+      expect(replacementStarted).toBe(false);
+      worker.emitMessage({
+        requestId: activeRequestId,
+        result: { result: createAnalyzeProjectUnaryResponse(), type: 'success' },
+        type: 'unary-complete',
+      });
+      const nextRequestId = await replacementRequestId.promise;
+      worker.emitMessage({
+        requestId: nextRequestId,
+        result: { result: undefined, type: 'success' },
+        type: 'stream-complete',
+      });
+
+      await cancelledResponse;
+      await replacementResponses;
+    });
+  });
+
+  it('should release the active queue entry before ending a completed stream', async t => {
     const worker = new FakeWorker(message => {
       if (message.type === 'analyze-stream') {
         worker.emitMessage({
@@ -932,7 +1140,7 @@ describe('analyze-project gRPC server', () => {
         expect(firstCall.ended).toBe(true);
         expect(secondCall.error).toBeUndefined();
         expect(secondCall.ended).toBe(true);
-        expect(state.analysisInProgress).toBe(false);
+        expect(state.analysisQueue.hasActive).toBe(false);
       });
     }
   });
@@ -1137,7 +1345,7 @@ describe('analyze-project gRPC server', () => {
     let unregisterCalls = 0;
     const startupShutdownTimeout = setTimeout(() => {}, 1_000);
     const state = createUnitServerState({
-      analysisInProgress: true,
+      activeAnalysis: true,
       leaseCall: {
         end: () => {
           throw new Error('lease end failed');
@@ -1188,7 +1396,7 @@ describe('analyze-project gRPC server', () => {
           forceShutdownCalls += 1;
         },
       } as unknown as grpc.Server,
-      state: createUnitServerState({ analysisInProgress: true }),
+      state: createUnitServerState({ activeAnalysis: true }),
       timeout: 0,
       unregisterGarbageCollectionObserver: () => {},
       worker: {

--- a/packages/grpc/tests/analyze-project-server.test.ts
+++ b/packages/grpc/tests/analyze-project-server.test.ts
@@ -947,7 +947,7 @@ describe('analyze-project gRPC server', () => {
     expect(state.analysisQueue.hasActive).toBe(false);
   });
 
-  it('should remove a cancelled request from the pending queue', async () => {
+  it('should remove a transport-cancelled request from the pending queue', async () => {
     const startedRequests = [createDeferred<string>(), createDeferred<string>()];
     let startedRequestCount = 0;
     let cancelCalls = 0;
@@ -1084,7 +1084,7 @@ describe('analyze-project gRPC server', () => {
     expect(calls[1].ended).toBe(true);
   });
 
-  it('should cancel an active unary request before starting the next request', async () => {
+  it('should propagate active unary transport cancellation before starting the next request', async () => {
     const unaryRequestId = createDeferred<string>();
     const replacementRequestId = createDeferred<string>();
     let replacementStarted = false;
@@ -1206,7 +1206,7 @@ describe('analyze-project gRPC server', () => {
     }
   });
 
-  it('should cancel an active worker analysis through the cancel RPC', async () => {
+  it('should cancel an active worker analysis through the explicit CancelAnalysis RPC', async () => {
     const streamRequestId = createDeferred<string>();
     const worker = new FakeWorker(message => {
       if (message.type === 'analyze-stream') {

--- a/packages/grpc/tests/analyze-project-server.test.ts
+++ b/packages/grpc/tests/analyze-project-server.test.ts
@@ -30,6 +30,7 @@ import {
   analyzeProjectServerInternals,
   startAnalyzeProjectServer,
 } from '../src/analyze-project-server.js';
+import { createServerState } from '../src/analyze-project-server-lifecycle.js';
 import { createAnalyzeProjectWorker } from '../src/analyze-project-worker/create-worker.js';
 import { sonarjs as analyzeProjectProto } from '../src/proto/analyze-project.js';
 import type {
@@ -444,10 +445,9 @@ function createUnitServerState({
   startupShutdownTimeout?: NodeJS.Timeout | null;
 } = {}) {
   return {
+    ...createServerState(),
     analysisInProgress,
     leaseCall: leaseCall as unknown as grpc.ServerDuplexStream<LeaseRequest, LeaseResponse> | null,
-    nextWorkerRequestId: 0,
-    shuttingDown: false,
     startupShutdownTimeout,
   };
 }
@@ -792,6 +792,75 @@ describe('analyze-project gRPC server', () => {
       });
       await activeResponsesPromise;
     });
+  });
+
+  it('should wait for a cancelled stream to complete before starting its replacement', async () => {
+    const firstRequestStarted = createDeferred<string>();
+    const replacementRequestStarted = createDeferred<string>();
+    let startedRequestCount = 0;
+    const worker = new FakeWorker(message => {
+      if (message.type === 'analyze-stream') {
+        startedRequestCount += 1;
+        (startedRequestCount === 1 ? firstRequestStarted : replacementRequestStarted).resolve(
+          message.requestId,
+        );
+      }
+    });
+    const state = createUnitServerState();
+    const streamHandler = analyzeProjectServerInternals.createAnalyzeProjectStreamHandler({
+      handleRequestInCurrentThread: async () => {
+        throw new Error('Unexpected in-process analyze-project request');
+      },
+      lifecycle: {
+        clearStartupShutdownTimeout: () => {},
+        requestCancel: async () => true,
+        scheduleStartupShutdownTimeout: () => {},
+        shutdown: async () => {},
+      },
+      newWorkerRequestId: (() => {
+        let requestId = 0;
+        return () => String(++requestId);
+      })(),
+      state,
+      worker: worker as unknown as Worker,
+    });
+    const firstCall = new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest());
+    const replacementCall = new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest());
+
+    streamHandler(
+      firstCall as unknown as grpc.ServerWritableStream<
+        AnalyzeProjectRequest,
+        AnalyzeProjectStreamResponse
+      >,
+    );
+    const firstRequestId = await firstRequestStarted.promise;
+    firstCall.emit('cancelled');
+    streamHandler(
+      replacementCall as unknown as grpc.ServerWritableStream<
+        AnalyzeProjectRequest,
+        AnalyzeProjectStreamResponse
+      >,
+    );
+    await delay(0);
+
+    expect(replacementCall.error).toBeUndefined();
+    expect(startedRequestCount).toBe(1);
+
+    worker.emitMessage({
+      requestId: firstRequestId,
+      result: { result: undefined, type: 'success' },
+      type: 'stream-complete',
+    });
+    const replacementRequestId = await replacementRequestStarted.promise;
+    worker.emitMessage({
+      requestId: replacementRequestId,
+      result: { result: undefined, type: 'success' },
+      type: 'stream-complete',
+    });
+    await delay(0);
+
+    expect(replacementCall.ended).toBe(true);
+    expect(state.analysisInProgress).toBe(false);
   });
 
   it('should release the analysis slot before ending a completed stream', async t => {

--- a/packages/grpc/tests/analyze-project-server.test.ts
+++ b/packages/grpc/tests/analyze-project-server.test.ts
@@ -456,25 +456,17 @@ class FakeAnalyzeProjectUnaryCall extends EventEmitter {
 
 function createUnitServerState({
   activeAnalysis = false,
-  cancellationGraceMs,
   leaseCall = null,
   maxPendingAnalysisRequests,
-  onCancellationFailure,
   startupShutdownTimeout = null,
 }: {
   activeAnalysis?: boolean;
-  cancellationGraceMs?: number;
   leaseCall?: { end: () => void } | null;
   maxPendingAnalysisRequests?: number;
-  onCancellationFailure?: () => void | Promise<void>;
   startupShutdownTimeout?: NodeJS.Timeout | null;
 } = {}) {
   const state = {
-    ...createServerState({
-      cancellationGraceMs,
-      maxPendingAnalysisRequests,
-      onCancellationFailure,
-    }),
+    ...createServerState({ maxPendingAnalysisRequests }),
     leaseCall: leaseCall as unknown as grpc.ServerDuplexStream<LeaseRequest, LeaseResponse> | null,
     startupShutdownTimeout,
   };

--- a/packages/grpc/tests/analyze-project-server.test.ts
+++ b/packages/grpc/tests/analyze-project-server.test.ts
@@ -420,6 +420,7 @@ class FakeWorker extends EventEmitter {
 }
 
 class FakeAnalyzeProjectStreamCall extends EventEmitter {
+  public cancelled = false;
   public ended = false;
   public error: grpc.ServiceError | undefined;
   public readonly responses: AnalyzeProjectStreamResponse[] = [];
@@ -444,26 +445,35 @@ class FakeAnalyzeProjectStreamCall extends EventEmitter {
   }
 }
 
+class FakeAnalyzeProjectUnaryCall extends EventEmitter {
+  constructor(
+    public readonly request: AnalyzeProjectRequest,
+    public cancelled = false,
+  ) {
+    super();
+  }
+}
+
 function createUnitServerState({
   activeAnalysis = false,
-  cancellationTimeoutMs,
+  cancellationGraceMs,
   leaseCall = null,
   maxPendingAnalysisRequests,
-  onCancellationTimeout,
+  onCancellationFailure,
   startupShutdownTimeout = null,
 }: {
   activeAnalysis?: boolean;
-  cancellationTimeoutMs?: number;
+  cancellationGraceMs?: number;
   leaseCall?: { end: () => void } | null;
   maxPendingAnalysisRequests?: number;
-  onCancellationTimeout?: () => void | Promise<void>;
+  onCancellationFailure?: () => void | Promise<void>;
   startupShutdownTimeout?: NodeJS.Timeout | null;
 } = {}) {
   const state = {
     ...createServerState({
-      cancellationTimeoutMs,
+      cancellationGraceMs,
       maxPendingAnalysisRequests,
-      onCancellationTimeout,
+      onCancellationFailure,
     }),
     leaseCall: leaseCall as unknown as grpc.ServerDuplexStream<LeaseRequest, LeaseResponse> | null,
     startupShutdownTimeout,
@@ -765,6 +775,57 @@ describe('analyze-project gRPC server', () => {
         });
       });
     }
+  });
+
+  it('should ignore analyze-project calls cancelled before handling', async t => {
+    const workerMessages: AnalyzeProjectWorkerInMessage[] = [];
+    const worker = new FakeWorker(message => workerMessages.push(message));
+    const state = createUnitServerState();
+    const dependencies = {
+      handleRequestInCurrentThread: async () => {
+        throw new Error('Unexpected in-process analyze-project request');
+      },
+      lifecycle: {
+        clearStartupShutdownTimeout: () => {},
+        requestCancel: async () => true,
+        scheduleStartupShutdownTimeout: () => {},
+        shutdown: async () => {},
+      },
+      newWorkerRequestId: () => '1',
+      state,
+      worker: worker as unknown as Worker,
+    };
+
+    await t.test('stream', async () => {
+      const call = new FakeAnalyzeProjectStreamCall(createAnalyzeProjectRequest());
+      call.cancelled = true;
+
+      await analyzeProjectServerInternals.createAnalyzeProjectStreamHandler(dependencies)(
+        call as unknown as grpc.ServerWritableStream<
+          AnalyzeProjectRequest,
+          AnalyzeProjectStreamResponse
+        >,
+      );
+
+      expect(call.ended).toBe(false);
+    });
+
+    await t.test('unary', async () => {
+      const call = new FakeAnalyzeProjectUnaryCall(createAnalyzeProjectRequest(), true);
+      let callbackCalled = false;
+
+      await analyzeProjectServerInternals.createAnalyzeProjectUnaryHandler(dependencies)(
+        call as unknown as grpc.ServerUnaryCall<AnalyzeProjectRequest, AnalyzeProjectUnaryResponse>,
+        () => {
+          callbackCalled = true;
+        },
+      );
+
+      expect(callbackCalled).toBe(false);
+    });
+
+    expect(workerMessages).toEqual([]);
+    expect(state.analysisQueue.hasActive).toBe(false);
   });
 
   it('should queue concurrent stream and unary requests in arrival order', async () => {


### PR DESCRIPTION
## Summary

- serialize stream and unary analysis calls through a server-owned FIFO queue, with one active request and up to 4 pending requests
- return `RESOURCE_EXHAUSTED` only when the pending queue is full, without relying on SonarQube for IDE request sequencing
- distinguish transport-call cancellation, which owns one submitted request, from the explicit `CancelAnalysis` RPC, which targets whichever analysis is active
- deduplicate the worker cancellation signal if both cancellation paths target the same active request, while allowing failed or unacknowledged signals to be retried
- reject calls cancelled before handling without starting analysis
- treat cancellation as cooperative: acknowledgement does not release the queue; only completion of the active execution starts the next request
- keep the gRPC server alive when cancellation fails or an analysis remains stuck; recovery for a truly stuck worker is not implemented and supervised worker replacement remains out of scope
- document and test ordering, backpressure, both cancellation paths, and queue ownership during cancellation

## Testing

- `npx tsc -b packages`
- `npm run bbf`
- `npm run bridge:test` (2366 tests passed)
- focused analyze-project queue and gRPC tests (56 tests passed)
- Prettier checks for changed Markdown and TypeScript files
- `git diff --check`
