### PR TITLE
JS-2379 Reset analysis caches before scanner requests

### DIFF
--- a/docs/node-analysis-caches.md
+++ b/docs/node-analysis-caches.md
@@ -168,9 +168,10 @@ The main entrypoints are:
 - `sanitizeProjectAnalysisInput()` in `packages/analysis/src/common/input-sanitize.ts`
 - `normalizeAnalyzeProjectRequest()` in `packages/grpc/src/analyze-project-normalize.ts`
 
-One additional nuance in `normalizeAnalyzeProjectRequest()`:
+All entrypoints initialize their file stores through `initFileStoresForAnalysis()`:
 
-- when the request has no explicit files and filesystem access is enabled, it explicitly resets the four file stores before rediscovering the project from disk
+- scanner analyses reset the shared caches before initializing the request
+- SonarQube for IDE analyses retain the caches for incremental reuse
 
 There is also a standalone gRPC path in `packages/grpc/src/service.ts` that always resets the shared caches before analyzing an inline virtual project rooted at `/`.
 
@@ -399,7 +400,7 @@ This is the path where the cache architecture matters most for latency.
 
 ### Standalone gRPC Service
 
-`packages/grpc/src/service.ts` intentionally does not share state between requests:
+`packages/grpc/src/service.ts` uses the same scanner initialization path and intentionally does not share state between requests:
 
 - it resets all four file stores
 - it clears the compiler-side source-file cache

--- a/docs/node-analysis-caches.md
+++ b/docs/node-analysis-caches.md
@@ -155,7 +155,7 @@ All project-style entrypoints go through the same basic sequence:
 
 1. Build a normalized `Configuration`.
 2. Sanitize explicit request files if they were provided.
-3. Call `initFileStores(configuration, inputFiles?)`.
+3. Call `initFileStoresForAnalysis(configuration, inputFiles?)`.
 4. Read the final analyzable file set from `sourceFileStore`.
 5. Seed compiler-side request context with `setSourceFilesContext(filesToAnalyze)`.
 6. Analyze with:
@@ -370,8 +370,8 @@ There is also a narrower per-analysis switch in `analyzer.ts`: `clearDependencie
 
 The compiler-side source-file content cache and parsed AST cache are cleared when:
 
-- `analyzeWithProgram()` finishes a SonarQube-style batch analysis
-- the standalone gRPC service resets all shared caches before a request
+- `initFileStoresForAnalysis()` starts a scanner analysis, including the standalone gRPC path
+- `analyzeWithProgram()` finishes a SonarQube-style batch analysis with a populated program cache
 
 They are intentionally kept warm across `analyzeWithIncrementalProgram()` calls.
 
@@ -383,8 +383,9 @@ The same codebase serves different lifecycles.
 
 The SonarQube path usually behaves closer to a per-analysis cache model:
 
+- `initFileStoresForAnalysis()` resets the file stores and compiler-side caches before analysis
 - `analyzeProject()` chooses `analyzeWithProgram()`
-- `analyzeWithProgram()` clears the program cache and the source-file content / AST cache at the end
+- `analyzeWithProgram()` also clears a populated program cache and the source-file content / AST cache at the end
 - file stores and tsconfig / manifest caches are still useful during the analysis itself, but the long-lived reuse story is limited
 
 ### SonarLint / SonarQube For IDE

--- a/packages/analysis/src/common/input-sanitize.ts
+++ b/packages/analysis/src/common/input-sanitize.ts
@@ -35,7 +35,7 @@ import {
   isStringArray,
   sanitizePaths,
 } from '../../../shared/src/helpers/sanitize.js';
-import { initFileStores } from '../file-stores/index.js';
+import { initFileStoresForAnalysis } from '../file-stores/index.js';
 import { type FileStatus, JSTS_ANALYSIS_DEFAULTS } from '../jsts/analysis/analysis.js';
 import type { RuleConfig as CssRuleConfig } from '../css/linter/config.js';
 import type { RuleConfig } from '../jsts/linter/config/rule-config.js';
@@ -101,7 +101,7 @@ export async function sanitizeProjectAnalysisInput(
     ? await sanitizeRawInputFiles(raw.files, configuration)
     : undefined;
 
-  await initFileStores(configuration, sanitizedFiles?.files);
+  await initFileStoresForAnalysis(configuration, sanitizedFiles?.files);
 
   return {
     rules: isJsTsRuleConfigArray(raw.rules) ? (raw.rules as RuleConfig[]) : [],

--- a/packages/analysis/src/file-stores/index.ts
+++ b/packages/analysis/src/file-stores/index.ts
@@ -29,6 +29,7 @@ import {
   dirnamePath,
 } from '../../../shared/src/helpers/files.js';
 import type { AnalyzableFiles } from '../projectAnalysis.js';
+import { clearSourceFileContentCache } from '../jsts/program/cache/sourceFileCache.js';
 
 export const sourceFileStore = new SourceFileStore();
 export const dependencyManifestStore = new DependencyManifestStore();
@@ -42,11 +43,27 @@ const fileStores: FileStore[] = [
   tsConfigStore,
 ];
 
-export function resetFileStores() {
+function resetFileStores() {
   sourceFileStore.clearCache();
   dependencyManifestStore.clearCache();
   generatedSourceStore.clearCache();
   tsConfigStore.clearCache();
+}
+
+/**
+ * Initializes the shared caches for a project analysis.
+ * Scanner analyses are independent, while SonarQube for IDE analyses reuse
+ * caches across requests for incremental performance.
+ */
+export async function initFileStoresForAnalysis(
+  configuration: Configuration,
+  inputFiles?: AnalyzableFiles,
+) {
+  if (!configuration.sonarlint) {
+    resetFileStores();
+    clearSourceFileContentCache();
+  }
+  await initFileStores(configuration, inputFiles);
 }
 
 export async function initFileStores(configuration: Configuration, inputFiles?: AnalyzableFiles) {

--- a/packages/grpc/src/analyze-project-normalize.ts
+++ b/packages/grpc/src/analyze-project-normalize.ts
@@ -21,7 +21,7 @@ import {
   type ConfigurationInput,
   type JsTsLanguage as InternalJsTsLanguage,
 } from '../../analysis/src/common/configuration.js';
-import { initFileStores, resetFileStores } from '../../analysis/src/file-stores/index.js';
+import { initFileStoresForAnalysis } from '../../analysis/src/file-stores/index.js';
 import {
   sanitizeInputFiles,
   type ProjectAnalysisFileInput as SanitizableProjectFileInput,
@@ -62,10 +62,7 @@ export async function normalizeAnalyzeProjectRequest(
   const bundles = normalizePathList(request.bundles, configuration.baseDir);
   const rulesWorkdir = normalizeOptionalPath(request.rulesWorkdir, configuration.baseDir);
 
-  if (!filesPresent && configuration.canAccessFileSystem) {
-    resetFileStores();
-  }
-  await initFileStores(configuration, sanitizedFiles?.files);
+  await initFileStoresForAnalysis(configuration, sanitizedFiles?.files);
 
   return {
     rules,

--- a/packages/grpc/src/service.ts
+++ b/packages/grpc/src/service.ts
@@ -22,21 +22,11 @@ import {
 } from './transformers/request.js';
 import { transformProjectOutputToResponse } from './transformers/response.js';
 import { analyzeProject } from '../../analysis/src/analyzeProject.js';
-import { initFileStores, resetFileStores } from '../../analysis/src/file-stores/index.js';
+import { initFileStoresForAnalysis } from '../../analysis/src/file-stores/index.js';
 import { info, error as logError } from '../../shared/src/helpers/logging.js';
 import { createConfiguration } from '../../analysis/src/common/configuration.js';
 import { ROOT_PATH } from '../../shared/src/helpers/files.js';
 import { sanitizeRawInputFiles } from '../../analysis/src/common/input-sanitize.js';
-import { clearSourceFileContentCache } from '../../analysis/src/jsts/program/cache/sourceFileCache.js';
-
-/**
- * gRPC requests are independent analyses. Reset all shared caches to avoid
- * leaking data between requests with overlapping file paths.
- */
-function resetGrpcCaches() {
-  resetFileStores();
-  clearSourceFileContentCache();
-}
 
 /**
  * gRPC handler for the Analyze RPC
@@ -52,8 +42,6 @@ export async function analyzeFileHandler(
       `Received Analyze request (${request.analysisId ?? 'no id'}) with ${request.sourceFiles?.length ?? 0} files`,
     );
 
-    resetGrpcCaches();
-
     // Create configuration for gRPC context
     // gRPC requests contain all file contents inline - no filesystem access needed
     const configuration = createConfiguration({
@@ -65,7 +53,7 @@ export async function analyzeFileHandler(
     // Transform, sanitize source files, and initialize file stores
     const rawFiles = transformSourceFilesToRawInputFiles(request.sourceFiles || []);
     const { files, pathMap } = await sanitizeRawInputFiles(rawFiles, configuration);
-    await initFileStores(configuration, files);
+    await initFileStoresForAnalysis(configuration, files);
 
     const projectInput = transformRequestToProjectInput(request);
 

--- a/packages/grpc/src/transformers/request.ts
+++ b/packages/grpc/src/transformers/request.ts
@@ -128,7 +128,7 @@ function transformActiveRules(activeRules: analyzer.IActiveRule[]): {
  *   └── activeRules[] ──→ transformActiveRules() ──→ RuleConfig[] (one per rule+language)
  * ```
  *
- * Note: The caller must call `initFileStores(configuration, inputFiles)` before calling
+ * Note: The caller must call `initFileStoresForAnalysis(configuration, inputFiles)` before calling
  * `analyzeProject`. The `analyzeProject` function retrieves files from the file store internally.
  *
  * @param request - The gRPC AnalyzeRequest containing source files and active rules

--- a/packages/grpc/tests/analyze-project-normalize.test.ts
+++ b/packages/grpc/tests/analyze-project-normalize.test.ts
@@ -219,8 +219,9 @@ describe('normalizeAnalyzeProjectRequest', () => {
     expect(normalized.configuration.maxFileSize).toBe(64);
   });
 
-  it('should reset the generated-source store before filesystem rediscovery', async () => {
+  it('should reset the generated-source store before a scanner analysis', async () => {
     const baseDir = await createBaseDir();
+    const sourceFile = normalizeToAbsolutePath(join(baseDir, 'src', 'main.ts'), baseDir);
     const staleGeneratedFile = normalizeToAbsolutePath(
       join(baseDir, 'src', 'generated.ts'),
       baseDir,
@@ -241,6 +242,13 @@ describe('normalizeAnalyzeProjectRequest', () => {
       configuration: {
         baseDir,
         canAccessFileSystem: true,
+        sonarlint: false,
+      },
+      files: {
+        [sourceFile]: {
+          fileContent: 'export const value = 1;',
+          fileType: FileType.FILE_TYPE_MAIN,
+        },
       },
       rules: [],
       cssRules: [],
@@ -248,6 +256,43 @@ describe('normalizeAnalyzeProjectRequest', () => {
     });
 
     expect(generatedSourceStore.getFamily(staleGeneratedFile)).toBeUndefined();
+  });
+
+  it('should preserve the generated-source store before a SonarQube for IDE analysis', async () => {
+    const baseDir = await createBaseDir();
+    const sourceFile = normalizeToAbsolutePath(join(baseDir, 'src', 'main.ts'), baseDir);
+    const generatedFile = normalizeToAbsolutePath(join(baseDir, 'src', 'generated.ts'), baseDir);
+    const generatedSourceState = generatedSourceStore as unknown as {
+      derivedFamilyByFile: Map<NormalizedAbsolutePath, string>;
+    };
+
+    generatedSourceStore.setup(
+      createConfiguration({
+        baseDir,
+        canAccessFileSystem: true,
+        sonarlint: true,
+      }),
+    );
+    generatedSourceState.derivedFamilyByFile = new Map([[generatedFile, 'generated-family']]);
+
+    await normalizeAnalyzeProjectRequest({
+      configuration: {
+        baseDir,
+        canAccessFileSystem: true,
+        sonarlint: true,
+      },
+      files: {
+        [sourceFile]: {
+          fileContent: 'export const value = 1;',
+          fileType: FileType.FILE_TYPE_MAIN,
+        },
+      },
+      rules: [],
+      cssRules: [],
+      bundles: [],
+    });
+
+    expect(generatedSourceStore.getFamily(generatedFile)).toBe('generated-family');
   });
 
   it('should keep empty files explicit when filesystem access is disabled', async () => {


### PR DESCRIPTION
## Summary

- centralize project-analysis cache initialization in `initFileStoresForAnalysis`
- reset shared file stores and the source-file content cache before independent scanner analyses from SQS, SQC, and SQAA
- preserve caches for SonarQube for IDE requests to retain incremental-analysis performance
- remove the endpoint-specific SQAA reset and document the shared cache lifecycle

## Why

The Node.js process is reused across analyses, and its caches are shared between requests. Independent scanner analyses must not reuse cached data from an earlier project analysis, especially when requests contain overlapping file paths. Applying the reset policy at the common file-store initialization boundary gives both gRPC endpoints the same lifecycle while keeping SonarQube for IDE caches incremental.

Sparse or omitted-file scanner requests remain supported: their caches are reset before files are rediscovered from the filesystem.

## Validation

- `npm run bbf`
- `npx knip --no-gitignore`
- focused analyze-project normalization tests (7 passing)
- `npm run bridge:test` (2,375 passing)
- `git diff --check`
- Prettier check for all changed files
