### PR TITLE
JS-2355 Expose Standalone Parser Port in public Configuration

### DIFF
--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerConfig.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerConfig.java
@@ -31,7 +31,7 @@ public record BridgeServerConfig(
   Configuration config,
   String workDirAbsolutePath,
   SonarProduct product,
-  @Nullable String existingNodeProcessPort
+  @Nullable Integer existingNodeProcessPort
 ) {
   public static BridgeServerConfig fromSensorContext(SensorContext context) {
     return new BridgeServerConfig(

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerConfig.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerConfig.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.javascript.bridge;
 
+import javax.annotation.Nullable;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.config.Configuration;
@@ -29,13 +30,15 @@ import org.sonar.api.config.Configuration;
 public record BridgeServerConfig(
   Configuration config,
   String workDirAbsolutePath,
-  SonarProduct product
+  SonarProduct product,
+  @Nullable String existingNodeProcessPort
 ) {
   public static BridgeServerConfig fromSensorContext(SensorContext context) {
     return new BridgeServerConfig(
       context.config(),
       context.fileSystem().workDir().getAbsolutePath(),
-      context.runtime().getProduct()
+      context.runtime().getProduct(),
+      null
     );
   }
 }

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -118,7 +118,7 @@ public class BridgeServerImpl implements BridgeServer {
   private boolean ownsNodeProcess;
 
   @Nullable
-  private String existingNodeProcessPortOverride;
+  private Integer existingNodeProcessPortOverride;
 
   // Used by pico container for dependency injection
   public BridgeServerImpl(
@@ -822,7 +822,7 @@ public class BridgeServerImpl implements BridgeServer {
 
   public String getExistingNodeProcessPort() {
     return existingNodeProcessPortOverride != null
-      ? existingNodeProcessPortOverride
+      ? String.valueOf(existingNodeProcessPortOverride)
       : System.getenv(SONARJS_EXISTING_NODE_PROCESS_PORT);
   }
 

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -117,6 +117,9 @@ public class BridgeServerImpl implements BridgeServer {
    */
   private boolean ownsNodeProcess;
 
+  @Nullable
+  private String existingNodeProcessPortOverride;
+
   // Used by pico container for dependency injection
   public BridgeServerImpl(
     NodeCommandBuilder nodeCommandBuilder,
@@ -396,6 +399,7 @@ public class BridgeServerImpl implements BridgeServer {
 
   @Override
   public void startServerLazily(BridgeServerConfig serverConfig) throws IOException {
+    existingNodeProcessPortOverride = serverConfig.existingNodeProcessPort();
     if (status == Status.FAILED) {
       if (shouldRestartFailedServer()) {
         // Reset the status, which will cause the server to retry deployment
@@ -414,6 +418,11 @@ public class BridgeServerImpl implements BridgeServer {
       if (!waitChannelReady(timeoutSeconds * 1000)) {
         status = Status.FAILED;
         closeChannel();
+        if (existingNodeProcessPortOverride != null) {
+          throw new IllegalStateException(
+            "Could not connect to existing Node.js process on " + hostAddress + ":" + port
+          );
+        }
         throw new ServerAlreadyFailedException();
       }
       serverHasStarted();
@@ -812,7 +821,9 @@ public class BridgeServerImpl implements BridgeServer {
   }
 
   public String getExistingNodeProcessPort() {
-    return System.getenv(SONARJS_EXISTING_NODE_PROCESS_PORT);
+    return existingNodeProcessPortOverride != null
+      ? existingNodeProcessPortOverride
+      : System.getenv(SONARJS_EXISTING_NODE_PROCESS_PORT);
   }
 
   static class LogOutputConsumer implements Consumer<String> {

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -503,6 +503,23 @@ class BridgeServerImplTest {
   }
 
   @Test
+  void test_getExistingNodeProcessPort_returns_config_value_when_set() throws IOException {
+    // The override is assigned at the top of startServerLazily, before any connection attempt,
+    // so getExistingNodeProcessPort() reflects the config value even after the expected throw.
+    bridgeServer = createUnitBridgeServer(1);
+    var configWithPort = new BridgeServerConfig(
+      serverConfig.config(),
+      serverConfig.workDirAbsolutePath(),
+      serverConfig.product(),
+      12345
+    );
+    assertThatThrownBy(() -> bridgeServer.startServerLazily(configWithPort))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("12345");
+    assertThat(bridgeServer.getExistingNodeProcessPort()).isEqualTo("12345");
+  }
+
+  @Test
   void test_getExistingNodeProcessPort_falls_back_to_env_var_when_config_null() {
     bridgeServer = createUnitBridgeServer();
     assertThat(bridgeServer.getExistingNodeProcessPort())

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -503,6 +503,13 @@ class BridgeServerImplTest {
   }
 
   @Test
+  void test_getExistingNodeProcessPort_falls_back_to_env_var_when_config_null() {
+    bridgeServer = createUnitBridgeServer();
+    assertThat(bridgeServer.getExistingNodeProcessPort())
+      .isEqualTo(System.getenv(BridgeServerImpl.SONARJS_EXISTING_NODE_PROCESS_PORT));
+  }
+
+  @Test
   void isAlive_should_not_require_a_lease_for_an_existing_node_process() throws Exception {
     bridgeServer = createUnitBridgeServer();
     var channel = mock(ManagedChannel.class);

--- a/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
+++ b/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
@@ -113,7 +113,7 @@ public class StandaloneParser implements AutoCloseable {
     private String[] nodeJsArgs;
 
     @Nullable
-    private String existingNodeProcessPort;
+    private Integer existingNodeProcessPort;
 
     private Builder() {}
 
@@ -137,25 +137,12 @@ public class StandaloneParser implements AutoCloseable {
       return this;
     }
 
-    public Builder existingNodeProcessPort(@Nullable String existingNodeProcessPort) {
-      if (existingNodeProcessPort != null) {
-        if (existingNodeProcessPort.isBlank()) {
-          throw new IllegalArgumentException("existingNodeProcessPort must not be blank");
-        }
-        int port;
-        try {
-          port = Integer.parseInt(existingNodeProcessPort);
-        } catch (NumberFormatException e) {
-          throw new IllegalArgumentException(
-            "Invalid existingNodeProcessPort: " + existingNodeProcessPort,
-            e
-          );
-        }
-        if (port < 1 || port > 65535) {
-          throw new IllegalArgumentException(
-            "existingNodeProcessPort should be a number between 1 and 65535, got " + port
-          );
-        }
+    public Builder existingNodeProcessPort(int existingNodeProcessPort) {
+      if (existingNodeProcessPort < 1 || existingNodeProcessPort > 65535) {
+        throw new IllegalArgumentException(
+          "existingNodeProcessPort should be a number between 1 and 65535, got " +
+          existingNodeProcessPort
+        );
       }
       this.existingNodeProcessPort = existingNodeProcessPort;
       return this;

--- a/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
+++ b/sonar-plugin/standalone/src/main/java/org/sonar/plugins/javascript/standalone/StandaloneParser.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.sonar.api.SonarProduct;
 import org.sonar.plugins.javascript.analyzeproject.grpc.AnalyzeProjectRequest;
 import org.sonar.plugins.javascript.analyzeproject.grpc.AnalyzeProjectUnaryResponse;
@@ -91,7 +92,8 @@ public class StandaloneParser implements AutoCloseable {
         new BridgeServerConfig(
           builder.configuration,
           temporaryFolder.newDir().getAbsolutePath(),
-          SonarProduct.SONARLINT
+          SonarProduct.SONARLINT,
+          builder.existingNodeProcessPort
         )
       );
     } catch (IOException e) {
@@ -109,6 +111,9 @@ public class StandaloneParser implements AutoCloseable {
     private int maxOldSpaceSize = -1;
     private org.sonar.api.config.Configuration configuration = new EmptyConfiguration();
     private String[] nodeJsArgs;
+
+    @Nullable
+    private String existingNodeProcessPort;
 
     private Builder() {}
 
@@ -129,6 +134,30 @@ public class StandaloneParser implements AutoCloseable {
 
     public Builder nodeJsArgs(String... nodeJsArgs) {
       this.nodeJsArgs = nodeJsArgs;
+      return this;
+    }
+
+    public Builder existingNodeProcessPort(@Nullable String existingNodeProcessPort) {
+      if (existingNodeProcessPort != null) {
+        if (existingNodeProcessPort.isBlank()) {
+          throw new IllegalArgumentException("existingNodeProcessPort must not be blank");
+        }
+        int port;
+        try {
+          port = Integer.parseInt(existingNodeProcessPort);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(
+            "Invalid existingNodeProcessPort: " + existingNodeProcessPort,
+            e
+          );
+        }
+        if (port < 1 || port > 65535) {
+          throw new IllegalArgumentException(
+            "existingNodeProcessPort should be a number between 1 and 65535, got " + port
+          );
+        }
+      }
+      this.existingNodeProcessPort = existingNodeProcessPort;
       return this;
     }
 

--- a/sonar-plugin/standalone/src/test/java/org/sonar/plugins/javascript/standalone/StandaloneParserTest.java
+++ b/sonar-plugin/standalone/src/test/java/org/sonar/plugins/javascript/standalone/StandaloneParserTest.java
@@ -105,37 +105,19 @@ class StandaloneParserTest {
   @Test
   void test_existing_node_port_out_of_range_throws() {
     assertThatThrownBy(() ->
-      StandaloneParser.builder().existingNodeProcessPort("70000")
+      StandaloneParser.builder().existingNodeProcessPort(70000)
     )
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining("between 1 and 65535");
-  }
-
-  @Test
-  void test_existing_node_port_not_a_number_throws() {
-    assertThatThrownBy(() ->
-      StandaloneParser.builder().existingNodeProcessPort("not-a-port")
-    )
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("Invalid existingNodeProcessPort");
   }
 
   @Test
   void test_existing_node_port_zero_throws() {
     assertThatThrownBy(() ->
-      StandaloneParser.builder().existingNodeProcessPort("0")
+      StandaloneParser.builder().existingNodeProcessPort(0)
     )
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining("between 1 and 65535");
-  }
-
-  @Test
-  void test_existing_node_port_blank_throws() {
-    assertThatThrownBy(() ->
-      StandaloneParser.builder().existingNodeProcessPort("  ")
-    )
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("blank");
   }
 
   @Test

--- a/sonar-plugin/standalone/src/test/java/org/sonar/plugins/javascript/standalone/StandaloneParserTest.java
+++ b/sonar-plugin/standalone/src/test/java/org/sonar/plugins/javascript/standalone/StandaloneParserTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.sonar.plugins.javascript.api.estree.ESTree.Program;
 
+
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
@@ -99,6 +100,42 @@ class StandaloneParserTest {
       Program program = builtParser.parse("var x = 1;");
       assertThat(program.body()).hasSize(1);
     }
+  }
+
+  @Test
+  void test_existing_node_port_out_of_range_throws() {
+    assertThatThrownBy(() ->
+      StandaloneParser.builder().existingNodeProcessPort("70000")
+    )
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("between 1 and 65535");
+  }
+
+  @Test
+  void test_existing_node_port_not_a_number_throws() {
+    assertThatThrownBy(() ->
+      StandaloneParser.builder().existingNodeProcessPort("not-a-port")
+    )
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Invalid existingNodeProcessPort");
+  }
+
+  @Test
+  void test_existing_node_port_zero_throws() {
+    assertThatThrownBy(() ->
+      StandaloneParser.builder().existingNodeProcessPort("0")
+    )
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("between 1 and 65535");
+  }
+
+  @Test
+  void test_existing_node_port_blank_throws() {
+    assertThatThrownBy(() ->
+      StandaloneParser.builder().existingNodeProcessPort("  ")
+    )
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("blank");
   }
 
   @Test


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration:**
    - Added `existingNodeProcessPort` field to `BridgeServerConfig` and exposed it in `StandaloneParser` builder
- **Bridge Server:**
    - Updated `BridgeServerImpl` to support overriding the node process port via configuration rather than only environment variables
- **Testing:**
    - Added unit tests in `StandaloneParserTest` to validate out-of-range and invalid node port configurations

<sub>This will update automatically on new commits.</sub>