### PR TITLE
JS-2352 Implement rule S7503: Async functions should use async features

### DIFF
--- a/its/ruling/src/test/expected/ant-design/typescript-S7503.json
+++ b/its/ruling/src/test/expected/ant-design/typescript-S7503.json
@@ -1,0 +1,28 @@
+{
+"ant-design:components/_util/__tests__/getScrollNode.test.ts": [
+5
+],
+"ant-design:components/anchor/__tests__/Anchor.test.tsx": [
+144,
+177,
+495,
+521,
+695,
+723
+],
+"ant-design:components/button/__tests__/index.test.tsx": [
+226
+],
+"ant-design:components/button/__tests__/wave.test.tsx": [
+104
+],
+"ant-design:components/segmented/__tests__/index.test.tsx": [
+216
+],
+"ant-design:components/statistic/__tests__/index.test.tsx": [
+71
+],
+"ant-design:components/upload/__tests__/type.test.tsx": [
+120
+]
+}

--- a/its/ruling/src/test/expected/courselit/typescript-S7503.json
+++ b/its/ruling/src/test/expected/courselit/typescript-S7503.json
@@ -1,0 +1,17 @@
+{
+"courselit:apps/web/components/admin/courses/index.tsx": [
+134
+],
+"courselit:apps/web/lib/graphql.ts": [
+102
+],
+"courselit:apps/web/pages/api/auth/logout.ts": [
+4
+],
+"courselit:apps/web/payments/stripe-payment.ts": [
+23
+],
+"courselit:packages/state-management/src/action-creators.ts": [
+35
+]
+}

--- a/its/ruling/src/test/expected/desktop/typescript-S7503.json
+++ b/its/ruling/src/test/expected/desktop/typescript-S7503.json
@@ -1,0 +1,222 @@
+{
+"desktop:app/src/lib/databases/pull-request-database.ts": [
+121,
+135
+],
+"desktop:app/src/lib/databases/repositories-database.ts": [
+167
+],
+"desktop:app/src/lib/git/checkout.ts": [
+21
+],
+"desktop:app/src/lib/git/cherry-pick.ts": [
+490
+],
+"desktop:app/src/lib/git/fetch.ts": [
+11
+],
+"desktop:app/src/lib/git/spawn.ts": [
+35
+],
+"desktop:app/src/lib/markdown-filters/close-keyword-filter.ts": [
+105
+],
+"desktop:app/src/lib/markdown-filters/commit-mention-filter.ts": [
+178
+],
+"desktop:app/src/lib/markdown-filters/commit-mention-link-filter.ts": [
+124
+],
+"desktop:app/src/lib/markdown-filters/issue-link-filter.ts": [
+106
+],
+"desktop:app/src/lib/markdown-filters/issue-mention-filter.ts": [
+127
+],
+"desktop:app/src/lib/markdown-filters/mention-filter.ts": [
+90
+],
+"desktop:app/src/lib/markdown-filters/team-mention-filter.ts": [
+75
+],
+"desktop:app/src/lib/markdown-filters/video-link-filter.ts": [
+45
+],
+"desktop:app/src/lib/markdown-filters/video-tag-filter.ts": [
+30
+],
+"desktop:app/src/lib/ssh/ssh-secret-storage.ts": [
+39
+],
+"desktop:app/src/lib/ssh/ssh-user-password.ts": [
+10,
+29
+],
+"desktop:app/src/lib/stats/stats-store.ts": [
+428
+],
+"desktop:app/src/lib/stores/app-store.ts": [
+1112,
+1164,
+1465,
+2476,
+2642,
+3106,
+3312,
+3343,
+3360,
+3370,
+5786,
+6554,
+6868
+],
+"desktop:app/src/lib/stores/commit-status-store.ts": [
+245
+],
+"desktop:app/src/lib/stores/helpers/tutorial-assessor.ts": [
+69
+],
+"desktop:app/src/lib/stores/repositories-store.ts": [
+72,
+88
+],
+"desktop:app/src/lib/trampoline/trampoline-server.ts": [
+60
+],
+"desktop:app/src/main-process/alive-origin-filter.ts": [
+8
+],
+"desktop:app/src/main-process/authenticated-avatar-filter.ts": [
+16
+],
+"desktop:app/src/main-process/main.ts": [
+210,
+485,
+503,
+506,
+510,
+514,
+566,
+571,
+576,
+582,
+590,
+595,
+599,
+614,
+623,
+650,
+664,
+671,
+675,
+678
+],
+"desktop:app/src/main-process/same-origin-filter.ts": [
+40,
+54
+],
+"desktop:app/src/ui/add-repository/add-existing-repository.tsx": [
+238
+],
+"desktop:app/src/ui/add-repository/create-repository.tsx": [
+169
+],
+"desktop:app/src/ui/app.tsx": [
+928,
+2955
+],
+"desktop:app/src/ui/autocompletion/emoji-autocompletion-provider.tsx": [
+44
+],
+"desktop:app/src/ui/banners/cherry-pick-conflicts-banner.tsx": [
+20
+],
+"desktop:app/src/ui/banners/conflicts-found-banner.tsx": [
+26
+],
+"desktop:app/src/ui/banners/rebase-conflicts-banner.tsx": [
+22
+],
+"desktop:app/src/ui/branches/branches-container.tsx": [
+348
+],
+"desktop:app/src/ui/changes/commit-message-avatar.tsx": [
+188
+],
+"desktop:app/src/ui/check-runs/ci-check-run-popover.tsx": [
+116
+],
+"desktop:app/src/ui/choose-fork-settings/choose-fork-settings-dialog.tsx": [
+113
+],
+"desktop:app/src/ui/clone-repository/clone-repository.tsx": [
+585
+],
+"desktop:app/src/ui/dispatcher/dispatcher.ts": [
+441,
+906,
+2954
+],
+"desktop:app/src/ui/dispatcher/error-handlers.ts": [
+123,
+227,
+268,
+332,
+359,
+380,
+434,
+480,
+529,
+573,
+627
+],
+"desktop:app/src/ui/history/compare.tsx": [
+650
+],
+"desktop:app/src/ui/history/merge-call-to-action-with-conflicts.tsx": [
+92,
+129
+],
+"desktop:app/src/ui/lib/configure-git-user.tsx": [
+88
+],
+"desktop:app/src/ui/lib/sandboxed-markdown.tsx": [
+140,
+152
+],
+"desktop:app/src/ui/missing-repository.tsx": [
+52,
+56
+],
+"desktop:app/src/ui/multi-commit-operation/base-rebase.tsx": [
+64
+],
+"desktop:app/src/ui/multi-commit-operation/cherry-pick.tsx": [
+46
+],
+"desktop:app/src/ui/multi-commit-operation/choose-branch/choose-target-branch.tsx": [
+209,
+219
+],
+"desktop:app/src/ui/multi-commit-operation/choose-branch/rebase-choose-branch-dialog.tsx": [
+88
+],
+"desktop:app/src/ui/multi-commit-operation/dialog/confirm-abort-dialog.tsx": [
+46
+],
+"desktop:app/src/ui/multi-commit-operation/dialog/warn-force-push-dialog.tsx": [
+95
+],
+"desktop:app/src/ui/multi-commit-operation/merge.tsx": [
+56
+],
+"desktop:app/src/ui/preferences/integrations.tsx": [
+36
+],
+"desktop:app/src/ui/publish-repository/publish-repository.tsx": [
+45
+],
+"desktop:app/src/ui/stashing/stash-diff-header.tsx": [
+92
+]
+}

--- a/its/ruling/src/test/expected/eigen/typescript-S7503.json
+++ b/its/ruling/src/test/expected/eigen/typescript-S7503.json
@@ -1,0 +1,343 @@
+{
+"eigen:dangerfile.ts": [
+144
+],
+"eigen:src/app/Components/Artist/ArtistArtworks/ArtistCollectionsRail.tests.tsx": [
+15
+],
+"eigen:src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx": [
+14
+],
+"eigen:src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx": [
+58,
+85
+],
+"eigen:src/app/Components/Artist/ArtistConsignButton.tests.tsx": [
+113,
+133,
+182
+],
+"eigen:src/app/Components/ArtistListItem.tsx": [
+67
+],
+"eigen:src/app/Components/ArtworkFilter/FilterModal.tests.tsx": [
+541,
+590
+],
+"eigen:src/app/Components/ArtworkFilter/Filters/GalleriesAndInstitutionsOptions.tests.tsx": [
+88
+],
+"eigen:src/app/Components/ArtworkFilter/Filters/LocationCitiesOptions.tests.tsx": [
+88
+],
+"eigen:src/app/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tests.tsx": [
+88
+],
+"eigen:src/app/Components/ArtworkFilter/Filters/TimePeriodOptions.tests.tsx": [
+96
+],
+"eigen:src/app/Components/ArtworkFilter/components/ArtworkFilterOptionCheckboxItem.tests.tsx": [
+53
+],
+"eigen:src/app/Components/Bidding/Screens/BidResult.tsx": [
+77
+],
+"eigen:src/app/Components/Bidding/Screens/ConfirmBid/index.tsx": [
+187
+],
+"eigen:src/app/Components/Bidding/Screens/PhoneNumberForm.tests.tsx": [
+20
+],
+"eigen:src/app/Components/Bidding/Screens/Registration.tsx": [
+228
+],
+"eigen:src/app/Components/Home/ArtistRails/RecommendedArtistsRail.tests.tsx": [
+15,
+29
+],
+"eigen:src/app/Components/PopoverMessage/PopoverMessage.tests.tsx": [
+21,
+39,
+58,
+78,
+97,
+117,
+186,
+205,
+221
+],
+"eigen:src/app/Components/SectionTitle.tests.tsx": [
+8,
+16,
+24
+],
+"eigen:src/app/Components/ShareSheet/ShareSheet.tests.tsx": [
+103,
+114,
+120,
+162,
+168
+],
+"eigen:src/app/Components/Show/ShowArtistsPreview.tests.tsx": [
+44
+],
+"eigen:src/app/Components/Show/ShowArtworksPreview.tests.tsx": [
+12
+],
+"eigen:src/app/Components/Toast/Toast.tests.tsx": [
+32
+],
+"eigen:src/app/NativeModules/ARScreenPresenterModule.tsx": [
+96
+],
+"eigen:src/app/Scenes/Artist/Artist.tests.tsx": [
+48,
+73,
+95,
+115,
+135,
+156
+],
+"eigen:src/app/Scenes/Artist/ArtistSavedSearch.tests.tsx": [
+59,
+72,
+82
+],
+"eigen:src/app/Scenes/Artwork/Artwork.tests.tsx": [
+110,
+279,
+297
+],
+"eigen:src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx": [
+23,
+37,
+46,
+55
+],
+"eigen:src/app/Scenes/Artwork/Components/ArtworkHeader.tsx": [
+107
+],
+"eigen:src/app/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tests.tsx": [
+26
+],
+"eigen:src/app/Scenes/Artwork/Components/Questions.tests.tsx": [
+30
+],
+"eigen:src/app/Scenes/Artwork/Components/RequestConditionReport.tsx": [
+47
+],
+"eigen:src/app/Scenes/BottomTabs/BottomTabsButton.tests.tsx": [
+51,
+57,
+65
+],
+"eigen:src/app/Scenes/Fair/FairBMWArtActivation.tests.tsx": [
+15
+],
+"eigen:src/app/Scenes/Fair/FairMoreInfo.tests.tsx": [
+54,
+95
+],
+"eigen:src/app/Scenes/Gene/Gene.tests.tsx": [
+71
+],
+"eigen:src/app/Scenes/Home/Components/EmailConfirmationBanner.tests.tsx": [
+88
+],
+"eigen:src/app/Scenes/Home/Components/SalesRail.tests.tsx": [
+165
+],
+"eigen:src/app/Scenes/Home/Home.tsx": [
+358
+],
+"eigen:src/app/Scenes/Inbox/Components/Conversations/Preview/Attachment/FileDownload.tests.tsx": [
+12
+],
+"eigen:src/app/Scenes/MyCollection/MyCollection.tsx": [
+138
+],
+"eigen:src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateScreen.tsx": [
+86
+],
+"eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx": [
+43
+],
+"eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx": [
+359
+],
+"eigen:src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx": [
+27
+],
+"eigen:src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tests.tsx": [
+100
+],
+"eigen:src/app/Scenes/MyCollection/Screens/Insights/AverageSalePriceAtAuction.tests.tsx": [
+23
+],
+"eigen:src/app/Scenes/MyCollection/Screens/Insights/AverageSalePriceSelectArtist.tests.tsx": [
+34
+],
+"eigen:src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsights.tsx": [
+76
+],
+"eigen:src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tests.tsx": [
+114
+],
+"eigen:src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingSocialPick.tests.tsx": [
+20,
+29,
+55,
+65
+],
+"eigen:src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tests.tsx": [
+67
+],
+"eigen:src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tsx": [
+163
+],
+"eigen:src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalizationModal.tests.tsx": [
+47
+],
+"eigen:src/app/Scenes/Onboarding/OnboardingSocialLink.tsx": [
+93
+],
+"eigen:src/app/Scenes/OrderHistory/OrderHistory.tests.tsx": [
+47,
+62
+],
+"eigen:src/app/Scenes/Partner/Components/PartnerArtwork.tests.tsx": [
+13
+],
+"eigen:src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx": [
+36,
+50,
+64,
+78
+],
+"eigen:src/app/Scenes/Partner/Components/PartnerOverview.tests.tsx": [
+62,
+82,
+101
+],
+"eigen:src/app/Scenes/Partner/Components/PartnerShows.tests.tsx": [
+70
+],
+"eigen:src/app/Scenes/Sales/Components/SaleListItem.tests.tsx": [
+38
+],
+"eigen:src/app/Scenes/SavedAddresses/SavedAddressesForm.tsx": [
+181
+],
+"eigen:src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx": [
+107
+],
+"eigen:src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx": [
+118,
+144,
+166,
+187,
+207
+],
+"eigen:src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx": [
+130,
+266,
+613,
+627
+],
+"eigen:src/app/Scenes/Search/AutosuggestResults.tests.tsx": [
+167,
+172,
+240,
+259,
+316
+],
+"eigen:src/app/Scenes/Search/SearchModel.tests.tsx": [
+36,
+49,
+56,
+69,
+87
+],
+"eigen:src/app/Scenes/Search/components/AutosuggestSearchResult.tests.tsx": [
+52,
+59,
+64,
+69,
+76,
+81,
+99,
+173,
+194,
+215
+],
+"eigen:src/app/Scenes/Search/components/CityGuideCTA.tests.tsx": [
+9
+],
+"eigen:src/app/Scenes/Search/components/CityGuideCTANew.tests.tsx": [
+9
+],
+"eigen:src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tests.tsx": [
+44
+],
+"eigen:src/app/Scenes/SellWithArtsy/mutations/createConsignSubmissionMutation.ts": [
+28
+],
+"eigen:src/app/Scenes/SellWithArtsy/mutations/removeAssetFromConsignmentSubmissionMutation.ts": [
+26
+],
+"eigen:src/app/Scenes/SellWithArtsy/mutations/updateConsignSubmissionMutation.ts": [
+24
+],
+"eigen:src/app/Scenes/Tag/Tag.tests.tsx": [
+66,
+74
+],
+"eigen:src/app/navigation/useReloadedDevNavigationState.ts": [
+73
+],
+"eigen:src/app/utils/ExecutionQueue.tests.ts": [
+29
+],
+"eigen:src/app/utils/PushNotification.tests.ts": [
+76,
+167
+],
+"eigen:src/app/utils/PushNotification.ts": [
+215
+],
+"eigen:src/app/utils/experiments/unleashClient.ts": [
+43
+],
+"eigen:src/app/utils/extractNodes.tests.ts": [
+4,
+11,
+18
+],
+"eigen:src/app/utils/getUrgencytag.tests.ts": [
+5,
+14,
+19
+],
+"eigen:src/app/utils/renderMarkdown.tests.tsx": [
+141
+],
+"eigen:src/app/utils/useWebViewEvents.tests.ts": [
+17
+],
+"eigen:src/palette/elements/Autocomplete/Autocomplete.tests.ts": [
+27,
+31,
+35,
+47,
+60,
+64,
+68
+],
+"eigen:src/shared/utils/Wrap.tests.tsx": [
+17,
+23,
+31,
+41,
+58
+]
+}

--- a/its/ruling/src/test/expected/fresh/typescript-S7503.json
+++ b/its/ruling/src/test/expected/fresh/typescript-S7503.json
@@ -1,0 +1,34 @@
+{
+"fresh:packages/fresh/src/app.ts": [
+47
+],
+"fresh:packages/fresh/src/app_test.tsx": [
+687,
+704
+],
+"fresh:packages/fresh/src/context_test.tsx": [
+230
+],
+"fresh:packages/fresh/src/dev/dev_build_cache.ts": [
+195,
+300
+],
+"fresh:packages/fresh/src/middlewares/mod_test.ts": [
+140
+],
+"fresh:packages/fresh/src/middlewares/static_files_test.ts": [
+49
+],
+"fresh:packages/fresh/src/middlewares/trailing_slashes_test.ts": [
+9,
+36
+],
+"fresh:packages/fresh/src/test_utils.ts": [
+106,
+125,
+132
+],
+"fresh:packages/fresh/tests/fixture_update_check/mod.ts": [
+5
+]
+}

--- a/its/ruling/src/test/expected/moose/typescript-S7503.json
+++ b/its/ruling/src/test/expected/moose/typescript-S7503.json
@@ -1,0 +1,17 @@
+{
+"moose:main/controllers/delete.ts": [
+5
+],
+"moose:main/controllers/stream.ts": [
+23
+],
+"moose:main/modules/menu.ts": [
+4
+],
+"moose:main/modules/playOnVlc.ts": [
+7
+],
+"moose:renderer/components/Downloads/Downloads.tsx": [
+53
+]
+}

--- a/its/ruling/src/test/expected/searchkit/typescript-S7503.json
+++ b/its/ruling/src/test/expected/searchkit/typescript-S7503.json
@@ -1,0 +1,5 @@
+{
+"searchkit:packages/searchkit-schema/src/resolvers/ResultsResolver.ts": [
+83
+]
+}

--- a/its/ruling/src/test/expected/vitest/typescript-S7503.json
+++ b/its/ruling/src/test/expected/vitest/typescript-S7503.json
@@ -1,0 +1,140 @@
+{
+"vitest:examples/fastify/src/app.ts": [
+9
+],
+"vitest:examples/lit/test/basic.test.ts": [
+6
+],
+"vitest:examples/opentelemetry/src/basic.test.ts": [
+9
+],
+"vitest:examples/projects/packages/server/src/app.ts": [
+9
+],
+"vitest:packages/browser-preview/src/preview.ts": [
+50
+],
+"vitest:packages/browser-webdriverio/src/webdriverio.ts": [
+270
+],
+"vitest:packages/browser/src/client/orchestrator.ts": [
+328
+],
+"vitest:packages/browser/src/client/tester/context.ts": [
+161,
+222,
+245
+],
+"vitest:packages/browser/src/node/commands/fs.ts": [
+28
+],
+"vitest:packages/browser/src/node/plugin.ts": [
+39,
+295,
+314,
+356
+],
+"vitest:packages/browser/src/node/rpc.ts": [
+141,
+214
+],
+"vitest:packages/browser/src/node/utils.ts": [
+67
+],
+"vitest:packages/mocker/src/browser/interceptor-msw.ts": [
+58
+],
+"vitest:packages/mocker/src/node/mockerPlugin.ts": [
+52
+],
+"vitest:packages/snapshot/src/env/node.ts": [
+16,
+20,
+36
+],
+"vitest:packages/ui/client/composables/client/static.ts": [
+51,
+73
+],
+"vitest:packages/ui/client/composables/codemirror.ts": [
+67
+],
+"vitest:packages/vitest/src/api/setup.ts": [
+68,
+74,
+247,
+257,
+267
+],
+"vitest:packages/vitest/src/integrations/env/loader.ts": [
+47
+],
+"vitest:packages/vitest/src/integrations/env/node.ts": [
+123
+],
+"vitest:packages/vitest/src/node/core.ts": [
+377
+],
+"vitest:packages/vitest/src/node/coverage.ts": [
+223,
+227,
+572
+],
+"vitest:packages/vitest/src/node/plugins/index.ts": [
+26,
+44
+],
+"vitest:packages/vitest/src/node/plugins/vitestResolver.ts": [
+45
+],
+"vitest:packages/vitest/src/node/pools/workers/forksWorker.ts": [
+44
+],
+"vitest:packages/vitest/src/node/pools/workers/threadsWorker.ts": [
+40
+],
+"vitest:packages/vitest/src/node/pools/workers/typecheckWorker.ts": [
+151
+],
+"vitest:packages/vitest/src/node/project.ts": [
+544
+],
+"vitest:packages/vitest/src/node/projects/resolveProjects.ts": [
+203
+],
+"vitest:packages/vitest/src/node/reporters/junit.ts": [
+159
+],
+"vitest:packages/vitest/src/node/sequencers/BaseSequencer.ts": [
+16,
+35
+],
+"vitest:packages/vitest/src/node/sequencers/RandomSequencer.ts": [
+6
+],
+"vitest:packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts": [
+287,
+291
+],
+"vitest:packages/vitest/src/runtime/nodejsWorkerLoader.ts": [
+13
+],
+"vitest:packages/vitest/src/runtime/runners/benchmark.ts": [
+177
+],
+"vitest:packages/vitest/src/runtime/runners/test.ts": [
+142
+],
+"vitest:packages/vitest/src/runtime/workers/base.ts": [
+44
+],
+"vitest:packages/vitest/src/typecheck/parse.ts": [
+6
+],
+"vitest:packages/vitest/src/typecheck/typechecker.ts": [
+272
+],
+"vitest:packages/vitest/src/utils/graph.ts": [
+6
+]
+}

--- a/its/ruling/src/test/expected/vuetify/typescript-S7503.json
+++ b/its/ruling/src/test/expected/vuetify/typescript-S7503.json
@@ -1,0 +1,5 @@
+{
+"vuetify:packages/api-generator/src/types.ts": [
+66
+]
+}

--- a/packages/analysis/src/jsts/rules/S7503/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7503/decorator.ts
@@ -1,0 +1,28 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+// https://sonarsource.github.io/rspec/#/rspec/S7503/javascript
+
+import type { Rule } from 'eslint';
+import { generateMeta } from '../helpers/generate-meta.js';
+import * as meta from './generated-meta.js';
+
+export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
+  return {
+    ...rule,
+    meta: generateMeta(meta, rule.meta),
+  };
+}

--- a/packages/analysis/src/jsts/rules/S7503/fixtures/index.ts
+++ b/packages/analysis/src/jsts/rules/S7503/fixtures/index.ts
@@ -1,0 +1,1 @@
+// intentionally left empty

--- a/packages/analysis/src/jsts/rules/S7503/fixtures/tsconfig.json
+++ b/packages/analysis/src/jsts/rules/S7503/fixtures/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"]
+  }
+}

--- a/packages/analysis/src/jsts/rules/S7503/index.ts
+++ b/packages/analysis/src/jsts/rules/S7503/index.ts
@@ -1,0 +1,20 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { rules } from '../external/typescript-eslint/index.js';
+import { decorate } from './decorator.js';
+
+export const rule = decorate(rules['require-await']);

--- a/packages/analysis/src/jsts/rules/S7503/meta.ts
+++ b/packages/analysis/src/jsts/rules/S7503/meta.ts
@@ -1,0 +1,21 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+export const implementation = 'decorated';
+export const eslintId = 'require-await';
+export const externalRules = [
+  { externalPlugin: 'typescript-eslint', externalRule: 'require-await' },
+];

--- a/packages/analysis/src/jsts/rules/S7503/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7503/unit.test.ts
@@ -1,0 +1,95 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { rule } from './index.js';
+import { RuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
+import { describe, it } from 'node:test';
+
+import path from 'node:path';
+import parser from '@typescript-eslint/parser';
+
+describe('S7503', () => {
+  it('S7503', () => {
+    const ruleTester = new RuleTester({
+      parser,
+      parserOptions: {
+        project: `./tsconfig.json`,
+        tsconfigRootDir: path.join(import.meta.dirname, 'fixtures'),
+      },
+    });
+
+    ruleTester.run('S7503', rule, {
+      valid: [
+        {
+          code: `
+async function foo() {
+  await bar();
+}
+`,
+          filename: path.join(import.meta.dirname, 'fixtures/index.ts'),
+        },
+        {
+          code: `
+async function empty() {}
+`,
+          filename: path.join(import.meta.dirname, 'fixtures/index.ts'),
+        },
+        {
+          code: `
+async function* generator() {
+  yield Promise.resolve(1);
+}
+`,
+          filename: path.join(import.meta.dirname, 'fixtures/index.ts'),
+        },
+        {
+          code: `
+async function withAwaitUsing() {
+  await using resource = getDisposable();
+}
+declare function getDisposable(): AsyncDisposable;
+`,
+          filename: path.join(import.meta.dirname, 'fixtures/index.ts'),
+        },
+      ],
+      invalid: [
+        {
+          code: `
+async function foo() {
+  bar();
+}
+`,
+          errors: 1,
+          filename: path.join(import.meta.dirname, 'fixtures/index.ts'),
+        },
+        {
+          code: `
+class Service {
+  @decorator()
+  async handle() {
+    return computeSync();
+  }
+}
+declare function decorator(): MethodDecorator;
+declare function computeSync(): number;
+`,
+          errors: 1,
+          filename: path.join(import.meta.dirname, 'fixtures/index.ts'),
+        },
+      ],
+    });
+  });
+});

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7503.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7503.json
@@ -26,8 +26,5 @@
     "js",
     "ts"
   ],
-  "defaultQualityProfiles": [
-    "Sonar way",
-    "Sonar agentic AI"
-  ]
+  "defaultQualityProfiles": []
 }

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7503.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7503.json
@@ -23,7 +23,6 @@
     "attribute": "CONVENTIONAL"
   },
   "compatibleLanguages": [
-    "js",
     "ts"
   ],
   "defaultQualityProfiles": []

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7503.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7503.json
@@ -1,0 +1,33 @@
+{
+  "title": "Async functions should use async features",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "async",
+    "type-dependent"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-7503",
+  "sqKey": "S7503",
+  "scope": "Main",
+  "quickfix": "covered",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM",
+      "RELIABILITY": "LOW"
+    },
+    "attribute": "CONVENTIONAL"
+  },
+  "compatibleLanguages": [
+    "js",
+    "ts"
+  ],
+  "defaultQualityProfiles": [
+    "Sonar way",
+    "Sonar agentic AI"
+  ]
+}

--- a/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7503.json
+++ b/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/javascript/S7503.json
@@ -25,5 +25,7 @@
   "compatibleLanguages": [
     "ts"
   ],
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [
+    "Sonar way"
+  ]
 }


### PR DESCRIPTION
Reuses the existing S7503 (currently Python-only, "Async functions should use async features") for JS/TS instead of minting a new rule number — it's an exact semantic match for typescript-eslint's `require-await`. Companion RSPEC PR to extend S7503 to JS/TS is tracked separately and not yet merged; the `S7503.json` resource in this PR is a hand-authored stub mirroring the intended RSPEC metadata and will be overwritten by `rspec:refresh` once that PR lands.

## Summary
- Decorates `@typescript-eslint/require-await` as a plain metadata wrapper (`packages/analysis/src/jsts/rules/S7503/`) — no custom FP-suppression logic.
- Investigated every community-reported "false positive" against `require-await` on the typescript-eslint tracker before deciding not to add exceptions. All were either already fixed upstream, deliberate maintainer-defended design, or reporter misunderstandings:
  - #11669 (async generators/iterators) — reporter agreed it wasn't a bug, closed it themselves.
  - #11425 (`await using` support) — closed as duplicate; already implemented upstream (#7866).
  - #11819 (`AsyncDisposableStack`) — maintainer confirmed the callback type accepts sync functions fine; report was simply wrong.
  - #11973 / #11085 (interface/decorator contracts requiring async) — maintainer: using `async` purely to coerce a return type into a `Promise` is "exactly what the rule exists to prevent"; rejected on principle.
  - #10368 (explicit `Promise<T>` return type) — maintainer rejected the proposal outright; the suggested workaround wouldn't even type-check.
  - #11731 (rule shouldn't be recommended by default) — a policy objection, not a detection bug; closed `wontfix` for lack of community consensus.
  - #11093 — a false *negative* in the other direction, unrelated to any of the above.
- Added `S7503.json` (Sonar-side RSPEC resource stub), `meta.ts`, `decorator.ts`, `index.ts`, `unit.test.ts`, and `fixtures/` (tsconfig targeting `esnext` for async generator / `await using` syntax).

## Test plan
- [x] `npx tsx --test packages/analysis/src/jsts/rules/S7503/unit.test.ts` passes (valid cases cover await, empty async functions, async generators, `await using`; invalid cases cover missing await and the interface/decorator-contract pattern rejected above).
- [ ] CI green
- [ ] Companion RSPEC PR merged and `rspec:refresh` re-run to replace the hand-authored `S7503.json` stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)