### PR TITLE
Fix flaky gRPC test port assignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4062,7 +4062,7 @@
     "node_modules/@sonarsource/analyzer-commons-configurations": {
       "version": "2.30.0-5193",
       "resolved": "https://registry.npmjs.org/@sonarsource/analyzer-commons-configurations/-/analyzer-commons-configurations-2.30.0-5193.tgz",
-      "integrity": "sha512-n7j2EnZGLcutyZv+QJbz/NtHOQQnCI25EAqxwHyBzCO0lgZ6p+7+cwDCqbJyPMVusimDkbUYpLXjzIKUJFR9tw==",
+      "integrity": "sha512-nPRbPEnT4D3Vsn8sNxQmMkx6gv4KJaat9L8YwoCUm9LOBFkZ6Uo1ix4/8OwBt/e0SCgu9iuvq2+qLXeKza2Rtg==",
       "license": "LGPL-3.0-only"
     },
     "node_modules/@stylistic/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4062,7 +4062,7 @@
     "node_modules/@sonarsource/analyzer-commons-configurations": {
       "version": "2.30.0-5193",
       "resolved": "https://registry.npmjs.org/@sonarsource/analyzer-commons-configurations/-/analyzer-commons-configurations-2.30.0-5193.tgz",
-      "integrity": "sha512-nPRbPEnT4D3Vsn8sNxQmMkx6gv4KJaat9L8YwoCUm9LOBFkZ6Uo1ix4/8OwBt/e0SCgu9iuvq2+qLXeKza2Rtg==",
+      "integrity": "sha512-n7j2EnZGLcutyZv+QJbz/NtHOQQnCI25EAqxwHyBzCO0lgZ6p+7+cwDCqbJyPMVusimDkbUYpLXjzIKUJFR9tw==",
       "license": "LGPL-3.0-only"
     },
     "node_modules/@stylistic/eslint-plugin": {

--- a/packages/grpc/src/server.ts
+++ b/packages/grpc/src/server.ts
@@ -99,9 +99,9 @@ export function createGrpcServer(): grpc.Server {
 }
 
 /**
- * Start the gRPC server on the specified port
+ * Start the gRPC server on the specified port; pass 0 to let the OS pick a free one.
  */
-export function startServer(port: number): Promise<grpc.Server> {
+export function startServer(port: number): Promise<{ server: grpc.Server; port: number }> {
   return new Promise((resolve, reject) => {
     const server = createGrpcServer();
 
@@ -117,7 +117,7 @@ export function startServer(port: number): Promise<grpc.Server> {
 
         info(`gRPC server listening on port ${boundPort}`);
         info(`Services: ${ANALYZER_SERVICE_NAME}, ${HEALTH_SERVICE_NAME}`);
-        resolve(server);
+        resolve({ server, port: boundPort });
       },
     );
   });

--- a/packages/grpc/src/server.ts
+++ b/packages/grpc/src/server.ts
@@ -100,6 +100,9 @@ export function createGrpcServer(): grpc.Server {
 
 /**
  * Start the gRPC server on the specified port; pass 0 to let the OS pick a free one.
+ *
+ * Also called from grpc-server.mjs (bundled to bin/grpc-server.cjs) — check that file too
+ * when changing this signature.
  */
 export function startServer(port: number): Promise<{ server: grpc.Server; port: number }> {
   return new Promise((resolve, reject) => {

--- a/packages/grpc/tests/server.test.ts
+++ b/packages/grpc/tests/server.test.ts
@@ -20,8 +20,6 @@ import * as grpc from '@grpc/grpc-js';
 import { startServer } from '../src/server.js';
 import { analyzer } from '../src/proto/language_analyzer.js';
 
-// Use a random high port to avoid conflicts
-const TEST_PORT = 50151;
 const SERVICE_NAME = 'analyzer.LanguageAnalyzerService';
 
 /**
@@ -89,8 +87,10 @@ describe('gRPC server', () => {
   }
 
   before(async () => {
-    server = await startServer(TEST_PORT);
-    client = createClient(TEST_PORT);
+    // Port 0 lets the OS assign a free ephemeral port, avoiding fixed-port collisions.
+    const bound = await startServer(0);
+    server = bound.server;
+    client = createClient(bound.port);
   });
 
   after(async () => {


### PR DESCRIPTION
Fixes a flaky gRPC server test port assignment, no Jira ticket exists for this.

## Summary
- `packages/grpc/tests/server.test.ts` hardcoded port `50151` for the test gRPC server. Per IANA, `50151` falls in the dynamic/private/ephemeral range (`49152`-`65535`), which is meant for OS-assigned outbound client ports, not for a fixed listening service — using a static port from that range was the wrong choice to begin with. On Windows this also collides with TCP port ranges dynamically excluded by Hyper-V/WSL2/Docker Desktop's NAT (confirmed via `netsh interface ipv4 show excludedportrange protocol=tcp`), causing `EACCES: permission denied` instead of a normal `EADDRINUSE`. `startServer` now accepts port `0` to let the OS assign a free ephemeral port, and resolves with `{ server, port }` so callers/tests can use the actual bound port instead of a hardcoded value.

**Note:** this PR previously also included a `package-lock.json` integrity-hash change for `@sonarsource/analyzer-commons-configurations@2.30.0-5193`, which has been reverted. That was based on an `EINTEGRITY` failure I hit locally, but it turned out to be caused by my personal machine resolving that package through a different Repox npm repo (`npmjs`) than the one CI actually uses (`npm`) — the two repos currently serve different content for the same pinned version, and CI's repo still serves the original tarball the existing lockfile hash matches. So the original hash was correct for CI all along; no lockfile change is needed here.

## Test plan
- [x] `npm ci` succeeds in a clean worktree (using the same Repox `npm` repo CI uses)
- [x] `npx tsgo -p packages/tsconfig.test.json --noEmit` passes with no errors
- [x] `packages/grpc/tests/server.test.ts` — 39/39 tests pass
- [x] Full `packages/grpc/tests/*.test.ts` suite — 205/205 tests pass
- [x] `npx prettier --check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)