### PR TITLE
JS-2327 Avoid preloading unrelated generated-source config files

### DIFF
--- a/packages/analysis/src/file-stores/generated-sources/snapshot-files.ts
+++ b/packages/analysis/src/file-stores/generated-sources/snapshot-files.ts
@@ -30,7 +30,7 @@ const GENERATED_SOURCE_SOURCE_CONFIG_EXTENSIONS = new Set([
 const GENERATED_SOURCE_STRUCTURED_CONFIG_EXTENSIONS = new Set(['.json', '.yaml', '.yml']);
 
 export function shouldCaptureGeneratedSourceSnapshotPath(filePath: NormalizedAbsolutePath) {
-  if (basename(filePath).toLowerCase() === PACKAGE_JSON) {
+  if (isPackageJsonPath(filePath)) {
     return false;
   }
 
@@ -43,4 +43,12 @@ export function shouldCaptureGeneratedSourceSnapshotPath(filePath: NormalizedAbs
     GENERATED_SOURCE_SOURCE_CONFIG_EXTENSIONS.has(extension) ||
     GENERATED_SOURCE_STRUCTURED_CONFIG_EXTENSIONS.has(extension)
   );
+}
+
+export function shouldPreloadGeneratedSourceSnapshotPath(filePath: NormalizedAbsolutePath) {
+  return !isPackageJsonPath(filePath) && shouldPreloadGeneratedSourcePath(filePath);
+}
+
+function isPackageJsonPath(filePath: NormalizedAbsolutePath) {
+  return basename(filePath).toLowerCase() === PACKAGE_JSON;
 }

--- a/packages/analysis/src/file-stores/generated-sources/store.ts
+++ b/packages/analysis/src/file-stores/generated-sources/store.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { basename } from 'node:path/posix';
-import type { FileStore } from '../store-type.js';
+import type { FileStore, FileStoreContext } from '../store-type.js';
 import type { DependencyManifestStore } from '../dependency-manifests.js';
 import {
   getProjectFileDiscoveryConfigKey,
@@ -42,7 +42,10 @@ import {
   logMatchedGeneratedSourceFiles,
   logGeneratedSourceObservability,
 } from './observability.js';
-import { shouldCaptureGeneratedSourceSnapshotPath } from './snapshot-files.js';
+import {
+  shouldCaptureGeneratedSourceSnapshotPath,
+  shouldPreloadGeneratedSourceSnapshotPath,
+} from './snapshot-files.js';
 
 type DependencyManifestLookup = Pick<DependencyManifestStore, 'getPackageJsons'>;
 
@@ -57,6 +60,7 @@ export class GeneratedSourceStore implements FileStore {
   private derivedFamilyByFile = new Map<NormalizedAbsolutePath, string>();
   private configPaths = new Set<NormalizedAbsolutePath>();
   private watchedConfigPaths = new Set<NormalizedAbsolutePath>();
+  private preloadCandidatePaths = new Set<NormalizedAbsolutePath>();
   private preloadedFiles = new Map<NormalizedAbsolutePath, File>();
   private sourceFiles = new Set<NormalizedAbsolutePath>();
   private walkedDirectories = new Set<NormalizedAbsolutePath>();
@@ -166,8 +170,12 @@ export class GeneratedSourceStore implements FileStore {
   }
 
   wantsFile(filename: NormalizedAbsolutePath, configuration: Configuration) {
-    if (shouldCaptureGeneratedSourceSnapshotPath(filename)) {
+    if (shouldPreloadGeneratedSourceSnapshotPath(filename)) {
       return 'content';
+    }
+
+    if (shouldCaptureGeneratedSourceSnapshotPath(filename)) {
+      return 'deferred-content';
     }
 
     return isJsTsFile(filename, configuration) ? 'path' : false;
@@ -178,6 +186,10 @@ export class GeneratedSourceStore implements FileStore {
     configuration: Configuration,
     file?: File,
   ): Promise<void> {
+    if (shouldCaptureGeneratedSourceSnapshotPath(filename)) {
+      this.preloadCandidatePaths.add(filename);
+    }
+
     if (isJsTsFile(filename, configuration)) {
       this.sourceFiles.add(filename);
     }
@@ -191,7 +203,7 @@ export class GeneratedSourceStore implements FileStore {
     this.walkedDirectories.add(dir);
   }
 
-  async postProcess(configuration: Configuration) {
+  async postProcess(configuration: Configuration, context: FileStoreContext) {
     if (!configuration.detectGeneratedCode) {
       this.clearCache();
       return;
@@ -207,11 +219,12 @@ export class GeneratedSourceStore implements FileStore {
       const packageJsons = this.dependencyManifestStore.getPackageJsons();
       const packageContexts = await collectGeneratedSourcePackageContexts(baseDir, packageJsons);
       this.addPackageJsonsToSnapshot(packageJsons);
-      const projectSnapshot = this.createProjectSnapshot();
       this.watchedConfigPaths = await collectGeneratedSourceDeclaredPreloadPaths(
         baseDir,
         packageContexts,
       );
+      await this.preloadDeclaredConfigFiles(context);
+      const projectSnapshot = this.createProjectSnapshot();
       const derived = await deriveGeneratedSources(baseDir, packageJsons, {
         packageContexts,
         projectSnapshot,
@@ -261,6 +274,7 @@ export class GeneratedSourceStore implements FileStore {
   }
 
   private clearSnapshotState() {
+    this.preloadCandidatePaths = new Set();
     this.preloadedFiles = new Map();
     this.sourceFiles = new Set();
     this.walkedDirectories = new Set();
@@ -269,6 +283,15 @@ export class GeneratedSourceStore implements FileStore {
   private addPackageJsonsToSnapshot(packageJsons: ReadonlyMap<NormalizedAbsolutePath, File>) {
     for (const file of packageJsons.values()) {
       this.preloadedFiles.set(file.filePath, file);
+    }
+  }
+
+  private async preloadDeclaredConfigFiles(context: FileStoreContext) {
+    for (const filePath of this.watchedConfigPaths) {
+      if (!this.preloadCandidatePaths.has(filePath) || this.preloadedFiles.has(filePath)) {
+        continue;
+      }
+      this.preloadedFiles.set(filePath, await context.getFile(filePath));
     }
   }
 

--- a/packages/analysis/src/file-stores/index.ts
+++ b/packages/analysis/src/file-stores/index.ts
@@ -19,7 +19,7 @@ import { DependencyManifestStore } from './dependency-manifests.js';
 import { GeneratedSourceStore } from './generated-sources/index.js';
 import { TsConfigStore } from './tsconfigs.js';
 import { findFiles } from '../common/find-files.js';
-import type { FileStore } from './store-type.js';
+import type { FileStore, FileStoreContext } from './store-type.js';
 import type { Configuration } from '../common/configuration.js';
 import {
   isRoot,
@@ -63,6 +63,8 @@ export async function initFileStores(configuration: Configuration, inputFiles?: 
     return;
   }
 
+  const context = createFileStoreContext(inputFiles);
+
   for (const store of pendingStores) {
     store.setup(configuration);
   }
@@ -76,14 +78,14 @@ export async function initFileStores(configuration: Configuration, inputFiles?: 
       }
 
       if (entry.isFile()) {
-        await processPendingFileStores(pendingStores, filePath, configuration);
+        await processPendingFileStores(pendingStores, filePath, configuration, context);
       }
     });
   } else if (inputFiles) {
-    await simulateFromInputFiles(inputFiles, configuration, pendingStores);
+    await simulateFromInputFiles(inputFiles, configuration, pendingStores, context);
   }
   for (const store of pendingStores) {
-    await store.postProcess(configuration);
+    await store.postProcess(configuration, context);
   }
 }
 
@@ -91,6 +93,7 @@ export async function simulateFromInputFiles(
   inputFiles: AnalyzableFiles,
   configuration: Configuration,
   pendingStores: FileStore[],
+  context = createFileStoreContext(inputFiles),
 ) {
   const { baseDir } = configuration;
   // simulate file system traversal from baseDir to each given input file
@@ -121,6 +124,7 @@ export async function simulateFromInputFiles(
       pendingStores,
       filePath,
       configuration,
+      context,
       inputFiles[filePath].fileContent,
     );
   }
@@ -130,19 +134,51 @@ async function processPendingFileStores(
   pendingStores: FileStore[],
   filePath: NormalizedAbsolutePath,
   configuration: Configuration,
+  context: FileStoreContext,
   fileContent?: string,
 ) {
+  const storeRequests = pendingStores.map(store => ({
+    store,
+    request: store.wantsFile(filePath, configuration),
+  }));
+  if (storeRequests.some(({ request }) => request === 'deferred-content')) {
+    context.retainFile(filePath);
+  }
+
   let sharedFile: File | undefined;
-  for (const store of pendingStores) {
-    const storeWantsFile = store.wantsFile(filePath, configuration);
+  for (const { store, request: storeWantsFile } of storeRequests) {
     if (storeWantsFile === 'content') {
-      sharedFile ??= {
-        filePath,
-        fileContent: fileContent ?? (await readFile(filePath)),
-      };
+      sharedFile ??= await context.getFile(filePath, fileContent);
       await store.processFile(filePath, configuration, sharedFile);
-    } else if (storeWantsFile === 'path') {
+    } else if (storeWantsFile === 'path' || storeWantsFile === 'deferred-content') {
       await store.processFile(filePath, configuration);
     }
   }
+}
+
+function createFileStoreContext(inputFiles?: AnalyzableFiles): FileStoreContext {
+  const retainedPaths = new Set<NormalizedAbsolutePath>();
+  const files = new Map<NormalizedAbsolutePath, Promise<File>>();
+
+  return {
+    retainFile(filePath) {
+      retainedPaths.add(filePath);
+    },
+    getFile(filePath, fileContent) {
+      let file = files.get(filePath);
+      if (!file) {
+        const inputFile = inputFiles?.[filePath];
+        file = inputFile
+          ? Promise.resolve(inputFile)
+          : Promise.resolve(fileContent ?? readFile(filePath)).then(fileContent => ({
+              filePath,
+              fileContent,
+            }));
+        if (retainedPaths.has(filePath)) {
+          files.set(filePath, file);
+        }
+      }
+      return file;
+    },
+  };
 }

--- a/packages/analysis/src/file-stores/store-type.ts
+++ b/packages/analysis/src/file-stores/store-type.ts
@@ -25,7 +25,10 @@ import type { AnalyzableFiles } from '../projectAnalysis.js';
 export type FileProcessingMode = 'path' | 'content' | 'deferred-content';
 
 export type FileStoreContext = {
-  /** Preserve a file if another store reads it, without triggering a read itself. */
+  /**
+   * Mark a file path so its content is cached on its first `getFile` call.
+   * Must be called before the first `getFile` call for that path.
+   */
   retainFile(filePath: NormalizedAbsolutePath): void;
   getFile(filePath: NormalizedAbsolutePath, fileContent?: string): Promise<File>;
 };

--- a/packages/analysis/src/file-stores/store-type.ts
+++ b/packages/analysis/src/file-stores/store-type.ts
@@ -18,7 +18,17 @@ import type { File, NormalizedAbsolutePath } from '../../../shared/src/helpers/f
 import type { Configuration } from '../common/configuration.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
 
-export type FileProcessingMode = 'path' | 'content';
+/**
+ * `deferred-content` processes the path during the walk while preserving any shared content read
+ * for a later request from `postProcess`.
+ */
+export type FileProcessingMode = 'path' | 'content' | 'deferred-content';
+
+export type FileStoreContext = {
+  /** Preserve a file if another store reads it, without triggering a read itself. */
+  retainFile(filePath: NormalizedAbsolutePath): void;
+  getFile(filePath: NormalizedAbsolutePath, fileContent?: string): Promise<File>;
+};
 
 export abstract class FileStore {
   /**
@@ -55,7 +65,7 @@ export abstract class FileStore {
    *
    * @param configuration - The project configuration
    */
-  abstract postProcess(configuration: Configuration): Promise<void>;
+  abstract postProcess(configuration: Configuration, context: FileStoreContext): Promise<void>;
 
   abstract processDirectory?(dir: NormalizedAbsolutePath, configuration: Configuration): void;
 }

--- a/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
+++ b/packages/analysis/tests/jsts/project-metadata/generated-sources.test.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
+import fs from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -43,7 +44,10 @@ import {
   collectGeneratedSourceTaskInvocations,
   getGeneratedSourceWatchedFilenames,
 } from '../../../src/file-stores/generated-sources/index.js';
-import { shouldCaptureGeneratedSourceSnapshotPath } from '../../../src/file-stores/generated-sources/snapshot-files.js';
+import {
+  shouldCaptureGeneratedSourceSnapshotPath,
+  shouldPreloadGeneratedSourceSnapshotPath,
+} from '../../../src/file-stores/generated-sources/snapshot-files.js';
 import {
   joinPaths,
   normalizeToAbsolutePath,
@@ -225,23 +229,61 @@ describe('generated sources project metadata', () => {
     );
   });
 
-  it('preloads detector inputs without snapshotting package.json or plain TSX source files', () => {
+  it('tracks config candidates while preloading only detector-specific inputs', () => {
     const baseDir = normalizeToAbsolutePath('/project');
+    const customConfigPath = joinPaths(baseDir, 'config', 'custom-codegen.ts');
+    const packageJsonPath = joinPaths(baseDir, 'package.json');
+    const openApiManifestPath = joinPaths(baseDir, 'src', '.openapi-generator', 'FILES');
+    const sourcePath = joinPaths(baseDir, 'src', 'App.tsx');
 
-    expect(
-      shouldCaptureGeneratedSourceSnapshotPath(joinPaths(baseDir, 'config', 'custom-codegen.ts')),
-    ).toBe(true);
-    expect(shouldCaptureGeneratedSourceSnapshotPath(joinPaths(baseDir, 'package.json'))).toBe(
-      false,
-    );
-    expect(
-      shouldCaptureGeneratedSourceSnapshotPath(
-        joinPaths(baseDir, 'src', '.openapi-generator', 'FILES'),
-      ),
-    ).toBe(true);
-    expect(shouldCaptureGeneratedSourceSnapshotPath(joinPaths(baseDir, 'src', 'App.tsx'))).toBe(
-      false,
-    );
+    expect(shouldCaptureGeneratedSourceSnapshotPath(customConfigPath)).toBe(true);
+    expect(shouldPreloadGeneratedSourceSnapshotPath(customConfigPath)).toBe(false);
+    expect(shouldCaptureGeneratedSourceSnapshotPath(packageJsonPath)).toBe(false);
+    expect(shouldPreloadGeneratedSourceSnapshotPath(packageJsonPath)).toBe(false);
+    expect(shouldCaptureGeneratedSourceSnapshotPath(openApiManifestPath)).toBe(true);
+    expect(shouldPreloadGeneratedSourceSnapshotPath(openApiManifestPath)).toBe(true);
+    expect(shouldCaptureGeneratedSourceSnapshotPath(sourcePath)).toBe(false);
+    expect(shouldPreloadGeneratedSourceSnapshotPath(sourcePath)).toBe(false);
+  });
+
+  it('does not read unrelated config candidates when scanner files are provided', async ({
+    mock,
+  }) => {
+    const baseDir = await createTempBaseDir();
+    const jsonPath = joinPaths(baseDir, 'benchmark-data.json');
+    const yamlPath = joinPaths(baseDir, 'test-data.yaml');
+    const htmlPath = joinPaths(baseDir, 'Documentation', 'swagger.html');
+
+    try {
+      await writeFixtureFile(jsonPath, '{}');
+      await writeFixtureFile(yamlPath, 'fixture: true\n');
+      await writeFixtureFile(htmlPath, '<html></html>');
+      const configuration = createConfiguration({ baseDir });
+      const { files: inputFiles } = await sanitizeRawInputFiles(
+        {
+          [htmlPath]: {
+            filePath: htmlPath,
+            fileType: 'MAIN',
+            fileContent: '<html></html>',
+          },
+        },
+        configuration,
+      );
+      const originalReadFile = fs.promises.readFile;
+      let unrelatedReadCount = 0;
+      mock.method(fs.promises, 'readFile', async (path, options) => {
+        if (path === jsonPath || path === yamlPath) {
+          unrelatedReadCount++;
+        }
+        return Reflect.apply(originalReadFile, fs.promises, [path, options]);
+      });
+
+      await initFileStores(configuration, inputFiles);
+
+      expect(unrelatedReadCount).toEqual(0);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
   });
 
   it('collects and normalizes package.json task invocations', async () => {
@@ -753,6 +795,53 @@ export default config;
       );
 
       expect(derived.familyByFile.get(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads an explicit GraphQL config only once across file stores', async ({ mock }) => {
+    const baseDir = await createTempBaseDir();
+    const configPath = joinPaths(baseDir, 'config', 'custom-codegen.ts');
+    const outputPath = joinPaths(baseDir, 'src', 'generated', 'sdk.ts');
+
+    try {
+      await writeFixtureFile(
+        joinPaths(baseDir, 'package.json'),
+        JSON.stringify({
+          devDependencies: {
+            [GRAPHQL_CODEGEN_FAMILY]: '1.0.0',
+          },
+          scripts: {
+            codegen: 'graphql-codegen --config ./config/custom-codegen.ts',
+          },
+        }),
+      );
+      await writeFixtureFile(
+        configPath,
+        `export default {
+  generates: {
+    './src/generated/sdk.ts': {
+      plugins: ['typescript'],
+    },
+  },
+};
+`,
+      );
+      await writeFixtureFile(outputPath, 'export const sdk = true;\n');
+      const originalReadFile = fs.promises.readFile;
+      let configReadCount = 0;
+      mock.method(fs.promises, 'readFile', async (path, options) => {
+        if (path === configPath) {
+          configReadCount++;
+        }
+        return Reflect.apply(originalReadFile, fs.promises, [path, options]);
+      });
+
+      await initFileStores(createConfiguration({ baseDir }));
+
+      expect(generatedSourceStore.getFamily(outputPath)).toEqual(GRAPHQL_CODEGEN_FAMILY);
+      expect(configReadCount).toEqual(1);
     } finally {
       await rm(baseDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Part of

## Summary

- keep broad generated-source config candidates path-only during filesystem traversal
- load only configs declared by discovered package scripts during post-processing
- reuse content already read by another file store instead of reading a selected config twice

## Motivation

Generated-source initialization could retain every JavaScript, TypeScript, JSON, and YAML file under the project base directory even when the scanner supplied only a small authoritative input set. Large repositories with unrelated data files could therefore exhaust the Node.js heap before file analysis started.

## Testing

- `npx tsc -b packages`
- `npm run bbf`
- targeted file-store and generated-source tests
- `npm run bridge:test` (2,354 tests)
