### PR TITLE
S2699: include Jasmine expectAsync in assertion detection

### DIFF
--- a/packages/analysis/src/jsts/rules/S2699/jasmine/fixtures/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S2699/jasmine/fixtures/cb.fixture.js
@@ -3,6 +3,10 @@ describe('jasmine assertions', () => {
     expect(1).toEqual(1);
   });
 
+  it('recognizes global expectAsync', async () => { // Compliant
+    await expectAsync(Promise.resolve(1)).toBeResolved();
+  });
+
   it('should recognize issue', () => { // Noncompliant {{Add at least one assertion to this test case.}}
     const value = 1;
   });

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -910,6 +910,24 @@ describe('RxJS marble testing with types', () => {
 });
 `,
         },
+        {
+          code: `
+declare function expectAsync<T>(promise: Promise<T>): {
+  toBeResolved: () => Promise<void>;
+  not: { toBeResolved: () => Promise<void> };
+};
+
+describe('Jasmine async matchers', () => {
+  it('should recognize expectAsync as an assertion', async () => {
+    await expectAsync(Promise.resolve(1)).toBeResolved();
+  });
+
+  it('should recognize chained not.toBeResolved', async () => {
+    await expectAsync(Promise.reject(1)).not.toBeResolved();
+  });
+});
+`,
+        },
         // expectTypeOf in TypeScript
         {
           code: `

--- a/packages/analysis/src/jsts/rules/helpers/testing/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/testing/assertion-detection.ts
@@ -66,13 +66,15 @@ const SUPPORTED_TEST_FRAMEWORK_DEPENDENCIES = [
   'vitest',
 ];
 
-// Known global `expect*(...)` entry points: the universal `expect`, rxjs marble
-// testing's `expectObservable`/`expectSubscriptions`, and vitest's `expectTypeOf`.
+// Known global `expect*(...)` entry points: the universal `expect`, Jasmine's
+// `expectAsync`, rxjs marble testing's `expectObservable`/`expectSubscriptions`,
+// and vitest's `expectTypeOf`.
 // Matched by exact name (not an `expect`-prefix) so unrelated identifiers such as
 // `expectation(...)` or `expected(...)` in production code are not treated as
 // assertions.
 const GLOBAL_EXPECT_NAMES = new Set([
   'expect',
+  'expectAsync',
   'expectObservable',
   'expectSubscriptions',
   'expectTypeOf',


### PR DESCRIPTION
Fix S2699 to recognize Jasmine async expectations created with expectAsync(...) as valid test assertions.

See: https://community.sonarsource.com/t/s2699-include-jasmine-expectasync-in-assertion-detection/187957

This includes:
- Extending the global assertion detector to treat expectAsync as an assertion entry point
- Adding regression coverage for a Jasmine async expectation

This prevents false positives where valid Jasmine tests are incorrectly reported as having no assertions.
See: https://jasmine.github.io/api/edge/async-matchers.html