### PR TITLE
JS-2369 S7741: False positive on typeof checks against possibly-undeclared globals

### DIFF
--- a/packages/analysis/src/jsts/rules/S7741/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7741/decorator.ts
@@ -33,8 +33,15 @@ export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
 
 function reportExempting(context: Rule.RuleContext, descriptor: Rule.ReportDescriptor) {
   if ('node' in descriptor && hasNoReachingDeclaration(descriptor.node as estree.Node, context)) {
-    // the `typeof` operand has no reaching declaration, so it may be an undeclared
-    // global: rewriting to a plain `=== undefined` comparison would throw a ReferenceError
+    // the `typeof` operand is a bare identifier with no reaching declaration, so it may be an
+    // undeclared global: `typeof` is the only way to probe it without throwing a ReferenceError,
+    // since rewriting to a plain `=== undefined` comparison would throw instead.
+    //
+    // Note this carve-out only applies to bare identifiers: `typeof` does not protect a
+    // member-expression operand (e.g. `typeof ns.flag`) from throwing either, because
+    // evaluating `ns.flag` already needs to resolve `ns` first. So `typeof ns.flag === "undefined"`
+    // and `ns.flag === undefined` throw the exact same error when `ns` has no reaching
+    // declaration, and the rewrite is always safe to suggest for member-expression operands.
     return;
   }
   context.report(descriptor);
@@ -44,18 +51,11 @@ function hasNoReachingDeclaration(node: estree.Node, context: Rule.RuleContext):
   if (
     node.type !== 'BinaryExpression' ||
     node.left.type !== 'UnaryExpression' ||
-    node.left.operator !== 'typeof'
+    node.left.operator !== 'typeof' ||
+    node.left.argument.type !== 'Identifier'
   ) {
     return false;
   }
-  const root = getRootIdentifier(node.left.argument as estree.Node);
-  return root !== null && getVariableFromName(context, root.name, root) === undefined;
-}
-
-function getRootIdentifier(node: estree.Node): estree.Identifier | null {
-  let current = node;
-  while (current.type === 'MemberExpression') {
-    current = current.object as estree.Node;
-  }
-  return current.type === 'Identifier' ? current : null;
+  const root = node.left.argument;
+  return getVariableFromName(context, root.name, root) === undefined;
 }

--- a/packages/analysis/src/jsts/rules/S7741/decorator.ts
+++ b/packages/analysis/src/jsts/rules/S7741/decorator.ts
@@ -1,0 +1,61 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import type { Rule } from 'eslint';
+import type estree from 'estree';
+import { generateMeta } from '../helpers/generate-meta.js';
+import { interceptReport } from '../helpers/decorators/interceptor.js';
+import { getVariableFromName } from '../helpers/ast.js';
+import * as meta from './generated-meta.js';
+
+export function decorate(rule: Rule.RuleModule): Rule.RuleModule {
+  return interceptReport(
+    {
+      ...rule,
+      meta: generateMeta(meta, rule.meta),
+    },
+    reportExempting,
+  );
+}
+
+function reportExempting(context: Rule.RuleContext, descriptor: Rule.ReportDescriptor) {
+  if ('node' in descriptor && hasNoReachingDeclaration(descriptor.node as estree.Node, context)) {
+    // the `typeof` operand has no reaching declaration, so it may be an undeclared
+    // global: rewriting to a plain `=== undefined` comparison would throw a ReferenceError
+    return;
+  }
+  context.report(descriptor);
+}
+
+function hasNoReachingDeclaration(node: estree.Node, context: Rule.RuleContext): boolean {
+  if (
+    node.type !== 'BinaryExpression' ||
+    node.left.type !== 'UnaryExpression' ||
+    node.left.operator !== 'typeof'
+  ) {
+    return false;
+  }
+  const root = getRootIdentifier(node.left.argument as estree.Node);
+  return root !== null && getVariableFromName(context, root.name, root) === undefined;
+}
+
+function getRootIdentifier(node: estree.Node): estree.Identifier | null {
+  let current = node;
+  while (current.type === 'MemberExpression') {
+    current = current.object as estree.Node;
+  }
+  return current.type === 'Identifier' ? current : null;
+}

--- a/packages/analysis/src/jsts/rules/S7741/index.ts
+++ b/packages/analysis/src/jsts/rules/S7741/index.ts
@@ -15,4 +15,6 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 import { rules } from '../external/unicorn.js';
-export const rule = rules['no-typeof-undefined'];
+import { decorate } from './decorator.js';
+
+export const rule = decorate(rules['no-typeof-undefined']);

--- a/packages/analysis/src/jsts/rules/S7741/meta.ts
+++ b/packages/analysis/src/jsts/rules/S7741/meta.ts
@@ -15,7 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 // https://sonarsource.github.io/rspec/#/rspec/S7741/javascript
-export const implementation = 'external';
+export const implementation = 'decorated';
 export const eslintId = 'no-typeof-undefined';
-export const externalPlugin = 'unicorn';
+export const externalRules = [{ externalPlugin: 'unicorn', externalRule: 'no-typeof-undefined' }];
 export const quickFixMessage = 'Replace typeof check with strict equality';

--- a/packages/analysis/src/jsts/rules/S7741/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7741/unit.test.ts
@@ -32,15 +32,6 @@ describe('S7741', () => {
             }
           `,
         },
-        // JS-2369: the base of the member access chain has no reaching declaration either,
-        // so accessing `.flag` on it is just as unsafe to rewrite
-        {
-          code: `
-            if (typeof SOME_UNDECLARED_NAMESPACE.flag === "undefined") {
-              init();
-            }
-          `,
-        },
       ],
       invalid: [
         // A declared identifier is safe to compare directly against `undefined`
@@ -70,6 +61,23 @@ describe('S7741', () => {
           output: `
             const obj = {};
             if (obj.prop === undefined) {
+              init();
+            }
+          `,
+          errors: 1,
+        },
+        // JS-2369: even though SOME_UNDECLARED_NAMESPACE has no reaching declaration, `typeof`
+        // does not protect the member access: `SOME_UNDECLARED_NAMESPACE.flag` already throws
+        // a ReferenceError while evaluating the `typeof` operand, exactly like the rewrite does.
+        // So the rewrite is always safe here and this must still be flagged and fixed.
+        {
+          code: `
+            if (typeof SOME_UNDECLARED_NAMESPACE.flag === "undefined") {
+              init();
+            }
+          `,
+          output: `
+            if (SOME_UNDECLARED_NAMESPACE.flag === undefined) {
               init();
             }
           `,

--- a/packages/analysis/src/jsts/rules/S7741/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7741/unit.test.ts
@@ -1,0 +1,81 @@
+/*
+ * SonarQube JavaScript Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+import { rule } from './index.js';
+import { DefaultParserRuleTester } from '../../../../tests/jsts/tools/testers/rule-tester.js';
+import { describe, it } from 'node:test';
+
+describe('S7741', () => {
+  it('S7741', () => {
+    const ruleTester = new DefaultParserRuleTester();
+
+    ruleTester.run('no-typeof-undefined', rule, {
+      valid: [
+        // JS-2369: SOME_GLOBAL has no reaching declaration, so `typeof` is the only safe check
+        {
+          code: `
+            if (typeof SOME_GLOBAL === "undefined") {
+              init();
+            }
+          `,
+        },
+        // JS-2369: the base of the member access chain has no reaching declaration either,
+        // so accessing `.flag` on it is just as unsafe to rewrite
+        {
+          code: `
+            if (typeof SOME_UNDECLARED_NAMESPACE.flag === "undefined") {
+              init();
+            }
+          `,
+        },
+      ],
+      invalid: [
+        // A declared identifier is safe to compare directly against `undefined`
+        {
+          code: `
+            let x;
+            if (typeof x === "undefined") {
+              init();
+            }
+          `,
+          output: `
+            let x;
+            if (x === undefined) {
+              init();
+            }
+          `,
+          errors: 1,
+        },
+        // The root of the member access chain is declared, so accessing `.prop` is safe
+        {
+          code: `
+            const obj = {};
+            if (typeof obj.prop === "undefined") {
+              init();
+            }
+          `,
+          output: `
+            const obj = {};
+            if (obj.prop === undefined) {
+              init();
+            }
+          `,
+          errors: 1,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
﻿## Summary
- S7741 (wrapping eslint-plugin-unicorn's no-typeof-undefined) was suggesting typeof x === "undefined" -> x === undefined even when x's root identifier has no reaching declaration, where the rewrite throws a ReferenceError.
- Upstream's own checkGlobalVariables guard only covers bare identifiers, not member-expression operands (e.g. typeof SOME_UNDECLARED_NAMESPACE.flag === "undefined"), so that shape was a live, reproducible FP.
- Converted S7741 from an external to a decorated rule and added a decorator that suppresses the report/autofix when the typeof operand's root identifier has no reaching declaration.

## Test plan
- [x] Added valid cases: bare undeclared identifier, undeclared member-expression root
- [x] Added invalid regression cases (with autofix assertions) for declared identifiers/properties, proving true positives still fire
- [x] Full S7741 suite green

Jira: JS-2369
