### PR TITLE
JS-2329 Fix test-file heuristic to preserve source metrics

### DIFF
--- a/packages/analysis/src/analyzeFile.ts
+++ b/packages/analysis/src/analyzeFile.ts
@@ -50,7 +50,7 @@ import { error, info } from '../../shared/src/helpers/logging.js';
  * which is set up in analyzeProject before any files are analyzed.
  *
  * @param fileName - The normalized absolute path of the file to analyze
- * @param file - The stored file data (filePath, fileContent, fileType, fileStatus)
+ * @param file - The stored file data (filePath, fileContent, fileType, ruleFileType, fileStatus)
  * @param configFields - Configuration fields for analysis behavior (from caller's config source)
  * @param program - Optional TypeScript program for type-checking
  * @param results - Output object to accumulate analysis results
@@ -89,12 +89,13 @@ export async function analyzeFile(
 
   // Build complete analysis input from stored file and provided configuration
   // jsTsConfigFields provides config-based values (analysisMode, skipAst, etc.)
-  // Per-file fields (filePath, fileContent, fileType, fileStatus) come from the stored file
+  // Per-file fields (filePath, fileContent, fileType, ruleFileType, fileStatus) come from the stored file
   const input: JsTsAnalysisInput = {
     ...jsTsConfigFields,
     filePath: file.filePath,
     fileContent: file.fileContent,
     fileType: file.fileType,
+    ruleFileType: file.ruleFileType,
     fileStatus: file.fileStatus,
     language: inferLanguageForProjectAnalysis(file.filePath, file.fileContent),
     tsConfigs: [],
@@ -114,6 +115,7 @@ export async function analyzeFile(
       filePath: input.filePath,
       fileContent: input.fileContent,
       fileType: input.fileType,
+      ruleFileType: input.ruleFileType,
       sonarlint: input.sonarlint,
     });
   } else if (isHtmlFile(fileName, htmlSuffixes)) {
@@ -167,6 +169,7 @@ async function mergeAdditionalCssAnalysis(
       filePath: input.filePath,
       fileContent: input.fileContent,
       fileType: input.fileType,
+      ruleFileType: input.ruleFileType,
       sonarlint: input.sonarlint,
     },
     false,

--- a/packages/analysis/src/common/filter/filter-path.ts
+++ b/packages/analysis/src/common/filter/filter-path.ts
@@ -79,11 +79,11 @@ export function filterPathAndGetFileType(
 }
 
 /**
- * Determines which rule set applies to a file. The filename heuristic deliberately affects only
+ * Returns the file type used for rule selection. The filename heuristic deliberately affects only
  * this classification: metrics and other file artifacts continue to use the scanner/path-derived
  * file type.
  */
-export function getRuleFileType(
+export function getFileTypeForRules(
   filePath: NormalizedAbsolutePath,
   fileType: FileType,
   params: FilterPathParams,

--- a/packages/analysis/src/common/filter/filter-path.ts
+++ b/packages/analysis/src/common/filter/filter-path.ts
@@ -67,7 +67,7 @@ export function filterPathAndGetFileType(
   filePath: NormalizedAbsolutePath,
   params: FilterPathParams,
 ): FileType | undefined {
-  if (matchesTestPath(filePath, params, true)) {
+  if (matchesTestPath(filePath, params)) {
     return 'TEST';
   }
 
@@ -78,43 +78,32 @@ export function filterPathAndGetFileType(
   debug(`File ignored due to analysis scope filters: ${filePath}`);
 }
 
+/**
+ * Determines which rule set applies to a file. The filename heuristic deliberately affects only
+ * this classification: metrics and other file artifacts continue to use the scanner/path-derived
+ * file type.
+ */
+export function getRuleFileType(
+  filePath: NormalizedAbsolutePath,
+  fileType: FileType,
+  params: FilterPathParams,
+): FileType {
+  if (fileType === 'TEST' || !matchesTestFileHeuristic(filePath, params)) {
+    return fileType;
+  }
+
+  debug(
+    `Test file detected: ${filePath}. If this file should not use test rules, please configure sonar.tests or adjust your sonar.sources/sonar.inclusions to explicitly include it as MAIN.`,
+  );
+  return 'TEST';
+}
+
 function fileIsUnder(filePath: NormalizedAbsolutePath, paths: NormalizedAbsolutePath[]): boolean {
   return paths.some(path => filePath === path || filePath.startsWith(`${path}/`));
 }
 
-function matchesTestPath(
-  filePath: NormalizedAbsolutePath,
-  params: FilterPathParams,
-  logHeuristicTestDetection: boolean,
-): boolean {
-  const {
-    testPaths,
-    testExclusions,
-    testInclusions,
-    inclusions,
-    sourcesPaths,
-    testFileExtensions,
-  } = params;
-
-  // If `sonar.tests` is not configured, fall back to the filename heuristic — unless the file
-  // qualifies as MAIN via the user's `sonar.inclusions` (which narrows `sonar.sources`), in which
-  // case the user has explicitly opted it into MAIN scope and we should not second-guess them.
-  if (!testPaths.length) {
-    if (
-      inclusions.length > 0 &&
-      fileIsUnder(filePath, sourcesPaths) &&
-      inclusions.some(inclusion => inclusion.match(filePath))
-    ) {
-      return false;
-    }
-    const doesLookLikeTestFile = isTestRelatedFile(filePath, testFileExtensions);
-    if (doesLookLikeTestFile && logHeuristicTestDetection) {
-      debug(
-        `Test file detected: ${filePath}. If this file should not be treated as a test, please configure sonar.tests or adjust your sonar.sources/sonar.inclusions to explicitly include it as MAIN.`,
-      );
-    }
-    return doesLookLikeTestFile;
-  }
+function matchesTestPath(filePath: NormalizedAbsolutePath, params: FilterPathParams): boolean {
+  const { testPaths, testExclusions, testInclusions } = params;
 
   if (!fileIsUnder(filePath, testPaths)) {
     return false;
@@ -126,6 +115,27 @@ function matchesTestPath(
     return testInclusions.some(inclusion => inclusion.match(filePath));
   }
   return true;
+}
+
+function matchesTestFileHeuristic(
+  filePath: NormalizedAbsolutePath,
+  params: FilterPathParams,
+): boolean {
+  const { testPaths, inclusions, sourcesPaths, testFileExtensions } = params;
+  if (testPaths.length) {
+    return false;
+  }
+
+  // `sonar.inclusions` narrows `sonar.sources`, so a matching file has been explicitly opted into
+  // MAIN rule selection and should not be second-guessed by the filename heuristic.
+  if (
+    inclusions.length > 0 &&
+    fileIsUnder(filePath, sourcesPaths) &&
+    inclusions.some(inclusion => inclusion.match(filePath))
+  ) {
+    return false;
+  }
+  return isTestRelatedFile(filePath, testFileExtensions);
 }
 
 function matchesMainPath(filePath: NormalizedAbsolutePath, params: FilterPathParams): boolean {

--- a/packages/analysis/src/common/input-sanitize.ts
+++ b/packages/analysis/src/common/input-sanitize.ts
@@ -27,7 +27,7 @@ import {
   getFilterPathParams,
   getShouldIgnoreParams,
 } from './configuration.js';
-import { filterPathAndGetFileType, getRuleFileType } from './filter/filter-path.js';
+import { filterPathAndGetFileType, getFileTypeForRules } from './filter/filter-path.js';
 import { shouldIgnoreFile } from './filter/filter.js';
 import {
   isObject,
@@ -168,7 +168,7 @@ export async function sanitizeInputFiles(
       filePath,
       fileContent,
       fileType,
-      ruleFileType: getRuleFileType(filePath, fileType, filterPathParams),
+      ruleFileType: getFileTypeForRules(filePath, fileType, filterPathParams),
       fileStatus: rawFileStatus ?? JSTS_ANALYSIS_DEFAULTS.fileStatus,
     };
     pathMap.set(filePath, key);

--- a/packages/analysis/src/common/input-sanitize.ts
+++ b/packages/analysis/src/common/input-sanitize.ts
@@ -143,10 +143,10 @@ export async function sanitizeInputFiles(
     };
   }
 
+  const filterPathParams = getFilterPathParams(configuration);
   for (const [key, fileInput] of Object.entries(inputFiles)) {
     const filePath = normalizeToAbsolutePath(fileInput.filePath, baseDir);
     const fileContent = fileInput.fileContent ?? (await readFile(filePath));
-    const filterPathParams = getFilterPathParams(configuration);
     let rawFileType: FileType | undefined = fileInput.fileType;
     if (rawFileType !== 'TEST') {
       // We cannot trust the caller to provide the correct fileType, so we attempt to infer it from

--- a/packages/analysis/src/common/input-sanitize.ts
+++ b/packages/analysis/src/common/input-sanitize.ts
@@ -27,7 +27,7 @@ import {
   getFilterPathParams,
   getShouldIgnoreParams,
 } from './configuration.js';
-import { filterPathAndGetFileType } from './filter/filter-path.js';
+import { filterPathAndGetFileType, getRuleFileType } from './filter/filter-path.js';
 import { shouldIgnoreFile } from './filter/filter.js';
 import {
   isObject,
@@ -146,17 +146,18 @@ export async function sanitizeInputFiles(
   for (const [key, fileInput] of Object.entries(inputFiles)) {
     const filePath = normalizeToAbsolutePath(fileInput.filePath, baseDir);
     const fileContent = fileInput.fileContent ?? (await readFile(filePath));
+    const filterPathParams = getFilterPathParams(configuration);
     let rawFileType: FileType | undefined = fileInput.fileType;
     if (rawFileType !== 'TEST') {
-      // We cannot trust the caller to provide the correct fileType, so we attempt to infer it from the file path if not explicitly set to 'TEST'.
-      const inferredFileType = filterPathAndGetFileType(
-        filePath,
-        getFilterPathParams(configuration),
-      );
+      // We cannot trust the caller to provide the correct fileType, so we attempt to infer it from
+      // configured source/test paths if not explicitly set to 'TEST'. Filename heuristics are kept
+      // separate because they must only affect rule selection.
+      const inferredFileType = filterPathAndGetFileType(filePath, filterPathParams);
       if (inferredFileType) {
         rawFileType = inferredFileType;
       }
     }
+    const fileType = rawFileType ?? JSTS_ANALYSIS_DEFAULTS.fileType;
     const rawFileStatus = fileInput.fileStatus;
 
     if (await shouldIgnoreFile({ filePath, fileContent }, getShouldIgnoreParams(configuration))) {
@@ -166,7 +167,8 @@ export async function sanitizeInputFiles(
     files[filePath] = {
       filePath,
       fileContent,
-      fileType: rawFileType ?? JSTS_ANALYSIS_DEFAULTS.fileType,
+      fileType,
+      ruleFileType: getRuleFileType(filePath, fileType, filterPathParams),
       fileStatus: rawFileStatus ?? JSTS_ANALYSIS_DEFAULTS.fileStatus,
     };
     pathMap.set(filePath, key);

--- a/packages/analysis/src/css/analysis/analysis.ts
+++ b/packages/analysis/src/css/analysis/analysis.ts
@@ -28,6 +28,7 @@ import type { CssIssue } from '../linter/issues/issue.js';
  */
 export interface CssAnalysisInput extends AnalysisInput {
   fileType?: FileType;
+  ruleFileType?: FileType;
 }
 
 /**

--- a/packages/analysis/src/css/analysis/analyzer.ts
+++ b/packages/analysis/src/css/analysis/analyzer.ts
@@ -37,8 +37,8 @@ import { extractSonarResolveCommentsFromCssRoot } from '../../common/sonar-resol
  * The input must be fully sanitized (all fields required) before calling this function.
  *
  * Stylelint config comes from the pre-initialized linter
- * (`LinterWrapper.initialize()`). For TEST files, rules are overridden to an
- * empty config to suppress issues while preserving parsing/highlighting behavior.
+ * (`LinterWrapper.initialize()`). Rule selection uses `ruleFileType`: when it is TEST, rules are
+ * overridden to an empty config to suppress issues. Metrics and highlighting follow `fileType`.
  * The CSS linter must be initialized before calling this function.
  *
  * Behavior:
@@ -46,6 +46,7 @@ import { extractSonarResolveCommentsFromCssRoot } from '../../common/sonar-resol
  * CSS in HTML/Vue MAIN: linted for issues, no CSS metrics.
  * CSS in HTML/Vue TEST: not linted (noMetrics + TEST early return), so no CSS issues.
  * Pure CSS MAIN: issues + metrics/highlighting.
+ * Pure CSS MAIN with TEST rule selection: no issues, metrics/highlighting kept.
  * Pure CSS TEST: no issues/metrics, highlighting only
  *
  * @param input the sanitized CSS analysis input to analyze

--- a/packages/analysis/src/css/analysis/analyzer.ts
+++ b/packages/analysis/src/css/analysis/analyzer.ts
@@ -57,6 +57,7 @@ export async function analyzeCSS(
   includeMetrics = true,
 ): Promise<CssAnalysisOutput> {
   const { filePath, fileContent, fileType } = input;
+  const ruleFileType = input.ruleFileType ?? fileType;
 
   const isTestFile = fileType === 'TEST';
 
@@ -71,7 +72,7 @@ export async function analyzeCSS(
     .replaceAll(/\r(?!\n)/g, '\n');
 
   // TEST files keep highlighting (parity with old CssMetricSensor), but issues remain suppressed.
-  const lintResult = await linter.lint(filePath, sanitizedCode, fileType);
+  const lintResult = await linter.lint(filePath, sanitizedCode, ruleFileType);
   const { root, issues: lintingIssues } = lintResult;
   throwIfCssParsingError(lintingIssues);
   const issues = isTestFile ? [] : lintingIssues;

--- a/packages/analysis/src/css/linter/wrapper.ts
+++ b/packages/analysis/src/css/linter/wrapper.ts
@@ -36,7 +36,7 @@ const testFileConfig = createStylelintConfig([]);
 export class LinterWrapper {
   /**
    * The stored Stylelint configuration from the active quality profile.
-   * Set by `initialize()` and consumed by `lint()` for MAIN files.
+   * Set by `initialize()` and consumed by `lint()` for files using MAIN rule selection.
    */
   private config: stylelint.Config | undefined;
 
@@ -70,24 +70,24 @@ export class LinterWrapper {
    * The PostCSS root from Stylelint's internal parse is returned so callers
    * can compute metrics and highlighting without parsing the file a second time.
    *
-   * MAIN files use the stored config from `initialize()`.
-   * TEST files use a shared empty-rules config.
+   * Files using MAIN rule selection use the stored config from `initialize()`.
+   * Files using TEST rule selection use a shared empty-rules config.
    *
    * @param filePath the path of the stylesheet
    * @param fileContent the stylesheet source code
-   * @param fileType whether the file is MAIN or TEST
+   * @param ruleFileType whether MAIN or TEST rules should be selected
    * @returns the found issues and the PostCSS AST root
    */
   async lint(
     filePath: NormalizedAbsolutePath,
     fileContent: string,
-    fileType: FileType = 'MAIN',
+    ruleFileType: FileType = 'MAIN',
   ): Promise<LintResult> {
     if (!this.config) {
       throw APIError.linterError(`Linter does not exist.`);
     }
 
-    const config = fileType === 'TEST' ? testFileConfig : this.config;
+    const config = ruleFileType === 'TEST' ? testFileConfig : this.config;
     const options: stylelint.LinterOptions = {
       code: fileContent,
       codeFilename: filePath,

--- a/packages/analysis/src/file-stores/source-files.ts
+++ b/packages/analysis/src/file-stores/source-files.ts
@@ -34,7 +34,7 @@ import {
   type NormalizedAbsolutePath,
   type File,
 } from '../../../shared/src/helpers/files.js';
-import { filterPathAndGetFileType } from '../common/filter/filter-path.js';
+import { filterPathAndGetFileType, getRuleFileType } from '../common/filter/filter-path.js';
 import { dirname } from 'node:path/posix';
 import type { FileType } from '../contracts/file.js';
 
@@ -45,7 +45,8 @@ export class SourceFileStore implements FileStore {
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
   private readonly ignoredPaths = new Set<string>();
-  private pendingFileType: { filePath: NormalizedAbsolutePath; fileType: FileType } | undefined =
+  private pendingFileTypes:
+    { filePath: NormalizedAbsolutePath; fileType: FileType; ruleFileType: FileType } | undefined =
     undefined;
   private files: AnalyzableFiles | undefined = undefined;
   private readonly directoryIndex = new DirectoryIndex();
@@ -99,7 +100,7 @@ export class SourceFileStore implements FileStore {
     this.analyzableFilesConfigKey = undefined;
     this.files = undefined;
     this.ignoredPaths.clear();
-    this.pendingFileType = undefined;
+    this.pendingFileTypes = undefined;
     this.directoryIndex.clear();
   }
 
@@ -121,17 +122,22 @@ export class SourceFileStore implements FileStore {
       return false;
     }
 
-    this.pendingFileType = { filePath: filename, fileType };
+    this.pendingFileTypes = {
+      filePath: filename,
+      fileType,
+      ruleFileType: getRuleFileType(filename, fileType, getFilterPathParams(configuration)),
+    };
     return 'content';
   }
 
   async processFile(filename: NormalizedAbsolutePath, configuration: Configuration, file?: File) {
-    const pendingFileType = this.pendingFileType;
-    this.pendingFileType = undefined;
+    const pendingFileTypes = this.pendingFileTypes;
+    this.pendingFileTypes = undefined;
+    const filterPathParams = getFilterPathParams(configuration);
     const fileType =
-      pendingFileType?.filePath === filename
-        ? pendingFileType.fileType
-        : filterPathAndGetFileType(filename, getFilterPathParams(configuration));
+      pendingFileTypes?.filePath === filename
+        ? pendingFileTypes.fileType
+        : filterPathAndGetFileType(filename, filterPathParams);
     // we don't call shouldIgnoreFile because the isJsTsExcluded method has already been
     // called while walking the project tree
     if (
@@ -143,6 +149,9 @@ export class SourceFileStore implements FileStore {
       this.files![filename] = promoteToAnalyzableFile(
         file,
         fileType,
+        pendingFileTypes?.filePath === filename
+          ? pendingFileTypes.ruleFileType
+          : getRuleFileType(filename, fileType, filterPathParams),
         JSTS_ANALYSIS_DEFAULTS.fileStatus,
       );
       this.directoryIndex.addFile(filename);
@@ -157,7 +166,7 @@ export class SourceFileStore implements FileStore {
   }
 
   async postProcess(_configuration: Configuration) {
-    this.pendingFileType = undefined;
+    this.pendingFileTypes = undefined;
   }
 
   private anyParentIsIgnored(filePath: NormalizedAbsolutePath) {

--- a/packages/analysis/src/file-stores/source-files.ts
+++ b/packages/analysis/src/file-stores/source-files.ts
@@ -34,20 +34,41 @@ import {
   type NormalizedAbsolutePath,
   type File,
 } from '../../../shared/src/helpers/files.js';
-import { filterPathAndGetFileType, getRuleFileType } from '../common/filter/filter-path.js';
+import { filterPathAndGetFileType, getFileTypeForRules } from '../common/filter/filter-path.js';
 import { dirname } from 'node:path/posix';
 import type { FileType } from '../contracts/file.js';
 
 export const UNINITIALIZED_ERROR = 'Files cache has not been initialized. Call loadFiles() first.';
+
+type ResolvedFileTypes = {
+  filePath: NormalizedAbsolutePath;
+  fileType: FileType;
+  ruleFileType: FileType;
+};
+
+function resolveFileTypes(
+  filename: NormalizedAbsolutePath,
+  configuration: Configuration,
+): ResolvedFileTypes | undefined {
+  const filterPathParams = getFilterPathParams(configuration);
+  const fileType = filterPathAndGetFileType(filename, filterPathParams);
+  if (!fileType) {
+    return;
+  }
+
+  return {
+    filePath: filename,
+    fileType,
+    ruleFileType: getFileTypeForRules(filename, fileType, filterPathParams),
+  };
+}
 
 export class SourceFileStore implements FileStore {
   private baseDir: NormalizedAbsolutePath | undefined = undefined;
   private canAccessFileSystem: boolean | undefined = undefined;
   private analyzableFilesConfigKey: string | undefined = undefined;
   private readonly ignoredPaths = new Set<string>();
-  private pendingFileTypes:
-    { filePath: NormalizedAbsolutePath; fileType: FileType; ruleFileType: FileType } | undefined =
-    undefined;
+  private pendingFileTypes: ResolvedFileTypes | undefined = undefined;
   private files: AnalyzableFiles | undefined = undefined;
   private readonly directoryIndex = new DirectoryIndex();
 
@@ -117,42 +138,34 @@ export class SourceFileStore implements FileStore {
       return false;
     }
 
-    const filterPathParams = getFilterPathParams(configuration);
-    const fileType = filterPathAndGetFileType(filename, filterPathParams);
-    if (!fileType) {
+    const fileTypes = resolveFileTypes(filename, configuration);
+    if (!fileTypes) {
       return false;
     }
 
-    this.pendingFileTypes = {
-      filePath: filename,
-      fileType,
-      ruleFileType: getRuleFileType(filename, fileType, filterPathParams),
-    };
+    this.pendingFileTypes = fileTypes;
     return 'content';
   }
 
   async processFile(filename: NormalizedAbsolutePath, configuration: Configuration, file?: File) {
     const pendingFileTypes = this.pendingFileTypes;
     this.pendingFileTypes = undefined;
-    const filterPathParams = getFilterPathParams(configuration);
-    const fileType =
+    const fileTypes =
       pendingFileTypes?.filePath === filename
-        ? pendingFileTypes.fileType
-        : filterPathAndGetFileType(filename, filterPathParams);
+        ? pendingFileTypes
+        : resolveFileTypes(filename, configuration);
     // we don't call shouldIgnoreFile because the isJsTsExcluded method has already been
     // called while walking the project tree
     if (
       file &&
-      fileType &&
+      fileTypes &&
       accept(filename, file.fileContent, getShouldIgnoreParams(configuration))
     ) {
       // Promote the shared walk entry in place so helper stores can reuse the same object.
       this.files![filename] = promoteToAnalyzableFile(
         file,
-        fileType,
-        pendingFileTypes?.filePath === filename
-          ? pendingFileTypes.ruleFileType
-          : getRuleFileType(filename, fileType, filterPathParams),
+        fileTypes.fileType,
+        fileTypes.ruleFileType,
         JSTS_ANALYSIS_DEFAULTS.fileStatus,
       );
       this.directoryIndex.addFile(filename);

--- a/packages/analysis/src/file-stores/source-files.ts
+++ b/packages/analysis/src/file-stores/source-files.ts
@@ -117,7 +117,8 @@ export class SourceFileStore implements FileStore {
       return false;
     }
 
-    const fileType = filterPathAndGetFileType(filename, getFilterPathParams(configuration));
+    const filterPathParams = getFilterPathParams(configuration);
+    const fileType = filterPathAndGetFileType(filename, filterPathParams);
     if (!fileType) {
       return false;
     }
@@ -125,7 +126,7 @@ export class SourceFileStore implements FileStore {
     this.pendingFileTypes = {
       filePath: filename,
       fileType,
-      ruleFileType: getRuleFileType(filename, fileType, getFilterPathParams(configuration)),
+      ruleFileType: getRuleFileType(filename, fileType, filterPathParams),
     };
     return 'content';
   }

--- a/packages/analysis/src/jsts/analysis/analysis.ts
+++ b/packages/analysis/src/jsts/analysis/analysis.ts
@@ -50,6 +50,7 @@ import type { CssIssue } from '../../css/linter/issues/issue.js';
  */
 export interface JsTsAnalysisInput extends AnalysisInput {
   fileType: FileType;
+  ruleFileType: FileType;
   fileStatus: FileStatus;
   language: JsTsLanguage;
   analysisMode: AnalysisMode;
@@ -79,6 +80,7 @@ export type FileStatus = 'SAME' | 'CHANGED' | 'ADDED';
  * - skipAst: true - skip AST serialization by default for performance
  * - clearDependenciesCache: false - preserve cache by default
  * - fileType: 'MAIN' - assume main source file unless told otherwise
+ * - ruleFileType: 'MAIN' - select main-file rules unless told otherwise
  */
 export const JSTS_ANALYSIS_DEFAULTS = {
   fileStatus: 'SAME' as FileStatus,
@@ -90,6 +92,7 @@ export const JSTS_ANALYSIS_DEFAULTS = {
   clearDependenciesCache: false,
   reportNclocForTestFiles: false,
   fileType: 'MAIN' as FileType,
+  ruleFileType: 'MAIN' as FileType,
 } as const;
 
 /**

--- a/packages/analysis/src/jsts/analysis/analyzer.ts
+++ b/packages/analysis/src/jsts/analysis/analyzer.ts
@@ -67,8 +67,15 @@ interface AnalysisLinterOptions {
  */
 export async function analyzeJSTS(input: JsTsAnalysisInput): Promise<JsTsAnalysisOutput> {
   debug(`Analyzing file "${input.filePath}"`);
-  const { filePath, fileType, analysisMode, fileStatus, language, detectedEsYear, targetEsYear } =
-    input;
+  const {
+    filePath,
+    ruleFileType,
+    analysisMode,
+    fileStatus,
+    language,
+    detectedEsYear,
+    targetEsYear,
+  } = input;
   const detectedModuleType = Linter.detectModuleType(filePath);
   getOptionalProjectAnalysisTelemetryCollector()?.recordModuleType(detectedModuleType);
 
@@ -91,7 +98,7 @@ export async function analyzeJSTS(input: JsTsAnalysisInput): Promise<JsTsAnalysi
   const { issues, suppressedIssues } = Linter.lint(
     parseResult,
     filePath,
-    fileType,
+    ruleFileType,
     fileStatus,
     analysisMode,
     language,

--- a/packages/analysis/src/projectAnalysis.ts
+++ b/packages/analysis/src/projectAnalysis.ts
@@ -61,6 +61,7 @@ type FileErrorResult = { error: string };
  */
 export type AnalyzableFile = File & {
   fileType: FileType;
+  ruleFileType: FileType;
   fileStatus: FileStatus;
 };
 
@@ -88,9 +89,10 @@ export function createAnalyzableFiles(): AnalyzableFiles {
 export function promoteToAnalyzableFile(
   file: File,
   fileType: FileType,
+  ruleFileType: FileType,
   fileStatus: FileStatus,
 ): AnalyzableFile {
-  return Object.assign(file, { fileType, fileStatus });
+  return Object.assign(file, { fileType, ruleFileType, fileStatus });
 }
 
 /**

--- a/packages/analysis/tests/analyzeProject-sonarqube.test.ts
+++ b/packages/analysis/tests/analyzeProject-sonarqube.test.ts
@@ -86,6 +86,52 @@ describe('SonarQube project analysis', () => {
     ).toBe(true);
   });
 
+  it('should apply the test-file heuristic only to rule selection', async () => {
+    const baseDir = join(fixtures, 'basic');
+    const filePath = join(baseDir, 'heuristic.test.js');
+    const heuristicRules: RuleConfig[] = [
+      {
+        key: 'S1116',
+        configurations: [],
+        fileTypeTargets: ['MAIN'],
+        language: 'js',
+        analysisModes: ['DEFAULT'],
+      },
+      {
+        key: 'S3504',
+        configurations: [],
+        fileTypeTargets: ['TEST'],
+        language: 'js',
+        analysisModes: ['DEFAULT'],
+      },
+    ];
+    const configuration = await initForTest(
+      { baseDir, disableTypeChecking: true },
+      {
+        [filePath]: {
+          filePath,
+          fileType: 'MAIN',
+          fileContent: 'var foo = 42;;',
+        },
+      },
+    );
+
+    const result = await analyzeProject({ rules: heuristicRules, bundles: [] }, configuration);
+    const fileResult = result.files[normalizeToAbsolutePath(filePath)];
+
+    expect(fileResult).toBeDefined();
+    expect(fileResult && 'issues' in fileResult).toBe(true);
+    if (fileResult && 'issues' in fileResult) {
+      expect(fileResult.issues).toEqual([expect.objectContaining({ ruleId: 'S3504' })]);
+      expect(fileResult.metrics).toEqual(
+        expect.objectContaining({
+          ncloc: [1],
+          statements: expect.any(Number),
+        }),
+      );
+    }
+  });
+
   it('should analyze files from referenced tsconfigs', async () => {
     const baseDir = join(fixtures, 'referenced');
     const mainFile = join(baseDir, 'main.ts');
@@ -749,6 +795,32 @@ describe('SonarQube project analysis', () => {
     }
     if (fileResult && 'highlights' in fileResult && fileResult.highlights) {
       expect(fileResult.highlights.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('should preserve CSS metrics when the heuristic selects test rules', async () => {
+    const baseDir = join(fixtures, 'css');
+    const cssFile = join(baseDir, '__tests__/heuristic.css');
+    const cssRules: CssRuleConfig[] = [{ key: 'no-extra-semicolons', configurations: [] }];
+    const configuration = await initForTest(
+      { baseDir },
+      {
+        [cssFile]: {
+          filePath: cssFile,
+          fileType: 'MAIN',
+          fileContent: 'a { color: red;; }',
+        },
+      },
+    );
+
+    const result = await analyzeProject({ rules: [], cssRules, bundles: [] }, configuration);
+    const fileResult = result.files[normalizeToAbsolutePath(cssFile)];
+
+    expect(fileResult).toBeDefined();
+    expect(fileResult && 'issues' in fileResult && 'metrics' in fileResult).toBe(true);
+    if (fileResult && 'issues' in fileResult && 'metrics' in fileResult) {
+      expect(fileResult.issues).toEqual([]);
+      expect(fileResult.metrics?.ncloc).toEqual([1]);
     }
   });
 

--- a/packages/analysis/tests/common/filter-path.test.ts
+++ b/packages/analysis/tests/common/filter-path.test.ts
@@ -16,7 +16,11 @@
  */
 import { describe, it, type Mock } from 'node:test';
 import { expect } from 'expect';
-import { filterPathAndGetFileType, isJsTsExcluded } from '../../src/common/filter/filter-path.js';
+import {
+  filterPathAndGetFileType,
+  getRuleFileType,
+  isJsTsExcluded,
+} from '../../src/common/filter/filter-path.js';
 import { createConfiguration, getFilterPathParams } from '../../src/common/configuration.js';
 import { normalizeToAbsolutePath } from '../../../shared/src/helpers/files.js';
 
@@ -183,7 +187,16 @@ describe('filter path', () => {
     expect(result).toBe('MAIN');
   });
 
-  describe('test-file heuristic fallback (no sonar.tests configured)', () => {
+  it('should keep a test-like source file MAIN for metrics', () => {
+    const filePath = normalizeToAbsolutePath('/project/src/file.test.js');
+    const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
+
+    const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+
+    expect(result).toBe('MAIN');
+  });
+
+  describe('test-file rule heuristic fallback (no sonar.tests configured)', () => {
     const testLikeFilenames = [
       '/project/src/foo.test.ts',
       '/project/src/bar.spec.js',
@@ -200,7 +213,7 @@ describe('filter path', () => {
       it(`should classify ${path} as TEST via heuristic when no test config is set`, () => {
         const filePath = normalizeToAbsolutePath(path);
         const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
-        const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+        const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
         expect(result).toBe('TEST');
       });
     }
@@ -208,14 +221,14 @@ describe('filter path', () => {
     it('should classify a non-test filename as MAIN when no test config is set', () => {
       const filePath = normalizeToAbsolutePath('/project/src/regular.ts');
       const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
     it('should not be fooled by filenames that merely contain "test"', () => {
       const filePath = normalizeToAbsolutePath('/project/src/testimony.ts');
       const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
@@ -227,7 +240,7 @@ describe('filter path', () => {
         sources: ['src'],
         tests: ['test'],
       });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
@@ -241,7 +254,7 @@ describe('filter path', () => {
         sources: ['src'],
         testInclusions: ['**/*IntegrationTest.ts'],
       });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
 
@@ -255,7 +268,7 @@ describe('filter path', () => {
         sources: ['src'],
         testExclusions: ['**/fixtures/**'],
       });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
 
@@ -267,7 +280,7 @@ describe('filter path', () => {
         sources: ['src'],
         inclusions: ['**/*.test.ts'],
       });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
@@ -278,14 +291,14 @@ describe('filter path', () => {
         sources: ['src'],
         jsSuffixes: ['.js', '.dummy'],
       });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
 
     it('should not classify .test.<unconfiguredSuffix> as TEST', () => {
       const filePath = normalizeToAbsolutePath('/project/src/foo.test.dummy');
       const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
@@ -297,7 +310,7 @@ describe('filter path', () => {
         jsSuffixes: ['.js'],
         tsSuffixes: [],
       });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
 
@@ -309,7 +322,7 @@ describe('filter path', () => {
         jsSuffixes: [],
         tsSuffixes: ['.ts'],
       });
-      const result = filterPathAndGetFileType(filePath, getFilterPathParams(config));
+      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
   });

--- a/packages/analysis/tests/common/filter-path.test.ts
+++ b/packages/analysis/tests/common/filter-path.test.ts
@@ -18,7 +18,7 @@ import { describe, it, type Mock } from 'node:test';
 import { expect } from 'expect';
 import {
   filterPathAndGetFileType,
-  getRuleFileType,
+  getFileTypeForRules,
   isJsTsExcluded,
 } from '../../src/common/filter/filter-path.js';
 import { createConfiguration, getFilterPathParams } from '../../src/common/configuration.js';
@@ -213,7 +213,7 @@ describe('filter path', () => {
       it(`should classify ${path} as TEST via heuristic when no test config is set`, () => {
         const filePath = normalizeToAbsolutePath(path);
         const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
-        const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+        const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
         expect(result).toBe('TEST');
       });
     }
@@ -221,14 +221,14 @@ describe('filter path', () => {
     it('should classify a non-test filename as MAIN when no test config is set', () => {
       const filePath = normalizeToAbsolutePath('/project/src/regular.ts');
       const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
     it('should not be fooled by filenames that merely contain "test"', () => {
       const filePath = normalizeToAbsolutePath('/project/src/testimony.ts');
       const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
@@ -240,7 +240,7 @@ describe('filter path', () => {
         sources: ['src'],
         tests: ['test'],
       });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
@@ -254,7 +254,7 @@ describe('filter path', () => {
         sources: ['src'],
         testInclusions: ['**/*IntegrationTest.ts'],
       });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
 
@@ -268,7 +268,7 @@ describe('filter path', () => {
         sources: ['src'],
         testExclusions: ['**/fixtures/**'],
       });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
 
@@ -280,7 +280,7 @@ describe('filter path', () => {
         sources: ['src'],
         inclusions: ['**/*.test.ts'],
       });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
@@ -291,14 +291,14 @@ describe('filter path', () => {
         sources: ['src'],
         jsSuffixes: ['.js', '.dummy'],
       });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
 
     it('should not classify .test.<unconfiguredSuffix> as TEST', () => {
       const filePath = normalizeToAbsolutePath('/project/src/foo.test.dummy');
       const config = createConfiguration({ baseDir: '/project', sources: ['src'] });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('MAIN');
     });
 
@@ -310,7 +310,7 @@ describe('filter path', () => {
         jsSuffixes: ['.js'],
         tsSuffixes: [],
       });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
 
@@ -322,7 +322,7 @@ describe('filter path', () => {
         jsSuffixes: [],
         tsSuffixes: ['.ts'],
       });
-      const result = getRuleFileType(filePath, 'MAIN', getFilterPathParams(config));
+      const result = getFileTypeForRules(filePath, 'MAIN', getFilterPathParams(config));
       expect(result).toBe('TEST');
     });
   });

--- a/packages/analysis/tests/common/input-sanitize.test.ts
+++ b/packages/analysis/tests/common/input-sanitize.test.ts
@@ -30,7 +30,7 @@ function buildInput(absolutePath: string, fileType?: 'MAIN' | 'TEST') {
   };
 }
 
-async function resolveFileType(
+async function resolveFileTypes(
   absolutePath: string,
   configurationInput: Parameters<typeof createConfiguration>[0],
   inputFileType?: 'MAIN' | 'TEST',
@@ -41,59 +41,60 @@ async function resolveFileType(
     configuration,
   );
   const normalized = normalizeToAbsolutePath(absolutePath, configuration.baseDir);
-  return files[normalized]?.fileType;
+  const file = files[normalized];
+  return file && { fileType: file.fileType, ruleFileType: file.ruleFileType };
 }
 
 describe('sanitizeInputFiles fileType resolution', () => {
   describe('No sonar.tests configured', () => {
-    it('upgrades MAIN to TEST when filename matches heuristic', async () => {
-      const result = await resolveFileType(
+    it('uses TEST rules but preserves MAIN metrics when filename matches heuristic', async () => {
+      const result = await resolveFileTypes(
         '/project/src/login.test.ts',
         { baseDir: '/project', sources: ['src'] },
         'MAIN',
       );
-      expect(result).toBe('TEST');
+      expect(result).toEqual({ fileType: 'MAIN', ruleFileType: 'TEST' });
     });
 
-    it('upgrades undefined fileType to TEST when filename matches heuristic', async () => {
-      const result = await resolveFileType('/project/src/login.spec.js', {
+    it('uses TEST rules but infers MAIN metrics for a test-like source file', async () => {
+      const result = await resolveFileTypes('/project/src/login.spec.js', {
         baseDir: '/project',
         sources: ['src'],
       });
-      expect(result).toBe('TEST');
+      expect(result).toEqual({ fileType: 'MAIN', ruleFileType: 'TEST' });
     });
 
     it('keeps MAIN for a non-test filename', async () => {
-      const result = await resolveFileType(
+      const result = await resolveFileTypes(
         '/project/src/auth.ts',
         { baseDir: '/project', sources: ['src'] },
         'MAIN',
       );
-      expect(result).toBe('MAIN');
+      expect(result).toEqual({ fileType: 'MAIN', ruleFileType: 'MAIN' });
     });
   });
 
   describe('explicit classification is authoritative', () => {
     it('preserves explicit TEST regardless of filename', async () => {
-      const result = await resolveFileType(
+      const result = await resolveFileTypes(
         '/project/src/auth.ts',
         { baseDir: '/project', sources: ['src'] },
         'TEST',
       );
-      expect(result).toBe('TEST');
+      expect(result).toEqual({ fileType: 'TEST', ruleFileType: 'TEST' });
     });
 
     it('preserves explicit MAIN for a test-named file when sonar.tests is configured', async () => {
-      const result = await resolveFileType(
+      const result = await resolveFileTypes(
         '/project/src/login.test.ts',
         { baseDir: '/project', sources: ['src'], tests: ['test'] },
         'MAIN',
       );
-      expect(result).toBe('MAIN');
+      expect(result).toEqual({ fileType: 'MAIN', ruleFileType: 'MAIN' });
     });
 
     it('preserves explicit MAIN for a test-named file when sonar.inclusions is configured', async () => {
-      const result = await resolveFileType(
+      const result = await resolveFileTypes(
         '/project/src/login.test.ts',
         {
           baseDir: '/project',
@@ -102,34 +103,34 @@ describe('sanitizeInputFiles fileType resolution', () => {
         },
         'MAIN',
       );
-      expect(result).toBe('MAIN');
+      expect(result).toEqual({ fileType: 'MAIN', ruleFileType: 'MAIN' });
     });
   });
 
   describe('path-based resolution still works', () => {
     it('upgrades undefined fileType to TEST when file lives under sonar.tests', async () => {
-      const result = await resolveFileType('/project/test/login.ts', {
+      const result = await resolveFileTypes('/project/test/login.ts', {
         baseDir: '/project',
         sources: ['src'],
         tests: ['test'],
       });
-      expect(result).toBe('TEST');
+      expect(result).toEqual({ fileType: 'TEST', ruleFileType: 'TEST' });
     });
 
     it('resolves to MAIN via sourcesPaths when no explicit fileType is provided', async () => {
-      const result = await resolveFileType('/project/src/auth.ts', {
+      const result = await resolveFileTypes('/project/src/auth.ts', {
         baseDir: '/project',
         sources: ['src'],
       });
-      expect(result).toBe('MAIN');
+      expect(result).toEqual({ fileType: 'MAIN', ruleFileType: 'MAIN' });
     });
 
     it('falls back to JSTS_ANALYSIS_DEFAULTS.fileType when nothing else resolves the type', async () => {
-      const result = await resolveFileType('/project/orphan/file.ts', {
+      const result = await resolveFileTypes('/project/orphan/file.ts', {
         baseDir: '/project',
         sources: ['src'],
       });
-      expect(result).toBe('MAIN');
+      expect(result).toEqual({ fileType: 'MAIN', ruleFileType: 'MAIN' });
     });
   });
 });

--- a/packages/analysis/tests/jsts/tools/helpers/input.ts
+++ b/packages/analysis/tests/jsts/tools/helpers/input.ts
@@ -30,6 +30,7 @@ type TestJsTsInput = {
   filePath: string;
   fileContent?: string;
   fileType?: 'MAIN' | 'TEST';
+  ruleFileType?: 'MAIN' | 'TEST';
   fileStatus?: 'SAME' | 'CHANGED' | 'ADDED';
   language?: 'js' | 'ts';
   analysisMode?: 'DEFAULT' | 'SKIP_UNCHANGED';
@@ -58,6 +59,7 @@ export async function jsTsInput(input: TestJsTsInput): Promise<JsTsAnalysisInput
     program: input.program,
     // Allow test-specific overrides
     ...(input.fileType !== undefined && { fileType: input.fileType }),
+    ruleFileType: input.ruleFileType ?? input.fileType ?? JSTS_ANALYSIS_DEFAULTS.ruleFileType,
     ...(input.fileStatus !== undefined && { fileStatus: input.fileStatus }),
     ...(input.analysisMode !== undefined && { analysisMode: input.analysisMode }),
     ...(input.ignoreHeaderComments !== undefined && {

--- a/packages/analysis/tests/source-files.test.ts
+++ b/packages/analysis/tests/source-files.test.ts
@@ -56,9 +56,11 @@ describe('files', () => {
     expect(sourceFileStore.getFiles()).toMatchObject({
       [file1]: {
         fileType: 'MAIN',
+        ruleFileType: 'MAIN',
       },
       [file2]: {
         fileType: 'TEST',
+        ruleFileType: 'TEST',
       },
     });
   });
@@ -97,15 +99,16 @@ describe('files', () => {
     ]).toEqual(['second.ts']);
   });
 
-  it('should promote shared walk files without allocating a wrapper', async () => {
+  it('should promote shared walk files without applying the rule heuristic to file type', async () => {
     const baseDir = normalizeToAbsolutePath('/project');
     const configuration = createConfiguration({ baseDir });
     const file: File = {
-      filePath: normalizeToAbsolutePath('/project/src/app.js'),
+      filePath: normalizeToAbsolutePath('/project/src/app.test.js'),
       fileContent: 'console.log("shared");\n',
     };
 
     sourceFileStore.setup(configuration);
+    expect(sourceFileStore.wantsFile(file.filePath, configuration)).toBe('content');
     await sourceFileStore.processFile(file.filePath, configuration, file);
 
     const storedFile = sourceFileStore.getFiles()[file.filePath];
@@ -114,6 +117,7 @@ describe('files', () => {
       filePath: file.filePath,
       fileContent: file.fileContent,
       fileType: 'MAIN',
+      ruleFileType: 'TEST',
       fileStatus: 'SAME',
     });
   });

--- a/packages/analysis/tests/source-files.test.ts
+++ b/packages/analysis/tests/source-files.test.ts
@@ -99,7 +99,7 @@ describe('files', () => {
     ]).toEqual(['second.ts']);
   });
 
-  it('should promote shared walk files without applying the rule heuristic to file type', async () => {
+  it('should promote shared walk files using the file types cached by wantsFile', async () => {
     const baseDir = normalizeToAbsolutePath('/project');
     const configuration = createConfiguration({ baseDir });
     const file: File = {
@@ -109,6 +109,28 @@ describe('files', () => {
 
     sourceFileStore.setup(configuration);
     expect(sourceFileStore.wantsFile(file.filePath, configuration)).toBe('content');
+    await sourceFileStore.processFile(file.filePath, configuration, file);
+
+    const storedFile = sourceFileStore.getFiles()[file.filePath];
+    expect(storedFile).toBe(file);
+    expect(storedFile).toMatchObject({
+      filePath: file.filePath,
+      fileContent: file.fileContent,
+      fileType: 'MAIN',
+      ruleFileType: 'TEST',
+      fileStatus: 'SAME',
+    });
+  });
+
+  it('should resolve file types when processing a file without cached walk state', async () => {
+    const baseDir = normalizeToAbsolutePath('/project');
+    const configuration = createConfiguration({ baseDir });
+    const file: File = {
+      filePath: normalizeToAbsolutePath('/project/src/app.test.js'),
+      fileContent: 'console.log("shared");\n',
+    };
+
+    sourceFileStore.setup(configuration);
     await sourceFileStore.processFile(file.filePath, configuration, file);
 
     const storedFile = sourceFileStore.getFiles()[file.filePath];


### PR DESCRIPTION
Part of

## Summary

- Keep scanner/config source classification authoritative for metrics, highlighting, CPD, and analysis scope.
- Introduce a separate classification for rule selection when the fallback test-file heuristic matches.
- Cover JS/TS and CSS files that look like tests while remaining `MAIN` files.

## Testing

- `npm run generate-meta`
- `npm run bridge:compile`
- Targeted analysis, filtering, sanitization, and source-store tests (81 passed)
- Prettier check on all changed files
