### PR TITLE
JS-2377 Remove redundant logging dependency handling

### DIFF
--- a/its/plugin/plugins/consumer-plugin/pom.xml
+++ b/its/plugin/plugins/consumer-plugin/pom.xml
@@ -25,10 +25,6 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.javascript</groupId>
       <artifactId>api</artifactId>
     </dependency>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -25,6 +25,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.18</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
       <scope>test</scope>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -30,11 +30,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator-junit5</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
     <jgit.version>7.7.1.202607240634-r</jgit.version>
     <junit.version>6.1.3</junit.version>
     <mockito.version>5.23.0</mockito.version>
-    <slf4j.version>2.0.18</slf4j.version>
     <jetbrains.annotations.version>26.1.0</jetbrains.annotations.version>
     <sonar.version>26.8.0.126808</sonar.version>
     <scanner-engine.version>13.10.0.4657</scanner-engine.version>
@@ -171,12 +170,6 @@
         <version>1.12</version>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.jetbrains</groupId>
         <artifactId>annotations</artifactId>
         <version>${jetbrains.annotations.version}</version>
@@ -269,12 +262,6 @@
         <groupId>org.sonarsource.scanner.engine</groupId>
         <artifactId>sensor-test-fixtures</artifactId>
         <version>${scanner-engine.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>1.6.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/sonar-plugin/bridge/pom.xml
+++ b/sonar-plugin/bridge/pom.xml
@@ -95,10 +95,6 @@
       <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <extensions>

--- a/sonar-plugin/css/pom.xml
+++ b/sonar-plugin/css/pom.xml
@@ -72,10 +72,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/sonar-plugin/sonar-javascript-plugin/pom.xml
+++ b/sonar-plugin/sonar-javascript-plugin/pom.xml
@@ -61,10 +61,6 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api</artifactId>
     </dependency>


### PR DESCRIPTION
Part of

## Summary

- Remove redundant SLF4J and Logback version overrides, transitive constraints, and update exceptions from plugin-bound code.
- Rely on Sonar Plugin API v14 and its test fixtures for SLF4J 2.0.18 and Logback 1.6.3 where they are part of the platform contract.
- Keep logging dependencies explicit only in standalone code or tests that use the implementation API directly.
