### PR TITLE
JS-2408 Fix FN on S7739: recognize Deferred/Promise assigned via MemberExpression

### DIFF
--- a/packages/analysis/src/jsts/rules/S7739/no-validation-lib/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7739/no-validation-lib/unit.test.ts
@@ -165,6 +165,17 @@ describe('S7739', () => {
         `,
           filename: testFilePath,
         },
+        // False Positive Pattern 5f: Arrow assigned to a namespaced Promise property
+        {
+          code: `
+          exports.Promise = () => {
+            this.then = function (resolve, reject) {
+              return this._promise.then(resolve, reject);
+            };
+          };
+        `,
+          filename: testFilePath,
+        },
         // False Positive Pattern 6: Object with then AND catch methods
         // Having both then and catch methods indicates an intentional thenable implementation.
         {
@@ -395,6 +406,16 @@ describe('S7739', () => {
             is: true,
             then: (schema) => schema,
           });
+        `,
+          filename: testFilePath,
+          errors: [{ messageId: NO_THENABLE_OBJECT_ERROR }],
+        },
+        // True Positive: computed member target is NOT treated as a Promise/Deferred name
+        {
+          code: `
+          ns[Deferred] = function () {
+            this.then = function (cb) { this.cb = cb; };
+          };
         `,
           filename: testFilePath,
           errors: [{ messageId: NO_THENABLE_OBJECT_ERROR }],

--- a/packages/analysis/src/jsts/rules/S7739/no-validation-lib/unit.test.ts
+++ b/packages/analysis/src/jsts/rules/S7739/no-validation-lib/unit.test.ts
@@ -152,6 +152,19 @@ describe('S7739', () => {
         `,
           filename: testFilePath,
         },
+        // False Positive Pattern 5e: Function expression assigned to a namespaced Deferred
+        // property (e.g. jQuery-style `ns.Deferred = function () {...}`), rather than a bare
+        // declaration name.
+        {
+          code: `
+          ns.Deferred = function () {
+            this.then = function (resolve, reject) {
+              return this._promise.then(resolve, reject);
+            };
+          };
+        `,
+          filename: testFilePath,
+        },
         // False Positive Pattern 6: Object with then AND catch methods
         // Having both then and catch methods indicates an intentional thenable implementation.
         {

--- a/packages/analysis/src/jsts/rules/S7739/rule.ts
+++ b/packages/analysis/src/jsts/rules/S7739/rule.ts
@@ -187,6 +187,22 @@ function isPromiseOrDeferredFunctionDeclaration(ancestor: Node): boolean {
 }
 
 /**
+ * Checks if an assignment target names 'Promise' or 'Deferred', either as a bare identifier
+ * (`Promise = ...`) or as the non-computed property of a MemberExpression
+ * (`ns.Deferred = ...`, a common module/namespace-attached constructor pattern).
+ */
+function isPromiseOrDeferredAssignmentTarget(target: Node): boolean {
+  if (target.type === 'Identifier') {
+    return isIdentifier(target, 'Promise', 'Deferred');
+  }
+  return (
+    target.type === 'MemberExpression' &&
+    !target.computed &&
+    isIdentifier(target.property, 'Promise', 'Deferred')
+  );
+}
+
+/**
  * Checks if an ancestor is a function expression/arrow assigned to 'Promise' or 'Deferred'.
  */
 function isPromiseOrDeferredFunctionExpression(ancestor: Node): boolean {
@@ -205,11 +221,10 @@ function isPromiseOrDeferredFunctionExpression(ancestor: Node): boolean {
   ) {
     return true;
   }
-  // Promise = function() { ... } or Promise = () => { ... }
+  // Promise = function() { ... }, ns.Deferred = function() { ... }, or the arrow equivalents
   return (
     funcParent.type === 'AssignmentExpression' &&
-    funcParent.left.type === 'Identifier' &&
-    isIdentifier(funcParent.left, 'Promise', 'Deferred')
+    isPromiseOrDeferredAssignmentTarget(funcParent.left)
   );
 }
 


### PR DESCRIPTION
## Jira

JS-2382 — S7739: `Promise`/`Deferred` naming exception misses namespace-attached
constructors (`ns.Deferred = function () {...}`).

## Paired analyzer keys

`javascript:S7739`, `typescript:S7739`

## Context

This is a follow-up to #7863 (JS-1821), split out per review discussion there. #7863 added
an explicit `@implements`/`implements` thenable-contract exception; it does **not** touch the
separate, pre-existing Promise/Deferred naming-based exception this PR fixes.

## Boundary

**Suppressed (new):** a `then()` method inside a function/arrow expression assigned to a
`Promise`/`Deferred`-named target is not reported when that target is a non-computed
`MemberExpression` property (`ns.Deferred = function () {...}`, `exports.Promise = () =>
{...}`), not just a bare identifier (`const Deferred = ...`, `Promise = ...`).

This is the common jQuery-style "Deferred implementation attached to a namespace object"
pattern, e.g.:

```js
ns.Deferred = function () {
  this.then = function (resolve, reject) {
    return this._promise.then(resolve, reject);
  };
};
```

**Unchanged:** all other exception paths (bare-identifier Promise/Deferred naming,
prototype assignment, Yup/Joi, sibling then/catch/finally, JSON Schema conditionals,
interface shape descriptors, the new #7863 thenable-contract exception).

**Still reported:** a computed member target (`ns['Deferred'] = ...`) and any other naming
shape not covered above — those remain out of scope for this narrow fix.

## Tests

`packages/analysis/src/jsts/rules/S7739/no-validation-lib/unit.test.ts` — new valid case
reproducing JS-2382's exact scenario, added alongside the existing bare-declaration-name
Promise/Deferred tests, without altering any existing assertion.

## RSPEC

No companion RSPEC PR: this follows the existing precedent of the rule's other undocumented
exception paths, consistent with #7863.
