### PR TITLE
JS-2368 S5332: False positive on http:// URLs used as schema/namespace identifiers (CycloneDX schema, SNOMED/SOAP/XMPP/ESCO namespaces)

### DIFF
--- a/packages/analysis/src/jsts/rules/S5332/rule.lib.ts
+++ b/packages/analysis/src/jsts/rules/S5332/rule.lib.ts
@@ -54,9 +54,41 @@ const INSECURE_PROTOCOLS = Object.keys(CLEARTEXT_PROTOCOL_ALTERNATIVES).map(s =>
 const SAFE_HOSTS =
   /(?:^localhost|^127(?:\.\d+){1,3}|^\[(?:0*:){7}:?0*1]|^\[::1]|^169\.254\.\d+\.\d+|^\[fd00:ec2::254]|^168\.63\.129\.16|^100\.100\.100\.200|^metadata\.google\.internal|^metadata\.internal|^host\.docker\.internal|^gateway\.docker\.internal|\.svc\.cluster\.local)(?=:|$)/i;
 
-// XML namespace URI authorities — port of CleartextProtocolFilter.NAMESPACE_URI_AUTHORITIES, extended with pre-existing sonar-js exceptions
-const NAMESPACE_URI_AUTHORITIES =
-  /(?:^www\.w3\.org|^schemas\.android\.com|^schemas\.microsoft\.com|^schemas\.xmlsoap\.org|^www\.sap\.com|^www\.opengis\.net|^hl7\.org|^unitsofmeasure\.org|^purl\.org|^docs\.oasis-open\.org|^xmlns\.com|^json-ld\.org|^schema\.org|^www\.springframework\.org|^maven\.apache\.org|^dublincore\.org|^ogp\.me|^xml\.apache\.org|^schemas\.openxmlformats\.org|^rdfs\.org|^schemas\.google\.com|^a9\.com|^ns\.adobe\.com|^ltsc\.ieee\.org|^docbook\.org|^graphml\.graphdrawing\.org|^json-schema\.org)(?=:|$)/i;
+// Namespace / spec-mandated identifier URI authorities — port of CleartextProtocolFilter.NAMESPACE_URI_AUTHORITIES, extended with pre-existing sonar-js exceptions
+const NAMESPACE_URI_AUTHORITIES = [
+  'www.w3.org',
+  'schemas.android.com',
+  'schemas.microsoft.com',
+  'schemas.xmlsoap.org',
+  'www.sap.com',
+  'www.opengis.net',
+  'hl7.org',
+  'unitsofmeasure.org',
+  'purl.org',
+  'docs.oasis-open.org',
+  'xmlns.com',
+  'json-ld.org',
+  'schema.org',
+  'www.springframework.org',
+  'maven.apache.org',
+  'dublincore.org',
+  'ogp.me',
+  'xml.apache.org',
+  'schemas.openxmlformats.org',
+  'rdfs.org',
+  'schemas.google.com',
+  'a9.com',
+  'ns.adobe.com',
+  'ltsc.ieee.org',
+  'docbook.org',
+  'graphml.graphdrawing.org',
+  'json-schema.org',
+  'cyclonedx.org',
+  'snomed.info',
+  'adlnet.gov',
+  'jabber.org',
+  'etherx.jabber.org',
+];
 
 // IANA-reserved documentation / placeholder domains — port of CleartextProtocolFilter.DOCUMENTATION_HOSTS
 const DOCUMENTATION_HOSTS =
@@ -255,6 +287,12 @@ function hasExceptionHost(value: string) {
 
 function isSafeHost(host: string) {
   return (
-    SAFE_HOSTS.test(host) || NAMESPACE_URI_AUTHORITIES.test(host) || DOCUMENTATION_HOSTS.test(host)
+    SAFE_HOSTS.test(host) ||
+    NAMESPACE_URI_AUTHORITIES.some(authority => isNamespaceAuthority(host, authority)) ||
+    DOCUMENTATION_HOSTS.test(host)
   );
+}
+
+function isNamespaceAuthority(host: string, authority: string) {
+  return host === authority || host.startsWith(`${authority}:`);
 }

--- a/packages/analysis/src/jsts/rules/S5332/rule.lib.ts
+++ b/packages/analysis/src/jsts/rules/S5332/rule.lib.ts
@@ -54,8 +54,12 @@ const INSECURE_PROTOCOLS = Object.keys(CLEARTEXT_PROTOCOL_ALTERNATIVES).map(s =>
 const SAFE_HOSTS =
   /(?:^localhost|^127(?:\.\d+){1,3}|^\[(?:0*:){7}:?0*1]|^\[::1]|^169\.254\.\d+\.\d+|^\[fd00:ec2::254]|^168\.63\.129\.16|^100\.100\.100\.200|^metadata\.google\.internal|^metadata\.internal|^host\.docker\.internal|^gateway\.docker\.internal|\.svc\.cluster\.local)(?=:|$)/i;
 
+// A plain string exempts the whole host; `{ host, pathPrefix }` exempts only the paths
+// reserved for namespace identifiers, so that real endpoints on the same host stay reported.
+type NamespaceAuthority = string | { host: string; pathPrefix: string };
+
 // Namespace / spec-mandated identifier URI authorities — port of CleartextProtocolFilter.NAMESPACE_URI_AUTHORITIES, extended with pre-existing sonar-js exceptions
-const NAMESPACE_URI_AUTHORITIES = [
+const NAMESPACE_URI_AUTHORITIES: NamespaceAuthority[] = [
   'www.w3.org',
   'schemas.android.com',
   'schemas.microsoft.com',
@@ -86,7 +90,10 @@ const NAMESPACE_URI_AUTHORITIES = [
   'cyclonedx.org',
   'snomed.info',
   'adlnet.gov',
-  'jabber.org',
+  // jabber.org is also a live public XMPP server, not just a namespace string — only exempt its
+  // well-known XEP namespaces (all registered under /protocol/); anything else on this host,
+  // e.g. the BOSH endpoint http://jabber.org/http-bind, is a real cleartext network target.
+  { host: 'jabber.org', pathPrefix: '/protocol/' },
   'etherx.jabber.org',
 ];
 
@@ -265,10 +272,14 @@ function getMessageAndData(protocol: string) {
 
 function hasExceptionHost(value: string) {
   let host: string;
+  // Left undefined when only the lenient fallback could extract the authority: path-scoped
+  // authorities then fail closed rather than being exempted on an unknown path.
+  let pathname: string | undefined;
 
   try {
     const url = new URL(value);
     host = url.hostname;
+    pathname = url.pathname;
     if (host.length === 0) {
       return false;
     }
@@ -282,17 +293,25 @@ function hasExceptionHost(value: string) {
     host = match[1];
   }
 
-  return isSafeHost(host);
+  return isSafeHost(host, pathname);
 }
 
-function isSafeHost(host: string) {
+function isSafeHost(host: string, pathname: string | undefined) {
   return (
     SAFE_HOSTS.test(host) ||
-    NAMESPACE_URI_AUTHORITIES.some(authority => isNamespaceAuthority(host, authority)) ||
+    NAMESPACE_URI_AUTHORITIES.some(entry => isNamespaceAuthority(host, pathname, entry)) ||
     DOCUMENTATION_HOSTS.test(host)
   );
 }
 
-function isNamespaceAuthority(host: string, authority: string) {
-  return host === authority || host.startsWith(`${authority}:`);
+function isNamespaceAuthority(
+  host: string,
+  pathname: string | undefined,
+  entry: NamespaceAuthority,
+) {
+  const authority = typeof entry === 'string' ? entry : entry.host;
+  if (host !== authority && !host.startsWith(`${authority}:`)) {
+    return false;
+  }
+  return typeof entry === 'string' || pathname?.startsWith(entry.pathPrefix) === true;
 }

--- a/packages/analysis/src/jsts/rules/S5332/rule.lib.ts
+++ b/packages/analysis/src/jsts/rules/S5332/rule.lib.ts
@@ -90,10 +90,12 @@ const NAMESPACE_URI_AUTHORITIES: NamespaceAuthority[] = [
   'cyclonedx.org',
   'snomed.info',
   'adlnet.gov',
-  // jabber.org is also a live public XMPP server, not just a namespace string — only exempt its
-  // well-known XEP namespaces (all registered under /protocol/); anything else on this host,
-  // e.g. the BOSH endpoint http://jabber.org/http-bind, is a real cleartext network target.
+  // jabber.org is also a live public XMPP server, not just a namespace string — only exempt the
+  // paths reserved for XEP namespaces (/protocol/ for protocol namespaces, /features/ for stream
+  // features); anything else on this host, e.g. the BOSH endpoint http://jabber.org/http-bind,
+  // is a real cleartext network target.
   { host: 'jabber.org', pathPrefix: '/protocol/' },
+  { host: 'jabber.org', pathPrefix: '/features/' },
   'etherx.jabber.org',
 ];
 

--- a/packages/analysis/src/jsts/rules/S5332/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5332/unit.test.ts
@@ -216,6 +216,22 @@ describe('S5332', () => {
       });`,
         },
         {
+          // JS-2368: $schema identifier mandated verbatim by the CycloneDX spec, never dereferenced
+          code: `
+      const bom = { "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json" };
+      `,
+        },
+        {
+          // JS-2368: coding-system identifier, only ever compared, never fetched
+          code: `
+      const SNOMED_SYSTEM = "http://snomed.info/sct";
+
+      function isSnomed(coding) {
+        return coding.system === SNOMED_SYSTEM;
+      }
+      `,
+        },
+        {
           code: `
         // Namespace URI authorities — existing entries
         url = 'http://schemas.microsoft.com/ws/2008/06/identity/claims/groups';
@@ -231,6 +247,11 @@ describe('S5332', () => {
         url = 'http://www.springframework.org/schema/beans';
         url = 'http://maven.apache.org/POM/4.0.0';
         url = 'http://ogp.me/ns#';
+
+        // Namespace URI authorities — added for JS-2368 (spec-mandated identifiers, never dereferenced)
+        url = 'http://adlnet.gov/expapi/verbs/completed';
+        url = 'http://jabber.org/protocol/muc';
+        url = 'http://etherx.jabber.org/streams';
       `,
         },
       ],
@@ -343,8 +364,15 @@ describe('S5332', () => {
       url = "http://metadata.google.internal.evil.com";
       url = "http://www.w3.org.evil.com/x";
       url = "http://schema.org.evil.com/Person";
+
+      // JS-2368: same attack against the newly-added namespace authorities
+      url = "http://cyclonedx.org.evil.com/schema/bom-1.5.schema.json";
+      url = "http://snomed.info.evil.com/sct";
+      url = "http://adlnet.gov.evil.com/expapi/verbs/completed";
+      url = "http://jabber.org.evil.com/protocol/muc";
+      url = "http://etherx.jabber.org.evil.com/streams";
       `,
-          errors: 6,
+          errors: 11,
         },
         {
           code: `

--- a/packages/analysis/src/jsts/rules/S5332/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5332/unit.test.ts
@@ -254,6 +254,16 @@ describe('S5332', () => {
         url = 'http://etherx.jabber.org/streams';
       `,
         },
+        {
+          // Namespace authorities carrying a port: only reachable through the lenient fallback,
+          // since a template placeholder makes strict URL parsing fail. Host matching is
+          // case-insensitive there too, as the literal is lower-cased before the lookup.
+          code: `
+        url = "http://cyclonedx.org:\${port}/schema/bom-1.5.schema.json";
+        url = "HTTP://CYCLONEDX.ORG:\${port}/schema/bom-1.5.schema.json";
+        url = "http://www.w3.org:\${port}/2001/XMLSchema";
+      `,
+        },
       ],
       invalid: [
         {
@@ -373,6 +383,18 @@ describe('S5332', () => {
       url = "http://etherx.jabber.org.evil.com/streams";
       `,
           errors: 11,
+        },
+        {
+          code: `
+      // jabber.org is a live public XMPP server: only its /protocol/ XEP namespaces are exempt,
+      // real endpoints on that host stay reported
+      url = "http://jabber.org/http-bind";
+      url = "http://jabber.org:5280/http-bind";
+      url = "http://jabber.org";
+      // the lenient fallback cannot see the path, so a path-scoped authority fails closed
+      url = "http://jabber.org:\${port}/protocol/muc";
+      `,
+          errors: 4,
         },
         {
           code: `

--- a/packages/analysis/src/jsts/rules/S5332/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S5332/unit.test.ts
@@ -252,6 +252,11 @@ describe('S5332', () => {
         url = 'http://adlnet.gov/expapi/verbs/completed';
         url = 'http://jabber.org/protocol/muc';
         url = 'http://etherx.jabber.org/streams';
+
+        // XMPP stream-feature namespaces live under /features/, not /protocol/
+        url = 'http://jabber.org/features/iq-auth';
+        url = 'http://jabber.org/features/iq-register';
+        url = 'http://jabber.org/features/compress';
       `,
         },
         {
@@ -386,15 +391,17 @@ describe('S5332', () => {
         },
         {
           code: `
-      // jabber.org is a live public XMPP server: only its /protocol/ XEP namespaces are exempt,
-      // real endpoints on that host stay reported
+      // jabber.org is a live public XMPP server: only its /protocol/ and /features/ XEP
+      // namespaces are exempt, real endpoints on that host stay reported
       url = "http://jabber.org/http-bind";
       url = "http://jabber.org:5280/http-bind";
       url = "http://jabber.org";
+      // the path prefixes are anchored on the trailing slash
+      url = "http://jabber.org/features";
       // the lenient fallback cannot see the path, so a path-scoped authority fails closed
       url = "http://jabber.org:\${port}/protocol/muc";
       `,
-          errors: 4,
+          errors: 5,
         },
         {
           code: `


### PR DESCRIPTION
﻿## Summary
- S5332 was flagging http:// URLs used purely as spec-mandated identifiers (JSON-Schema $schema, coding-system/namespace URIs) that are never dereferenced.
- Extends the existing NAMESPACE_URI_AUTHORITIES allowlist (from JS-1877) with cyclonedx.org, snomed.info, adlnet.gov, jabber.org, etherx.jabber.org.
- Refactored the allowlist check from a single alternation regex to a plain string array + exact-authority helper, avoiding a regex-complexity issue on the extended list.

## Test plan
- [x] Added CycloneDX $schema and SNOMED coding-system reproducers, confirmed red before the fix, green after
- [x] Added subdomain-spoofing negative tests per new host (e.g. cyclonedx.org.evil.com) to prove exact-authority anchoring
- [x] Full S5332 suite green

Jira: JS-2368
