### PR TITLE
JS-2405 S2699: include Jasmine expectAsync in assertion detection

### DIFF
--- a/packages/analysis/src/jsts/rules/S2699/jasmine/fixtures/cb.fixture.js
+++ b/packages/analysis/src/jsts/rules/S2699/jasmine/fixtures/cb.fixture.js
@@ -3,6 +3,10 @@ describe('jasmine assertions', () => {
     expect(1).toEqual(1);
   });
 
+  it('recognizes global expectAsync', async () => { // Compliant
+    await expectAsync(Promise.resolve(1)).toBeResolved();
+  });
+
   it('should recognize issue', () => { // Noncompliant {{Add at least one assertion to this test case.}}
     const value = 1;
   });

--- a/packages/analysis/src/jsts/rules/S2699/jasmine/fixtures/package.json
+++ b/packages/analysis/src/jsts/rules/S2699/jasmine/fixtures/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "jasmine": "1.2.3"
+    "jasmine-core": "5.7.1"
   }
 }

--- a/packages/analysis/src/jsts/rules/S2699/jasmine/fixtures/package.json
+++ b/packages/analysis/src/jsts/rules/S2699/jasmine/fixtures/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "jasmine-core": "5.7.1"
+    "jasmine": "5.7.1"
   }
 }

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -910,6 +910,24 @@ describe('RxJS marble testing with types', () => {
 });
 `,
         },
+        {
+          code: `
+declare function expectAsync<T>(promise: Promise<T>): {
+  toBeResolved: () => Promise<void>;
+  not: { toBeResolved: () => Promise<void> };
+};
+
+describe('Jasmine async matchers', () => {
+  it('should recognize expectAsync as an assertion', async () => {
+    await expectAsync(Promise.resolve(1)).toBeResolved();
+  });
+
+  it('should recognize chained not.toBeResolved', async () => {
+    await expectAsync(Promise.reject(1)).not.toBeResolved();
+  });
+});
+`,
+        },
         // expectTypeOf in TypeScript
         {
           code: `

--- a/packages/analysis/src/jsts/rules/S2699/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S2699/unit.test.ts
@@ -912,6 +912,8 @@ describe('RxJS marble testing with types', () => {
         },
         {
           code: `
+import { expect } from 'chai';
+
 declare function expectAsync<T>(promise: Promise<T>): {
   toBeResolved: () => Promise<void>;
   not: { toBeResolved: () => Promise<void> };

--- a/packages/analysis/src/jsts/rules/helpers/testing/assertion-detection.ts
+++ b/packages/analysis/src/jsts/rules/helpers/testing/assertion-detection.ts
@@ -66,13 +66,15 @@ const SUPPORTED_TEST_FRAMEWORK_DEPENDENCIES = [
   'vitest',
 ];
 
-// Known global `expect*(...)` entry points: the universal `expect`, rxjs marble
-// testing's `expectObservable`/`expectSubscriptions`, and vitest's `expectTypeOf`.
+// Known global `expect*(...)` entry points: the universal `expect`, Jasmine's
+// `expectAsync`, rxjs marble testing's `expectObservable`/`expectSubscriptions`,
+// and vitest's `expectTypeOf`.
 // Matched by exact name (not an `expect`-prefix) so unrelated identifiers such as
 // `expectation(...)` or `expected(...)` in production code are not treated as
 // assertions.
 const GLOBAL_EXPECT_NAMES = new Set([
   'expect',
+  'expectAsync',
   'expectObservable',
   'expectSubscriptions',
   'expectTypeOf',

--- a/packages/analysis/src/jsts/rules/helpers/testing/assertion-frameworks.ts
+++ b/packages/analysis/src/jsts/rules/helpers/testing/assertion-frameworks.ts
@@ -123,15 +123,7 @@ const assertionFrameworks = {
   },
   globalExpect: {
     imports: ['bun:test', '@playwright/test'],
-    dependencies: [
-      'jasmine',
-      'jasmine-core',
-      'jasmine-node',
-      'karma-jasmine',
-      'jest',
-      'cypress',
-      '@playwright/test',
-    ],
+    dependencies: ['jasmine', 'jest', 'cypress', '@playwright/test'],
     isAssertion: (context, node) =>
       node.type === 'CallExpression' && isGlobalExpectAssertion(context, node),
     isTSAssertion: isGlobalTSExpectAssertion,

--- a/packages/analysis/src/jsts/rules/helpers/testing/assertion-frameworks.ts
+++ b/packages/analysis/src/jsts/rules/helpers/testing/assertion-frameworks.ts
@@ -123,7 +123,15 @@ const assertionFrameworks = {
   },
   globalExpect: {
     imports: ['bun:test', '@playwright/test'],
-    dependencies: ['jasmine', 'jest', 'cypress', '@playwright/test'],
+    dependencies: [
+      'jasmine',
+      'jasmine-core',
+      'jasmine-node',
+      'karma-jasmine',
+      'jest',
+      'cypress',
+      '@playwright/test',
+    ],
     isAssertion: (context, node) =>
       node.type === 'CallExpression' && isGlobalExpectAssertion(context, node),
     isTSAssertion: isGlobalTSExpectAssertion,


### PR DESCRIPTION
Internal continuation of #7879 so CI can run on the contribution.

This PR cherry-picks the external contribution's two commits unchanged and preserves Owen Jennings as author.

Original PR: #7879

Community report: https://community.sonarsource.com/t/s2699-include-jasmine-expectasync-in-assertion-detection/187957

## Summary

- Treat Jasmine `expectAsync(...)` as an assertion entry point for S2699.
- Add regression coverage for Jasmine async expectations.
- Prevent false positives where valid Jasmine tests are reported as having no assertions.