### PR TITLE
A3S-52 Fail analysis when external Node process is unavailable

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -205,7 +205,8 @@ You can review the Ruling difference by running `diff -rq src/test/expected targ
 You can run your own Node.js process manually and set the environment variable
 `SONARJS_EXISTING_NODE_PROCESS_PORT` with the value of the port where your process is listening to.
 When set, SonarJS will not start a new Node process and will send the analysis requests to the
-specified port instead.
+specified port instead. If that process cannot be reached, the analysis fails instead of silently
+skipping the affected analysis.
 
 When using this for the ruling tests, make sure that you run them in series (and not in parallel),
 by removing `@Execution(ExecutionMode.CONCURRENT)` from the ruling test.

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServer.java
@@ -39,6 +39,9 @@ public interface BridgeServer extends Startable {
 
   boolean isAlive();
 
+  /** Returns whether the bridge is configured to use an externally managed Node.js process. */
+  boolean isExternalNodeProcessConfigured();
+
   TelemetryData getTelemetry();
 
   void analyzeProject(ProjectAnalysisHandler handler);

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -414,6 +414,11 @@ public class BridgeServerImpl implements BridgeServer {
       if (!waitChannelReady(timeoutSeconds * 1000)) {
         status = Status.FAILED;
         closeChannel();
+        LOG.error(
+          "Failed to connect to the existing Node.js process on port {} configured through environment variable {}",
+          port,
+          SONARJS_EXISTING_NODE_PROCESS_PORT
+        );
         throw new ServerAlreadyFailedException();
       }
       serverHasStarted();
@@ -605,7 +610,7 @@ public class BridgeServerImpl implements BridgeServer {
 
   @Override
   public boolean isExternalNodeProcessConfigured() {
-    return getExistingNodeProcessPort() != null;
+    return nodeAlreadyRunningPort() != 0;
   }
 
   private boolean shouldRestartFailedServer() {

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -603,6 +603,11 @@ public class BridgeServerImpl implements BridgeServer {
     return result;
   }
 
+  @Override
+  public boolean isExternalNodeProcessConfigured() {
+    return getExistingNodeProcessPort() != null;
+  }
+
   private boolean shouldRestartFailedServer() {
     return (
       latestOKIsAliveTimestamp != null &&

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -414,11 +414,7 @@ public class BridgeServerImpl implements BridgeServer {
       if (!waitChannelReady(timeoutSeconds * 1000)) {
         status = Status.FAILED;
         closeChannel();
-        LOG.error(
-          "Failed to connect to the existing Node.js process on port {} configured through environment variable {}",
-          port,
-          SONARJS_EXISTING_NODE_PROCESS_PORT
-        );
+        logExternalNodeProcessConnectionFailure();
         throw new ServerAlreadyFailedException();
       }
       serverHasStarted();
@@ -434,6 +430,9 @@ public class BridgeServerImpl implements BridgeServer {
         return;
       } else if (status == Status.STARTED) {
         status = Status.FAILED;
+        if (!ownsNodeProcess) {
+          logExternalNodeProcessConnectionFailure();
+        }
         throw new ServerAlreadyFailedException();
       }
       deploy(serverConfig.config());
@@ -442,6 +441,14 @@ public class BridgeServerImpl implements BridgeServer {
       status = Status.FAILED;
       throw e;
     }
+  }
+
+  private void logExternalNodeProcessConnectionFailure() {
+    LOG.error(
+      "Failed to connect to the existing Node.js process on port {} configured through environment variable {}",
+      port,
+      SONARJS_EXISTING_NODE_PROCESS_PORT
+    );
   }
 
   @Override
@@ -578,20 +585,22 @@ public class BridgeServerImpl implements BridgeServer {
     Context.CancellableContext analyzeContext,
     AtomicBoolean finished
   ) {
-    return Thread.ofVirtual().name("bridge-analyze-project-cancel").start(() -> {
-      while (!finished.get()) {
-        if (handler.getContext().isCancelled()) {
-          analyzeContext.cancel(new CancellationException(ANALYSIS_CANCELLED_MESSAGE));
-          return;
+    return Thread.ofVirtual()
+      .name("bridge-analyze-project-cancel")
+      .start(() -> {
+        while (!finished.get()) {
+          if (handler.getContext().isCancelled()) {
+            analyzeContext.cancel(new CancellationException(ANALYSIS_CANCELLED_MESSAGE));
+            return;
+          }
+          try {
+            Thread.sleep(STREAM_CANCELLATION_POLL_INTERVAL_MS);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
         }
-        try {
-          Thread.sleep(STREAM_CANCELLATION_POLL_INTERVAL_MS);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          return;
-        }
-      }
-    });
+      });
   }
 
   public boolean isAlive() {
@@ -600,7 +609,7 @@ public class BridgeServerImpl implements BridgeServer {
     }
     var state = channel.getState(false);
     var result =
-      (state == ConnectivityState.READY) &&
+      state == ConnectivityState.READY &&
       (!ownsNodeProcess || (leaseObserver != null && !leaseTerminated));
     if (result) {
       latestOKIsAliveTimestamp = System.currentTimeMillis();

--- a/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
+++ b/sonar-plugin/bridge/src/main/java/org/sonar/plugins/javascript/bridge/BridgeServerImpl.java
@@ -402,6 +402,9 @@ public class BridgeServerImpl implements BridgeServer {
         status = Status.NOT_STARTED;
       } else {
         // required for SonarLint context to avoid restarting already failed server
+        if (isExternalNodeProcessConfigured()) {
+          logExternalNodeProcessConnectionFailure();
+        }
         throw new ServerAlreadyFailedException();
       }
     }

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.ERROR;
 import static org.slf4j.event.Level.INFO;
 import static org.slf4j.event.Level.WARN;
 import static org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl.NODE_EXECUTABLE_PROPERTY;
@@ -489,6 +490,7 @@ class BridgeServerImplTest {
     var bridgeServerMock = bridgeServer;
 
     doReturn("0").when(bridgeServerMock).getExistingNodeProcessPort();
+    assertThat(bridgeServerMock.isExternalNodeProcessConfigured()).isFalse();
     doReturn(false).when(bridgeServerMock).isAlive();
     doAnswer(invocation -> null)
       .when(bridgeServerMock)
@@ -501,6 +503,23 @@ class BridgeServerImplTest {
 
     verify(bridgeServerMock).deploy(serverConfig.config());
     verify(bridgeServerMock).startServer(serverConfig);
+  }
+
+  @Test
+  void should_log_configured_port_when_existing_node_is_unavailable() {
+    bridgeServer = spy(createUnitBridgeServer(SHORT_STARTUP_TIMEOUT_SECONDS));
+    var bridgeServerMock = bridgeServer;
+    var startupTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(SHORT_STARTUP_TIMEOUT_SECONDS);
+
+    doReturn("60000").when(bridgeServerMock).getExistingNodeProcessPort();
+    doReturn(false).when(bridgeServerMock).waitChannelReady(startupTimeoutMillis);
+
+    assertThatThrownBy(() -> bridgeServerMock.startServerLazily(serverConfig)).isInstanceOf(
+      ServerAlreadyFailedException.class
+    );
+    assertThat(logTester.logs(ERROR)).contains(
+      "Failed to connect to the existing Node.js process on port 60000 configured through environment variable SONARJS_EXISTING_NODE_PROCESS_PORT"
+    );
   }
 
   @Test

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -471,6 +471,7 @@ class BridgeServerImplTest {
     clearInvocations(bridgeServerMock);
 
     doReturn("60000").when(bridgeServerMock).getExistingNodeProcessPort();
+    assertThat(bridgeServerMock.isExternalNodeProcessConfigured()).isTrue();
     doReturn(true).when(bridgeServerMock).waitChannelReady(startupTimeoutMillis);
     doReturn(true).when(bridgeServerMock).isAlive();
     bridgeServerMock.startServerLazily(serverConfig);

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -40,6 +40,8 @@ import static org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl.NODE_FO
 import static org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl.SKIP_NODE_PROVISIONING_PROPERTY;
 
 import com.google.protobuf.ByteString;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
@@ -67,11 +69,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
-import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
-import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
-import org.sonar.scanner.plugin.api.impl.config.MapSettings;
-import org.sonar.scanner.plugin.api.impl.utils.DefaultTempFolder;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.TempFolder;
 import org.sonar.api.utils.Version;
@@ -93,6 +90,9 @@ import org.sonar.plugins.javascript.nodejs.NodeCommandBuilderImpl;
 import org.sonar.plugins.javascript.nodejs.NodeCommandException;
 import org.sonar.plugins.javascript.nodejs.ProcessWrapper;
 import org.sonar.plugins.javascript.nodejs.ProcessWrapperImpl;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
+import org.sonar.scanner.plugin.api.impl.utils.DefaultTempFolder;
 
 class BridgeServerImplTest {
 
@@ -523,6 +523,24 @@ class BridgeServerImplTest {
   }
 
   @Test
+  void should_log_configured_port_when_existing_node_stops_after_connection() {
+    bridgeServer = spy(createUnitBridgeServer(SHORT_STARTUP_TIMEOUT_SECONDS));
+    var bridgeServerMock = bridgeServer;
+    var startupTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(SHORT_STARTUP_TIMEOUT_SECONDS);
+
+    doReturn("60000").when(bridgeServerMock).getExistingNodeProcessPort();
+    doReturn(true).when(bridgeServerMock).waitChannelReady(startupTimeoutMillis);
+    doReturn(false).when(bridgeServerMock).isAlive();
+
+    assertThatThrownBy(() -> bridgeServerMock.startServerLazily(serverConfig)).isInstanceOf(
+      ServerAlreadyFailedException.class
+    );
+    assertThat(logTester.logs(ERROR)).contains(
+      "Failed to connect to the existing Node.js process on port 60000 configured through environment variable SONARJS_EXISTING_NODE_PROCESS_PORT"
+    );
+  }
+
+  @Test
   void isAlive_should_not_require_a_lease_for_an_existing_node_process() throws Exception {
     bridgeServer = createUnitBridgeServer();
     var channel = mock(ManagedChannel.class);
@@ -628,9 +646,11 @@ class BridgeServerImplTest {
     when(handler.getRequest()).thenReturn(AnalyzeProjectRequest.getDefaultInstance());
     when(handler.getFuture()).thenReturn(future);
 
-    try (MockedStatic<AnalyzeProjectServiceGrpc> mockedGrpc = mockStatic(
-      AnalyzeProjectServiceGrpc.class
-    )) {
+    try (
+      MockedStatic<AnalyzeProjectServiceGrpc> mockedGrpc = mockStatic(
+        AnalyzeProjectServiceGrpc.class
+      )
+    ) {
       bridgeServer.analyzeProject(handler);
 
       mockedGrpc.verifyNoInteractions();

--- a/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
+++ b/sonar-plugin/bridge/src/test/java/org/sonar/plugins/javascript/bridge/BridgeServerImplTest.java
@@ -510,6 +510,8 @@ class BridgeServerImplTest {
     bridgeServer = spy(createUnitBridgeServer(SHORT_STARTUP_TIMEOUT_SECONDS));
     var bridgeServerMock = bridgeServer;
     var startupTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(SHORT_STARTUP_TIMEOUT_SECONDS);
+    var expectedMessage =
+      "Failed to connect to the existing Node.js process on port 60000 configured through environment variable SONARJS_EXISTING_NODE_PROCESS_PORT";
 
     doReturn("60000").when(bridgeServerMock).getExistingNodeProcessPort();
     doReturn(false).when(bridgeServerMock).waitChannelReady(startupTimeoutMillis);
@@ -517,9 +519,13 @@ class BridgeServerImplTest {
     assertThatThrownBy(() -> bridgeServerMock.startServerLazily(serverConfig)).isInstanceOf(
       ServerAlreadyFailedException.class
     );
-    assertThat(logTester.logs(ERROR)).contains(
-      "Failed to connect to the existing Node.js process on port 60000 configured through environment variable SONARJS_EXISTING_NODE_PROCESS_PORT"
+    assertThat(logTester.logs(ERROR)).contains(expectedMessage);
+
+    logTester.clear();
+    assertThatThrownBy(() -> bridgeServerMock.startServerLazily(serverConfig)).isInstanceOf(
+      ServerAlreadyFailedException.class
     );
+    assertThat(logTester.logs(ERROR)).contains(expectedMessage);
   }
 
   @Test
@@ -538,6 +544,22 @@ class BridgeServerImplTest {
     assertThat(logTester.logs(ERROR)).contains(
       "Failed to connect to the existing Node.js process on port 60000 configured through environment variable SONARJS_EXISTING_NODE_PROCESS_PORT"
     );
+  }
+
+  @Test
+  void should_not_log_external_node_failure_when_managed_bridge_stops() throws Exception {
+    bridgeServer = spy(createUnitBridgeServer(SHORT_STARTUP_TIMEOUT_SECONDS));
+    var bridgeServerMock = bridgeServer;
+
+    doReturn("0").when(bridgeServerMock).getExistingNodeProcessPort();
+    bridgeServerMock.serverHasStarted();
+    setPrivateBooleanField(bridgeServerMock, "ownsNodeProcess", true);
+    doReturn(false).when(bridgeServerMock).isAlive();
+
+    assertThatThrownBy(() -> bridgeServerMock.startServerLazily(serverConfig)).isInstanceOf(
+      ServerAlreadyFailedException.class
+    );
+    assertThat(logTester.logs(ERROR)).isEmpty();
   }
 
   @Test

--- a/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensor.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/analysis/WebSensor.java
@@ -180,6 +180,9 @@ public class WebSensor implements ProjectSensor {
       // do not propagate the exception
       LOG.info(e.toString());
     } catch (ServerAlreadyFailedException e) {
+      if (bridgeServer.isExternalNodeProcessConfigured()) {
+        throw analysisFailure(e);
+      }
       LOG.debug(
         "Skipping the start of the bridge server " +
           "as it failed to start during the first analysis or it's not answering anymore"
@@ -199,12 +202,16 @@ public class WebSensor implements ProjectSensor {
         e
       );
     } catch (Exception e) {
-      LOG.error("Failure during analysis", e);
-      throw new IllegalStateException("Analysis of " + LANG + " files failed", e);
+      throw analysisFailure(e);
     } finally {
       moduleConfiguration.clear();
       CacheStrategies.logReport();
     }
+  }
+
+  private static IllegalStateException analysisFailure(Exception e) {
+    LOG.error("Failure during analysis", e);
+    return new IllegalStateException("Analysis of " + LANG + " files failed", e);
   }
 
   private JsTsContext<SensorContext> contextWithCollectedTsConfigPaths(

--- a/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
+++ b/sonar-plugin/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/analysis/WebSensorTest.java
@@ -1559,7 +1559,7 @@ class WebSensorTest {
   }
 
   @Test
-  void log_debug_if_already_failed_server() throws Exception {
+  void should_skip_analysis_when_managed_bridge_server_already_failed() throws Exception {
     doThrow(new ServerAlreadyFailedException()).when(bridgeServerMock).startServerLazily(any());
     createSensor().execute(context);
 
@@ -1567,6 +1567,19 @@ class WebSensorTest {
       "Skipping the start of the bridge server as it failed to start during the first analysis or it's not answering anymore",
       "No rules will be executed"
     );
+  }
+
+  @Test
+  void should_fail_analysis_when_external_bridge_server_is_unavailable() throws Exception {
+    doThrow(new ServerAlreadyFailedException()).when(bridgeServerMock).startServerLazily(any());
+    when(bridgeServerMock.isExternalNodeProcessConfigured()).thenReturn(true);
+
+    assertThatThrownBy(() -> createSensor().execute(context))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Analysis of JS/TS files failed")
+      .hasCauseInstanceOf(ServerAlreadyFailedException.class);
+
+    assertThat(logTester.logs(Level.ERROR)).contains("Failure during analysis");
   }
 
   @Test


### PR DESCRIPTION
Part of A3S-46

## Summary

- expose whether the bridge is configured to use an externally managed Node.js process
- fail `WebSensor` when that external process is unavailable instead of returning successful partial analysis
- preserve the existing skip behavior for failures of the internally managed bridge, including the established port `0` sentinel
- log the configured external port and environment variable when attachment fails
- document the fail-closed behavior of `SONARJS_EXISTING_NODE_PROCESS_PORT`

## Why

When the configured external Node.js process could not be reached, `BridgeServerImpl` raised
`ServerAlreadyFailedException`, but `WebSensor` swallowed that exception and completed without
running the web-language rules. SQAA could therefore report a successful analysis without SonarJS
results.

## Validation

- `npm ci`
- `npm run bbf`
- `mvn -pl sonar-plugin/sonar-javascript-plugin -am -Dtest=BridgeServerImplTest,WebSensorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 49 bridge tests and 64 sensor tests pass
- `git diff --check`
