### PR TITLE
JS-2420 Exclude root tests from Maven submodules

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -62,6 +62,7 @@
     <!-- sonar scanner properties -->
     <sonar.sources>src/main</sonar.sources>
     <sonar.tests>src/test</sonar.tests>
+    <sonar.test.exclusions>../**/packages/**/*.test.ts</sonar.test.exclusions>
     <sonar.javascript.lcov.reportPaths/>
     <sonar.typescript.tsconfigPath/>
   </properties>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -62,7 +62,7 @@
     <!-- sonar scanner properties -->
     <sonar.sources>src/main</sonar.sources>
     <sonar.tests>src/test</sonar.tests>
-    <sonar.test.exclusions>../**/packages/**/*.test.ts</sonar.test.exclusions>
+    <sonar.test.inclusions>**/*.test.ts</sonar.test.inclusions>
     <sonar.javascript.lcov.reportPaths/>
     <sonar.typescript.tsconfigPath/>
   </properties>

--- a/sonar-plugin/pom.xml
+++ b/sonar-plugin/pom.xml
@@ -23,9 +23,10 @@
     <!-- sonar scanner properties -->
     <sonar.sources>src/main</sonar.sources>
     <sonar.tests>src/test</sonar.tests>
+    <sonar.test.inclusions>**/*.test.ts</sonar.test.inclusions>
     <sonar.javascript.lcov.reportPaths/>
     <sonar.typescript.tsconfigPath/>
-    <sonar.test.exclusions>tests/**/fixtures/**/*,tests/**/rules/comment-based/**/*,../**/packages/**/*.test.ts</sonar.test.exclusions>
+    <sonar.test.exclusions>tests/**/fixtures/**/*,tests/**/rules/comment-based/**/*</sonar.test.exclusions>
   </properties>
 
 

--- a/sonar-plugin/pom.xml
+++ b/sonar-plugin/pom.xml
@@ -25,7 +25,7 @@
     <sonar.tests>src/test</sonar.tests>
     <sonar.javascript.lcov.reportPaths/>
     <sonar.typescript.tsconfigPath/>
-    <sonar.test.exclusions>tests/**/fixtures/**/*,tests/**/rules/comment-based/**/*</sonar.test.exclusions>
+    <sonar.test.exclusions>tests/**/fixtures/**/*,tests/**/rules/comment-based/**/*,../**/packages/**/*.test.ts</sonar.test.exclusions>
   </properties>
 
 


### PR DESCRIPTION
## Summary

- override the root package-specific test inclusion in the two Maven child trees
- preserve root package-test analysis while preventing 4,194 repeated scanner warnings

## Why

Scanner Maven removes `sonar.tests` when a module's configured `src/test` directory does not exist. Scanner Engine then inherits the root `packages/` test path, visits all 699 package tests for each empty aggregator module, and warns that every file is outside the module base directory.

The child inclusion differs from the root configuration, so Scanner Engine evaluates it against module-relative paths. Inherited files outside a module cannot match and are rejected before the module-base-directory warning. The root keeps its existing `packages/**/*.test.ts` inclusion.

There are currently no `.test.ts` files under the Maven modules' configured `src/test` roots, so this preserves the indexed-file set.

Related run: https://github.com/SonarSource/SonarJS/actions/runs/34201047965/job/101997190668

## Validation

- `mvn -q help:evaluate -Dexpression=sonar.test.inclusions -DforceStdout`
- `mvn -q -pl sonar-plugin/api help:evaluate -Dexpression=sonar.test.inclusions -DforceStdout`
- `mvn -q -pl its/plugin/plugins/eslint-custom-rules-plugin help:evaluate -Dexpression=sonar.test.inclusions -DforceStdout`
- `git diff --check`
- [SonarQube NEXT analysis](https://github.com/SonarSource/SonarJS/actions/runs/34219004988/job/102040238302): zero module-basedir warnings (previously 4,194), 46 remaining scanner warnings, and 3,473 files indexed
