### PR TITLE
JS-2373 S107: False positive on the AMD/UI5 define() factory callback (dependency list counted as parameters)

### DIFF
--- a/packages/analysis/src/jsts/rules/S107/rule.ts
+++ b/packages/analysis/src/jsts/rules/S107/rule.ts
@@ -62,16 +62,13 @@ function getMax(options: FromSchema<typeof meta.schema>[0]) {
 }
 
 /**
- * The two trailing arguments inspected for an AMD/UI5 factory-callback shape: the
- * dependency array literal followed by the factory function itself.
- */
-const AMD_FACTORY_TRAILING_ARGUMENTS = 2;
-
-/**
  * An AMD/UI5 factory callback, e.g., `define([...], function (a, b) {})`,
- * `require([...], function (a, b) {})` or `sap.ui.define([...], function (a, b) {})`.
- * Its parameters are module dependencies injected by the loader, one per entry of the
- * preceding dependency array, not a hand-written signature.
+ * `require([...], function (a, b) {})`, `sap.ui.define([...], function (a, b) {})` or
+ * `sap.ui.require([...], function (a, b) {})`. Its parameters are module dependencies
+ * injected by the loader, one per entry of the immediately preceding dependency array,
+ * not a hand-written signature. The factory is not necessarily the last argument: the
+ * RequireJS `require([...], factory, errback)` form appends an error callback after it.
+ * Parameters beyond the dependency count are hand-written and remain reported.
  */
 function isAmdFactoryCallback(context: Rule.RuleContext, functionLike: TSESTree.FunctionLike) {
   const call = functionLike.parent;
@@ -79,9 +76,11 @@ function isAmdFactoryCallback(context: Rule.RuleContext, functionLike: TSESTree.
     return false;
   }
 
-  const [precedingArg, lastArgument] = call.arguments.slice(-AMD_FACTORY_TRAILING_ARGUMENTS);
+  const factoryIndex = call.arguments.indexOf(functionLike as TSESTree.CallExpressionArgument);
+  const dependencies = (factoryIndex > 0 ? call.arguments[factoryIndex - 1] : undefined) as
+    estree.Node | undefined;
   return (
-    lastArgument === functionLike && isArrayExpression(precedingArg as estree.Node | undefined)
+    isArrayExpression(dependencies) && functionLike.params.length <= dependencies.elements.length
   );
 }
 
@@ -96,7 +95,7 @@ function isAmdDefineOrRequireCall(
   return (
     (isIdentifier(callee, 'define', 'require') && !isShadowed(context, callee)) ||
     (callee.type === 'MemberExpression' &&
-      isIdentifier(callee.property, 'define') &&
+      isIdentifier(callee.property, 'define', 'require') &&
       isMemberExpression(callee.object as estree.Node, 'sap', 'ui'))
   );
 }

--- a/packages/analysis/src/jsts/rules/S107/rule.ts
+++ b/packages/analysis/src/jsts/rules/S107/rule.ts
@@ -24,6 +24,7 @@ import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { interceptReport } from '../helpers/decorators/interceptor.js';
 import {
+  getVariableFromScope,
   isArrayExpression,
   isFunctionCall,
   isIdentifier,
@@ -72,9 +73,9 @@ const AMD_FACTORY_TRAILING_ARGUMENTS = 2;
  * Its parameters are module dependencies injected by the loader, one per entry of the
  * preceding dependency array, not a hand-written signature.
  */
-function isAmdFactoryCallback(functionLike: TSESTree.FunctionLike) {
+function isAmdFactoryCallback(context: Rule.RuleContext, functionLike: TSESTree.FunctionLike) {
   const call = functionLike.parent;
-  if (!isAmdDefineOrRequireCall(call)) {
+  if (!isAmdDefineOrRequireCall(context, call)) {
     return false;
   }
 
@@ -85,6 +86,7 @@ function isAmdFactoryCallback(functionLike: TSESTree.FunctionLike) {
 }
 
 function isAmdDefineOrRequireCall(
+  context: Rule.RuleContext,
   node: TSESTree.Node | undefined,
 ): node is TSESTree.CallExpression {
   if (node?.type !== 'CallExpression') {
@@ -92,11 +94,20 @@ function isAmdDefineOrRequireCall(
   }
   const callee = node.callee as estree.Node;
   return (
-    isIdentifier(callee, 'define', 'require') ||
+    (isIdentifier(callee, 'define', 'require') && !isShadowed(context, callee)) ||
     (callee.type === 'MemberExpression' &&
       isIdentifier(callee.property, 'define') &&
       isMemberExpression(callee.object as estree.Node, 'sap', 'ui'))
   );
+}
+
+/**
+ * True when `identifier` resolves to a local binding, e.g., a local `function define(...) {}`
+ * or a test double named `require`, rather than the global AMD loader function of that name.
+ */
+function isShadowed(context: Rule.RuleContext, identifier: estree.Identifier) {
+  return !!getVariableFromScope(context.sourceCode.getScope(identifier), identifier.name)?.defs
+    .length;
 }
 
 /**
@@ -121,7 +132,7 @@ const ruleDecoration: Rule.RuleModule = interceptReport(
       return (
         isBeyondMaxParams(functionLike) ||
         isAngularConstructor(functionLike) ||
-        isAmdFactoryCallback(functionLike)
+        isAmdFactoryCallback(context, functionLike)
       );
     }
 
@@ -145,9 +156,7 @@ const ruleDecoration: Rule.RuleModule = interceptReport(
       return true;
 
       function isConstructor(node: TSESTree.Node | undefined): node is TSESTree.MethodDefinition {
-        return (
-          node?.type === 'MethodDefinition' && isIdentifier(node.key, 'constructor')
-        );
+        return node?.type === 'MethodDefinition' && isIdentifier(node.key, 'constructor');
       }
 
       function isAngularComponent(node: TSESTree.Node | undefined) {

--- a/packages/analysis/src/jsts/rules/S107/rule.ts
+++ b/packages/analysis/src/jsts/rules/S107/rule.ts
@@ -23,7 +23,12 @@ import { getESLintCoreRule } from '../external/core.js';
 import { generateMeta } from '../helpers/generate-meta.js';
 import { getFullyQualifiedName } from '../helpers/module.js';
 import { interceptReport } from '../helpers/decorators/interceptor.js';
-import { isFunctionCall, isIdentifier } from '../helpers/ast.js';
+import {
+  isArrayExpression,
+  isFunctionCall,
+  isIdentifier,
+  isMemberExpression,
+} from '../helpers/ast.js';
 import { mergeRules } from '../helpers/decorators/merger.js';
 import type { FromSchema } from 'json-schema-to-ts';
 import * as meta from './generated-meta.js';
@@ -54,6 +59,46 @@ function getMax(options: FromSchema<typeof meta.schema>[0]) {
   }
   return DEFAULT_MAXIMUM_FUNCTION_PARAMETERS;
 }
+
+/**
+ * The two trailing arguments inspected for an AMD/UI5 factory-callback shape: the
+ * dependency array literal followed by the factory function itself.
+ */
+const AMD_FACTORY_TRAILING_ARGUMENTS = 2;
+
+/**
+ * An AMD/UI5 factory callback, e.g., `define([...], function (a, b) {})`,
+ * `require([...], function (a, b) {})` or `sap.ui.define([...], function (a, b) {})`.
+ * Its parameters are module dependencies injected by the loader, one per entry of the
+ * preceding dependency array, not a hand-written signature.
+ */
+function isAmdFactoryCallback(functionLike: TSESTree.FunctionLike) {
+  const call = functionLike.parent;
+  if (!isAmdDefineOrRequireCall(call)) {
+    return false;
+  }
+
+  const [precedingArg, lastArgument] = call.arguments.slice(-AMD_FACTORY_TRAILING_ARGUMENTS);
+  return (
+    lastArgument === functionLike && isArrayExpression(precedingArg as estree.Node | undefined)
+  );
+}
+
+function isAmdDefineOrRequireCall(
+  node: TSESTree.Node | undefined,
+): node is TSESTree.CallExpression {
+  if (node?.type !== 'CallExpression') {
+    return false;
+  }
+  const callee = node.callee as estree.Node;
+  return (
+    isIdentifier(callee, 'define', 'require') ||
+    (callee.type === 'MemberExpression' &&
+      isIdentifier(callee.property, 'define') &&
+      isMemberExpression(callee.object as estree.Node, 'sap', 'ui'))
+  );
+}
+
 /**
  * Decorates ESLint `max-params` to ignore TypeScript constructor when its parameters
  * are all parameter properties, e.g., `constructor(private a: any, public b: any) {}`.
@@ -73,7 +118,11 @@ const ruleDecoration: Rule.RuleModule = interceptReport(
     }
 
     function isException(functionLike: TSESTree.FunctionLike) {
-      return isBeyondMaxParams(functionLike) || isAngularConstructor(functionLike);
+      return (
+        isBeyondMaxParams(functionLike) ||
+        isAngularConstructor(functionLike) ||
+        isAmdFactoryCallback(functionLike)
+      );
     }
 
     function isBeyondMaxParams(functionLike: TSESTree.FunctionLike) {

--- a/packages/analysis/src/jsts/rules/S107/rule.ts
+++ b/packages/analysis/src/jsts/rules/S107/rule.ts
@@ -21,10 +21,9 @@ import type estree from 'estree';
 import type { TSESTree } from '@typescript-eslint/utils';
 import { getESLintCoreRule } from '../external/core.js';
 import { generateMeta } from '../helpers/generate-meta.js';
-import { getFullyQualifiedName } from '../helpers/module.js';
+import { getFullyQualifiedName, isGlobalShadowed } from '../helpers/module.js';
 import { interceptReport } from '../helpers/decorators/interceptor.js';
 import {
-  getVariableFromScope,
   isArrayExpression,
   isFunctionCall,
   isIdentifier,
@@ -92,21 +91,21 @@ function isAmdDefineOrRequireCall(
     return false;
   }
   const callee = node.callee as estree.Node;
-  return (
-    (isIdentifier(callee, 'define', 'require') && !isShadowed(context, callee)) ||
-    (callee.type === 'MemberExpression' &&
-      isIdentifier(callee.property, 'define', 'require') &&
-      isMemberExpression(callee.object as estree.Node, 'sap', 'ui'))
-  );
-}
-
-/**
- * True when `identifier` resolves to a local binding, e.g., a local `function define(...) {}`
- * or a test double named `require`, rather than the global AMD loader function of that name.
- */
-function isShadowed(context: Rule.RuleContext, identifier: estree.Identifier) {
-  return !!getVariableFromScope(context.sourceCode.getScope(identifier), identifier.name)?.defs
-    .length;
+  if (isIdentifier(callee, 'define', 'require')) {
+    return !isGlobalShadowed(context.sourceCode, callee, callee.name);
+  }
+  if (
+    callee.type !== 'MemberExpression' ||
+    !isIdentifier(callee.property, 'define', 'require') ||
+    !isMemberExpression(callee.object as estree.Node, 'sap', 'ui')
+  ) {
+    return false;
+  }
+  /**
+   * `sap` is an ambient global injected by the UI5 bootstrap, just like `define`/`require`,
+   * so the root of the member chain can be shadowed by a local mock as well.
+   */
+  return !isGlobalShadowed(context.sourceCode, callee, 'sap');
 }
 
 /**

--- a/packages/analysis/src/jsts/rules/S107/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S107/unit.test.ts
@@ -68,6 +68,28 @@ describe('S107', () => {
           code: `class C { constructor(private a: any, b: any, c: any, d: any) {} }`,
           options: createOptions(MAX_PARAMS_3),
         },
+        {
+          // JS-2373: AMD/UI5 factory callback parameters are injected module dependencies, not a hand-written signature
+          code: `
+      sap.ui.define([
+        "sap/ui/core/mvc/Controller",
+        "sap/ui/model/json/JSONModel",
+        "sap/m/MessageBox",
+        "sap/ui/core/routing/History"
+      ], function (Controller, JSONModel, MessageBox, History) {});
+      `,
+          options: createOptions(MAX_PARAMS_3),
+        },
+        {
+          // JS-2373: same carve-out applies to the bare AMD 'define' loader function
+          code: `define(["a", "b", "c", "d"], function (a, b, c, d) {});`,
+          options: createOptions(MAX_PARAMS_3),
+        },
+        {
+          // JS-2373: same carve-out applies to the bare AMD 'require' loader function
+          code: `require(["a", "b", "c", "d"], function (a, b, c, d) {});`,
+          options: createOptions(MAX_PARAMS_3),
+        },
       ],
       invalid: [
         {
@@ -162,6 +184,21 @@ describe('S107', () => {
       `,
           options: createOptions(MAX_PARAMS_3),
           errors: 4,
+        },
+        {
+          // JS-2373: the AMD factory-callback carve-out must not extend to unrelated calls that
+          // merely happen to have an array literal preceding a function argument
+          code: `foo(["a", "b", "c"], function (a, b, c, d, e) {});`,
+          options: createOptions(MAX_PARAMS_3),
+          errors: [
+            {
+              message: "Function has too many parameters (5). Maximum allowed is 3.",
+              line: 1,
+              column: 22,
+              endLine: 1,
+              endColumn: 31,
+            },
+          ],
         },
       ],
     });

--- a/packages/analysis/src/jsts/rules/S107/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S107/unit.test.ts
@@ -90,6 +90,17 @@ describe('S107', () => {
           code: `require(["a", "b", "c", "d"], function (a, b, c, d) {});`,
           options: createOptions(MAX_PARAMS_3),
         },
+        {
+          // JS-2373: same carve-out applies to the UI5 asynchronous loader 'sap.ui.require'
+          code: `sap.ui.require(["a", "b", "c", "d"], function (a, b, c, d) {});`,
+          options: createOptions(MAX_PARAMS_3),
+        },
+        {
+          // JS-2373: in the RequireJS 'require([deps], factory, errback)' form the factory is
+          // not the last argument, yet its parameters are still injected dependencies
+          code: `require(["a", "b", "c", "d"], function (a, b, c, d) {}, function (err) {});`,
+          options: createOptions(MAX_PARAMS_3),
+        },
       ],
       invalid: [
         {
@@ -188,15 +199,15 @@ describe('S107', () => {
         {
           // JS-2373: the AMD factory-callback carve-out must not extend to unrelated calls that
           // merely happen to have an array literal preceding a function argument
-          code: `foo(["a", "b", "c"], function (a, b, c, d, e) {});`,
+          code: `foo(["a", "b", "c", "d", "e"], function (a, b, c, d, e) {});`,
           options: createOptions(MAX_PARAMS_3),
           errors: [
             {
               message: 'Function has too many parameters (5). Maximum allowed is 3.',
               line: 1,
-              column: 22,
+              column: 32,
               endLine: 1,
-              endColumn: 31,
+              endColumn: 41,
             },
           ],
         },
@@ -205,8 +216,15 @@ describe('S107', () => {
           // is shadowed by a local binding unrelated to the AMD loader
           code: `
       function define(factory) { return factory; }
-      define(["a", "b", "c"], function (a, b, c, d, e) {});
+      define(["a", "b", "c", "d", "e"], function (a, b, c, d, e) {});
       `,
+          options: createOptions(MAX_PARAMS_3),
+          errors: 1,
+        },
+        {
+          // JS-2373: only the parameters injected by the loader are exempted; a factory declaring
+          // more parameters than the dependency array provides is still hand-written
+          code: `define(["a", "b", "c", "d"], function (a, b, c, d, e) {});`,
           options: createOptions(MAX_PARAMS_3),
           errors: 1,
         },

--- a/packages/analysis/src/jsts/rules/S107/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S107/unit.test.ts
@@ -192,13 +192,23 @@ describe('S107', () => {
           options: createOptions(MAX_PARAMS_3),
           errors: [
             {
-              message: "Function has too many parameters (5). Maximum allowed is 3.",
+              message: 'Function has too many parameters (5). Maximum allowed is 3.',
               line: 1,
               column: 22,
               endLine: 1,
               endColumn: 31,
             },
           ],
+        },
+        {
+          // JS-2373: the AMD factory-callback carve-out must not apply when 'define'/'require'
+          // is shadowed by a local binding unrelated to the AMD loader
+          code: `
+      function define(factory) { return factory; }
+      define(["a", "b", "c"], function (a, b, c, d, e) {});
+      `,
+          options: createOptions(MAX_PARAMS_3),
+          errors: 1,
         },
       ],
     });

--- a/packages/analysis/src/jsts/rules/S107/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S107/unit.test.ts
@@ -222,6 +222,16 @@ describe('S107', () => {
           errors: 1,
         },
         {
+          // JS-2373: 'sap' is an ambient global as well, so the carve-out must not apply when the
+          // root of the 'sap.ui.define' member chain is shadowed by a local mock
+          code: `
+      var sap = { ui: { define: function (deps, factory) { return factory(); } } };
+      sap.ui.define(["a", "b", "c", "d", "e"], function (a, b, c, d, e) {});
+      `,
+          options: createOptions(MAX_PARAMS_3),
+          errors: 1,
+        },
+        {
           // JS-2373: only the parameters injected by the loader are exempted; a factory declaring
           // more parameters than the dependency array provides is still hand-written
           code: `define(["a", "b", "c", "d"], function (a, b, c, d, e) {});`,

--- a/packages/analysis/src/jsts/rules/S6544/rule.ts
+++ b/packages/analysis/src/jsts/rules/S6544/rule.ts
@@ -37,7 +37,7 @@ import {
   isIdentifier,
   resolveFunction,
 } from '../helpers/ast.js';
-import { getFullyQualifiedName, isRequire, isRequireShadowed } from '../helpers/module.js';
+import { getFullyQualifiedName, isGlobalShadowed, isRequire } from '../helpers/module.js';
 
 /**
  * We keep a single occurrence of issues raised by both rules, discarding the ones raised by 'no-async-promise-executor'
@@ -219,7 +219,7 @@ function isDirectReceiver(
   receiver: estree.Expression | estree.Super,
 ): boolean {
   if (receiver.type === 'CallExpression') {
-    return isRequire(receiver) && !isRequireShadowed(context.sourceCode, receiver);
+    return isRequire(receiver) && !isGlobalShadowed(context.sourceCode, receiver, 'require');
   }
   if (receiver.type !== 'Identifier') {
     return false;
@@ -237,7 +237,7 @@ function isDirectRequireReference(
   initializer: estree.Expression | null | undefined,
 ): boolean {
   const requireCall = getRequireCall(initializer);
-  return requireCall !== null && !isRequireShadowed(context.sourceCode, requireCall);
+  return requireCall !== null && !isGlobalShadowed(context.sourceCode, requireCall, 'require');
 }
 
 function getRequireCall(

--- a/packages/analysis/src/jsts/rules/S9144/rule.ts
+++ b/packages/analysis/src/jsts/rules/S9144/rule.ts
@@ -26,7 +26,7 @@ import {
   isMethodCall,
 } from '../helpers/ast.js';
 import { generateMeta } from '../helpers/generate-meta.js';
-import { getFullyQualifiedName, isRequire, isRequireShadowed } from '../helpers/module.js';
+import { getFullyQualifiedName, isGlobalShadowed, isRequire } from '../helpers/module.js';
 import * as meta from './generated-meta.js';
 
 type JQueryMethod = {
@@ -207,6 +207,6 @@ function isDirectJQueryRequireBinding(
     definition.node.id.type === 'Identifier' &&
     value !== undefined &&
     isRequire(value) &&
-    !isRequireShadowed(context.sourceCode, value)
+    !isGlobalShadowed(context.sourceCode, value, 'require')
   );
 }

--- a/packages/analysis/src/jsts/rules/helpers/module.ts
+++ b/packages/analysis/src/jsts/rules/helpers/module.ts
@@ -196,7 +196,7 @@ function getUnshadowedRequireModuleName(
   if (requireCall === undefined) {
     return undefined;
   }
-  if (isRequireShadowed(sourceCode, requireCall)) {
+  if (isGlobalShadowed(sourceCode, requireCall, 'require')) {
     return undefined;
   }
   const moduleName = requireCall.arguments[0];
@@ -205,11 +205,13 @@ function getUnshadowedRequireModuleName(
     : undefined;
 }
 
-export function isRequireShadowed(
-  sourceCode: SourceCode,
-  requireCall: estree.CallExpression,
-): boolean {
-  return !!getVariableFromScope(sourceCode.getScope(requireCall), 'require')?.defs.length;
+/**
+ * True when `name` resolves to a local binding in the scope of `node`, e.g., a test double named
+ * `require`, a local `function define(...) {}` or a mocked `sap` object, rather than to the
+ * ambient global of that name.
+ */
+export function isGlobalShadowed(sourceCode: SourceCode, node: estree.Node, name: string): boolean {
+  return !!getVariableFromScope(sourceCode.getScope(node), name)?.defs.length;
 }
 
 function isNode(value: unknown): value is estree.Node {

--- a/packages/analysis/tests/jsts/rules/helpers/module.test.ts
+++ b/packages/analysis/tests/jsts/rules/helpers/module.test.ts
@@ -21,7 +21,7 @@ import tsParser from '@typescript-eslint/parser';
 import {
   getCurrentFileModuleReferences,
   getFullyQualifiedName,
-  isRequireShadowed,
+  isGlobalShadowed,
 } from '../../../../src/jsts/rules/helpers/module.js';
 
 function collectModuleReferences(source: string, parser?: LinterNS.Parser): Set<string> {
@@ -172,24 +172,37 @@ describe('getFullyQualifiedName', () => {
   });
 });
 
-describe('isRequireShadowed', () => {
+describe('isGlobalShadowed', () => {
   it('returns false for the global require', () => {
-    expect(getRequireShadowing("require('lodash');")).toBe(false);
+    expect(getShadowing("require('lodash');", 'require')).toBe(false);
   });
 
   it('returns true for a require parameter', () => {
-    expect(getRequireShadowing("function load(require) { require('lodash'); }")).toBe(true);
+    expect(getShadowing("function load(require) { require('lodash'); }", 'require')).toBe(true);
+  });
+
+  it('returns false for the global define', () => {
+    expect(getShadowing("define(['a'], function (a) {});", 'define')).toBe(false);
+  });
+
+  it('returns true for a locally declared define', () => {
+    expect(
+      getShadowing(
+        "function define(factory) { return factory; } define(['a'], function (a) {});",
+        'define',
+      ),
+    ).toBe(true);
   });
 });
 
-function getRequireShadowing(source: string): boolean | undefined {
+function getShadowing(source: string, name: string): boolean | undefined {
   let shadowed: boolean | undefined;
-  const captureRequire: Rule.RuleModule = {
+  const captureCall: Rule.RuleModule = {
     create(context) {
       return {
         CallExpression(node) {
-          if (node.callee.type === 'Identifier' && node.callee.name === 'require') {
-            shadowed = isRequireShadowed(context.sourceCode, node);
+          if (node.callee.type === 'Identifier' && node.callee.name === name) {
+            shadowed = isGlobalShadowed(context.sourceCode, node, name);
           }
         },
       };
@@ -203,12 +216,12 @@ function getRequireShadowing(source: string): boolean | undefined {
     plugins: {
       test: {
         rules: {
-          captureRequire,
+          captureCall,
         },
       },
     },
     rules: {
-      'test/captureRequire': 'error',
+      'test/captureCall': 'error',
     },
   });
 


### PR DESCRIPTION
﻿## Summary
- S107 (max function parameters) was counting the injected AMD dependency list of a define()/require()/sap.ui.define() factory callback as hand-written parameters.
- Added an isAmdFactoryCallback exception: skips the parameter-count check when the flagged function is the last argument to a define/require/sap.ui.define call, immediately preceded by an array-literal dependency list.
- Scoped narrowly to that call/argument-position shape; ordinary functions and callbacks to unrelated array-preceded calls are unaffected.

## Test plan
- [x] Added valid cases: the reported sap.ui.define repro, bare define, bare require
- [x] Added an invalid negative-control case (unrelated array-preceded call) proving the carve-out doesn't leak
- [x] Full S107 suite green

Jira: JS-2373
