### PR TITLE
JS-2236 Fix S2004 nested-function depth in the analyze-project unary handler

### DIFF
--- a/packages/grpc/src/analyze-project-server.ts
+++ b/packages/grpc/src/analyze-project-server.ts
@@ -260,18 +260,15 @@ function createAnalyzeProjectUnaryHandler({
           return toAnalyzeProjectUnaryResponse(result.result.output, result.result.pathMap);
         }
 
-        const result = (
-          await (() => {
-            const requestId = newWorkerRequestId();
-            return waitForWorkerCompletion(worker, 'unary-complete', requestId, () =>
-              worker.postMessage({
-                type: 'analyze-unary',
-                requestId,
-                request: call.request,
-              } satisfies AnalyzeProjectWorkerInMessage),
-            ) as Promise<UnaryCompleteMessage>;
-          })()
-        ).result;
+        const requestId = newWorkerRequestId();
+        const completion = (await waitForWorkerCompletion(worker, 'unary-complete', requestId, () =>
+          worker.postMessage({
+            type: 'analyze-unary',
+            requestId,
+            request: call.request,
+          } satisfies AnalyzeProjectWorkerInMessage),
+        )) as UnaryCompleteMessage;
+        const result = completion.result;
         if (result.type === 'failure') {
           throw toGrpcErrorFromFailure(result);
         }


### PR DESCRIPTION
## Scope

`packages/grpc/src/analyze-project-server.ts:266` raises `typescript:S2004`
(*Refactor this code to not nest functions more than 4 levels deep*, High
maintainability).

## Purpose

Clear that issue without changing the unary handler's behaviour.

## Implementation

The worker branch wrapped `waitForWorkerCompletion` in an IIFE whose only
purpose was to scope `requestId`, which pushed the `postMessage` callback to a
fifth nesting level. Hoisting `requestId` and awaiting `waitForWorkerCompletion`
directly removes that level and mirrors the streaming handler above, which
already reads flat.

Verified by running the repo's own S2004 rule (`threshold: 4`) against the file:
1 issue at L266 before, 0 after.